### PR TITLE
Allow for specifying the from address used in emails sent by UAA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 language: java
 jdk:
   - oraclejdk8

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/message/EmailService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/message/EmailService.java
@@ -22,11 +22,25 @@ public class EmailService implements MessageService {
     private JavaMailSender mailSender;
     private final String loginUrl;
     private final String companyName;
+    private final String fromAddress;
 
-    public EmailService(JavaMailSender mailSender, String loginUrl, String companyName) {
+    public EmailService(JavaMailSender mailSender, String loginUrl, String companyName, String fromAddress) {
         this.mailSender = mailSender;
         this.loginUrl = loginUrl;
         this.companyName = companyName;
+
+        // if we are provided a from address use that, if not fallback to default based on loginUrl
+        if (fromAddress != null && !fromAddress.isEmpty()) {
+            this.fromAddress = fromAddress;
+        } else {
+            String host = UriComponentsBuilder.fromHttpUrl(loginUrl).build().getHost();
+            this.fromAddress = "admin@" + host;
+        }
+
+    }
+
+    public String getFromAddress() {
+        return fromAddress;
     }
 
     public JavaMailSender getMailSender() {
@@ -38,14 +52,14 @@ public class EmailService implements MessageService {
     }
 
     private Address[] getSenderAddresses() throws AddressException, UnsupportedEncodingException {
-        String host = UriComponentsBuilder.fromHttpUrl(loginUrl).build().getHost();
         String name = null;
         if (IdentityZoneHolder.get().equals(IdentityZone.getUaa())) {
             name = StringUtils.hasText(companyName) ? companyName : "Cloud Foundry";
         } else {
             name = IdentityZoneHolder.get().getName();
         }
-        return new Address[]{new InternetAddress("admin@" + host, name)};
+
+        return new Address[]{new InternetAddress(fromAddress, name)};
     }
 
     @Override

--- a/server/src/main/resources/login-ui.xml
+++ b/server/src/main/resources/login-ui.xml
@@ -511,6 +511,7 @@
         <constructor-arg index="0" ref="#{T(org.springframework.util.StringUtils).hasText('${smtp.host:}') ? 'smtpJavaMailSender' : 'fakeJavaMailSender'}"/>
         <constructor-arg index="1" value="${login.url:http://localhost:8080/uaa}"/>
         <constructor-arg index="2" value="${login.branding.companyName:}"/>
+        <constructor-arg index="3" value="${smtp.from_address:}" />
     </bean>
 
     <bean id="smtpJavaMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/EmailServiceTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/EmailServiceTests.java
@@ -25,7 +25,7 @@ public class EmailServiceTests {
 
     @Test
     public void testSendOssMimeMessage() throws Exception {
-        EmailService emailService = new EmailService(mailSender, "http://login.example.com/login", "");
+        EmailService emailService = new EmailService(mailSender, "http://login.example.com/login", "", null);
 
         emailService.sendMessage("user@example.com", MessageType.CHANGE_EMAIL, "Test Message", "<html><body>hi</body></html>");
 
@@ -42,14 +42,14 @@ public class EmailServiceTests {
 
     @Test
     public void testSendPivotalMimeMessage() throws Exception {
-        EmailService emailService = new EmailService(mailSender, "http://login.example.com/login", "Best Company");
+        EmailService emailService = new EmailService(mailSender, "http://login.example.com/login", "Best Company", "something-specific@bestcompany.example.com");
 
         emailService.sendMessage("user@example.com", MessageType.CHANGE_EMAIL, "Test Message", "<html><body>hi</body></html>");
 
         FakeJavaMailSender.MimeMessageWrapper mimeMessageWrapper = mailSender.getSentMessages().get(0);
         assertThat(mimeMessageWrapper.getFrom(), hasSize(1));
         InternetAddress fromAddress = (InternetAddress) mimeMessageWrapper.getFrom().get(0);
-        assertThat(fromAddress.getAddress(), equalTo("admin@login.example.com"));
+        assertThat(fromAddress.getAddress(), equalTo("something-specific@bestcompany.example.com"));
         assertThat(fromAddress.getPersonal(), equalTo("Best Company"));
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java
@@ -214,6 +214,9 @@ public class BootstrapTests {
         } else {
             assertEquals(JavaMailSenderImpl.class, emailService.getMailSender().getClass());
         }
+
+        assertEquals("admin@localhost", emailService.getFromAddress());
+
         PasswordPolicy passwordPolicy = context.getBean("defaultUaaPasswordPolicy",PasswordPolicy.class);
         assertEquals(0, passwordPolicy.getMinLength());
         assertEquals(255, passwordPolicy.getMaxLength());
@@ -390,6 +393,8 @@ public class BootstrapTests {
         assertNotNull("Unable to find the JavaMailSender object on EmailService for validation.", emailService.getMailSender());
         assertEquals(FakeJavaMailSender.class, emailService.getMailSender().getClass());
 
+        assertEquals("test@example.com", emailService.getFromAddress());
+
         PasswordPolicy passwordPolicy = context.getBean("defaultUaaPasswordPolicy",PasswordPolicy.class);
         assertEquals(8, passwordPolicy.getMinLength());
         assertEquals(100, passwordPolicy.getMaxLength());
@@ -480,6 +485,8 @@ public class BootstrapTests {
             EmailService emailService = context.getBean("emailService", EmailService.class);
             assertNotNull("Unable to find the JavaMailSender object on EmailService for validation.", emailService.getMailSender());
             assertEquals(JavaMailSenderImpl.class, emailService.getMailSender().getClass());
+
+            assertEquals("admin@" + login, emailService.getFromAddress());
 
         } finally {
             System.clearProperty("database.maxactive");

--- a/uaa/src/test/resources/test/bootstrap/bootstrap-test.yml
+++ b/uaa/src/test/resources/test/bootstrap/bootstrap-test.yml
@@ -109,6 +109,7 @@ links:
 
 smtp:
   host: ''
+  from_address: test@example.com
 
 uaa:
   url: https://uaa.some.test.domain.com:555/uaa


### PR DESCRIPTION
This adds support for login.smtp.from_address to be used for all emails sent by UAA.

@fhanik This is the change we [discussed on slack](https://cloudfoundry.slack.com/archives/uaa/p1462400170000392) with the additional tests your requested.

Feedback appreciated.