### PR TITLE
Allow configuration of username validation regex

### DIFF
--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioning.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioning.java
@@ -91,6 +91,8 @@ public class JdbcScimUserProvisioning extends AbstractQueryable<ScimUser> implem
 
 	private final RowMapper<ScimUser> mapper = new ScimUserRowMapper();
 
+	private Pattern usernamePattern = Pattern.compile("[a-zA-Z0-9+\\-_.@]+");
+
 	public JdbcScimUserProvisioning(JdbcTemplate jdbcTemplate, JdbcPagingListFactory pagingListFactory) {
 		super(jdbcTemplate, pagingListFactory, new ScimUserRowMapper());
 		Assert.notNull(jdbcTemplate);
@@ -175,8 +177,8 @@ public class JdbcScimUserProvisioning extends AbstractQueryable<ScimUser> implem
 	}
 
 	private void validate(final ScimUser user) throws InvalidScimResourceException {
-		if (!user.getUserName().matches("[a-z0-9+-_.@]+")) {
-			throw new InvalidScimResourceException("Username must be lower case alphanumeric with optional characters '._@'.");
+		if (!usernamePattern.matcher(user.getUserName()).matches()) {
+			throw new InvalidScimResourceException("Username must match pattern: " + usernamePattern.pattern());
 		}
 		if (user.getEmails()==null || user.getEmails().isEmpty()) {
 			throw new InvalidScimResourceException("An email must be provided.");
@@ -325,6 +327,14 @@ public class JdbcScimUserProvisioning extends AbstractQueryable<ScimUser> implem
 	public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
 		Assert.notNull(passwordEncoder, "passwordEncoder cannot be null");
 		this.passwordEncoder = passwordEncoder;
+	}
+
+	/**
+	 * Sets the regular expression which will be used to validate the username.
+	 */
+	public void setUsernamePattern(String usernamePattern) {
+		Assert.hasText(usernamePattern, "Username pattern must not be empty");
+		this.usernamePattern = Pattern.compile(usernamePattern);
 	}
 
 	private static final class ScimUserRowMapper implements RowMapper<ScimUser> {

--- a/scim/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioningTests.java
+++ b/scim/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioningTests.java
@@ -133,10 +133,10 @@ public class JdbcScimUserProvisioningTests {
 
 	@Test
 	public void canCreateUser() {
-		ScimUser user = new ScimUser(null, "JO@FOO.COM", "Jo", "User");
+		ScimUser user = new ScimUser(null, "jo@foo.com", "Jo", "User");
 		user.addEmail("jo@blah.com");
 		ScimUser created = db.createUser(user, "j7hyqpassX");
-		assertEquals("JO@FOO.COM", created.getUserName());
+		assertEquals("jo@foo.com", created.getUserName());
 		assertNotNull(created.getId());
 		assertNotSame(user.getId(), created.getId());
 		Map<String, Object> map = template.queryForMap("select * from users where id=?", created.getId());
@@ -147,10 +147,10 @@ public class JdbcScimUserProvisioningTests {
 
 	@Test
 	public void canCreateUserWithoutGivenNameAndFamilyName() {
-		ScimUser user = new ScimUser(null, "JO@FOO.COM", null, null);
+		ScimUser user = new ScimUser(null, "jo@foo.com", null, null);
 		user.addEmail("jo@blah.com");
 		ScimUser created = db.createUser(user, "j7hyqpassX");
-		assertEquals("JO@FOO.COM", created.getUserName());
+		assertEquals("jo@foo.com", created.getUserName());
 		assertNotNull(created.getId());
 		assertNotSame(user.getId(), created.getId());
 		Map<String, Object> map = template.queryForMap("select * from users where id=?", created.getId());
@@ -213,9 +213,18 @@ public class JdbcScimUserProvisioningTests {
 		ScimUser joe = db.update(JOE_ID, jo);
 		assertEquals("joe", joe.getUserName());
 	}
-
+/*
+	@Test(expected = InvalidScimResourceException.class)
+	public void updateWithCapitalLetterInUsernameIsError() throws Exception {
+		ScimUser jo = new ScimUser(null, "joSephine", "Jo", "NewUser");
+		jo.addEmail("jo@blah.com");
+		jo.setVersion(1);
+		ScimUser joe = db.update(JOE_ID, jo);
+		assertEquals("joe", joe.getUserName());
+	}
+*/
 	@Test
-	public void canChangePasswordWithouOldPassword() throws Exception {
+	public void canChangePasswordWithoutOldPassword() throws Exception {
 		assertTrue(db.changePassword(JOE_ID, null, "koala123$marissa"));
 		String storedPassword = template.queryForObject("SELECT password from users where ID=?", String.class, JOE_ID);
 		assertTrue(BCrypt.checkpw("koala123$marissa", storedPassword));

--- a/uaa/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
+++ b/uaa/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
@@ -124,6 +124,7 @@ public class UaaConfiguration {
 		public boolean userids_enabled;
 		public boolean userOverride;
 		public List<String> users;
+		public String username_pattern;
 	}
 
 	public static class PasswordPolicy {

--- a/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
@@ -24,6 +24,7 @@
 		</property>
 		<property name="queryConverter" ref="scimUserQueryConverter" />
 		<property name="deactivateOnDelete" value="${scim.delete.deactivate:false}" />
+		<property name="usernamePattern" value="${scim.username_pattern:[a-zA-Z0-9+\-_.@]+}" />
 	</bean>
 
 	<bean id="scimUserQueryConverter" class="org.cloudfoundry.identity.uaa.scim.jdbc.ScimSearchQueryConverter">

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimUserEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimUserEndpointsIntegrationTests.java
@@ -51,7 +51,7 @@ public class ScimUserEndpointsIntegrationTests {
 
 	private final String JOEL = "joel_" + new RandomValueStringGenerator().generate().toLowerCase();
 
-	private final String JOE = "joe_" + new RandomValueStringGenerator().generate().toLowerCase();
+	private final String JOE = "JOE_" + new RandomValueStringGenerator().generate().toLowerCase();
 
 	private final String DELETE_ME = "deleteme_" + new RandomValueStringGenerator().generate().toLowerCase();
 

--- a/uaa/src/test/resources/test/config/uaa.yml
+++ b/uaa/src/test/resources/test/config/uaa.yml
@@ -9,6 +9,7 @@ oauth:
       - my
       - support
 scim:
+  username_pattern: '[a-z0-9+\-_.@]+'
   users:
     - paul|wombat|paul@test.org|Paul|Smith|uaa.admin
     - stefan|wallaby|stefan@test.org|Stefan|Schmidt


### PR DESCRIPTION
Introduces the scim.username_pattern configuration option
which can be used to override the validation check performed
on the SCIM username.

Also [Fixes #59047048] [cfid-811].
