### PR TITLE
Use a reserved TLD when initializing user email

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManager.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManager.java
@@ -128,7 +128,7 @@ public class LoginAuthenticationManager implements AuthenticationManager, Applic
 				email = name;
 			}
 			else {
-				email = name + "@unknown.org";
+				email = name + "@unknown.invalid";
 			}
 		}
 		String givenName = info.get("given_name");


### PR DESCRIPTION
Using a valid domain name to initialize null email addresses seems unwise, especially when there exists one reserved for such uses (cf. RFC 2606).
