### PR TITLE
SAML provider: possibility to specify 'addShadowUserOnLogin' in login.yml

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/login/saml/IdentityProviderConfigurator.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/login/saml/IdentityProviderConfigurator.java
@@ -343,6 +343,7 @@ public class IdentityProviderConfigurator implements InitializingBean {
             String linkText = (String)((Map)entry.getValue()).get("linkText");
             String iconUrl  = (String)((Map)entry.getValue()).get("iconUrl");
             String zoneId  = (String)((Map)entry.getValue()).get("zoneId");
+            Boolean addShadowUserOnLogin = (Boolean)((Map)entry.getValue()).get("addShadowUserOnLogin");
             List<String> emailDomain = (List<String>) saml.get("emailDomain");
             IdentityProviderDefinition def = new IdentityProviderDefinition();
             if (alias==null) {
@@ -362,6 +363,7 @@ public class IdentityProviderConfigurator implements InitializingBean {
             def.setIconUrl(iconUrl);
             def.setEmailDomain(emailDomain);
             def.setZoneId(StringUtils.hasText(zoneId) ? zoneId : IdentityZone.getUaa().getId());
+            def.setAddShadowUserOnLogin(addShadowUserOnLogin==null?true:addShadowUserOnLogin);
             toBeFetchedProviders.add(def);
         }
     }

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/login/saml/IdentityProviderConfiguratorTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/login/saml/IdentityProviderConfiguratorTests.java
@@ -440,4 +440,64 @@ public class IdentityProviderConfiguratorTests {
 
     }
 
+    @Test
+    public void testSetAddShadowUserOnLoginFromYaml() throws Exception {
+        String yaml = "  providers:\n" +
+                "    provider-without-shadow-user-definition:\n" +
+                "      idpMetadata: |\n" +
+                "        <?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "        <md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"provider1\">" +
+                "        <md:IDPSSODescriptor WantAuthnRequestsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">" +
+                "        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>" +
+                "        <md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://example.com\"/>" +
+                "        </md:IDPSSODescriptor>" +
+                "        </md:EntityDescriptor>\n" +
+                "      nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\n" +
+                "    provider-with-shadow-users-enabled:\n" +
+                "      idpMetadata: |\n" +
+                "        <?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "        <md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"provider2\">" +
+                "        <md:IDPSSODescriptor WantAuthnRequestsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">" +
+                "        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>" +
+                "        <md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://example.com\"/>" +
+                "        </md:IDPSSODescriptor>" +
+                "        </md:EntityDescriptor>\n" +
+                "      nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\n" +
+                "      addShadowUserOnLogin: true\n" +
+                "    provider-with-shadow-user-disabled:\n" +
+                "      idpMetadata: |\n" +
+                "        <?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+                "        <md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"provider3\">" +
+                "        <md:IDPSSODescriptor WantAuthnRequestsSigned=\"true\" protocolSupportEnumeration=\"urn:oasis:names:tc:SAML:2.0:protocol\">" +
+                "        <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>" +
+                "        <md:SingleSignOnService Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" Location=\"https://example.com\"/>" +
+                "        </md:IDPSSODescriptor>" +
+                "        </md:EntityDescriptor>\n" +
+                "      nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\n" +
+                "      addShadowUserOnLogin: false\n";
+
+        parseYaml(yaml);
+        conf.setIdentityProviders(data);
+        conf.afterPropertiesSet();
+
+        for (IdentityProviderDefinition def : conf.getIdentityProviderDefinitions()) {
+            switch (def.getIdpEntityAlias()) {
+                case "provider-without-shadow-user-definition" : {
+                    assertTrue("If not specified, addShadowUserOnLogin is set to true", def.isAddShadowUserOnLogin());
+                    break;
+                }
+                case "provider-with-shadow-users-enabled" : {
+                    assertTrue("addShadowUserOnLogin can be set to true", def.isAddShadowUserOnLogin());
+                    break;
+                }
+                case "provider-with-shadow-user-disabled" : {
+                    assertFalse("addShadowUserOnLogin can be set to false", def.isAddShadowUserOnLogin());
+                    break;
+                }
+                default: fail(String.format("Unknown provider %s", def.getIdpEntityAlias()));
+            }
+
+        }
+    }
+
 }

--- a/uaa/src/main/resources/login.yml
+++ b/uaa/src/main/resources/login.yml
@@ -131,6 +131,7 @@ login:
 #        showSamlLoginLink: true
 #        linkText: 'Okta Preview 1'
 #        iconUrl: 'http://link.to/icon.jpg'
+#        addShadowUserOnLogin: true
 #      okta-local-2:
 #        idpMetadata: |
 #          <?xml version="1.0" encoding="UTF-8"?><md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="http://www.okta.com/k2lw4l5bPODCMIIDBRYZ"><md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol"><md:KeyDescriptor use="signing"><ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#"><ds:X509Data><ds:X509Certificate>MIICmTCCAgKgAwIBAgIGAUPATqmEMA0GCSqGSIb3DQEBBQUAMIGPMQswCQYDVQQGEwJVUzETMBEG
@@ -150,12 +151,14 @@ login:
 #        metadataTrustCheck: true
 #        showSamlLoginLink: true
 #        linkText: 'Okta Preview 2'
+#        addShadowUserOnLogin: true
 #      vsphere.local:
 #        idpMetadata: https://win2012-sso2.localdomain:7444/websso/SAML2/Metadata/vsphere.local
 #        nameID: urn:oasis:names:tc:SAML:2.0:nameid-format:persistent
 #        assertionConsumerIndex: 0
 #        showSamlLoginLink: true
 #        linkText: 'Log in with vCenter SSO'
+#        addShadowUserOnLogin: true
 #      openam-local:
 #        idpMetadata: http://localhost:8081/openam/saml2/jsp/exportmetadata.jsp?entityid=http://localhost:8081/openam
 #        nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
@@ -164,6 +167,7 @@ login:
 #        signRequest: false
 #        showSamlLoginLink: true
 #        linkText: 'Log in with OpenAM'
+#        addShadowUserOnLogin: true
 #END SAML PROVIDERS
 
   authorize:


### PR DESCRIPTION
Same as https://github.com/cloudfoundry/uaa/pull/217, but this time against `develop` and with test cases:

At the moment, it is not possible to specify the newly introduced property addShadowUserOnLogin for saml providers in login.yml - in the database, it always ends up as "addShadowUserOnLogin":false.

This PR extends the IdentityProviderConfigurator to respect the this property also - so it can be specified in login.yml.

I also added the property in the example configurations in login.yml (this is only for demonstration, it still defaults to true to not break things).