### PR TITLE
ResponseBody annotation on changeSecret

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientAdminEndpoints.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientAdminEndpoints.java
@@ -455,6 +455,7 @@ public class ClientAdminEndpoints implements InitializingBean {
     }
 
     @RequestMapping(value = "/oauth/clients/{client}/secret", method = RequestMethod.PUT)
+    @ResponseBody
     public SimpleMessage changeSecret(@PathVariable String client, @RequestBody SecretChangeRequest change) {
 
         ClientDetails clientDetails;


### PR DESCRIPTION
Method needs annotation with @ResponseBody to avoid Spring applying the default view behaviour and treating it as a template.

Previously /oauth/clients/{client}/secret caused an internal server error since the template it was looking for didn't exist.