### PR TITLE
[cfid-598] remove small uaa.yml from war file

### DIFF
--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -1,30 +1,3 @@
-oauth:
-  authorize:
-   ssl: # set this to "true" to force https to be used by the user approval page
-  clients:
-    admin:
-      authorized-grant-types: client_credentials
-      scope: uaa.none
-      authorities: uaa.admin,clients.read,clients.write,clients.secret
-      id: admin
-      secret: adminsecret
-
-password-policy:
-  required-score: 0
-
-issuer.uri: http://localhost:8080/uaa
----
-
-platform: hsqldb
-database.driverClassName: org.hsqldb.jdbcDriver
-database.url: jdbc:hsqldb:mem:jdbcUaaTests
-database.username: sa
-database.password:
-
----
-
-platform: postgresql
-database.driverClassName: org.postgresql.Driver
-database.url: jdbc:postgresql:uaa
-database.username: root
-database.password: changeme
+# Configuration in this file is overridden by an external file
+# if any of these exist: 
+# [$UAA_CONFIG_URL, $UAA_CONFIG_PATH/uaa.yml, $CLOUDFOUNDRY_CONFIG_PATH/uaa.yml]

--- a/uaa/src/main/webapp/WEB-INF/spring/env.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/env.xml
@@ -4,13 +4,14 @@
 	This product includes a number of subcomponents with separate copyright notices and license terms. Your use of these subcomponents 
 	is subject to the terms and conditions of the subcomponent's license, as noted in the LICENSE file. -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.1.xsd">
 
 	<bean id="applicationProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
 		<property name="propertiesArray">
 			<list>
+				<ref bean="platformProperties" />
 				<bean class="org.cloudfoundry.identity.uaa.config.YamlPropertiesFactoryBean">
 					<property name="resources" value="classpath:/uaa.yml" />
 					<property name="documentMatchers">
@@ -65,6 +66,12 @@
 
 	<beans profile="default,hsqldb">
 		<description>Profile for hsqldb scripts on an empty database</description>
+		<util:properties id="platformProperties">
+			<prop key="database.driverClassName">org.hsqldb.jdbcDriver</prop>
+			<prop key="database.url">jdbc:hsqldb:mem:uaadb</prop>
+			<prop key="database.username">sa</prop>
+			<prop key="database.password"></prop>
+		</util:properties>
 		<bean id="platform" class="java.lang.String">
 			<constructor-arg value="hsqldb" />
 		</bean>
@@ -75,6 +82,12 @@
 
 	<beans profile="postgresql">
 		<description>Profile for postgresql scripts on an existing database</description>
+		<util:properties id="platformProperties">
+			<prop key="database.driverClassName">org.postgresql.Driver</prop>
+			<prop key="database.url">jdbc:postgresql:uaa</prop>
+			<prop key="database.username">root</prop>
+			<prop key="database.password">changeme</prop>
+		</util:properties>
 		<bean id="platform" class="java.lang.String">
 			<constructor-arg value="postgresql" />
 		</bean>

--- a/uaa/src/main/webapp/WEB-INF/spring/oauth-clients.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/oauth-clients.xml
@@ -23,9 +23,10 @@
 
 	<bean id="clientAdminBootstrap" class="org.cloudfoundry.identity.uaa.oauth.ClientAdminBootstrap">
 		<property name="clientRegistrationService" ref="clientRegistrationService" />
-		<property name="defaultOverride" value="${oauth.client.override:true}"/>
-		<property name="clients" value="#{@config['oauth']?.clients}" />
-		<property name="autoApproveClients" value="#{(@config['oauth']==null or @config['oauth']['client']==null or @config['oauth']['client']['autoapprove']==null)?'vmc':(@config['oauth']['client']?.autoapprove?:'vmc')}" />
+		<property name="defaultOverride" value="${oauth.client.override:true}" />
+		<property name="clients" value="#{@config['oauth']==null or @config['oauth']['clients']==null ? null : @config['oauth']?.clients}" />
+		<property name="autoApproveClients"
+			value="#{(@config['oauth']==null or @config['oauth']['client']==null or @config['oauth']['client']['autoapprove']==null)?'vmc':(@config['oauth']['client']?.autoapprove?:'vmc')}" />
 	</bean>
 
 	<beans profile="cloud">
@@ -41,12 +42,20 @@
 			<property name="clientRegistrationService" ref="clientRegistrationService" />
 			<property name="clients">
 				<map>
+					<entry key="admin">
+						<map>
+							<entry key="id" value="admin" />
+							<entry key="authorized-grant-types" value="client_credentials" />
+							<entry key="scope" value="uaa.none" />
+							<entry key="authorities" value="uaa.admin,clients.read,clients.write,clients.secret" />
+							<entry key="secret" value="adminsecret" />
+						</map>
+					</entry>
 					<entry key="vmc">
 						<map>
 							<entry key="id" value="vmc" />
 							<entry key="authorized-grant-types" value="implicit,password,refresh_token" />
-							<entry key="scope"
-								value="cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids" />
+							<entry key="scope" value="cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids" />
 							<entry key="authorities" value="uaa.none" />
 							<entry key="autoapprove" value="true" />
 						</map>
@@ -56,8 +65,7 @@
 							<entry key="id" value="app" />
 							<entry key="secret" value="appclientsecret" />
 							<entry key="authorized-grant-types" value="password,authorization_code,refresh_token,client_credentials" />
-							<entry key="scope"
-								value="cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids" />
+							<entry key="scope" value="cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids" />
 							<entry key="authorities" value="uaa.resource" />
 							<entry key="autoapprove">
 								<list>
@@ -82,7 +90,7 @@
 							<entry key="scope" value="openid,uaa.user" />
 							<entry key="authorized-grant-types" value="client_credentials,authorization_code" />
 							<entry key="authorities" value="oauth.login" />
-							<entry key="autoapprove" value="true"/>
+							<entry key="autoapprove" value="true" />
 						</map>
 					</entry>
 					<entry key="dashboard">

--- a/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
@@ -158,7 +158,7 @@
 		<property name="userDatabase" ref="userDatabase" />
 		<property name="signerProvider" ref="signerProvider" />
 		<property name="defaultUserAuthorities" ref="defaultUserAuthorities" />
-		<property name="issuer" value="${issuer.uri}" />
+		<property name="issuer" value="${issuer.uri:http://localhost:8080/uaa}" />
 		<property name="approvalStore" ref="approvalStore" />
 	</bean>
 

--- a/uaa/src/main/webapp/WEB-INF/spring/password-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/password-endpoints.xml
@@ -23,7 +23,7 @@
 	</bean>
 
     <bean id="zxcvbnScoreCalculator" class="org.cloudfoundry.identity.uaa.password.ZxcvbnPasswordScoreCalculator">
-        <constructor-arg value="${password-policy.required-score:2}" />
+        <constructor-arg value="${password-policy.required-score:0}" />
     </bean>
 
 </beans>


### PR DESCRIPTION
All the entries from the uaa.yml have been moved into inline XML.  The file
is still there with a comment to say how to override it.  The main problem
that we might anticipate is that there is no longer an admin client in the
bootstrap except in the default profile.  Most of our users seem to want to
put the admin client in ther custom uaa.yml anyway, so that's probably not
such a problem.

[Fixes #44222845]
