### PR TITLE
Update auto approval to handle Boolean.TRUE as well as "true"

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/AccessController.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/AccessController.java
@@ -112,7 +112,7 @@ public class AccessController {
 				Collection<? extends String> scopes = (Collection<? extends String>) autoApproved;
 				autoApprovedScopes.addAll(scopes);
 			}
-			else if ("true".equals(autoApproved)) {
+			else if (autoApproved instanceof Boolean && (Boolean) autoApproved || "true".equals(autoApproved)) {
 				autoApprovedScopes.addAll(modifiableClient.getScope());
 			}
 

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/UserManagedAuthzApprovalHandler.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/UserManagedAuthzApprovalHandler.java
@@ -92,7 +92,7 @@ public class UserManagedAuthzApprovalHandler implements UserApprovalHandler {
 					Collection<? extends String> scopes = (Collection<? extends String>) autoApproved;
 					autoApprovedScopes.addAll(scopes);
 				}
-				else if ("true".equals(autoApproved)) {
+				else if (autoApproved instanceof Boolean && (Boolean) autoApproved || "true".equals(autoApproved)) {
 					autoApprovedScopes.addAll(client.getScope());
 				}
 			}

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpoints.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpoints.java
@@ -122,7 +122,7 @@ public class ApprovalsAdminEndpoints implements InitializingBean {
 				Collection<? extends String> scopes = (Collection<? extends String>) autoApproved;
 				autoApprovedScopes.addAll(scopes);
 			}
-			else if ("true".equals(autoApproved)) {
+			else if (autoApproved instanceof Boolean && (Boolean) autoApproved || "true".equals(autoApproved)) {
 				autoApprovedScopes.addAll(client.getScope());
 			}
 

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
@@ -177,7 +177,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 			Collection<? extends String> scopes = (Collection<? extends String>) autoApproved;
 			autoApprovedScopes.addAll(scopes);
 		}
-		else if ("true".equals(autoApproved)) {
+		else if (autoApproved instanceof Boolean && (Boolean) autoApproved || "true".equals(autoApproved)) {
 			autoApprovedScopes.addAll(originalScopes);
 		}
 
@@ -536,7 +536,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 				Collection<? extends String> approvedScopes = (Collection<? extends String>) autoApproved;
 				autoApprovedScopes.addAll(approvedScopes);
 			}
-			else if ("true".equals(autoApproved)) {
+			else if (autoApproved instanceof Boolean && (Boolean) autoApproved || "true".equals(autoApproved)) {
 				autoApprovedScopes.addAll(client.getScope());
 			}
 


### PR DESCRIPTION
I recently switched to the develop branch and discovered that none of the scope auto approvals were working.  This made it so I couldn't log in with UAA.

Turns out that Jackson was unmarshalling the autoapprove boolean value to a Boolean.TRUE.

I noticed this fixed already in ApprovalsAdminEndpoints.  I just propagated that fix into the rest of uaa.

Mike
