### PR TITLE
Handle UsernameNotFoundException thrown from UaaUserDatabase

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
@@ -36,6 +36,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.jwt.Jwt;
 import org.springframework.security.jwt.JwtHelper;
 import org.springframework.security.oauth2.client.resource.OAuth2AccessDeniedException;
@@ -705,7 +706,13 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         if (null != email) {
             String userId = (String)claims.get(USER_ID);
 
-            UaaUser user = userDatabase.retrieveUserById(userId);
+            UaaUser user;
+            try {
+              user = userDatabase.retrieveUserById(userId);
+            }
+            catch (UsernameNotFoundException e) {
+              throw new InvalidTokenException("Invalid access token (user ID not found): " + userId);
+            }
 
             Integer accessTokenIssuedAt = (Integer) claims.get(IAT);
             long accessTokenIssueDate = accessTokenIssuedAt.longValue() * 1000l;


### PR DESCRIPTION
If a token is supplied that contains a GUID for a user that isn't
present in the database, a UsernameNotFoundException is thrown. The
exception isn't handled by the calling method and since it's runtime it
propogates, triggering a HttpClientErrorException in any Spring security
app using UAA as the OAuth2 provider.
Instead the user lookup is surrounded by a try catch which throws an
appropriate InvalidTokenException, if the user isn't found, which is
handled correctly.