### PR TITLE
Update README.md with github Repo showing UAA instead of generic forking info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Here are some ways for you to get involved in the community:
   vote on the ones that you are interested in.
 * Github is for social coding: if you want to write code, we encourage
   contributions through pull requests from
-  [forks of this repository](http://help.github.com/forking/).  If you
+  [forks of this repository](https://github.com/cloudfoundry/uaa). If you
   want to contribute code this way, please reference an existing issue
   if there is one as well covering the specific issue you are
   addressing.  Always submit pull requests to the "develop" branch.

--- a/docs/UAA-Tokens.md
+++ b/docs/UAA-Tokens.md
@@ -40,8 +40,8 @@ and the actual value that we are interested is
 
     eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJiYzNlNzQ1Ni05MWY1LTQ5NjEtYjg4ZC1kYjcwNTYyNmJhNzciLCJzdWIiOiI3Zjc5MWVhOS05OWI5LTQyM2QtOTg4Yi05MzFmMDIyMmE3OWYiLCJzY29wZSI6WyJjbG91ZF9jb250cm9sbGVyLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwib3BlbmlkIiwicGFzc3dvcmQud3JpdGUiLCJzY2ltLnVzZXJpZHMiXSwiY2xpZW50X2lkIjoiYXBwIiwiY2lkIjoiYXBwIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9pZCI6IjdmNzkxZWE5LTk5YjktNDIzZC05ODhiLTkzMWYwMjIyYTc5ZiIsInVzZXJfbmFtZSI6Im1hcmlzc2EiLCJlbWFpbCI6Im1hcmlzc2FAdGVzdC5vcmciLCJpYXQiOjE0MDY1Njg5MzUsImV4cCI6MTQwNjYxMjEzNSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3VhYS9vYXV0aC90b2tlbiIsImF1ZCI6WyJzY2ltIiwib3BlbmlkIiwiY2xvdWRfY29udHJvbGxlciIsInBhc3N3b3JkIl19.ZOhp7HmYF0ufvxXrkut40eHZbHFzAb5EETT2NL7n2Cs
 
-If you run it through a [decoder](https://developers.google.com/wallet/digital/docs/jwtdecoder) you can quickly see the body
-of the access token.
+You can look at the body of the access token using a [decoder](http://jwt.calebb.net/)
+More on decoding can be found [here](https://developers.google.com/accounts/docs/OpenIDConnect#validatinganidtoken) 
 
     {
         "exp": 1406612135, 

--- a/docs/UAA-Tokens.md
+++ b/docs/UAA-Tokens.md
@@ -41,7 +41,7 @@ and the actual value that we are interested is
     eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJiYzNlNzQ1Ni05MWY1LTQ5NjEtYjg4ZC1kYjcwNTYyNmJhNzciLCJzdWIiOiI3Zjc5MWVhOS05OWI5LTQyM2QtOTg4Yi05MzFmMDIyMmE3OWYiLCJzY29wZSI6WyJjbG91ZF9jb250cm9sbGVyLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwib3BlbmlkIiwicGFzc3dvcmQud3JpdGUiLCJzY2ltLnVzZXJpZHMiXSwiY2xpZW50X2lkIjoiYXBwIiwiY2lkIjoiYXBwIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9pZCI6IjdmNzkxZWE5LTk5YjktNDIzZC05ODhiLTkzMWYwMjIyYTc5ZiIsInVzZXJfbmFtZSI6Im1hcmlzc2EiLCJlbWFpbCI6Im1hcmlzc2FAdGVzdC5vcmciLCJpYXQiOjE0MDY1Njg5MzUsImV4cCI6MTQwNjYxMjEzNSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3VhYS9vYXV0aC90b2tlbiIsImF1ZCI6WyJzY2ltIiwib3BlbmlkIiwiY2xvdWRfY29udHJvbGxlciIsInBhc3N3b3JkIl19.ZOhp7HmYF0ufvxXrkut40eHZbHFzAb5EETT2NL7n2Cs
 
 You can look at the body of the access token using a [decoder](http://jwt.calebb.net/). 
-More on decoding can be found [here](https://developers.google.com/accounts/docs/OpenIDConnect#validatinganidtoken) 
+More on Tokens can be found [here](https://developers.google.com/accounts/docs/OpenIDConnect#validatinganidtoken) 
 
     {
         "exp": 1406612135, 

--- a/docs/UAA-Tokens.md
+++ b/docs/UAA-Tokens.md
@@ -40,7 +40,7 @@ and the actual value that we are interested is
 
     eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJiYzNlNzQ1Ni05MWY1LTQ5NjEtYjg4ZC1kYjcwNTYyNmJhNzciLCJzdWIiOiI3Zjc5MWVhOS05OWI5LTQyM2QtOTg4Yi05MzFmMDIyMmE3OWYiLCJzY29wZSI6WyJjbG91ZF9jb250cm9sbGVyLnJlYWQiLCJjbG91ZF9jb250cm9sbGVyLndyaXRlIiwib3BlbmlkIiwicGFzc3dvcmQud3JpdGUiLCJzY2ltLnVzZXJpZHMiXSwiY2xpZW50X2lkIjoiYXBwIiwiY2lkIjoiYXBwIiwiZ3JhbnRfdHlwZSI6InBhc3N3b3JkIiwidXNlcl9pZCI6IjdmNzkxZWE5LTk5YjktNDIzZC05ODhiLTkzMWYwMjIyYTc5ZiIsInVzZXJfbmFtZSI6Im1hcmlzc2EiLCJlbWFpbCI6Im1hcmlzc2FAdGVzdC5vcmciLCJpYXQiOjE0MDY1Njg5MzUsImV4cCI6MTQwNjYxMjEzNSwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL3VhYS9vYXV0aC90b2tlbiIsImF1ZCI6WyJzY2ltIiwib3BlbmlkIiwiY2xvdWRfY29udHJvbGxlciIsInBhc3N3b3JkIl19.ZOhp7HmYF0ufvxXrkut40eHZbHFzAb5EETT2NL7n2Cs
 
-You can look at the body of the access token using a [decoder](http://jwt.calebb.net/)
+You can look at the body of the access token using a [decoder](http://jwt.calebb.net/). 
 More on decoding can be found [here](https://developers.google.com/accounts/docs/OpenIDConnect#validatinganidtoken) 
 
     {


### PR DESCRIPTION
The current link pointing to a generic doc http://help.github.com/forking/. 
It must be pointing to the correct UAA repository https://github.com/cloudfoundry/uaa
Github contribution to UAA must be from forking this repository.