### PR TITLE
Bugfix/authorization code with token

### DIFF
--- a/client-lib/src/main/java/org/cloudfoundry/identity/client/token/TokenRequest.java
+++ b/client-lib/src/main/java/org/cloudfoundry/identity/client/token/TokenRequest.java
@@ -113,8 +113,6 @@ public class TokenRequest {
                         authorizationEndpoint,
                         clientId,
                         clientSecret,
-                        username,
-                        password,
                         redirectUri,
                         authCodeAPIToken,
                         state

--- a/client-lib/src/test/java/org/cloudfoundry/identity/client/integration/ClientAPITokenIntegrationTest.java
+++ b/client-lib/src/test/java/org/cloudfoundry/identity/client/integration/ClientAPITokenIntegrationTest.java
@@ -254,8 +254,6 @@ public class ClientAPITokenIntegrationTest {
             .setState(generator.generate())
             .setClientId("app")
             .setClientSecret("appclientsecret")
-            .setUsername("marissa")
-            .setPassword("koala")
             .setScopes(Arrays.asList("openid"))
             .setAuthCodeAPIToken(passwordContext.getToken().getValue());
         UaaContext context = factory.authenticate(authorizationCode);


### PR DESCRIPTION
The client library provides a function for authenticating the user based on an previously issued JWT token.
The API incorrectly requires username and password for this flow, as the user is authenticated based on a JWT token.
This bugfix removes the requirement in the client for username/password. Server behavior is unchanged.