### PR TITLE
Externalize lockout parameters

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
@@ -261,8 +261,12 @@
         <property name="accountLoginPolicy">
             <bean class="org.cloudfoundry.identity.uaa.authentication.manager.PeriodLockoutPolicy">
                 <constructor-arg ref="jdbcAuditService" />
-                <property name="lockoutAfterFailures" value="5" />
-                <property name="lockoutPeriodSeconds" value="300" />
+                <property name="lockoutAfterFailures"
+                  value="#{@applicationProperties.containsKey('oauth.endpoint.lockoutAfterFailures')?@config['oauth']['endpoint']['lockoutAfterFailures']:'5'}" />
+                <property name="countFailuresWithin"
+                  value="#{@applicationProperties.containsKey('oauth.endpoint.countFailuresWithinSeconds')?@config['oauth']['endpoint']['countFailuresWithinSeconds']:'3600'}" />
+                <property name="lockoutPeriodSeconds"
+                  value="#{@applicationProperties.containsKey('oauth.endpoint.lockoutPeriodSeconds')?@config['oauth']['endpoint']['lockoutPeriodSeconds']:'300'}" />
             </bean>
         </property>
     </bean>


### PR DESCRIPTION
We'd like to be able to customise some of the password lockout parameters in line with corporate requirements etc. 

(corresponding PR in cf-release: https://github.com/cloudfoundry/cf-release/pull/406)
