### PR TITLE
Added origin in JWT token and refresh token.

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/Claims.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/Claims.java
@@ -45,4 +45,5 @@ public class Claims {
     public static final String AUTH_TIME = "auth_time";
     public static final String ZONE_ID = "zid";
     public static final String REVOCATION_SIGNATURE = "rev_sig";
+    public static final String ORIGIN = "origin";
 }

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServicesTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServicesTests.java
@@ -693,6 +693,7 @@ public class UaaTokenServicesTests {
         assertEquals(claims.get(Claims.USER_NAME), username);
         assertEquals(claims.get(Claims.EMAIL), email);
         assertEquals(claims.get(Claims.CID), CLIENT_ID);
+        assertEquals(claims.get(Claims.ORIGIN), Origin.UAA);
         assertEquals(expectedScopes,claims.get(Claims.SCOPE));
         assertEquals(claims.get(Claims.AUD), resourceIds);
         assertTrue(((String) claims.get(Claims.JTI)).length() > 0);
@@ -721,6 +722,7 @@ public class UaaTokenServicesTests {
             assertEquals(refreshTokenClaims.get(Claims.CID), CLIENT_ID);
             assertEquals(refreshTokenClaims.get(Claims.SCOPE), requestedAuthScopes);
             assertEquals(refreshTokenClaims.get(Claims.AUD), resourceIds);
+            assertEquals(refreshTokenClaims.get(Claims.ORIGIN), Origin.UAA);
             if (!noRefreshToken) {
                 assertNotNull("token revocation signature must be present.",refreshTokenClaims.get(Claims.REVOCATION_SIGNATURE));
             }


### PR DESCRIPTION
A number of our users are building multi-tenant applications which receive tokens from zones with multiple identity providers. In some scenarios they need to know what identity provider authenticated the user. Also this can be useful to disambiguate users from different identity providers with the same username.