### PR TITLE
Only update the user if the event says to do so

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/AuthEvent.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/AuthEvent.java
@@ -19,11 +19,18 @@ import org.springframework.context.ApplicationEvent;
  */
 abstract public class AuthEvent extends ApplicationEvent {
 
-    public AuthEvent(UaaUser user) {
+	private boolean userUpdated = true;
+
+    public AuthEvent(UaaUser user, boolean userUpdated) {
         super(user);
+        this.userUpdated = userUpdated;
     }
 
     public UaaUser getUser() {
         return (UaaUser) source;
+    }
+
+    public boolean isUserUpdated() {
+    	return userUpdated;
     }
 }

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalGroupAuthorizationEvent.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalGroupAuthorizationEvent.java
@@ -29,8 +29,8 @@ public class ExternalGroupAuthorizationEvent extends AuthEvent {
 
     private boolean addGroups = false;
 
-    public ExternalGroupAuthorizationEvent(UaaUser user, Collection<? extends GrantedAuthority> externalAuthorities, boolean addGroups) {
-        super(user);
+    public ExternalGroupAuthorizationEvent(UaaUser user, boolean userUpdated, Collection<? extends GrantedAuthority> externalAuthorities, boolean addGroups) {
+        super(user, userUpdated);
         this.addGroups = addGroups;
         this.externalAuthorities = externalAuthorities;
     }

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LdapLoginAuthenticationManager.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LdapLoginAuthenticationManager.java
@@ -70,15 +70,17 @@ public class LdapLoginAuthenticationManager extends ExternalLoginAuthenticationM
 
     @Override
     protected UaaUser userAuthenticated(Authentication request, UaaUser user) {
+    	boolean userUpdated = false;
         //we must check and see if the email address has changed between authentications
         if (request.getPrincipal() !=null && request.getPrincipal() instanceof ExtendedLdapUserDetails) {
             ExtendedLdapUserDetails details = (ExtendedLdapUserDetails)request.getPrincipal();
             UaaUser fromRequest = getUser(details, getExtendedAuthorizationInfo(request));
             if (fromRequest.getEmail()!=null && !fromRequest.getEmail().equals(user.getEmail())) {
                 user = user.modifyEmail(fromRequest.getEmail());
+                userUpdated = true;
             }
         }
-        ExternalGroupAuthorizationEvent event = new ExternalGroupAuthorizationEvent(user, request.getAuthorities(), isAutoAddAuthorities());
+        ExternalGroupAuthorizationEvent event = new ExternalGroupAuthorizationEvent(user, userUpdated, request.getAuthorities(), isAutoAddAuthorities());
         publish(event);
         return getUserDatabase().retrieveUserById(user.getId());
     }

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/NewUserAuthenticatedEvent.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/NewUserAuthenticatedEvent.java
@@ -22,6 +22,6 @@ import org.cloudfoundry.identity.uaa.user.UaaUser;
 public class NewUserAuthenticatedEvent extends AuthEvent {
 
     public NewUserAuthenticatedEvent(UaaUser user) {
-        super(user);
+        super(user, true);
     }
 }

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.scim.bootstrap;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.identity.uaa.authentication.Origin;
@@ -32,12 +38,6 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
 
 /**
  * Convenience class for provisioning user accounts from {@link UaaUser}
@@ -165,9 +165,11 @@ public class ScimUserBootstrap implements InitializingBean, ApplicationListener<
             for (GrantedAuthority authority : exEvent.getExternalAuthorities()) {
                 addToGroup(exEvent.getUser().getId(), authority.getAuthority(), exEvent.getUser().getOrigin(), exEvent.isAddGroups());
             }
-            //update the user itself
-            ScimUser user = getScimUser(event.getUser());
-            updateUser(user, event.getUser(), false);
+            if(event.isUserUpdated()) {
+                //update the user itself
+                ScimUser user = getScimUser(event.getUser());
+                updateUser(user, event.getUser(), false);
+            }
         } else {
             addUser(event.getUser());
         }

--- a/scim/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
+++ b/scim/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
@@ -287,7 +287,7 @@ public class ScimUserBootstrapTests {
         assertEquals(1, users.size());
         userId = users.get(0).getId();
         user = getUaaUser(userAuthorities, origin, email, firstName, lastName, password, externalId, userId, username);
-        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, getAuthorities(externalAuthorities),add));
+        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, false, getAuthorities(externalAuthorities),add));
 
         users = db.query("userName eq \""+username +"\" and origin eq \""+origin+"\"");
         assertEquals(1, users.size());
@@ -295,7 +295,7 @@ public class ScimUserBootstrapTests {
         validateAuthoritiesCreated(add?externalAuthorities:new String[0], userAuthorities, origin, created);
 
         externalAuthorities = new String[] {"extTest1","extTest2"};
-        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, getAuthorities(externalAuthorities),add));
+        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, false, getAuthorities(externalAuthorities),add));
         validateAuthoritiesCreated(add?externalAuthorities:new String[0], userAuthorities, origin, created);
     }
 
@@ -344,7 +344,7 @@ public class ScimUserBootstrapTests {
         userId = users.get(0).getId();
         user = getUaaUser(userAuthorities, origin, newEmail, firstName, lastName, password, externalId, userId, username);
 
-        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, getAuthorities(externalAuthorities),true));
+        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, true, getAuthorities(externalAuthorities),true));
         users = db.query("userName eq \""+username +"\" and origin eq \""+origin+"\"");
         assertEquals(1, users.size());
         ScimUser created = users.get(0);
@@ -352,7 +352,15 @@ public class ScimUserBootstrapTests {
         assertEquals(newEmail, created.getPrimaryEmail());
 
         user = user.modifyEmail("test123@test.org");
-        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, getAuthorities(externalAuthorities),true));
+        //Ensure email doesn't get updated if event instructs not to update.
+        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, false, getAuthorities(externalAuthorities),true));
+        users = db.query("userName eq \""+username +"\" and origin eq \""+origin+"\"");
+        assertEquals(1, users.size());
+        created = users.get(0);
+        validateAuthoritiesCreated(externalAuthorities, userAuthorities, origin, created);
+        assertEquals(newEmail, created.getPrimaryEmail());
+
+        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, true, getAuthorities(externalAuthorities),true));
         users = db.query("userName eq \""+username +"\" and origin eq \""+origin+"\"");
         assertEquals(1, users.size());
         created = users.get(0);


### PR DESCRIPTION
This is an attempt at fixing Issue https://github.com/cloudfoundry/uaa/issues/176.

I tried all kinds of less intrusive fixes but nothing worked.

Setting version=-1 gets undone by:
https://github.com/cloudfoundry/uaa/blob/master/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioning.java#L226

I prepared a patch for this but that didn't fix it either because when ldap updates the user is also updates the password since the password is always bogus which causes existing tokens to be invalidated:
https://github.com/cloudfoundry/uaa/blob/master/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java#L136

So, finally instead of trying the fragile solution of making ldap's update of a user not intrusive I decided to attempt to just fix the issue directly.

So, this PR simply adds a flag to AuthEvent that tells ScimUserBootstrap if the user has changed and should be updated or not.  This fixes both my OptimisticLockException problems on user update and my token invalidation problems on password change and should be a solid fix going forward.

Let me know what you think.