### PR TITLE
Do not enforce CORS filter on same origin requests

### DIFF
--- a/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
@@ -125,6 +125,9 @@ public class CorsFilter extends OncePerRequestFilter {
                 return;
             }
             String origin = request.getHeader(HttpHeaders.ORIGIN);
+            if (!isCrossOriginRequest(origin)) {
+                return;
+            }
             String requestUri = request.getRequestURI();
             if (!isCorsXhrAllowedRequestUri(requestUri) || !isCorsXhrAllowedOrigin(origin)) {
                 response.setStatus(HttpStatus.FORBIDDEN.value());
@@ -156,6 +159,15 @@ public class CorsFilter extends OncePerRequestFilter {
         return StringUtils.hasText(xRequestedWith)
                 || (StringUtils.hasText(accessControlRequestHeaders) && containsHeader(
                         accessControlRequestHeaders, "X-Requested-With"));
+    }
+
+    private boolean isCrossOriginRequest(final String origin) {
+        if (StringUtils.isEmpty(origin)) {
+            return false;
+        }
+        else {
+            return true;
+        }
     }
 
     void buildCorsXhrPreFlightResponse(final HttpServletRequest request, final HttpServletResponse response) {
@@ -224,10 +236,6 @@ public class CorsFilter extends OncePerRequestFilter {
     }
 
     private boolean isCorsXhrAllowedOrigin(final String origin) {
-        if (StringUtils.isEmpty(origin)) {
-            return false;
-        }
-
         for (Pattern pattern : this.corsXhrAllowedOriginPatterns) {
             // Making sure that the pattern matches
             if (pattern.matcher(origin).find()) {

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
@@ -118,16 +118,13 @@ public class CorsFilter extends OncePerRequestFilter {
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
             final FilterChain filterChain) throws ServletException, IOException {
 
-        if (isXhrRequest(request)) {
+        if (isXhrRequest(request) && isCrossOriginRequest(request)) {
             String method = request.getMethod();
             if (!isCorsXhrAllowedMethod(method)) {
                 response.setStatus(HttpStatus.METHOD_NOT_ALLOWED.value());
                 return;
             }
             String origin = request.getHeader(HttpHeaders.ORIGIN);
-            if (!isCrossOriginRequest(origin)) {
-                return;
-            }
             String requestUri = request.getRequestURI();
             if (!isCorsXhrAllowedRequestUri(requestUri) || !isCorsXhrAllowedOrigin(origin)) {
                 response.setStatus(HttpStatus.FORBIDDEN.value());
@@ -161,8 +158,8 @@ public class CorsFilter extends OncePerRequestFilter {
                         accessControlRequestHeaders, "X-Requested-With"));
     }
 
-    private boolean isCrossOriginRequest(final String origin) {
-        if (StringUtils.isEmpty(origin)) {
+    private boolean isCrossOriginRequest(final HttpServletRequest request) {
+        if (StringUtils.isEmpty(request.getHeader(HttpHeaders.ORIGIN))) {
             return false;
         }
         else {

--- a/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
+++ b/common/src/main/java/org/cloudfoundry/identity/uaa/web/CorsFilter.java
@@ -118,7 +118,12 @@ public class CorsFilter extends OncePerRequestFilter {
     protected void doFilterInternal(final HttpServletRequest request, final HttpServletResponse response,
             final FilterChain filterChain) throws ServletException, IOException {
 
-        if (isXhrRequest(request) && isCrossOriginRequest(request)) {
+        if (!isCrossOriginRequest(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if (isXhrRequest(request)) {
             String method = request.getMethod();
             if (!isCorsXhrAllowedMethod(method)) {
                 response.setStatus(HttpStatus.METHOD_NOT_ALLOWED.value());

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/web/CorsFilterTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/web/CorsFilterTests.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.http.HttpStatus;
 
 public class CorsFilterTests {
 
@@ -76,6 +77,22 @@ public class CorsFilterTests {
         corsFilter.doFilter(request, response, filterChain);
 
         assertEquals("example.com", response.getHeaderValue("Access-Control-Allow-Origin"));
+    }
+
+    @Test
+    public void testSameOriginRequest() throws ServletException, IOException {
+        CorsFilter corsFilter = createConfiguredCorsFilter();
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request.addHeader("X-Requested-With", "XMLHttpRequest");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain filterChain = newMockFilterChain();
+
+        corsFilter.doFilter(request, response, filterChain);
+
+        assertEquals(200, response.getStatus());
     }
 
     @Test


### PR DESCRIPTION
Resolves #224. Browsers do not send the Origin header on same origin (scheme/host/port match) requests, so the filter should ignore such requests.