### PR TITLE
Upgrade to HTTP client 4.3.6

### DIFF
--- a/shared_versions.gradle
+++ b/shared_versions.gradle
@@ -3,7 +3,7 @@ ext {
   aspectJVersion = '1.6.9'
   bcpkixVersion  = '1.47'
   cglibVersion = '2.2.2'
-  commonsHttpClientVersion = '4.3.3'
+  commonsHttpClientVersion = '4.3.6'
   commonsLoggingVersion = '1.2'
   flywayVersion = '4.0'
   guavaVersion = '19.0'


### PR DESCRIPTION
HttpClient before 4.3.6 is vulnerable, see
https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-5262
