### PR TITLE
Update docs to show aud derivation from scope when there's multiple dots

### DIFF
--- a/docs/UAA-Tokens.md
+++ b/docs/UAA-Tokens.md
@@ -123,7 +123,7 @@ in the token when a request to the UAA is made for a password change.
 
 Scopes, are arbitrary strings, defined by the client itself. The UAA does use the base name of a scope and adds it to the 
 [audience](http://tools.ietf.org/html/draft-ietf-oauth-json-web-token-25#section-4.1.3) field. The 'base name' is defined
-as anything before the first dot. 
+as anything before the last dot. 
 
 ### Client authorities, UAA groups and scopes
 In the UAA each client has a list of ```client authorities```. This is ```List&lt;String&gt;``` of scopes


### PR DESCRIPTION
Eg scope zones.12345.admin results in aud zones.12345