### PR TITLE
Allow to build uaa with Java 8.

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/AuthEvent.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/AuthEvent.java
@@ -7,10 +7,10 @@ import org.springframework.context.ApplicationEvent;
  * ****************************************************************************
  * Cloud Foundry
  * Copyright (c) [2009-2015] Pivotal Software, Inc. All Rights Reserved.
- * <p/>
+ * <p>
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
- * <p/>
+ * <p>
  * This product includes a number of subcomponents with
  * separate copyright notices and license terms. Your use of these
  * subcomponents is subject to the terms and conditions of the

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/codestore/ExpiringCodeStore.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/codestore/ExpiringCodeStore.java
@@ -22,7 +22,7 @@ public interface ExpiringCodeStore {
      * Generate and persist a one-time code with an expiry date.
      * 
      * @param data JSON object to be associated with the code
-     * @return code
+     * @return code the generated one-time code
      * @throws java.lang.NullPointerException if data or expiresAt is null
      * @throws java.lang.IllegalArgumentException if expiresAt is in the past
      */
@@ -31,7 +31,7 @@ public interface ExpiringCodeStore {
     /**
      * Retrieve a code and delete it if it exists.
      * 
-     * @param code
+     * @param code the one-time code to look for
      * @return code or null if the code is not found
      * @throws java.lang.NullPointerException if the code is null
      */

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/config/CustomPropertyConstructor.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/config/CustomPropertyConstructor.java
@@ -42,6 +42,10 @@ public class CustomPropertyConstructor extends Constructor {
      * The values of YAML keys with the alias name will be mapped to the
      * Javabean
      * property.
+     *
+     * @param alias the bean property alias
+     * @param type the bean property type
+     * @param name the bean property name
      */
     protected final void addPropertyAlias(String alias, Class<?> type, String name) {
         Map<String, Property> typeMap = properties.get(type);

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/config/PasswordPolicy.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/config/PasswordPolicy.java
@@ -4,10 +4,10 @@ package org.cloudfoundry.identity.uaa.config;
  * ****************************************************************************
  * Cloud Foundry
  * Copyright (c) [2009-2015] Pivotal Software, Inc. All Rights Reserved.
- * <p/>
+ * <p>
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
- * <p/>
+ * <p>
  * This product includes a number of subcomponents with
  * separate copyright notices and license terms. Your use of these
  * subcomponents is subject to the terms and conditions of the

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/config/YamlConfigurationValidator.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/config/YamlConfigurationValidator.java
@@ -52,6 +52,8 @@ public class YamlConfigurationValidator<T> implements FactoryBean<T>, Initializi
      * Sets a validation constructor which will be applied to the YAML doc to
      * see whether it matches the expected
      * Javabean.
+     *
+     * @param constructor the validation constructor, must not be {@literal null}
      */
     public YamlConfigurationValidator(Constructor constructor) {
         Assert.notNull(constructor);

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/config/YamlMapFactoryBean.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/config/YamlMapFactoryBean.java
@@ -35,7 +35,7 @@ import org.springframework.beans.factory.FactoryBean;
  *    one: two
  * three: four
  * 
- * <pre>
+ * </pre>
  * 
  * plus (later in the list)
  * 
@@ -45,7 +45,7 @@ import org.springframework.beans.factory.FactoryBean;
  *    one: 2
  * five: six
  * 
- * <pre>
+ * </pre>
  * 
  * results in an effecive input of
  * 
@@ -56,7 +56,7 @@ import org.springframework.beans.factory.FactoryBean;
  *    three: four
  * five: six
  * 
- * <pre>
+ * </pre>
  * 
  * Note that the value of "foo" in the first document is not simply replaced with the value in the second, but it's nested values are merged.
  * 

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/config/YamlProcessor.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/config/YamlProcessor.java
@@ -58,7 +58,7 @@ public class YamlProcessor {
      * A map of document matchers allowing callers to selectively use only some
      * of the documents in a YAML resource. In
      * YAML documents are separated by
-     * <code>---<code> lines, and each document is converted to properties before the match is made. E.g.
+     * <code>---</code> lines, and each document is converted to properties before the match is made. E.g.
      * 
      * <pre>
      * environment: dev

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/error/UaaException.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/error/UaaException.java
@@ -112,10 +112,10 @@ public class UaaException extends RuntimeException {
     }
 
     /**
-     * Creates an {@link UaaException} from a Map<String,String>.
+     * Creates an {@link UaaException} from a {@link Map}.
      *
-     * @param errorParams
-     * @return
+     * @param errorParams a map with additional error information
+     * @return the exception with error information
      */
     public static UaaException valueOf(Map<String, String> errorParams) {
         String errorCode = errorParams.get(ERROR);

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/ldap/extension/DefaultLdapAuthoritiesPopulator.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/ldap/extension/DefaultLdapAuthoritiesPopulator.java
@@ -69,15 +69,15 @@ import java.util.Set;
  * The configuration below shows how the group search might be performed with the above schema.
  * <pre>
  * &lt;bean id="ldapAuthoritiesPopulator"
- *       class="org.springframework.security.authentication.ldap.populator.DefaultLdapAuthoritiesPopulator">
- *   &lt;constructor-arg ref="contextSource"/>
- *   &lt;constructor-arg value="ou=groups"/>
- *   &lt;property name="groupRoleAttribute" value="ou"/>
- * &lt;!-- the following properties are shown with their default values -->
- *   &lt;property name="searchSubTree" value="false"/>
- *   &lt;property name="rolePrefix" value="ROLE_"/>
- *   &lt;property name="convertToUpperCase" value="true"/>
- * &lt;/bean>
+ *       class="org.springframework.security.authentication.ldap.populator.DefaultLdapAuthoritiesPopulator"&gt;
+ *   &lt;constructor-arg ref="contextSource"/&gt;
+ *   &lt;constructor-arg value="ou=groups"/&gt;
+ *   &lt;property name="groupRoleAttribute" value="ou"/&gt;
+ * &lt;!-- the following properties are shown with their default values --&gt;
+ *   &lt;property name="searchSubTree" value="false"/&gt;
+ *   &lt;property name="rolePrefix" value="ROLE_"/&gt;
+ *   &lt;property name="convertToUpperCase" value="true"/&gt;
+ * &lt;/bean&gt;
  * </pre>
  * A search for roles for user "uid=ben,ou=people,dc=springframework,dc=org" would return the single granted authority
  * "ROLE_DEVELOPER".
@@ -277,7 +277,7 @@ public class DefaultLdapAuthoritiesPopulator implements LdapAuthoritiesPopulator
 
     /**
      * Sets the prefix which will be prepended to the values loaded from the directory.
-     * Defaults to "ROLE_" for compatibility with <tt>RoleVoter/tt>.
+     * Defaults to "ROLE_" for compatibility with <tt>RoleVoter</tt>.
      *
      * @deprecated Map the authorities in the {@code AuthenticationProvider} using a {@code GrantedAuthoritiesMapper}.
      */

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/ldap/extension/NestedLdapAuthoritiesPopulator.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/ldap/extension/NestedLdapAuthoritiesPopulator.java
@@ -53,7 +53,7 @@ import java.util.Set;
  * member: uid=filip,ou=people,dc=springframework,dc=org
  * ou: java-developer
  * </pre>
- * </p>
+ * <p>
  * During an authentication
  */
 

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/login/saml/FixedHttpMetaDataProvider.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/login/saml/FixedHttpMetaDataProvider.java
@@ -22,8 +22,7 @@ import org.opensaml.saml2.metadata.provider.HTTPMetadataProvider;
 import org.opensaml.saml2.metadata.provider.MetadataProviderException;
 
 /**
- * This class works around the problem described in {@link https
- * ://issues.apache.org/jira/browse/HTTPCLIENT-646} when a socket factory is set
+ * This class works around the problem described in <a href="http://issues.apache.org/jira/browse/HTTPCLIENT-646">http://issues.apache.org/jira/browse/HTTPCLIENT-646</a> when a socket factory is set
  * on the OpenSAML
  * {@link HTTPMetadataProvider#setSocketFactory(ProtocolSocketFactory)} all
  * subsequent GET Methods should be executed using a relative URL, otherwise the

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientDetailsValidator.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/ClientDetailsValidator.java
@@ -20,7 +20,7 @@ public interface ClientDetailsValidator {
     /**
      * 
      * @param clientDetails
-     * @param create true if this is a creation request, false if this is a modification request
+     * @param mode represents the request {@link Mode}
      * @return A validated and possibly modified client
      */
     ClientDetails validate(ClientDetails clientDetails, Mode mode) throws InvalidClientDetailsException;

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
@@ -91,7 +91,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
     /**
      * Set to true to include all claims received from the UAA /check_token endpoint as string request parameters
      * accessible through OAuth2Authentication.getOAuth2Request().getRequestParameters()
-     * @param storeClaims
+     * @param storeClaims true to include all claims, otherwise false
      */
     public void setStoreClaims(boolean storeClaims) {
         this.storeClaims = storeClaims;

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/SignerProvider.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/SignerProvider.java
@@ -171,8 +171,8 @@ public class SignerProvider implements InitializingBean {
      * This code is public domain.
      *
      *  The MurmurHash3 algorithm was created by Austin Appleby and put into the public domain.
-     *  @see - http://code.google.com/p/smhasher/
-     *  @see - https://github.com/yonik/java_util/blob/master/src/util/hash/MurmurHash3.java
+     *  @see <a href="http://code.google.com/p/smhasher">http://code.google.com/p/smhasher</a>
+     *  @see <a href="https://github.com/yonik/java_util/blob/master/src/util/hash/MurmurHash3.java">https://github.com/yonik/java_util/blob/master/src/util/hash/MurmurHash3.java</a>
      */
     public static int murmurhash3x8632(byte[] data, int offset, int len, int seed) {
 

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/security/web/SecurityFilterChainPostProcessor.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/security/web/SecurityFilterChainPostProcessor.java
@@ -165,7 +165,7 @@ public class SecurityFilterChainPostProcessor implements BeanPostProcessor {
     /**
      * Additional filters to add to the chain after either HttpsEnforcementFilter or UaaLoggingFilter
      * has been added to the head of the chain. Filters will be inserted in Map iteration order,
-     * at the position given by the entry key (or the end of the chain if the key > size).
+     * at the position given by the entry key (or the end of the chain if the key &gt; size).
      * @param additionalFilters
      */
     public void setAdditionalFilters(Map<FilterPosition,Filter> additionalFilters) {

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/util/UaaStringUtils.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/util/UaaStringUtils.java
@@ -80,7 +80,7 @@ public class UaaStringUtils {
     }
 
     /**
-     * @param properties
+     * @param properties the properties with potential password values
      * @return new properties with no plaintext passwords
      */
     public static Properties hidePasswords(Properties properties) {
@@ -122,7 +122,7 @@ public class UaaStringUtils {
      * Returns a pattern that does a single level regular expression match where
      * the * character is a wildcard until it encounters the next literal
      * @param s
-     * @return
+     * @return the wildcard pattern
      */
     public static String constructSimpleWildcardPattern(String s) {
         String result = escapeRegExCharacters(s);

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneSwitchingFilter.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneSwitchingFilter.java
@@ -18,7 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * If the X-Identity-Zone-Id header is set and the user has a scope
- * of zones.<id>.admin, this filter switches the IdentityZone in the IdentityZoneHolder
+ * of zones.&lt;id&gt;.admin, this filter switches the IdentityZone in the IdentityZoneHolder
  * to the one in the header.
  * 
  * @author wtran@pivotal.io

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/zone/UaaIdentityProviderDefinition.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/zone/UaaIdentityProviderDefinition.java
@@ -9,10 +9,10 @@ import org.cloudfoundry.identity.uaa.config.PasswordPolicy;
 /*******************************************************************************
  * Cloud Foundry
  * Copyright (c) [2009-2015] Pivotal Software, Inc. All Rights Reserved.
- * <p/>
+ * <p>
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
- * <p/>
+ * <p>
  * This product includes a number of subcomponents with
  * separate copyright notices and license terms. Your use of these
  * subcomponents is subject to the terms and conditions of the

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/util/IndirectBeanCreator.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/util/IndirectBeanCreator.java
@@ -13,7 +13,7 @@
 package org.cloudfoundry.identity.uaa.login.util;
 
 /**
- * @see http://forum.spring.io/forum/spring-projects/container/74457-move-bean-s-class-attribute-value-to-external-properties
+ * @see <a href="http://forum.spring.io/forum/spring-projects/container/74457-move-bean-s-class-attribute-value-to-external-properties">http://forum.spring.io/forum/spring-projects/container/74457-move-bean-s-class-attribute-value-to-external-properties</a>
  */
 public class IndirectBeanCreator {
     public static <T> T getBean(final Class<T> clazz) throws IllegalAccessException, InstantiationException {

--- a/samples/app/src/main/java/org/cloudfoundry/identity/app/web/HomeController.java
+++ b/samples/app/src/main/java/org/cloudfoundry/identity/app/web/HomeController.java
@@ -55,7 +55,7 @@ public class HomeController {
     }
 
     /**
-     * @param userInfoUri the userInfoUri to set
+     * @param dataUri the dataUri to set
      */
     public void setDataUri(String dataUri) {
         this.dataUri = dataUri;

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimExternalGroupBootstrap.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimExternalGroupBootstrap.java
@@ -66,8 +66,8 @@ public class ScimExternalGroupBootstrap implements InitializingBean {
     /**
      * Specify the membership info as a list of strings, where each string takes
      * the format -
-     * <group-name>|<external-group-names>
-     * <p/>
+     * {@code <group-name>|<external-group-names>}
+     * <p>
      * external-group-names space separated list of external groups
      *
      * @param externalGroupMaps

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimGroupBootstrap.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimGroupBootstrap.java
@@ -77,7 +77,7 @@ public class ScimGroupBootstrap implements InitializingBean {
     /**
      * Specify the membership info as a list of strings, where each string takes
      * the format -
-     * <group-name>|<comma-separated usernames of members>[|write]
+     * {@code <group-name>|<comma-separated usernames of members>[|write]}
      * the optional 'write' field in the end marks the users as admins of the
      * group
      * 

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
@@ -28,10 +28,10 @@ import java.util.Map;
  * ****************************************************************************
  * Cloud Foundry
  * Copyright (c) [2009-2015] Pivotal Software, Inc. All Rights Reserved.
- * <p/>
+ * <p>
  * This product is licensed to you under the Apache License, Version 2.0 (the "License").
  * You may not use this product except in compliance with the License.
- * <p/>
+ * <p>
  * This product includes a number of subcomponents with
  * separate copyright notices and license terms. Your use of these
  * subcomponents is subject to the terms and conditions of the

--- a/uaa/src/test/java/org/springframework/security/ldap/server/ApacheDsSSLContainer.java
+++ b/uaa/src/test/java/org/springframework/security/ldap/server/ApacheDsSSLContainer.java
@@ -146,8 +146,8 @@ public class ApacheDsSSLContainer extends ApacheDSContainer {
             X509CertImpl selfSignedCert = new X509CertImpl(certInfo);
             selfSignedCert.sign(keyPair.getPrivate(), signatureAlgorithm);
             return selfSignedCert;
-        } catch (IOException var11) {
-            throw new CertificateEncodingException("getSelfCert: " + var11.getMessage());
+        } catch (IOException ioe) {
+            throw new CertificateEncodingException("Error during creation of self-signed Certificate: " + ioe.getMessage());
         }
     }
 


### PR DESCRIPTION
The project can now be build with Java 7 and Java 8 with all tests passing.

We now support to build uaa with Java 8 via ``./gradlew clean build.``
This PR contains fixes for all JavaDoc errors and some JavaDoc warnings.
Refactored ``ApacheDsSSLContainer`` used for LDAP tests to avoid using internal
com.sun.* API that is not available in Java 8 (e.g. ``CertAndKeyGen``).

Fixed some test cases in ``PasswordResetEndpointTest``
 - ``changePassword_Returns422UnprocessableEntity_NewPasswordSameAsOld``
 - ``testPasswordsMustSatisfyPolicy``
that failed under Java 8 because to different ordering of the resulting JSON objects due to internal changes in the underlying ``HashMap`` implementation.
The provided ``JsonObjectMatcher`` provides support for property order in-sensitve matching of ``JSON Objects`` that are represented as Strings.