### PR TITLE
Fixed ContainerException when cargoRunLocal is invoked more than once

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,8 +229,12 @@ task resetCoverage(type: Delete) {
 
 apply plugin: 'cargo'
 
+task cleanCargoConfDir {
+  delete file(System.getenv('TMPDIR') + '/cargo/conf')
+}
+
 cargoStartLocal.dependsOn assemble, prepareDatabase
-cargoRunLocal.dependsOn assemble
+cargoRunLocal.dependsOn cleanCargoConfDir, assemble
 
 task flushCoverageData(type: Exec) {
   commandLine "curl", "-s", "-v", "-X", "POST", "http://localhost:8080/uaa/healthz/coverage/flush"


### PR DESCRIPTION
This commit fixes an issue we've observed when using cargoRunLocal to launch UAA
during the BOSH integration tests:

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':cargoRunLocal'.
       at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:69)
       at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.execute(ExecuteActionsTaskExecuter.java:46)
       at org.gradle.api.internal.tasks.execution.PostExecutionAnalysisTaskExecuter.execute(PostExecutionAnalysisTaskExecuter.java:35)
       at org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter.execute(SkipUpToDateTaskExecuter.java:64)
       at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:58)
       at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:42)
       at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:52)
       at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:53)
       at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:43)
       at org.gradle.api.internal.AbstractTask.executeWithoutThrowingTaskFailure(AbstractTask.java:296)
       at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.executeTask(AbstractTaskPlanExecutor.java:79)
       at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.processTask(AbstractTaskPlanExecutor.java:63)
       at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.run(AbstractTaskPlanExecutor.java:51)
       at org.gradle.execution.taskgraph.DefaultTaskPlanExecutor.process(DefaultTaskPlanExecutor.java:23)
       at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter.execute(DefaultTaskGraphExecuter.java:86)
       at org.gradle.execution.SelectedTaskExecutionAction.execute(SelectedTaskExecutionAction.java:29)
       at org.gradle.execution.DefaultBuildExecuter.execute(DefaultBuildExecuter.java:61)
       at org.gradle.execution.DefaultBuildExecuter.access$200(DefaultBuildExecuter.java:23)
       at org.gradle.execution.DefaultBuildExecuter$2.proceed(DefaultBuildExecuter.java:67)
       at org.gradle.execution.DryRunBuildExecutionAction.execute(DryRunBuildExecutionAction.java:32)
       at org.gradle.execution.DefaultBuildExecuter.execute(DefaultBuildExecuter.java:61)
       at org.gradle.execution.DefaultBuildExecuter.execute(DefaultBuildExecuter.java:54)
       at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:148)
       at org.gradle.initialization.DefaultGradleLauncher.doBuild(DefaultGradleLauncher.java:105)
       at org.gradle.initialization.DefaultGradleLauncher.run(DefaultGradleLauncher.java:85)
       at org.gradle.launcher.exec.InProcessBuildActionExecuter$DefaultBuildController.run(InProcessBuildActionExecuter.java:81)
       at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:33)
       at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:24)
       at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:39)
       at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:29)
       at org.gradle.launcher.cli.RunBuildAction.run(RunBuildAction.java:50)
       at org.gradle.internal.Actions$RunnableActionAdapter.execute(Actions.java:171)
       at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:237)
       at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:210)
       at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:35)
       at org.gradle.launcher.cli.JavaRuntimeValidationAction.execute(JavaRuntimeValidationAction.java:24)
       at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:206)
       at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:169)
       at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:33)
       at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:22)
       at org.gradle.launcher.Main.doAction(Main.java:33)
       at org.gradle.launcher.bootstrap.EntryPoint.run(EntryPoint.java:45)
       at org.gradle.launcher.bootstrap.ProcessBootstrap.runNoExit(ProcessBootstrap.java:54)
       at org.gradle.launcher.bootstrap.ProcessBootstrap.run(ProcessBootstrap.java:35)
       at org.gradle.launcher.GradleMain.main(GradleMain.java:23)
       at org.gradle.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:30)
       at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:127)
       at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:56)
Caused by: : org.codehaus.cargo.container.ContainerException: Failed to create a Tomcat 7.x standalone configuration
       at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:116)
       at org.gradle.api.internal.project.ant.BasicAntBuilder.nodeCompleted(BasicAntBuilder.java:71)
       at org.gradle.api.internal.project.ant.BasicAntBuilder.doInvokeMethod(BasicAntBuilder.java:86)
       at org.gradle.api.plugins.cargo.tasks.local.LocalCargoContainerTask.runAction(LocalCargoContainerTask.groovy:172)
       at org.gradle.api.plugins.cargo.tasks.AbstractCargoContainerTask$_start_closure1.doCall(AbstractCargoContainerTask.groovy:92)
       at org.gradle.api.plugins.cargo.tasks.AbstractCargoContainerTask$_start_closure1.doCall(AbstractCargoContainerTask.groovy)
       at org.gradle.api.plugins.cargo.util.LoggingHandler.withAntLoggingListener(LoggingHandler.groovy:38)
       at org.gradle.api.plugins.cargo.util.LoggingHandler$withAntLoggingListener.call(Unknown Source)
       at org.gradle.api.plugins.cargo.tasks.AbstractCargoContainerTask.start(AbstractCargoContainerTask.groovy:91)
       at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:63)
       at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.doExecute(AnnotationProcessingTaskFactory.java:218)
       at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.execute(AnnotationProcessingTaskFactory.java:211)
       at org.gradle.api.internal.project.taskfactory.AnnotationProcessingTaskFactory$StandardTaskAction.execute(AnnotationProcessingTaskFactory.java:200)
       at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:570)
       at org.gradle.api.internal.AbstractTask$TaskActionWrapper.execute(AbstractTask.java:553)
       at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeAction(ExecuteActionsTaskExecuter.java:80)
       at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:61)
       ... 47 more
Caused by: org.codehaus.cargo.container.ContainerException: Failed to create a Tomcat 7.x standalone configuration
       at org.codehaus.cargo.container.spi.configuration.AbstractLocalConfiguration.configure(AbstractLocalConfiguration.java:272)
       at org.codehaus.cargo.container.spi.configuration.builder.AbstractStandaloneLocalConfigurationWithXMLConfigurationBuilder.configure(AbstractStandaloneLocalConfigurationWithXMLConfigurationBuilder.java:123)
       at org.codehaus.cargo.container.spi.AbstractLocalContainer.start(AbstractLocalContainer.java:199)
       at org.codehaus.cargo.ant.CargoTask.executeActions(CargoTask.java:585)
       at org.codehaus.cargo.ant.CargoTask.execute(CargoTask.java:532)
       at org.apache.tools.ant.UnknownElement.execute(UnknownElement.java:292)
       at org.apache.tools.ant.dispatch.DispatchUtils.execute(DispatchUtils.java:106)
       ... 63 more
Caused by: org.codehaus.cargo.container.ContainerException: Invalid configuration dir [/var/folders/59/qs_m75x572g_mb3749fwjd0c0000gp/T/cargo/conf]. When using standalone configurations, the configuration dir must point to an empty directory. Note that everything in that dir will get deleted by Cargo.
       at org.codehaus.cargo.container.spi.configuration.AbstractStandaloneLocalConfiguration.setupConfigurationDir(AbstractStandaloneLocalConfiguration.java:151)
       at org.codehaus.cargo.container.tomcat.internal.AbstractCatalinaStandaloneLocalConfiguration.doConfigure(AbstractCatalinaStandaloneLocalConfiguration.java:87)
       at org.codehaus.cargo.container.spi.configuration.AbstractLocalConfiguration.configure(AbstractLocalConfiguration.java:268)
       ... 69 more
```