### PR TITLE
remove unnecessary requirement for accept header

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
@@ -157,11 +157,6 @@
     <bean id="groupsUpdateRequestMatcher" class="org.cloudfoundry.identity.uaa.security.web.UaaRequestMatcher">
         <constructor-arg value="/Groups" />
         <property name="method" value="PUT" />
-        <property name="accept">
-            <list>
-                <value>application/json</value>
-            </list>
-        </property>
     </bean>
 
     <bean id="groupsReadRequestMatcher" class="org.cloudfoundry.identity.uaa.security.web.UaaRequestMatcher">


### PR DESCRIPTION
The Spring controller requires the accept header for the /Groups PUT request but not others. This makes  the request consistent with all other requests.   I ran "mvn test" and it passed.

I am speculating the reason this was originall included was a bug (previously fixed) in UAARequestMatcher in which HTTP requests were not correctly compared (equals didn't distinguish based on method alone.  Before that bug fix the difference in request header requirement helped separate out the PUT from the GET request.
