### PR TITLE
Respect nonce

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/Claims.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/Claims.java
@@ -45,4 +45,5 @@ public class Claims {
     public static final String AUTH_TIME = "auth_time";
     public static final String ZONE_ID = "zid";
     public static final String REVOCATION_SIGNATURE = "rev_sig";
+    public static final String NONCE = "nonce";
 }

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
@@ -94,6 +94,7 @@ import static org.cloudfoundry.identity.uaa.oauth.Claims.GRANT_TYPE;
 import static org.cloudfoundry.identity.uaa.oauth.Claims.IAT;
 import static org.cloudfoundry.identity.uaa.oauth.Claims.ISS;
 import static org.cloudfoundry.identity.uaa.oauth.Claims.JTI;
+import static org.cloudfoundry.identity.uaa.oauth.Claims.NONCE;
 import static org.cloudfoundry.identity.uaa.oauth.Claims.SCOPE;
 import static org.cloudfoundry.identity.uaa.oauth.Claims.SUB;
 import static org.cloudfoundry.identity.uaa.oauth.Claims.USER_ID;
@@ -237,6 +238,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 audience /*request.createOAuth2Request(client).getResourceIds()*/,
                 grantType,
                 refreshTokenValue,
+                (String)claims.get(NONCE),
                 additionalAuthorizationInfo,
                 new HashSet<String>(),
                 revocableHashSignature); //TODO populate response types
@@ -284,6 +286,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     private OAuth2AccessToken createAccessToken(String userId, String username, String userEmail, int validitySeconds,
                     Collection<GrantedAuthority> clientScopes, Set<String> requestedScopes, String clientId,
                     Set<String> resourceIds, String grantType, String refreshToken,
+                    String nonce,
                     Map<String, String> additionalAuthorizationAttributes, Set<String> responseTypes,
                     String revocableHashSignature) throws AuthenticationException {
         String tokenId = UUID.randomUUID().toString();
@@ -304,6 +307,9 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         info.put(JTI, accessToken.getValue());
         if (null != additionalAuthorizationAttributes) {
             info.put(ADDITIONAL_AZ_ATTR, additionalAuthorizationAttributes);
+        }
+        if (nonce != null) {
+            info.put(NONCE, nonce);
         }
         accessToken.setAdditionalInformation(info);
 
@@ -442,6 +448,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 authentication.getOAuth2Request().getResourceIds(),
                 grantType,
                 refreshToken != null ? refreshToken.getValue() : null,
+                authentication.getOAuth2Request().getRequestParameters().get("nonce"),
                 additionalAuthorizationAttributes,
                 responseTypes,
                 revocableHashSignature);

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
@@ -213,6 +213,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         // if we have reached so far, issue an access token
         Integer validity = client.getAccessTokenValiditySeconds();
 
+        String nonce = (String) claims.get(NONCE);
+
         @SuppressWarnings("unchecked")
         Map<String, String> additionalAuthorizationInfo = (Map<String, String>) claims.get(ADDITIONAL_AZ_ATTR);
 
@@ -238,7 +240,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 audience /*request.createOAuth2Request(client).getResourceIds()*/,
                 grantType,
                 refreshTokenValue,
-                (String)claims.get(NONCE),
+                nonce,
                 additionalAuthorizationInfo,
                 new HashSet<String>(),
                 revocableHashSignature); //TODO populate response types
@@ -431,6 +433,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             modifiableUserScopes.addAll(OAuth2Utils.parseParameterList(externalScopes));
         }
 
+        String nonce = authentication.getOAuth2Request().getRequestParameters().get(Claims.NONCE);
+
         Map<String, String> additionalAuthorizationAttributes = getAdditionalAuthorizationAttributes(authentication
                         .getOAuth2Request().getRequestParameters().get("authorities"));
 
@@ -448,7 +452,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 authentication.getOAuth2Request().getResourceIds(),
                 grantType,
                 refreshToken != null ? refreshToken.getValue() : null,
-                authentication.getOAuth2Request().getRequestParameters().get("nonce"),
+                nonce,
                 additionalAuthorizationAttributes,
                 responseTypes,
                 revocableHashSignature);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -706,7 +706,7 @@ public class TokenMvcMockTests extends InjectedMockContextTest {
             .param(OAuth2Utils.SCOPE, "openid")
             .param(OAuth2Utils.STATE, state)
             .param(OAuth2Utils.CLIENT_ID, clientId)
-            .param("nonce", "testnonce")
+            .param(Claims.NONCE, "testnonce")
             .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI);
 
         result = getMockMvc().perform(oauthTokenPost).andExpect(status().is3xxRedirection()).andReturn();
@@ -738,7 +738,7 @@ public class TokenMvcMockTests extends InjectedMockContextTest {
 
         //nonce must be in id_token if was in auth request, see http://openid.net/specs/openid-connect-core-1_0.html#IDToken
         Map<String,Object> claims = getClaimsForToken((String)token.get("id_token"));
-        assertEquals("testnonce", claims.get("nonce"));
+        assertEquals("testnonce", claims.get(Claims.NONCE));
 
 
         //hybrid flow defined in - response_types=code token id_token

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -706,6 +706,7 @@ public class TokenMvcMockTests extends InjectedMockContextTest {
             .param(OAuth2Utils.SCOPE, "openid")
             .param(OAuth2Utils.STATE, state)
             .param(OAuth2Utils.CLIENT_ID, clientId)
+            .param("nonce", "testnonce")
             .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI);
 
         result = getMockMvc().perform(oauthTokenPost).andExpect(status().is3xxRedirection()).andReturn();
@@ -734,6 +735,10 @@ public class TokenMvcMockTests extends InjectedMockContextTest {
         assertNotNull(token.get("id_token"));
         assertEquals(token.get("access_token"), token.get("id_token"));
         validateOpenIdConnectToken((String)token.get("id_token"), developer.getId(), clientId);
+
+        //nonce must be in id_token if was in auth request, see http://openid.net/specs/openid-connect-core-1_0.html#IDToken
+        Map<String,Object> claims = getClaimsForToken((String)token.get("id_token"));
+        assertEquals("testnonce", claims.get("nonce"));
 
 
         //hybrid flow defined in - response_types=code token id_token


### PR DESCRIPTION
OpenID Connect implementation doesn't respect *nonce* sent from client, while it must do that.
Here is the implementation of the feature.
This fixes [cfid-3214](https://www.pivotaltracker.com/n/projects/997278/stories/82159480)

Formal description from http://openid.net/specs/openid-connect-core-1_0.html#IDToken
**nonce**
*String value used to associate a Client session with an ID Token, and to mitigate replay attacks. The value is passed through unmodified from the Authentication Request to the ID Token. If present in the ID Token, Clients MUST verify that the nonce Claim Value is equal to the value of the nonce parameter sent in the Authentication Request. If present in the Authentication Request, Authorization Servers MUST include a nonce Claim in the ID Token with the Claim Value being the nonce value sent in the Authentication Request. Authorization Servers SHOULD perform no other processing on nonce values used. The nonce value is a case sensitive string.*