### PR TITLE
Allow customizable SAML XML Dsig algorithms (SHA-256 and SHA-512)

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SAMLBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SAMLBootstrap.java
@@ -1,0 +1,63 @@
+/*
+ * *****************************************************************************
+ *      Cloud Foundry
+ *      Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *
+ *      This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ *      You may not use this product except in compliance with the License.
+ *
+ *      This product includes a number of subcomponents with
+ *      separate copyright notices and license terms. Your use of these
+ *      subcomponents is subject to the terms and conditions of the
+ *      subcomponent's license, as noted in the LICENSE file.
+ * *****************************************************************************
+ */
+package org.cloudfoundry.identity.uaa.provider.saml;
+
+import org.opensaml.Configuration;
+import org.opensaml.xml.security.BasicSecurityConfiguration;
+import org.opensaml.xml.signature.SignatureConstants;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.BeansException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+ /* Enables SHA256 or SHA512 Digital Signatures and Signature Reference Digests to SAML Requests & Assertions
+  */
+public class SAMLBootstrap extends org.springframework.security.saml.SAMLBootstrap {
+
+    public static final String DEFAULT_ALGORITHM = SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1;
+    String signatureUrl =  DEFAULT_ALGORITHM;
+    
+    protected final static Logger log = LoggerFactory.getLogger(SAMLBootstrap.class);
+        
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+      super.postProcessBeanFactory(beanFactory);
+      init();
+    }
+        
+    protected void init() {
+      BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();
+      config.registerSignatureAlgorithmURI("RSA", signatureUrl);
+      if (signatureUrl.equals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1))
+        config.setSignatureReferenceDigestMethod(SignatureConstants.ALGO_ID_DIGEST_SHA1);
+      else if (signatureUrl.equals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256))
+        config.setSignatureReferenceDigestMethod(SignatureConstants.ALGO_ID_DIGEST_SHA256);
+      else if (signatureUrl.equals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512))
+        config.setSignatureReferenceDigestMethod(SignatureConstants.ALGO_ID_DIGEST_SHA512);
+    }
+    
+    public void setSignatureAlgorithm(String url) {
+      if (SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1.equals(url) ||
+        SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256.equals(url) ||
+        SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512.equals(url)) {
+        this.signatureUrl = url;
+        log.info("Using SAML XML digital signature: " + url);
+      }
+      else {
+        log.warn("Invalid SAML XML digital signature: " + url + ", defaulting to " + this.signatureUrl);
+      }
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SAMLBootstrapTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SAMLBootstrapTest.java
@@ -1,0 +1,58 @@
+package org.cloudfoundry.identity.uaa.provider.saml;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import org.opensaml.Configuration;
+import org.opensaml.xml.security.BasicSecurityConfiguration;
+import org.opensaml.xml.signature.SignatureConstants;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.BeansException;
+
+public class SAMLBootstrapTest {
+
+    @Test
+    public void testSHA1SignatureAlgorithm()  {
+      SAMLBootstrap boot = new SAMLBootstrap();
+      boot.setSignatureAlgorithm( SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1 );
+      boot.init();
+      
+      BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();
+      assertEquals(SignatureConstants.ALGO_ID_DIGEST_SHA1, config.getSignatureReferenceDigestMethod());
+      assertEquals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1, config.getSignatureAlgorithmURI("RSA"));
+      
+    }
+    
+    @Test
+    public void testSHA256SignatureAlgorithm()  {
+      SAMLBootstrap boot = new SAMLBootstrap();
+      boot.setSignatureAlgorithm( SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256 );
+      boot.init();
+      
+      BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();
+      assertEquals(SignatureConstants.ALGO_ID_DIGEST_SHA256, config.getSignatureReferenceDigestMethod());
+      assertEquals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256, config.getSignatureAlgorithmURI("RSA"));      
+    }
+        
+    @Test
+    public void testSHA512SignatureAlgorithm()  {
+      SAMLBootstrap boot = new SAMLBootstrap();
+      boot.setSignatureAlgorithm( SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512 );
+      boot.init();
+      
+      BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();
+      assertEquals(SignatureConstants.ALGO_ID_DIGEST_SHA512, config.getSignatureReferenceDigestMethod());
+      assertEquals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA512, config.getSignatureAlgorithmURI("RSA"));      
+    }
+    
+    @Test
+    public void testBadSignatureAlgorithm()  {
+      SAMLBootstrap boot = new SAMLBootstrap();
+      boot.setSignatureAlgorithm( "bad" );
+      boot.init();
+      
+      BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();
+      assertEquals(SignatureConstants.ALGO_ID_DIGEST_SHA1, config.getSignatureReferenceDigestMethod());
+      assertEquals(SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1, config.getSignatureAlgorithmURI("RSA"));     
+    }
+}

--- a/uaa/src/main/resources/login.yml
+++ b/uaa/src/main/resources/login.yml
@@ -137,6 +137,10 @@ login:
     signRequest: true
     #Local/SP metadata - want incoming assertions signed
     #wantAssertionSigned: true
+    #Local/SP metadata - signature algorithm
+    # can also be http://www.w3.org/2001/04/xmldsig-more#rsa-sha256 or 
+    # or http://www.w3.org/2001/04/xmldsig-more#rsa-sha512
+    #signatureAlgorithm: http://www.w3.org/2000/09/xmldsig#rsa-sha1
     socket:
       # URL metadata fetch - pool timeout
       connectionManagerTimeout: 10000

--- a/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
@@ -327,7 +327,9 @@ qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/
         </bean>
 
         <!-- Initialization of OpenSAML library -->
-        <bean class="org.springframework.security.saml.SAMLBootstrap" />
+        <bean class="org.cloudfoundry.identity.uaa.provider.saml.SAMLBootstrap">
+          <property name="signatureAlgorithm" value="${login.saml.signatureAlgorithm:http://www.w3.org/2000/09/xmldsig#rsa-sha1}" />
+        </bean>
 
         <!-- Initialization of the velocity engine -->
         <bean id="velocityEngine" class="org.springframework.security.saml.util.VelocityFactory" factory-method="getEngine" />


### PR DESCRIPTION
SHA-1 is the current default signature algorithm for SAML XML digital signatures in Spring SAML and thus UAA but is compromised and not accepted at some customers.   

This patch enables UAA to default to SHA-256 or SHA-512 signatures while preserving SHA-1 as the current default.

