### PR TITLE
New "token_keys" endpoint (JWKS Set Format)

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenKeyEndpoint.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenKeyEndpoint.java
@@ -16,7 +16,9 @@ import java.lang.reflect.Field;
 import java.math.BigInteger;
 import java.security.Principal;
 import java.security.interfaces.RSAPublicKey;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.logging.Log;
@@ -86,6 +88,23 @@ public class TokenKeyEndpoint implements InitializingBean {
                 }
             }
         }
+        return result;
+    }
+
+    /**
+     * Get the verification key for the token signatures wrapped into keys array.
+     * Wrapping done for compatibility with some clients expecting this even for single key, like mod_auth_openidc.
+     * The principal has to be provided only if the key is secret
+     * (shared not public).
+     *
+     * @param principal the currently authenticated user if there is one
+     * @return the key used to verify tokens, wrapped in keys array
+     */
+    @RequestMapping(value = "/token_keys", method = RequestMethod.GET)
+    @ResponseBody
+    public Map<String, List<Map<String, String>>> getKeys(Principal principal) {
+        Map<String, List<Map<String, String>>> result = new LinkedHashMap<>();
+        result.put("keys", Collections.singletonList(getKey(principal)));
         return result;
     }
 

--- a/uaa/src/main/webapp/WEB-INF/spring/resource-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/resource-endpoints.xml
@@ -36,6 +36,16 @@
         <csrf disabled="true"/>
     </http>
 
+    <http name="tokenKeysSecurity" pattern="/token_keys" create-session="stateless" entry-point-ref="basicAuthenticationEntryPoint"
+          authentication-manager-ref="clientAuthenticationManager" use-expressions="true"
+          xmlns="http://www.springframework.org/schema/security">
+        <intercept-url pattern="/**" access="isAnonymous() or hasAuthority('uaa.resource')" />
+        <anonymous enabled="true" />
+        <custom-filter ref="clientAuthenticationFilter" position="BASIC_AUTH_FILTER" />
+        <access-denied-handler ref="oauthAccessDeniedHandler" />
+        <csrf disabled="true"/>
+    </http>
+
     <http name="clientInfoSecurity" pattern="/clientinfo" create-session="stateless" entry-point-ref="basicAuthenticationEntryPoint"
         authentication-manager-ref="clientAuthenticationManager" use-expressions="true"
         xmlns="http://www.springframework.org/schema/security">

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -131,6 +132,37 @@ public class TokenKeyEndpointMockMvcTests extends InjectedMockContextTest {
         validateKey(key);
     }
 
+    @Test
+    public void checkTokenKeysValues() throws Exception {
+        String basicDigestHeaderValue = "Basic "
+                + new String(Base64.encodeBase64(("app:appclientsecret").getBytes()));
+
+        MvcResult result = getMockMvc().perform(
+                get("/token_keys")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .header("Authorization", basicDigestHeaderValue))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> keys = JsonUtils.readValue(result.getResponse().getContentAsString(), Map.class);
+        validateKeys(keys);
+    }
+
+    @Test
+    public void checkTokenKeysValuesAnonymous() throws Exception {
+
+        MvcResult result = getMockMvc().perform(
+                get("/token_keys")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> keys = JsonUtils.readValue(result.getResponse().getContentAsString(), Map.class);
+        validateKeys(keys);
+    }
+
     public void validateKey(Map<String,Object> key) {
         Object kty = key.get("kty");
         assertNotNull(kty);
@@ -196,6 +228,13 @@ public class TokenKeyEndpointMockMvcTests extends InjectedMockContextTest {
         assertTrue(n instanceof String);
         //TODO - Validate the key?
 
+    }
+
+    public void validateKeys(Map<String, Object> response) {
+        List<Map<String, Object>> keys = (List<Map<String, Object>>)response.get("keys");
+        assertNotNull(keys);
+        assertEquals(1, keys.size());
+        validateKey(keys.get(0));
     }
 
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
@@ -141,7 +141,6 @@ public class TokenKeyEndpointMockMvcTests extends InjectedMockContextTest {
                 get("/token_keys")
                         .accept(MediaType.APPLICATION_JSON)
                         .header("Authorization", basicDigestHeaderValue))
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -155,7 +154,6 @@ public class TokenKeyEndpointMockMvcTests extends InjectedMockContextTest {
         MvcResult result = getMockMvc().perform(
                 get("/token_keys")
                         .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
                 .andExpect(status().isOk())
                 .andReturn();
 


### PR DESCRIPTION
New "token_keys" endpoint returns token key wrapped in "keys" array.
Some clients may require this format (like mod_auth_openidc).

See JWKS Set Format defined in RFC 7517: https://tools.ietf.org/html/rfc7517#section-5

Real world example: https://www.googleapis.com/oauth2/v3/certs