### PR TITLE
Client side Password Validation

### DIFF
--- a/login/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
@@ -155,6 +155,7 @@ public class InvitationsController {
                 model.addAttribute(provider.getType(), provider);
                 model.addAttribute("code", newCode);
                 model.addAttribute("email", codeData.get("email"));
+                model.addAttribute("passwordPolicy", passwordValidator.getPasswordPolicy());
                 logger.debug(String.format("Sending user to accept invitation page email:%s, id:%s", codeData.get("email"), codeData.get("user_id")));
             }
             return "invitations/accept_invite";

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/AccountCreationService.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/AccountCreationService.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.login;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 
 import java.io.IOException;
@@ -13,6 +14,8 @@ public interface AccountCreationService {
     ScimUser createUser(String username, String password, String origin);
 
     String getDefaultRedirect() throws IOException;
+
+    PasswordPolicy getPasswordPolicy();
 
     class ExistingUserResponse {
         @JsonProperty

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/AccountsController.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/AccountsController.java
@@ -56,6 +56,7 @@ public class AccountsController {
                                   @RequestParam(value = "redirect_uri", required = false) String redirectUri) {
         model.addAttribute("client_id", clientId);
         model.addAttribute("redirect_uri", redirectUri);
+        model.addAttribute("passwordPolicy", accountCreationService.getPasswordPolicy());
         return "accounts/new_activation_email";
     }
 
@@ -99,6 +100,7 @@ public class AccountsController {
         } catch (HttpClientErrorException e) {
 
             model.addAttribute("error_message_code", "code_expired");
+            model.addAttribute("passwordPolicy", accountCreationService.getPasswordPolicy());
             response.setStatus(HttpStatus.UNPROCESSABLE_ENTITY.value());
             return "accounts/link_prompt";
         }

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/ChangePasswordController.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/ChangePasswordController.java
@@ -44,7 +44,8 @@ public class ChangePasswordController {
     }
 
     @RequestMapping(value="/change_password", method = GET)
-    public String changePasswordPage() {
+    public String changePasswordPage(Model model) {
+        model.addAttribute("passwordPolicy", changePasswordService.getPasswordPolicy());
         return "change_password";
     }
 

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/ChangePasswordService.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/ChangePasswordService.java
@@ -12,6 +12,9 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.login;
 
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
+
 public interface ChangePasswordService {
     void changePassword(String username, String currentPassword, String newPassword);
+    PasswordPolicy getPasswordPolicy();
 }

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/EmailAccountCreationService.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/EmailAccountCreationService.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.identity.uaa.codestore.ExpiringCode;
 import org.cloudfoundry.identity.uaa.codestore.ExpiringCodeStore;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.error.UaaException;
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceAlreadyExistsException;
@@ -155,6 +156,11 @@ public class EmailAccountCreationService implements AccountCreationService {
             }
             throw new UaaException("Couldn't create user:"+username, x);
         }
+    }
+
+    @Override
+    public PasswordPolicy getPasswordPolicy() {
+        return passwordValidator.getPasswordPolicy();
     }
 
     private String getSubjectText() {

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/ResetPasswordController.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/ResetPasswordController.java
@@ -168,6 +168,7 @@ public class ResetPasswordController {
             Timestamp fiveMinutes = new Timestamp(System.currentTimeMillis()+(1000*60*5));
             model.addAttribute("code", codeStore.generateCode(expiringCode.getData(), fiveMinutes, null).getCode());
             model.addAttribute("email", email);
+            model.addAttribute("passwordPolicy", resetPasswordService.getPasswordPolicy());
             return "reset_password";
         }
     }

--- a/login/src/main/java/org/cloudfoundry/identity/uaa/login/UaaChangePasswordService.java
+++ b/login/src/main/java/org/cloudfoundry/identity/uaa/login/UaaChangePasswordService.java
@@ -14,6 +14,7 @@ package org.cloudfoundry.identity.uaa.login;
 
 import org.cloudfoundry.identity.uaa.password.event.PasswordChangeEvent;
 import org.cloudfoundry.identity.uaa.password.event.PasswordChangeFailureEvent;
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
@@ -84,5 +85,10 @@ public class UaaChangePasswordService implements ChangePasswordService, Applicat
         if (publisher!=null) {
             publisher.publishEvent(event);
         }
+    }
+
+    @Override
+    public PasswordPolicy getPasswordPolicy() {
+        return passwordValidator.getPasswordPolicy();
     }
 }

--- a/login/src/main/resources/templates/web/accounts/new_activation_email.html
+++ b/login/src/main/resources/templates/web/accounts/new_activation_email.html
@@ -3,7 +3,12 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorator="layouts/main"
       th:with="pivotal=${@environment.getProperty('login.brand') == 'pivotal'},isUaa=${T(org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder).isUaa()}">
+<head>
+    <th:block layout:include="pw_validation :: deps"></th:block>
+    <th:block layout:include="pw_validation :: head"></th:block>
+</head>
 <div class="island-landscape" layout:fragment="page-content">
+    <th:block layout:include="pw_validation :: pw-validate('password', 'password_confirmation')"></th:block>
     <div class="island-title">
         <h1>Create your <th:block th:text="${pivotal and isUaa ? 'Pivotal ID' : 'account'}">account</th:block></h1>
         <p th:if="${pivotal and isUaa}">
@@ -23,7 +28,9 @@
             <input type="hidden" name="redirect_uri" th:value="${redirect_uri}"/>
             <input name="email" type="email" placeholder="Enter your email" autofocus="autofocus" required="required" class="form-control"/>
             <input name="password" type="password" required="required" placeholder="Password" autocomplete="off" class="form-control"/>
+            <th:block layout:include="pw_validation :: pw-requirements"></th:block>
             <input name="password_confirmation" type="password" required="required" placeholder="Confirm" autocomplete="off" class="form-control"/>
+            <th:block layout:include="pw_validation :: pw-confirm-req"></th:block>
             <input type="submit" value="Send activation link" class="island-button"/>
         </form>
     </div>

--- a/login/src/main/resources/templates/web/change_password.html
+++ b/login/src/main/resources/templates/web/change_password.html
@@ -4,11 +4,13 @@
       layout:decorator="layouts/main">
 <head>
     <th:block layout:include="nav :: head"></th:block>
+    <th:block layout:include="pw_validation :: head"></th:block>
 </head>
 <div class="header" layout:fragment="page-header">
     <th:block layout:include="nav :: nav"></th:block>
 </div>
 <div class="island" layout:fragment="page-content">
+    <th:block layout:include="pw_validation :: pw-validate('new_password', 'confirm_password')"></th:block>
     <h1>Change Password</h1>
     <div class="island-content">
         <form th:action="@{/change_password.do}" method="post" novalidate="novalidate">
@@ -16,7 +18,9 @@
             <div th:if="${message_code}" th:text="#{'change_password.' + ${message_code}}" class="error-message"></div>
             <input name="current_password" type="password" placeholder="Current password" autocomplete="off" autofocus="autofocus" class="form-control"/>
             <input name="new_password" type="password" placeholder="New password" autocomplete="off" class="form-control"/>
+            <th:block layout:include="pw_validation :: pw-requirements"></th:block>
             <input name="confirm_password" type="password" placeholder="Confirm new password" autocomplete="off" class="form-control"/>
+            <th:block layout:include="pw_validation :: pw-confirm-req"></th:block>
             <input type="submit" value="Change password" class="island-button"/>
         </form>
     </div>

--- a/login/src/main/resources/templates/web/invitations/accept_invite.html
+++ b/login/src/main/resources/templates/web/invitations/accept_invite.html
@@ -3,12 +3,17 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorator="layouts/main"
       th:with="pivotal=${@environment.getProperty('login.brand') == 'pivotal'},isUaa=${T(org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder).isUaa()}">
+<head>
+    <th:block layout:include="pw_validation :: deps"></th:block>
+    <th:block layout:include="pw_validation :: head"></th:block>
+</head>
 <div class="island-landscape" layout:fragment="page-content">
     <div class="island-title">
         <h1>Create your <th:block th:text="${pivotal and isUaa ? 'Pivotal ID' : 'account'}">account</th:block></h1>
         <p th:if="${pivotal and isUaa}">A <strong>Pivotal ID</strong> lets you sign in to many Pivotal products using a single username and password.</p>
     </div>
     <div class="island-content">
+        <th:block layout:include="pw_validation :: pw-validate('password', 'password_confirmation')"></th:block>
         <div th:text="|Email: ${email}|" th:unless="${error_message_code == 'code_expired'}" class="email-display">Email: user@example.com</div>
         <div th:if="${error_message_code}" class="alert alert-error">
             <p th:text="#{'account_activation.' + ${error_message_code}}">Error Message</p>
@@ -21,7 +26,9 @@
             <form th:action="@{/invitations/accept.do}" method="post" novalidate="novalidate">
                 <input name="code" type="hidden" value="code" th:value="${code}"/>
                 <input name="password" type="password" placeholder="Password" autocomplete="off" class="form-control"/>
+                <th:block layout:include="pw_validation :: pw-requirements"></th:block>
                 <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
+                <th:block layout:include="pw_validation :: pw-confirm-req"></th:block>
                 <input type="submit" th:value="${pivotal and isUaa ? 'Create Pivotal ID' : 'Create account'}" class="island-button"/>
             </form>
           </th:block>

--- a/login/src/main/resources/templates/web/pw_validation.html
+++ b/login/src/main/resources/templates/web/pw_validation.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
+<head>
+    <!-- Some pages already have JQuery, when they do not, import this too -->
+    <th:block layout:fragment="deps">
+        <script type="text/javascript" src="/vendor/jquery/javascripts/jquery.js" th:src="@{'/vendor/jquery/javascripts/jquery.js'}"></script>
+    </th:block>
+    <th:block layout:fragment="head">
+        <script type="text/javascript" src="/resources/javascripts/pw_validation.js" th:src="@{'/resources/javascripts/pw_validation.js'}"></script>
+    </th:block>
+</head>
+<th:block layout:fragment="pw-validate(passwordField, confirmPasswordField)">
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        $(document).ready(function(){
+            // Get all the password policy requirements.
+            // In case the policy equals to null, initialize the values to 0.
+            var specialCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireSpecialCharacter()}]]*/;
+            var uppercaseCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireUpperCaseCharacter()}]]*/;
+            var lowercaseCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireLowerCaseCharacter()}]]*/;
+            var numberCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getRequireDigit()}]]*/;
+            var lengthCount = /*[[${passwordPolicy == null ? 0 : passwordPolicy.getMinLength()}]]*/;
+            validatePassword(specialCount, uppercaseCount, lowercaseCount,
+                              numberCount, lengthCount,
+                              /*[[${passwordField}]]*/,
+                              /*[[${confirmPasswordField}]]*/
+                            );
+        });
+        /*]]>*/
+    </script>
+</th:block>
+<th:block layout:fragment="pw-requirements">
+    <div id="password-requirements" class="password-req-box">
+        <h5>Password must meet the following requirements:</h5>
+        <ul class="list-unstyled" id="password-requirements-list">
+            <li id="special-req" class="text-danger">At least <strong><span id="special-count">one</span> special letters</strong></li>
+            <li id="uppercase-req" class="text-danger">At least <strong><span id="uppercase-count">one</span> uppercase letters</strong></li>
+            <li id="lowercase-req" class="text-danger">At least <strong><span id="lowercase-count">one</span> lowercase letters</strong></li>
+            <li id="number-req" class="text-danger">At least <strong><span id="number-count">one</span> numbers</strong></li>
+            <li id="length-req" class="text-danger">At least <strong><span id="length-count">one</span> characters long</strong></li>
+        </ul>
+    </div>
+</th:block>
+<th:block layout:fragment="pw-confirm-req">
+    <div id="pw-confirm-requirement" class="password-req-box">
+        <h5 id='match-passwords-text'>Your passwords <strong><span id="match-passwords">DO NOT</span></strong> match</h5>
+    </div>
+</th:block>
+</html>

--- a/login/src/main/resources/templates/web/reset_password.html
+++ b/login/src/main/resources/templates/web/reset_password.html
@@ -2,7 +2,12 @@
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorator="layouts/main">
+<head>
+    <th:block layout:include="pw_validation :: deps"></th:block>
+    <th:block layout:include="pw_validation :: head"></th:block>
+</head>
 <div class="island" layout:fragment="page-content">
+    <th:block layout:include="pw_validation :: pw-validate('password', 'password_confirmation')"></th:block>
     <h1>Reset Password</h1>
     <div class="island-content">
         <div th:text="|Email: ${email}|" class="email-display">Email: user@example.com</div>
@@ -11,7 +16,9 @@
             <input type="hidden" name="email" th:value="${email}"/>
             <div th:if="${message_code}" th:text="#{'reset_password.' + ${message_code}}" class="error-message"></div>
             <input name="password" type="password" placeholder="New Password" autocomplete="off" class="form-control"/>
+            <th:block layout:include="pw_validation :: pw-requirements"></th:block>
             <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
+            <th:block layout:include="pw_validation :: pw-confirm-req"></th:block>
             <input type="submit" value="Create new password" class="island-button"/>
         </form>
     </div>

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/login/ResetPasswordService.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/login/ResetPasswordService.java
@@ -13,6 +13,7 @@
 package org.cloudfoundry.identity.uaa.login;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
 
@@ -22,6 +23,8 @@ public interface ResetPasswordService {
     ForgotPasswordInfo forgotPassword(String email, String clientId, String redirectUri);
 
     ResetPasswordResponse resetPassword(String code, String password) throws InvalidPasswordException;
+
+    PasswordPolicy getPasswordPolicy();
 
     class ResetPasswordResponse {
         @JsonProperty("user")

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/login/UaaResetPasswordService.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/login/UaaResetPasswordService.java
@@ -20,6 +20,7 @@ import org.cloudfoundry.identity.uaa.error.UaaException;
 import org.cloudfoundry.identity.uaa.password.event.PasswordChangeEvent;
 import org.cloudfoundry.identity.uaa.password.event.PasswordChangeFailureEvent;
 import org.cloudfoundry.identity.uaa.password.event.ResetPasswordRequestEvent;
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.endpoints.PasswordChange;
@@ -177,5 +178,10 @@ public class UaaResetPasswordService implements ResetPasswordService, Applicatio
         if (publisher!=null) {
             publisher.publishEvent(event);
         }
+    }
+
+    @Override
+    public PasswordPolicy getPasswordPolicy() {
+        return passwordValidator.getPasswordPolicy();
     }
 }

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/NullPasswordValidator.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/NullPasswordValidator.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.scim.validate;
 
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
 
 /**
@@ -24,5 +25,11 @@ public class NullPasswordValidator implements PasswordValidator {
     @Override
     public void validate(String password) throws InvalidPasswordException {
         //noop
+    }
+
+    @Override
+    public PasswordPolicy getPasswordPolicy() {
+        //noop
+        return null;
     }
 }

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/PasswordValidator.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/PasswordValidator.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.scim.validate;
 
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
 
 /**
@@ -29,4 +30,9 @@ public interface PasswordValidator {
      *
      */
     void validate(String password) throws InvalidPasswordException;
+    /**
+     * Gets the password policy used by the validator;
+     *
+     */
+    PasswordPolicy getPasswordPolicy();
 }

--- a/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
+++ b/scim/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
@@ -1,9 +1,9 @@
 package org.cloudfoundry.identity.uaa.scim.validate;
 
-import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.PasswordPolicy;
 import org.cloudfoundry.identity.uaa.zone.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.provider.UaaIdentityProviderDefinition;
@@ -45,15 +45,11 @@ public class UaaPasswordPolicyValidator implements PasswordValidator {
     }
 
     @Override
-    public void validate(String password) throws InvalidPasswordException {
-        if (password == null) {
-            throw new IllegalArgumentException("Password cannot be null");
-        }
-
+    public PasswordPolicy getPasswordPolicy() {
         IdentityProvider<UaaIdentityProviderDefinition> idp = provisioning.retrieveByOrigin(OriginKeys.UAA, IdentityZoneHolder.get().getId());
         if (idp==null) {
             //should never happen
-            return;
+            return null;
         }
 
         PasswordPolicy policy = globalDefaultPolicy;
@@ -61,6 +57,20 @@ public class UaaPasswordPolicyValidator implements PasswordValidator {
         UaaIdentityProviderDefinition idpDefinition = idp.getConfig();
         if (idpDefinition != null && idpDefinition.getPasswordPolicy() != null) {
             policy = idpDefinition.getPasswordPolicy();
+        }
+
+        return policy;
+    }
+
+    @Override
+    public void validate(String password) throws InvalidPasswordException {
+        if (password == null) {
+            throw new IllegalArgumentException("Password cannot be null");
+        }
+
+        PasswordPolicy policy = getPasswordPolicy();
+        if (policy == null) {
+            return;
         }
 
         org.passay.PasswordValidator validator = getPasswordValidator(policy);

--- a/uaa/src/main/webapp/resources/javascripts/pw_validation.js
+++ b/uaa/src/main/webapp/resources/javascripts/pw_validation.js
@@ -1,0 +1,106 @@
+// validatePassword contains the logic for client side password validation.
+// It is passed in rule threshold information and then sets up watchers to check
+// the password as it is typed in. It then compares the password to the value
+// of the confirmation password.
+// This function is to be used in with the html from pw_validation.html
+function validatePassword(specialCount, uppercaseCount, lowercaseCount,
+                            numberCount, lengthCount, passwordField,
+                            confirmPasswordField) {
+    // Set the values for the password policy requirements into the html.
+    document.getElementById("special-count").innerHTML=''+specialCount+'';
+    document.getElementById("uppercase-count").innerHTML=''+uppercaseCount+'';
+    document.getElementById("lowercase-count").innerHTML=''+lowercaseCount+'';
+    document.getElementById("number-count").innerHTML=''+numberCount+'';
+    document.getElementById("length-count").innerHTML=''+lengthCount+'';
+
+    // Hide rules that aren't set or set to zero.
+    if ( specialCount === 0 ) {$('#special-req').hide();}
+    if ( uppercaseCount === 0 ) {$('#uppercase-req').hide();}
+    if ( lowercaseCount === 0 ) {$('#lowercase-req').hide();}
+    if ( numberCount === 0 ) {$('#number-req').hide();}
+    if ( lengthCount === 0 ) {$('#length-req').hide();}
+
+    // Create a simple boolean to check if no policy is set.
+    var noRules = ((specialCount === 0) && (uppercaseCount === 0) &&
+                    (lowercaseCount === 0) && (numberCount === 0) &&
+                    (lengthCount === 0));
+    // If no policy, make sure it stays hidden.
+    if (noRules == true) {$('#password-requirements').hide();}
+
+    // validateField is a helper function.
+    // Depending on the current conditional, it will set the CSS class for the
+    // corresponding 'html_field' text to either 'text-success' or 'text-danger'
+    function validateField(errorCase, htmlField) {
+        if ( errorCase === true ) {
+            $(htmlField).removeClass('text-success').addClass('text-danger');
+        } else {
+            $(htmlField).removeClass('text-danger').addClass('text-success');
+        }
+    }
+
+    // compareNewPasswords is a helper function.
+    // It will look at the values of passwordField and confirmPasswordField
+    // and compare them. If equal, it will set a placeholder text to read 'DO'.
+    // Else, it will be set to 'DO NOT'.
+    // This placeholder text will either fit in a broader text to either read:
+    // "Passwords 'DO/ DO NOT' match."
+    function compareNewPasswords() {
+        // Get the password value.
+        var pw = $("input[type='password'][name='" + passwordField + "']").val();
+        // Get the confirm password value.
+        var confirmPw = $("input[type='password'][name='" + confirmPasswordField + "']").val();
+        if (pw === confirmPw) {
+            document.getElementById("match-passwords").innerHTML='DO';
+        } else {
+            document.getElementById("match-passwords").innerHTML='DO NOT';
+        }
+    }
+
+    // Setup password validator.
+    $("input[type='password'][name='" + passwordField + "']").keyup(function() {
+        // Compare new passwords.
+        compareNewPasswords();
+
+        // If no rules, no need to do anything else.
+        if ( noRules == true ) {return;}
+
+        // Get the password value.
+        var pw = $(this).val();
+
+        // Validate the length of the password.
+        validateField( ( pw.length < lengthCount ), '#length-req');
+
+        // Validate the number of special characters.
+        validateField(( ( pw.length - pw.replace( /[^0-9a-zA-Z]/g, '' ).length ) < specialCount ), '#special-req');
+
+        // Validate the number of lowercase letters
+        validateField(( (pw.length - pw.replace(/[a-z]/g, '').length) < lowercaseCount ), '#lowercase-req');
+
+        // Validate the number of uppercase letters
+        validateField(( (pw.length - pw.replace(/[A-Z]/g, '').length) < uppercaseCount ), '#uppercase-req');
+
+        // Validate the number of digits
+        validateField(( (pw.length - pw.replace(/[0-9]/g, '').length) < numberCount ), '#number-req');
+    }).focus(function() {  // When the user clicks into the password field.
+        // If no rules, no need to do anything.
+        if ( noRules === true ) {return;}
+        // Else, show the requirements box.
+        $('#password-requirements').show();
+    }).blur(function() {  // When the user clicks out of the password field.
+        // If no rules, no need to do anything.
+        if ( noRules === true ) {return;}
+        // Else, hide the requirements box.
+        $('#password-requirements').hide();
+    });
+
+    // Setup matcher for password confirmation.
+    $("input[type='password'][name='" + confirmPasswordField + "']").keyup(function() {
+        compareNewPasswords();
+    }).focus(function() {  // When the user clicks into the confirm password field.
+        // Show the confirmation requirement box.
+        $('#pw-confirm-requirement').show();
+    }).blur(function() {  // When the user clicks out of the password field.
+        // Hide the confirmation requirement box.
+        $('#pw-confirm-requirement').hide();
+    });
+}

--- a/uaa/src/main/webapp/resources/oss/stylesheets/application.css
+++ b/uaa/src/main/webapp/resources/oss/stylesheets/application.css
@@ -8956,3 +8956,28 @@ h1 {
 
 .panel-container {
   margin-top: 32px; }
+
+.password-req-box {
+  position: relative;
+  width: 100%;
+  background: #fefefe;
+  font-size: .875em;
+  border-radius: 5px;
+  box-shadow:0 1px 3px #ccc;
+  border:1px solid #ddd;
+  margin-bottom: 15px;
+  display: none;
+  text-align: center;
+}
+
+.password-req-box::before {
+  content: "\25B2";
+  position:absolute;
+  top:-12px;
+  left:45%;
+  font-size:14px;
+  line-height:14px;
+  color:#ddd;
+  text-shadow:none;
+  display:block;
+}


### PR DESCRIPTION
For a better user experience, users would like to know the password
requirements prior to the first submission of credentials.

Based on issue #253 
Work card:
https://trello.com/c/tc2CAVkh/439-ui-changing-setting-password-should-show-requirements-beforehand

![image](https://cloud.githubusercontent.com/assets/7788930/11506343/0e8c40f6-981d-11e5-9dac-08b48a0cce42.png)
