### PR TITLE
Clarify how a CSRF token is required to interact with the POST /login…

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -260,6 +260,7 @@ Browser Requests Code: ``GET /oauth/authorize``
 
         HTTP/1.1 302 Found
         Location: https://www.cloudfoundry.example.com?code=F45jH
+        Set-Cookie: X-Uaa-Csrf=abcdef; Expires=Thu, 04-Aug-2016 18:10:38 GMT; HttpOnly
 
 * Response Codes::
 
@@ -272,7 +273,7 @@ Browser Requests Code: ``GET /oauth/authorize``
 *Sample curl commands for this flow*
 
 * ``curl -v "http://localhost:8080/uaa/oauth/authorize?response_type=code&client_id=app&scope=password.write&redirect_uri=http%3A%2F%2Fwww.example.com%2Fcallback" --cookie cookies.txt --cookie-jar cookies.txt``
-* ``curl -v http://localhost:8080/uaa/login.do -d "username=marissa&password=koala" --cookie cookies.txt --cookie-jar cookies.txt``
+* ``curl -v http://localhost:8080/uaa/login.do -H "Referer: http://login.cloudfoundry.example.com/login" -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "username=marissa&password=koala&X-Uaa-Csrf=abcdef" --cookie cookies.txt --cookie-jar cookies.txt``
 * ``curl -v "http://localhost:8080/uaa/oauth/authorize?response_type=code&client_id=app&scope=password.write&redirect_uri=http%3A%2F%2Fwww.example.com%2Fcallback" --cookie cookies.txt --cookie-jar cookies.txt``
 * ``curl -v http://localhost:8080/uaa/oauth/authorize -d "scope.0=scope.password.write&user_oauth_approval=true" --cookie cookies.txt --cookie-jar cookies.txt``
 
@@ -309,7 +310,7 @@ URI.
 *Sample curl commands for this flow*
 
 * ``curl -v -H "Accept:application/json" "http://localhost:8080/uaa/oauth/authorize?response_type=code&client_id=app&scope=password.write&redirect_uri=http%3A%2F%2Fwww.example.com%2Fcallback" --cookie cookies.txt --cookie-jar cookies.txt``
-* ``curl -v -H "Accept:application/json" http://localhost:8080/uaa/login.do -d "username=marissa&password=koala" --cookie cookies.txt --cookie-jar cookies.txt``
+* ``curl -v -H "Accept:application/json" http://localhost:8080/uaa/login.do -H "Referer: http://login.cloudfoundry.example.com/login" -H "Accept: application/json" -H "Content-Type: application/x-www-form-urlencoded" -d "username=marissa&password=koala&X-Uaa-Csrf=abcdef" --cookie cookies.txt --cookie-jar cookies.txt``
 * ``curl -v -H "Accept:application/json" "http://localhost:8080/uaa/oauth/authorize?response_type=code&client_id=app&scope=password.write&redirect_uri=http%3A%2F%2Fwww.example.com%2Fcallback" --cookie cookies.txt --cookie-jar cookies.txt``
 * ``curl -v -H "Accept:application/json" http://localhost:8080/uaa/oauth/authorize -d "scope.0=scope.password.write&user_oauth_approval=true" --cookie cookies.txt --cookie-jar cookies.txt``
 
@@ -3276,12 +3277,13 @@ Internal Login: ``POST /login.do``
 * Request: ``POST /login.do``
 * Request Body, example -- depends on configuration (e.g. do we need OTP / PIN / password etc.)::
 
-    username={username}&password={password}...
+    username={username}&password={password}&X-Uaa-Csrf={token}...
 
 * Response Header, includes location if redirect, and cookie for subsequent interaction (e.g. authorization)::
 
     Location: http://myapp.cloudfoundry.com/mycoolpage
     Set-Cookie: JSESSIONID=ldfjhsdhafgkasd
+    Set-Cookie: X-Uaa-Csrf=abcdef; Expires=Thu, 04-Aug-2016 18:10:38 GMT; HttpOnly
 
 * Response Codes::
 
@@ -3351,5 +3353,3 @@ Response Headers    ::
 
 Management Endpoints
 ====================
-
-

--- a/docs/login/Login-APIs.md
+++ b/docs/login/Login-APIs.md
@@ -44,10 +44,11 @@ be received from ``GET /login``, which will set it as a response cookie called `
 | ------------- | ----------------:|
 | Accept        | application/json |
 | Content-Type  | application/x-www-form-urlencoded  |
+| Referer       | http://login.cloudfoundry.example.com/login |
 
 The raw data for the request must be submitted in the following format, and must include the CSRF token (sample below):
 ```
-'username=admin&password=mypassword&X-Uaa-Csrf=zU0cuo'
+'username=admin&password=mypassword&X-Uaa-Csrf=abcdef'
 ```
 Finally, in addition to being submitted as part of the raw data, the CSRF token must also be added to the POST request as a cookie, also named ``X-Uaa-Csrf``.
 ## Logout: `GET /logout.do`

--- a/docs/login/Login-APIs.md
+++ b/docs/login/Login-APIs.md
@@ -37,13 +37,26 @@ Browser POSTs to `/login.do` with user credentials (same as UAA).
 Login Server returns a cookie that can be used to authenticate future
 requests (until the session expires or the user logs out).
 
+In order to use this endpoint, a Cross-Site Request Forgery (CSRF) token needs to first
+be received from ``GET /login``, which will set it as a response cookie called ``X-Uaa-Csrf``.  Furthermore, the following headers are required in the POST for successful authentication:
+
+| Header        | Value            |
+| ------------- | ----------------:|
+| Accept        | application/json |
+| Content-Type  | application/x-www-form-urlencoded  |
+
+The raw data for the request must be submitted in the following format, and must include the CSRF token (sample below):
+```
+'username=admin&password=mypassword&X-Uaa-Csrf=zU0cuo'
+```
+Finally, in addition to being submitted as part of the raw data, the CSRF token must also be added to the POST request as a cookie, also named ``X-Uaa-Csrf``.
 ## Logout: `GET /logout.do`
 
 The Login Server is a Single Sign On server for the Cloud Foundry
 platform (and possibly user apps as well), so if a user logs out he
 logs out of all the apps.  Users need to be reminded of the
 consequences of their actions, so the recommendation for application
-authors is to 
+authors is to
 
 * provide a local logout feature specific to the client application
   and use that to clear state in the client


### PR DESCRIPTION
Added a section to the Login Server API's document to better clarify how to POST to the /login.do endpoint.