### PR TITLE
Switch from MySQL Connector/J JDBC client to MariaDB JDBC Client Library...

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -271,10 +271,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.23</version>
-			<scope>test</scope>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>1.1.3</version>
 		</dependency>
 
 <!--		<dependency>

--- a/common/src/test/resources/mysql.properties
+++ b/common/src/test/resources/mysql.properties
@@ -1,4 +1,4 @@
-database.driverClassName: com.mysql.jdbc.Driver
+database.driverClassName: org.mariadb.jdbc.Driver
 database.url: jdbc:mysql://localhost:3306/uaa
 database.username: root
 database.password:

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,15 @@
 				<snapshots>
 					<enabled>false</enabled>
 				</snapshots>
-		  </repository>
+			</repository>
+			<repository>
+				<id>spring-external</id>
+				<name>Spring External</name>
+				<url>http://repo.springsource.org/ext-release-local</url>
+				<snapshots>
+					<enabled>false</enabled>
+				</snapshots>
+			</repository>
 		</repositories>
 	  </profile>
 		<profile>

--- a/scim/pom.xml
+++ b/scim/pom.xml
@@ -173,12 +173,11 @@
 			<scope>test</scope>
 		</dependency>
 
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.23</version>
-            <scope>test</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>1.1.3</version>
+		</dependency>
 
 <!--        <dependency>
             <groupId>com.oracle</groupId>

--- a/scim/src/test/resources/mysql.properties
+++ b/scim/src/test/resources/mysql.properties
@@ -1,4 +1,4 @@
-database.driverClassName: com.mysql.jdbc.Driver
+database.driverClassName: org.mariadb.jdbc.Driver
 database.url: jdbc:mysql://localhost:3306/uaa
 database.username: root
 database.password:

--- a/uaa/pom.xml
+++ b/uaa/pom.xml
@@ -362,12 +362,11 @@
 			<scope>runtime</scope>
 		</dependency>
 
-        <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.23</version>
-            <scope>runtime</scope>
-        </dependency>
+		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>1.1.3</version>
+		</dependency>
         
 <!--        <dependency>
         	<groupId>com.oracle</groupId>

--- a/uaa/src/main/webapp/WEB-INF/spring/env.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/env.xml
@@ -88,7 +88,7 @@
     <beans profile="mysql">
         <description>Profile for mysql scripts on an existing database</description>
         <util:properties id="platformProperties">
-            <prop key="database.driverClassName">com.mysql.jdbc.Driver</prop>
+            <prop key="database.driverClassName">org.mariadb.jdbc.Driver</prop>
             <prop key="database.url">jdbc:mysql://localhost:3306/uaa</prop>
             <prop key="database.username">root</prop>
             <prop key="database.password"></prop>


### PR DESCRIPTION
....

[Finishes #55528568]

A few notes:
- This uses version 1.1.1, which is a bit outdated
- MariaDB clients are not in maven, see: https://mariadb.atlassian.net/browse/CONJ-3
- We should probably setup a maven repo (or help MariaDB set theirs up) with all releases of the client

Test suite passes on MySQL
