### PR TITLE
Making JdbcPagingList.sublist() compatible with java.util.List specification.

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientAdminEndpoints.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientAdminEndpoints.java
@@ -35,6 +35,7 @@ import org.cloudfoundry.identity.uaa.rest.SearchResultsFactory;
 import org.cloudfoundry.identity.uaa.rest.SimpleAttributeNameMapper;
 import org.cloudfoundry.identity.uaa.security.DefaultSecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.security.SecurityContextAccessor;
+import org.cloudfoundry.identity.uaa.util.UaaPagingUtils;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.expression.spel.SpelEvaluationException;
@@ -227,7 +228,7 @@ public class ClientAdminEndpoints implements InitializingBean {
 		} catch (IllegalArgumentException e) {
 			throw new UaaException("Invalid filter expression: [" + filter + "]", HttpStatus.BAD_REQUEST.value());
 		}
-		for (ClientDetails client : clients.subList(startIndex - 1, startIndex + count - 1)) {
+		for (ClientDetails client : UaaPagingUtils.subList(clients, startIndex, count)) {
 			result.add(removeSecret(client));
 		}
 

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpoints.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpoints.java
@@ -30,6 +30,7 @@ import org.cloudfoundry.identity.uaa.message.SimpleMessage;
 import org.cloudfoundry.identity.uaa.security.DefaultSecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.security.SecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
+import org.cloudfoundry.identity.uaa.util.UaaPagingUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -99,9 +100,9 @@ public class ApprovalsAdminEndpoints implements InitializingBean {
 	int count) {
 		String username = getCurrentUsername();
 		logger.debug("Fetching all approvals for user: " + username);
-		List<Approval> approvals = approvalStore.getApprovals(
-				String.format("%s and " + USER_FILTER_TEMPLATE, filter, username)).subList(startIndex - 1,
-				startIndex + count - 1);
+		List<Approval> input = approvalStore.getApprovals(
+				String.format("%s and " + USER_FILTER_TEMPLATE, filter, username));
+		List<Approval> approvals = UaaPagingUtils.subList(input, startIndex, count);
 
 		// Find the clients for these approvals
 		Set<String> clientIds = new HashSet<String>();

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/rest/SearchResultsFactory.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/rest/SearchResultsFactory.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.rest;
 
+import org.cloudfoundry.identity.uaa.util.UaaPagingUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -20,7 +21,7 @@ public class SearchResultsFactory {
 		Map<String, Expression> expressions = buildExpressions(attributes, mapper);
 		StandardEvaluationContext context = new StandardEvaluationContext();
 		Collection<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
-		for (T object : input.subList(startIndex - 1, startIndex + count - 1)) {
+		for (T object : UaaPagingUtils.subList(input, startIndex, count)) {
 			Map<String, Object> map = new LinkedHashMap<String, Object>();
 			for (String attribute : expressions.keySet()) {
 				map.put(attribute, expressions.get(attribute).getValue(context, object));

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/rest/jdbc/JdbcPagingList.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/rest/jdbc/JdbcPagingList.java
@@ -88,8 +88,10 @@ public class JdbcPagingList<E> extends AbstractList<E> {
 
 	@Override
 	public List<E> subList(int fromIndex, int toIndex) {
-		int end = toIndex > size ? size : toIndex;
-		return new SafeIteratorList<E>(super.subList(fromIndex, end));
+		if(fromIndex < 0 || toIndex > size || fromIndex > toIndex) {
+			throw new IndexOutOfBoundsException("The indexes provided are outside the bounds of this list.");
+		}
+		return new SafeIteratorList<E>(super.subList(fromIndex, toIndex));
 	}
 
 	private String getLimitSql(String sql, int index, int size) {

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/util/UaaPagingUtils.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/util/UaaPagingUtils.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.identity.uaa.util;
+
+import java.util.List;
+
+public class UaaPagingUtils {
+
+	/**
+	 * Calculates the substring of a list based on a 1 based start index never exceeding
+	 * the bounds of the list. 
+	 * @param input
+	 * @param startIndex
+	 * @param count
+	 * @return
+	 */
+	public static <T> List<T> subList(List<T> input, int startIndex, int count) {
+		int fromIndex = startIndex-1;
+		int toIndex = fromIndex+count;
+		if(toIndex >= input.size()) {
+			toIndex = input.size();
+		}
+		return input.subList(fromIndex, toIndex);
+	}
+}

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/rest/jdbc/JdbcPagingListTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/rest/jdbc/JdbcPagingListTests.java
@@ -10,7 +10,7 @@
  * subcomponents is subject to the terms and conditions of the
  * subcomponent's license, as noted in the LICENSE file.
  */
-package org.cloudfoundry.identity.uaa.scim.jdbc;
+package org.cloudfoundry.identity.uaa.rest.jdbc;
 
 import org.cloudfoundry.identity.uaa.rest.jdbc.JdbcPagingList;
 import org.cloudfoundry.identity.uaa.test.NullSafeSystemProfileValueSource;
@@ -154,24 +154,17 @@ public class JdbcPagingListTests {
 		assertEquals(5, count);
 	}
 
-	@Test
+	@Test(expected=IndexOutOfBoundsException.class)
 	public void testSubListExtendsBeyondSize() throws Exception {
 		list = new JdbcPagingList<Map<String, Object>>(template, "SELECT * from foo", new ColumnMapRowMapper(), 3);
-		list = list.subList(1, 40);
-		assertEquals(4, list.size());
-		int count = 0;
-		for (Map<String, Object> map : list) {
-			count++;
-			assertNotNull(map.get("name"));
-		}
-		assertEquals(4, count);
+		list.subList(1, 40);
 	}
 
 	@Test
 	public void testSubListFromDeletedElements() throws Exception {
 		list = new JdbcPagingList<Map<String, Object>>(template, "SELECT * from foo", new ColumnMapRowMapper(), 3);
 		template.update("DELETE from foo where id>3");
-		list = list.subList(1, 40);
+		list = list.subList(1, list.size());
 		assertEquals(4, list.size());
 		int count = 0;
 		for (Map<String, Object> map : list) {

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/util/UaaPagingUtilsTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/util/UaaPagingUtilsTests.java
@@ -1,0 +1,74 @@
+package org.cloudfoundry.identity.uaa.util;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class UaaPagingUtilsTests {
+
+	
+	List<String> list;
+	
+	@Before
+	public void createList() {
+		list = new ArrayList<String>();
+		list.add("one");
+		list.add("two");
+		list.add("three");
+		list.add("four");
+	}
+
+	
+	@Test
+	public void testPagingSubListHighCount() {
+		List<String> result = UaaPagingUtils.subList(list, 1, 100);
+		assertEquals(4, result.size());
+        assertEquals("one", result.get(0));
+		assertEquals("four", result.get(3));
+	}
+
+	@Test
+	public void testPagingSubListLowCount() {
+		List<String> result = UaaPagingUtils.subList(list, 1, 2);
+		assertEquals(2, result.size());
+        assertEquals("one", result.get(0));
+		assertEquals("two", result.get(1));
+	}
+
+	@Test
+	public void testPagingSubListEqualCount() {
+		List<String> result = UaaPagingUtils.subList(list, 1, 4);
+		assertEquals(4, result.size());
+        assertEquals("one", result.get(0));
+		assertEquals("four", result.get(3));
+
+	}
+
+	@Test
+	public void testPagingSubListOneCount() {
+		List<String> result = UaaPagingUtils.subList(list, 1, 1);
+		assertEquals(1, result.size());
+		assertEquals("one", result.get(0));
+	}
+
+	@Test
+	public void testPagingSubListPage() {
+		List<String> result = UaaPagingUtils.subList(list, 3, 2);
+		assertEquals(2, result.size());
+		assertEquals("three", result.get(0));
+		assertEquals("four", result.get(1));
+	}
+
+	@Test
+	public void testPagingSubListPageHighCount() {
+		List<String> result = UaaPagingUtils.subList(list, 2, 100);
+		assertEquals(3, result.size());
+		assertEquals("two", result.get(0));
+		assertEquals("four", result.get(2));
+	}
+
+}

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpoints.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpoints.java
@@ -14,6 +14,7 @@ import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidScimResourceException;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimException;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceNotFoundException;
+import org.cloudfoundry.identity.uaa.util.UaaPagingUtils;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParseException;
@@ -77,7 +78,7 @@ public class ScimGroupEndpoints {
 		List<ScimGroup> input;
 		try {
 			input = dao.query(filter, sortBy, "ascending".equalsIgnoreCase(sortOrder));
-			for (ScimGroup group : input.subList(startIndex - 1, startIndex + count - 1)) {
+			for (ScimGroup group : UaaPagingUtils.subList(input, startIndex, count)) {
 				group.setMembers(membershipManager.getMembers(group.getId()));
 			}
 		}

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
@@ -40,6 +40,7 @@ import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimException;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceConflictException;
+import org.cloudfoundry.identity.uaa.util.UaaPagingUtils;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -225,7 +226,7 @@ public class ScimUserEndpoints implements InitializingBean {
 		List<ScimUser> input;
 		try {
 			input = dao.query(filter, sortBy, sortOrder.equals("ascending"));
-			for (ScimUser user : input.subList(startIndex - 1, startIndex + count - 1)) {
+			for (ScimUser user : UaaPagingUtils.subList(input, startIndex, count)) {
 				syncApprovals(syncGroups(user));
 			}
 		}


### PR DESCRIPTION
I've signed and sent the contributor agreement and have rebased the pull request to the "develop" branch.

I'm creating an alternative implementation of ScimUserProvisioning. In this implementation instead of returning Lists of type JdbcPagingList I return instances of ArrayList instances. This then fails in several ScimUserEndpoint because JdbcPagingList.subList() doesn't conform to java.util.List.

List.subList() is supposed to throw an IndexOutOfBoundsException if the "toIndex" is greater than the size of the List. JdbcPagingList does not do this (by design it appears).

This patch brings JdbcPagingList.subList() into conformance with List.subList() and changes all of the uses of List.subList() in the application to match how List.subList() should be used.
