### PR TITLE
Correct the URL for registering a UAA client.

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -601,11 +601,11 @@ Response body   *example*::
 
 =============== ===============================================================
 
-Register Client: ``POST /oauth/clients/{client_id}``
+Register Client: ``POST /oauth/clients``
 -------------------------------------------------------
 
 ==============  ===============================================
-Request         ``POST /oauth/clients/{client_id}``
+Request         ``POST /oauth/clients``
 Access          allowed by clients or users with ``ROLE_ADMIN`` and ``scope=write``
 Request body    client details
 Response code    ``201 CREATED`` if successful


### PR DESCRIPTION
From testing, it appears that POSTing to /oauth/clients is the correct way to
register a new client application, not to /oauth/clients/{client_id}. This
corrects the API documentation.
