### PR TITLE
Set the template abandonedtimeout to an integer

### DIFF
--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -17,7 +17,7 @@
 #  maxidle: 10
 #  removeabandoned: false
 #  logabandoned: true
-#  abandonedtimeout: true
+#  abandonedtimeout: 300
 #  evictionintervalms: 15000
 #  caseinsensitive: false
 


### PR DESCRIPTION
abandonedtimeout should be set to an integer, not a boolean. With it set to a boolean startup fails and no migrations run.