### PR TITLE
Use new plugin id for gradle flyway plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -198,7 +198,7 @@ dependencies {
   }
 }
 
-apply plugin: 'flyway'
+apply plugin: 'org.flywaydb.flyway'
 
 flyway {
   switch (databaseType()) {


### PR DESCRIPTION
We now use the "org.flywaydb.flyway" gradle plugin in.
The previously used "flyway" id caused a deprecation warning:
```
The 'flyway' plugin ID is deprecated and will be removed in Flyway 4.0. Update your build to use 'org.flywaydb.flyway' instead.
```