### PR TITLE
Fix multiple endpoint failures when using start/count

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/rest/SearchResultsFactory.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/rest/SearchResultsFactory.java
@@ -39,7 +39,7 @@ public class SearchResultsFactory {
         Map<String, Expression> expressions = buildExpressions(attributes, mapper);
         StandardEvaluationContext context = new StandardEvaluationContext();
         Collection<Map<String, Object>> results = new ArrayList<Map<String, Object>>();
-        for (T object : UaaPagingUtils.subList(input, startIndex, count)) {
+        for (T object : input) {
             Map<String, Object> map = new LinkedHashMap<String, Object>();
             for (String attribute : expressions.keySet()) {
                 map.put(attribute, expressions.get(attribute).getValue(context, object));

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/util/UaaPagingUtils.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/util/UaaPagingUtils.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.util;
 
+import java.util.Collections;
 import java.util.List;
 
 public class UaaPagingUtils {
@@ -31,6 +32,9 @@ public class UaaPagingUtils {
         int toIndex = fromIndex + count;
         if (toIndex >= input.size()) {
             toIndex = input.size();
+        }
+        if (fromIndex >= toIndex) {
+            return Collections.emptyList();
         }
         return input.subList(fromIndex, toIndex);
     }

--- a/scim/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/scim/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -410,10 +410,29 @@ public class ScimUserEndpointsTests {
     }
 
     @Test
+    public void testFindWhenStartGreaterThanTotal() {
+        SearchResults<?> results = endpoints.findUsers("id", "id pr", null, "ascending", 3, 100);
+        assertEquals(2, results.getTotalResults());
+        assertEquals(0, results.getResources().size());
+    }
+
+    @Test
     public void testFindAllNames() {
         SearchResults<?> results = endpoints.findUsers("userName", "id pr", null, "ascending", 1, 100);
         Collection<Object> values = getSetFromMaps(results.getResources(), "userName");
         assertTrue(values.contains("olds"));
+    }
+
+    @Test
+    public void testFindAllNamesWithStartIndex() {
+        SearchResults<?> results = endpoints.findUsers("name", "id pr", null, "ascending", 1, 100);
+        assertEquals(2, results.getResources().size());
+
+        results = endpoints.findUsers("name", "id pr", null, "ascending", 2, 100);
+        assertEquals(1, results.getResources().size());
+
+        results = endpoints.findUsers("name", "id pr", null, "ascending", 3, 100);
+        assertEquals(0, results.getResources().size());
     }
 
     @Test


### PR DESCRIPTION
- If the sublist generated is invalid, return an empty list
- When filtering with attributes, do not sublist again
- Add testcases to cover the above
