### PR TITLE
String comparison using == in SignerProvider.java

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/SignerProvider.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/SignerProvider.java
@@ -59,7 +59,7 @@ public class SignerProvider implements InitializingBean {
 			}
 		}
 		else {
-			Assert.state(this.signingKey == this.verifierKey,
+			Assert.state(this.signingKey.equals(this.verifierKey),
 					"For MAC signing you do not need to specify the verifier key separately, and if you do it must match the signing key");
 		}
 	}

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/SignerProviderTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/SignerProviderTests.java
@@ -91,8 +91,8 @@ public class SignerProviderTests {
 		signerProvider.afterPropertiesSet();
 	}
 
-	@Test(expected = IllegalStateException.class)
-	public void keysNotSameWithMacSigner() throws Exception {
+	@Test
+	public void keyMatchingWithMacSigner() throws Exception {
 		signerProvider.setSigningKey("aKey");
 		signerProvider.setVerifierKey(new String("aKey"));
 		signerProvider.afterPropertiesSet();


### PR DESCRIPTION
In `SignerProvider.java`, an exception is thrown using the condition `this.signingKey == this.verifierKey`.  It appears the intent of this check is to compare the value of the strings, and so using `equals()` should be the correct way, instead of ==.  A test in `SignerProviderTests.java` seems to obey the same logic, and so I have updated the test to check for the condition that `equals()` fulfills.
