### PR TITLE
Modified CORS filter so that allowed headers for XHR requests is configurable.

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
@@ -94,6 +94,12 @@ public class UaaConfiguration {
     public String LOGIN_SECRET;
     @Valid
     public OAuth multitenant;
+    @Valid
+    public String corsXhrAllowedHeaders;
+    @Valid
+    public String corsXhrAllowedOrigins;
+    @Valid
+    public String corsXhrAllowedUris;
 
     public static class Zones {
         @Valid
@@ -227,6 +233,10 @@ public class UaaConfiguration {
             addPropertyAlias("access-token-validity", OAuthClient.class, "accessTokenValidity");
             addPropertyAlias("refresh-token-validity", OAuthClient.class, "refreshTokenValidity");
             addPropertyAlias("user.override", Scim.class, "userOverride");
+
+            addPropertyAlias("cors.xhr.allowed.headers", UaaConfiguration.class, "corsXhrAllowedHeaders");
+            addPropertyAlias("cors.xhr.allowed.origins", UaaConfiguration.class, "corsXhrAllowedOrigins");
+            addPropertyAlias("cors.xhr.allowed.uris", UaaConfiguration.class, "corsXhrAllowedUris");
         }
 
         @Override

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
@@ -76,6 +76,9 @@ public class CorsFilter extends OncePerRequestFilter {
 
     private final List<Pattern> corsXhrAllowedOriginPatterns = new ArrayList<Pattern>();
 
+    @Value("#{'${cors.xhr.allowed.headers:Accept,Authorization}'.split(',')}")
+    private List<String> allowedHeaders;
+
     @PostConstruct
     public void initialize() {
 
@@ -150,7 +153,7 @@ public class CorsFilter extends OncePerRequestFilter {
                         accessControlRequestHeaders, "X-Requested-With"));
     }
 
-    static void buildCorsXhrPreFlightResponse(final HttpServletRequest request, final HttpServletResponse response) {
+    void buildCorsXhrPreFlightResponse(final HttpServletRequest request, final HttpServletResponse response) {
         String accessControlRequestMethod = request.getHeader("Access-Control-Request-Method");
         if (null == accessControlRequestMethod) {
             response.setStatus(HttpStatus.BAD_REQUEST.value());
@@ -180,10 +183,10 @@ public class CorsFilter extends OncePerRequestFilter {
         return headers.contains(header.toLowerCase());
     }
 
-    private static boolean headersAllowed(final String accessControlRequestHeaders) {
+    private boolean headersAllowed(final String accessControlRequestHeaders) {
         List<String> headers = Arrays.asList(accessControlRequestHeaders.replace(" ", "").split(","));
         for (String header : headers) {
-            if (!"Authorization".equalsIgnoreCase(header) && !"X-Requested-With".equalsIgnoreCase(header)) {
+            if (!"X-Requested-With".equalsIgnoreCase(header) && !this.allowedHeaders.contains(header)) {
                 return false;
             }
         }
@@ -240,5 +243,9 @@ public class CorsFilter extends OncePerRequestFilter {
 
     public void setCorsXhrAllowedOrigins(List<String> corsXhrAllowedOrigins) {
         this.corsXhrAllowedOrigins = corsXhrAllowedOrigins;
+    }
+
+    public void setAllowedHeaders(List<String> allowedHeaders) {
+        this.allowedHeaders = allowedHeaders;
     }
 }

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/web/CorsFilterTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/web/CorsFilterTests.java
@@ -355,6 +355,9 @@ public class CorsFilterTests {
         List<String> allowedOrigins = new ArrayList<String>(Arrays.asList(new String[] { "example.com$" }));
         setInternalState(corsFilter, "corsXhrAllowedOrigins", allowedOrigins);
 
+        List<String> allowedHeaders = Arrays.asList(new String[] {"Accept", "Authorization"});
+        corsFilter.setAllowedHeaders(allowedHeaders);
+
         corsFilter.initialize();
         return corsFilter;
     }

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -182,5 +182,6 @@ oauth:
 #      -----END RSA PRIVATE KEY-----
 
 # Configure whitelist for allowing cross-origin XMLHttpRequest requests.
-#cors.xhr.allowed.uris: ^/uaa/userinfo$,^/uaa/logout\.do$
+#cors.xhr.allowed.headers: Accept,Authorization
 #cors.xhr.allowed.origins: ^localhost$,^.*\.localhost$
+#cors.xhr.allowed.uris: ^/uaa/userinfo$,^/uaa/logout\.do$


### PR DESCRIPTION
We rolled the CORS changes out into our staging environment and our front-end development teams discovered that they we needed to relax our policy on allowed headers. Thus, I made allowed headers configurable. I also discovered some issues with the validation of configuration properties while deploying and fixed those.

These changes have been tested in our staging environments by teams building single page JS apps that makes CORS XHR requests in Firefox and Chrome.