### PR TITLE
External Identity Providers issuer validation issue #392

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
@@ -31,6 +31,7 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
     private String relyingPartySecret;
     private List<String> scopes;
     private boolean addShadowUserOnLogin = true;
+    private String issuer;
 
     public URL getAuthUrl() {
         return authUrl;
@@ -128,6 +129,15 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
 
     public T setAddShadowUserOnLogin(boolean addShadowUserOnLogin) {
         this.addShadowUserOnLogin = addShadowUserOnLogin;
+        return (T) this;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+
+    public T setIssuer(String issuer) {
+        this.issuer = issuer;
         return (T) this;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBean.java
@@ -54,6 +54,7 @@ public class OauthIdentityProviderDefinitionFactoryBean {
         idpDefinition.setAddShadowUserOnLogin(idpDefinitionMap.get("addShadowUserOnLogin") == null ? true : (boolean) idpDefinitionMap.get("addShadowUserOnLogin"));
         idpDefinition.setSkipSslValidation(idpDefinitionMap.get("skipSslValidation") == null ? false : (boolean) idpDefinitionMap.get("skipSslValidation"));
         idpDefinition.setTokenKey((String) idpDefinitionMap.get("tokenKey"));
+        idpDefinition.setIssuer((String) idpDefinitionMap.get("issuer"));
         idpDefinition.setAttributeMappings((Map<String, Object>) idpDefinitionMap.get(ATTRIBUTE_MAPPINGS));
         idpDefinition.setScopes((List<String>) idpDefinitionMap.get("scopes"));
         try {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
@@ -232,7 +232,7 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
 
         TokenValidation validation = validate(idToken)
             .checkSignature(new CommonSignatureVerifier(tokenKey))
-            .checkIssuer(config.getTokenUrl().toString())
+            .checkIssuer((StringUtils.isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()))
             .checkAudience(config.getRelyingPartyId())
             .checkExpiry()
             .throwIfInvalid();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManagerTest.java
@@ -73,8 +73,10 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -102,6 +104,7 @@ public class XOAuthAuthenticationManagerTest {
     private static final String CODE = "the_code";
 
     private static final String ORIGIN = "the_origin";
+    private static final String ISSUER = "cf-app.com";
     private IdentityProvider<AbstractXOAuthIdentityProviderDefinition> identityProvider;
     private Map<String, Object> claims;
     private HashMap<String, Object> attributeMappings;
@@ -437,6 +440,31 @@ public class XOAuthAuthenticationManagerTest {
         XOAuthCodeToken otherToken = new XOAuthCodeToken(CODE, "other_origin", "http://localhost/callback/the_origin");
         xoAuthAuthenticationManager.getUser(otherToken);
         assertEquals("other_origin", xoAuthAuthenticationManager.getOrigin());
+    }
+
+    @Test
+    public void testGetUserIssuerOverrideNotUsed() throws Exception {
+        mockToken();
+        assertNotNull(xoAuthAuthenticationManager.getUser(xCodeToken));
+    }
+
+    @Test
+    public void testGetUserIssuerOverrideUsedNoMatch() throws Exception {
+        config.setIssuer(ISSUER);
+        mockToken();
+        try {
+            xoAuthAuthenticationManager.getUser(xCodeToken);
+            fail("InvalidTokenException should have been thrown");
+        } catch(InvalidTokenException ex) { }
+    }
+
+    @Test
+    public void testGetUserIssuerOverrideUsedMatch() throws Exception {
+        config.setIssuer(ISSUER);
+        claims.remove("iss");
+        claims.put("iss", ISSUER);
+        mockToken();
+        assertNotNull(xoAuthAuthenticationManager.getUser(xCodeToken));
     }
 
     @Test

--- a/uaa/src/main/resources/login.yml
+++ b/uaa/src/main/resources/login.yml
@@ -56,6 +56,7 @@ login:
 #        tokenUrl: http://my-token.com
 #        tokenKey: my-token-key
 #        tokenKeyUrl:
+#        issuer: token issuer (iss)
 #        scopes:
 #          - openid
 #          - scope.example

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
@@ -239,7 +239,8 @@ public class IdentityProviderEndpointsDocs extends InjectedMockContextTest {
             ADD_SHADOW_USER_ON_LOGIN,
             EXTERNAL_GROUPS,
             ATTRIBUTE_MAPPING,
-            fieldWithPath("config.attributeMappings.user_name").optional("preferred_username").type(STRING).description("Map `user_name` to the attribute for username in the provider assertion.")
+            fieldWithPath("config.attributeMappings.user_name").optional("preferred_username").type(STRING).description("Map `user_name` to the attribute for username in the provider assertion."),
+            fieldWithPath("config.issuer").optional(null).type(STRING).description("The OAuth 2.0 token issuer. This value is used to validate the issuer inside the token.")
         });
         Snippet requestFields = requestFields(idempotentFields);
 


### PR DESCRIPTION
Fix issue when validating the token's issuer(iss) coming back from an external identity provider. Previously the tokenUrl was used as the value the issuer was compared against. This may not always be the case and so a new configuration item (issuer). If "issuer" is set it will be used instead of the tokenUrl.