### PR TITLE
Fix OpenID Connect code flow by always returning id_token

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenServices.java
@@ -325,8 +325,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     }
 
     private void populateIdToken(OpenIdToken token, Set<String> scopes, Set<String> responseTypes) {
-        if (scopes.contains("openid") &&
-            responseTypes.contains(OpenIdToken.ID_TOKEN)) {
+        if (scopes.contains("openid")) {
             token.setIdTokenValue(token.getValue());
         }
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -691,6 +691,8 @@ public class TokenMvcMockTests extends InjectedMockContextTest {
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(p, "", UaaAuthority.USER_AUTHORITIES);
         Assert.assertTrue(auth.isAuthenticated());
 
+        //code flow defined in - response_types=code
+        //http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth
         SecurityContextHolder.getContext().setAuthentication(auth);
         MockHttpSession session = new MockHttpSession();
         session.setAttribute(
@@ -722,10 +724,6 @@ public class TokenMvcMockTests extends InjectedMockContextTest {
             .session(session)
             .param(OAuth2Utils.GRANT_TYPE, "authorization_code")
             .param("code", code)
-            .param(OAuth2Utils.RESPONSE_TYPE, "token id_token")
-            .param(OAuth2Utils.SCOPE, "openid")
-            .param(OAuth2Utils.STATE, state)
-            .param(OAuth2Utils.CLIENT_ID, clientId)
             .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI);
         result = getMockMvc().perform(oauthTokenPost).andExpect(status().isOk()).andReturn();
         token = JsonUtils.readValue(result.getResponse().getContentAsString(), Map.class);


### PR DESCRIPTION
Token Endpoint must always return id_token; client not required to send response_types with "id_token" in Token Request, expecting this violates the specification and ruins code flow (for apache module mod_auth_openidc at least).
See http://openid.net/specs/openid-connect-core-1_0.html#TokenRequest