### PR TITLE
Add interface UaaTokenEnhancer

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/ClaimConstants.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/ClaimConstants.java
@@ -49,4 +49,5 @@ public class ClaimConstants {
     public static final String PROFILE = "profile";
     public static final String USER_ATTRIBUTES = "user_attributes";
     public static final String REVOCABLE = "revocable";
+    public static final String EXTERNAL_ATTR = "ext_attr";
 }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/Claims.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/Claims.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Claims {
@@ -80,6 +81,8 @@ public class Claims {
     private String userAttributes;
     @JsonProperty(ClaimConstants.REVOCABLE)
     private boolean revocable;
+    @JsonProperty(ClaimConstants.EXTERNAL_ATTR)
+    private Map<String,String> extAttr;
 
     public String getUserId() {
         return userId;
@@ -308,5 +311,13 @@ public class Claims {
 
     public void setRevocable(boolean revocable) {
         this.revocable = revocable;
+    }
+
+    public Map<String,String> getExtAttr() {
+        return extAttr;
+    }
+
+    public void setExtAttr(Map<String,String> extAttr) {
+        this.extAttr = extAttr;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenEnhancer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenEnhancer.java
@@ -1,0 +1,11 @@
+package org.cloudfoundry.identity.uaa.oauth;
+
+import java.util.Map;
+
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+public interface UaaTokenEnhancer {
+	
+	Map<String,String> getExternalAttributes(OAuth2Authentication authentication);
+
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
@@ -272,6 +272,7 @@ public class CheckTokenEndpointTests {
         clientDetailsService.setClientDetailsStore(clientDetailsStore);
         tokenServices.setClientDetailsService(clientDetailsService);
         tokenServices.setTokenProvisioning(tokenProvisioning);
+        tokenServices.setUaaTokenEnhancer(new TestTokenEnhancer());
     }
 
     private void configureDefaultZoneKeys(Map<String, String> keys) {
@@ -568,6 +569,14 @@ public class CheckTokenEndpointTests {
         Claims result = endpoint.checkToken(getAccessToken(), Collections.emptyList());
         assertEquals("olds", result.getUserName());
         assertEquals("12345", result.getUserId());
+    }
+
+    @Test
+    public void testExtAttrInResult() {
+        setAccessToken(tokenServices.createAccessToken(authentication));
+        Claims result = endpoint.checkToken(getAccessToken(), Collections.emptyList());
+        assertNotNull("external attributes not present", result.getExtAttr());
+        assertEquals("test", result.getExtAttr().get("purpose"));
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TestTokenEnhancer.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TestTokenEnhancer.java
@@ -1,0 +1,17 @@
+package org.cloudfoundry.identity.uaa.oauth;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+public class TestTokenEnhancer implements UaaTokenEnhancer {
+
+	@Override
+	public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+		Map<String, String> externalAttributes = new HashMap<String, String>();
+		externalAttributes.put("purpose", "test");
+		return externalAttributes;
+	}
+
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -131,6 +131,7 @@ public class UaaTokenServicesTests {
 
     private TestApplicationEventPublisher<TokenIssuedEvent> publisher;
     private UaaTokenServices tokenServices = new UaaTokenServices();
+    private TestTokenEnhancer testTokenEnhancer = new TestTokenEnhancer();
 
     private final int accessTokenValidity = 60 * 60 * 12;
     private final int refreshTokenValidity = 60 * 60 * 24 * 30;
@@ -245,6 +246,8 @@ public class UaaTokenServicesTests {
             )
         );
 
+        tokenServices.setUaaTokenEnhancer(testTokenEnhancer);
+
         tokenProvisioning = mock(RevocableTokenProvisioning.class);
         when(tokenProvisioning.create(anyObject())).thenAnswer((Answer<RevocableToken>) invocation -> {
             RevocableToken arg = (RevocableToken)invocation.getArguments()[0];
@@ -324,6 +327,8 @@ public class UaaTokenServicesTests {
         assertThat(accessToken, issuerUri(is(ISSUER_URI)));
         assertThat(accessToken, zoneId(is(IdentityZoneHolder.get().getId())));
         assertThat(accessToken.getRefreshToken(), is(nullValue()));
+        Map<String,String> extendedAttributes = (Map<String,String>) accessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
 
         assertCommonEventProperties(accessToken, CLIENT_ID, expectedJson);
     }
@@ -372,6 +377,8 @@ public class UaaTokenServicesTests {
         assertThat(accessToken, validFor(is(3600)));
         assertThat(accessToken, issuerUri(is("http://"+subdomain+".localhost:8080/uaa/oauth/token")));
         assertThat(accessToken.getRefreshToken(), is(nullValue()));
+        Map<String,String> extendedAttributes = (Map<String,String>) accessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
 
         Assert.assertEquals(1, publisher.getEventCount());
 
@@ -402,6 +409,8 @@ public class UaaTokenServicesTests {
         assertThat(accessToken, issuerUri(is(ISSUER_URI)));
         assertThat(accessToken, scope(is(requestedAuthScopes)));
         assertThat(accessToken, validFor(is(60 * 60 * 12)));
+        Map<String,String> extendedAttributes = (Map<String,String>) accessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
 
         OAuth2RefreshToken refreshToken = accessToken.getRefreshToken();
         this.assertCommonUserRefreshTokenProperties(refreshToken);
@@ -431,6 +440,8 @@ public class UaaTokenServicesTests {
             assertThat(accessToken, issuerUri(is(ISSUER_URI)));
             assertThat(accessToken, scope(is(requestedAuthScopes)));
             assertThat(accessToken, validFor(is(60 * 60 * 12)));
+            Map<String,String> extendedAttributes = (Map<String,String>) accessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+            Assert.assertEquals("test", extendedAttributes.get("purpose"));
 
             OAuth2RefreshToken refreshToken = accessToken.getRefreshToken();
             this.assertCommonUserRefreshTokenProperties(refreshToken);
@@ -459,6 +470,8 @@ public class UaaTokenServicesTests {
         assertThat(accessToken, issuerUri(is(ISSUER_URI)));
         assertThat(accessToken, scope(is(requestedAuthScopes)));
         assertThat(accessToken, validFor(is(60 * 60 * 12)));
+        Map<String,String> extendedAttributes = (Map<String,String>) accessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
 
         OAuth2RefreshToken refreshToken = accessToken.getRefreshToken();
         this.assertCommonUserRefreshTokenProperties(refreshToken);
@@ -490,6 +503,8 @@ public class UaaTokenServicesTests {
         assertThat(accessToken, issuerUri(is(ISSUER_URI)));
         assertThat(accessToken, scope(is(requestedAuthScopes)));
         assertThat(accessToken, validFor(is(60 * 60 * 12)));
+        Map<String,String> extendedAttributes = (Map<String,String>) accessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
 
         OAuth2RefreshToken refreshToken = accessToken.getRefreshToken();
         this.assertCommonUserRefreshTokenProperties(refreshToken);
@@ -517,6 +532,8 @@ public class UaaTokenServicesTests {
         assertThat(refreshedAccessToken, issuerUri(is(ISSUER_URI)));
         assertThat(refreshedAccessToken, scope(is(requestedAuthScopes)));
         assertThat(refreshedAccessToken, validFor(is(60 * 60 * 12)));
+        Map<String,String> extendedAttributes = (Map<String,String>) refreshedAccessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
     }
 
     @Test
@@ -546,6 +563,8 @@ public class UaaTokenServicesTests {
         assertThat(refreshedAccessToken, issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa/oauth/token")));
         assertThat(refreshedAccessToken, scope(is(requestedAuthScopes)));
         assertThat(refreshedAccessToken, validFor(is(3600)));
+        Map<String,String> extendedAttributes = (Map<String,String>) refreshedAccessToken.getAdditionalInformation().get(ClaimConstants.EXTERNAL_ATTR);
+        Assert.assertEquals("test", extendedAttributes.get("purpose"));
     }
 
     private OAuth2AccessToken getOAuth2AccessToken() {


### PR DESCRIPTION
Add possibility to enhance access tokens and refresh tokens with custom attributes. You may plug-in a UaaTokenEnhancer into the bean UaaTokenServices. We don't use the existing interface org.springframework.security.oauth2.provider.token.TokenEnhancer, because it would be applied too late (after token serialization) and it doesn't seem to support the refresh flow.