### PR TITLE
Reinstate original empty scopes error message

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationRequestManager.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationRequestManager.java
@@ -258,10 +258,9 @@ public class UaaAuthorizationRequestManager implements OAuth2RequestFactory {
         // Check that a token with empty scope is not going to be granted
         if (result.isEmpty() && !clientDetails.getScope().isEmpty()) {
             throw new InvalidScopeException(
-                "Invalid scope (empty) - this user is not userScopes any of the requestedScopes requestedScopes: " + requestedScopes
-                + " (either you requestedScopes a scope that was not userScopes or client '"
-                + clientDetails.getClientId()
-                + "' is not userScopes to act on behalf of this user)", allowed);
+                "Invalid scope (empty) - this user is not allowed any of the requested scopes: " + requestedScopes
+                + " (either you requested a scope that was not allowed or client '"
+                + clientDetails.getClientId() + "' is not allowed to act on behalf of this user)", allowed);
         }
 
         return result;

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationRequestManagerTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationRequestManagerTests.java
@@ -177,7 +177,7 @@ public class UaaAuthorizationRequestManagerTests {
         assertEquals(StringUtils.commaDelimitedListToSet(""), new TreeSet<String>(request.getScope()));
     }
 
-    @Test(expected = InvalidScopeException.class)
+    @Test
     public void testEmptyScopeFailsClientWithScopes() {
         SecurityContextAccessor securityContextAccessor = new StubSecurityContextAccessor() {
             @Override
@@ -193,8 +193,13 @@ public class UaaAuthorizationRequestManagerTests {
         factory.setSecurityContextAccessor(securityContextAccessor);
         client.setScope(StringUtils.commaDelimitedListToSet("one,two")); // not
                                                                          // empty
-        AuthorizationRequest request = factory.createAuthorizationRequest(parameters);
-        assertEquals(StringUtils.commaDelimitedListToSet(""), new TreeSet<String>(request.getScope()));
+        try {
+          factory.createAuthorizationRequest(parameters);
+          throw new AssertionError();
+        }
+        catch (InvalidScopeException ex) {
+          assertEquals("Invalid scope (empty) - this user is not allowed any of the requested scopes: [one, two] (either you requested a scope that was not allowed or client 'null' is not allowed to act on behalf of this user)", ex.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
It looks like the empty scope message was unintentionally mangled as part of a rename aimed at code - this PR reinstates the original message.  It's certainly quite confusing to encouter the current one!

I've also extended the existing test to cover the text of the message.