### PR TITLE
Set the client_id column to varchar(255) in oauth_code table.

### DIFF
--- a/common/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V2_7_4__Fix_Client_Id_Length.sql
+++ b/common/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V2_7_4__Fix_Client_Id_Length.sql
@@ -1,0 +1,13 @@
+--
+-- Cloud Foundry
+-- Copyright (c) [2015] Pivotal Software, Inc. All Rights Reserved.
+--
+-- This product is licensed to you under the Apache License, Version 2.0 (the "License").
+-- You may not use this product except in compliance with the License.
+--
+-- This product includes a number of subcomponents with
+-- separate copyright notices and license terms. Your use of these
+-- subcomponents is subject to the terms and conditions of the
+-- subcomponent's license, as noted in the LICENSE file.
+--
+ALTER TABLE oauth_code ALTER COLUMN client_id VARCHAR(255);

--- a/common/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_7_4__Fix_Client_Id_Length.sql
+++ b/common/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_7_4__Fix_Client_Id_Length.sql
@@ -1,0 +1,13 @@
+--
+-- Cloud Foundry
+-- Copyright (c) [2015] Pivotal Software, Inc. All Rights Reserved.
+--
+-- This product is licensed to you under the Apache License, Version 2.0 (the "License").
+-- You may not use this product except in compliance with the License.
+--
+-- This product includes a number of subcomponents with
+-- separate copyright notices and license terms. Your use of these
+-- subcomponents is subject to the terms and conditions of the
+-- subcomponent's license, as noted in the LICENSE file.
+--
+ALTER TABLE oauth_code MODIFY client_id VARCHAR(255);

--- a/common/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V2_7_4__Fix_Client_Id_Length.sql
+++ b/common/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V2_7_4__Fix_Client_Id_Length.sql
@@ -1,0 +1,14 @@
+--
+-- Cloud Foundry
+-- Copyright (c) [2015] Pivotal Software, Inc. All Rights Reserved.
+--
+-- This product is licensed to you under the Apache License, Version 2.0 (the "License").
+-- You may not use this product except in compliance with the License.
+--
+-- This product includes a number of subcomponents with
+-- separate copyright notices and license terms. Your use of these
+-- subcomponents is subject to the terms and conditions of the
+-- subcomponent's license, as noted in the LICENSE file.
+--
+ALTER TABLE oauth_code ALTER COLUMN client_id TYPE VARCHAR(255);
+

--- a/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenStoreTests.java
+++ b/common/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/UaaTokenStoreTests.java
@@ -52,6 +52,7 @@ public class UaaTokenStoreTests extends JdbcTestBase {
     private OAuth2Authentication clientAuthentication;
     private OAuth2Authentication usernamePasswordAuthentication;
     private OAuth2Authentication uaaAuthentication;
+    public static final String LONG_CLIENT_ID = "a-client-id-that-is-longer-than-thirty-six-characters-but-less-than-two-hundred-fifty-five-characters-wow-two-hundred-fifty-five-characters-is-actually-a-very-long-client-id-and-we-hope-that-size-limit-should-be-sufficient-for-any-reasonable-application";
 
     private UaaPrincipal principal = new UaaPrincipal("userid","username","username@test.org", Origin.UAA, null, IdentityZone.getUaa().getId());
 
@@ -63,7 +64,7 @@ public class UaaTokenStoreTests extends JdbcTestBase {
 
         store = new UaaTokenStore(dataSource);
         springSecurityStore = new JdbcAuthorizationCodeServices(dataSource);
-        BaseClientDetails client = new BaseClientDetails("clientid", null, "openid","client_credentials,password", "oauth.login", null);
+        BaseClientDetails client = new BaseClientDetails(LONG_CLIENT_ID, null, "openid", "client_credentials,password", "oauth.login", null);
         Map<String,String> parameters = new HashMap<>();
         parameters.put(OAuth2Utils.CLIENT_ID, client.getClientId());
 


### PR DESCRIPTION
Test with a long client id in UaaTokenStoreTests.

Fixes #239.

[#105230034]
https://www.pivotaltracker.com/story/show/105230034