### PR TITLE
Correct Content-Type in check_token endpoint

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -619,7 +619,7 @@ This endpoint mirrors the OpenID Connect ``/check_id`` endpoint, so not very RES
         POST /check_token HTTP/1.1
         Host: server.example.com
         Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
-        Content-Type: application/x-www-form-encoded
+        Content-Type: application/x-www-form-urlencoded
 
         token=eyJ0eXAiOiJKV1QiL
 


### PR DESCRIPTION
With `Content-Type: application/x-www-form-encoded` and the `POST` body equal to `token=....` we get the following `400` error from UAA:
```
Required String parameter 'token' is not present
```

When we change to `Content-Type: x-www-form-urlencoded` then we get a `200 OK` response.