### PR TITLE
Changed ClientAdminEndpoints.setSecurityContextAccessor method access modifier to public

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientAdminEndpoints.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientAdminEndpoints.java
@@ -122,7 +122,7 @@ public class ClientAdminEndpoints implements InitializingBean {
         this.clientDetailsService = clientDetailsService;
     }
 
-    void setSecurityContextAccessor(SecurityContextAccessor securityContextAccessor) {
+    public void setSecurityContextAccessor(SecurityContextAccessor securityContextAccessor) {
         this.securityContextAccessor = securityContextAccessor;
     }
 


### PR DESCRIPTION
It should be public (like in the [ApprovalsAdminEndpoints](https://github.com/cloudfoundry/uaa/blob/6d214c2728e076523419e3fb0c20c8395485cb03/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpoints.java) or [UaaAuthorizationRequestManager](https://github.com/cloudfoundry/uaa/blob/6d214c2728e076523419e3fb0c20c8395485cb03/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationRequestManager.java)) to allow a custom [SecurityContextAccessor](https://github.com/cloudfoundry/uaa/blob/6d214c2728e076523419e3fb0c20c8395485cb03/common/src/main/java/org/cloudfoundry/identity/uaa/security/SecurityContextAccessor.java) to be used.
