### PR TITLE
Support customization of Login and Password prompts

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -249,12 +249,12 @@
             <util:list>
                 <bean class="org.cloudfoundry.identity.uaa.authentication.login.Prompt">
                     <constructor-arg name="name" value="username" />
-                    <constructor-arg name="text" value="Email" />
+                    <constructor-arg name="text" value="${login.prompt.username.text:Email}" />
                     <constructor-arg name="type" value="text" />
                 </bean>
                 <bean class="org.cloudfoundry.identity.uaa.authentication.login.Prompt">
                     <constructor-arg name="name" value="password" />
-                    <constructor-arg name="text" value="Password" />
+                    <constructor-arg name="text" value="${login.prompt.password.text:Password}" />
                     <constructor-arg name="type" value="password" />
                 </bean>
                 <bean class="org.cloudfoundry.identity.uaa.authentication.login.Prompt">


### PR DESCRIPTION
In our organization we don't use Email we use ldap integration so we would prefer to prompt for a "Username".

This PR provides initial support for getting username and password prompts from configuration keeping the default the same as the previous value.  If this PR gets accepted I can submit one to support prompt configuration in cf-release.

I find it odd nobody has done this already.  So, if I'm missing something a pointer in the correct direction would be great.