### PR TITLE
Corrected logic of setting additional authorization attributes to avoid ClassCastException as they are returned as Map by CheckTokenEndpoint.

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codehaus.jackson.map.ObjectMapper;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -65,6 +66,8 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 	private String clientId;
 
 	private String clientSecret;
+
+	private ObjectMapper mapper = new ObjectMapper();
 
 	public RemoteTokenServices() {
 		restTemplate = new RestTemplate();
@@ -141,8 +144,12 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 
 
 		if (map.containsKey(Claims.ADDITIONAL_AZ_ATTR)) {
-			clientAuthentication.setAuthorizationParameters(Collections.singletonMap(Claims.ADDITIONAL_AZ_ATTR,
-			(String) map.get(Claims.ADDITIONAL_AZ_ATTR)));
+			try {
+				clientAuthentication.setAuthorizationParameters(Collections.singletonMap(Claims.ADDITIONAL_AZ_ATTR,
+						mapper.writeValueAsString(map.get(Claims.ADDITIONAL_AZ_ATTR))));
+			} catch (IOException e) {
+				throw new IllegalStateException("Cannot convert access token to JSON", e);
+			}
 		}
 
 		Authentication userAuthentication = getUserAuthentication(map, scope);

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServicesTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServicesTests.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -86,13 +87,14 @@ public class RemoteTokenServicesTests {
 
 	@Test
 	public void testTokenRetrievalWithAdditionalAuthorizationAttributes() throws Exception {
-		String tokenAdditionalAuthorizationAttributes = "{\"test\": 1}";
-		body.put(Claims.ADDITIONAL_AZ_ATTR, tokenAdditionalAuthorizationAttributes);
+		ObjectMapper mapper = new ObjectMapper();
+		Map additionalAuthorizationAttributesMap = Collections.singletonMap("test", 1);
+		body.put(Claims.ADDITIONAL_AZ_ATTR, additionalAuthorizationAttributesMap);
 
 		OAuth2Authentication result = services.loadAuthentication("FOO");
 
 		assertNotNull(result);
-		assertEquals(tokenAdditionalAuthorizationAttributes, result.getAuthorizationRequest()
+		assertEquals(mapper.writeValueAsString(additionalAuthorizationAttributesMap), result.getAuthorizationRequest()
 				.getAuthorizationParameters().get(Claims.ADDITIONAL_AZ_ATTR));
 	}
 }


### PR DESCRIPTION
I'm really sorry that I didn't notice that previously.
**CheckTokenEndpoint** returns additional authorization attributes as Map (cause they are initially formed as JSON). Without these changes **java.lang.ClassCastException: java.util.LinkedHashMap cannot be cast to java.lang.String** will be thrown.
