### PR TITLE
String to Authority conversion bugfix

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/user/UaaAuthority.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/user/UaaAuthority.java
@@ -82,7 +82,7 @@ public enum UaaAuthority implements GrantedAuthority {
 	}
 
 	public static GrantedAuthority authority(String value) {
-		return value.contains("uaa.admin") ? UAA_ADMIN : value.contains("uaa.admin") ? UAA_USER
+		return value.contains("uaa.admin") ? UAA_ADMIN : value.contains("uaa.user") ? UAA_USER
 				: new SimpleGrantedAuthority(value);
 	}
 }

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/user/UaaAuthorityTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/user/UaaAuthorityTests.java
@@ -16,8 +16,11 @@
 package org.cloudfoundry.identity.uaa.user;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import org.junit.Ignore;
 import org.junit.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /**
  * @author Dave Syer
@@ -39,6 +42,20 @@ public class UaaAuthorityTests {
 	@Test
 	public void testAdminFromAuthorities() {
 		assertEquals(UaaAuthority.UAA_ADMIN, UaaAuthority.fromAuthorities("uaa.user,uaa.admin"));
+	}
+	
+	@Test
+	public void testAuthority() {
+		assertEquals(UaaAuthority.UAA_ADMIN, UaaAuthority.authority("uaa.admin"));
+		assertEquals(UaaAuthority.UAA_USER, UaaAuthority.authority("uaa.user"));
+		assertEquals(new SimpleGrantedAuthority("tacos"), UaaAuthority.authority("tacos"));
+	}
+	
+	@Test
+	@Ignore("Is this a worth while test")
+	public void testSubstringAuthority() {
+		assertFalse(UaaAuthority.UAA_ADMIN.equals(UaaAuthority.authority("some.scope.with.subscope.uaa.admin")));
+
 	}
 
 }


### PR DESCRIPTION
The "authority" call on GrantedAuthority seems to have a logic error. I've attached a patch and unit test.

I've also added an additional test called "testSubstringAuthority" which is ignored. I wasn't sure what the desired behavior should be if an authority contain the phrase "uaa.admin". For example, "truluaa.adminbob" shouldn't give you "uaa.admin", but I'm not sure if it was coded that way for a reason.
