### PR TITLE
oidc: set JWT iss claim to UAA server location

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -1209,6 +1209,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         this.issuer = issuer;
     }
 
+    /* TODO: This should be renamed to getIssuerEndpoint or something similar as its current name is confusing
+             (The method is for getting the issuer endpoint, not the OAuth token URL which the name could suggest.) */
     public String getTokenEndpoint() {
         try {
             return UaaTokenUtils.constructTokenEndpointUrl(issuer);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaTokenUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaTokenUtils.java
@@ -185,6 +185,6 @@ public final class UaaTokenUtils {
         if (hasText(IdentityZoneHolder.get().getSubdomain())) {
             hostToUse = IdentityZoneHolder.get().getSubdomain() + "." + hostToUse;
         }
-        return UriComponentsBuilder.fromUriString(issuer).host(hostToUse).pathSegment("oauth/token").build().toUriString();
+        return UriComponentsBuilder.fromUriString(issuer).host(hostToUse).build().toUriString();
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
@@ -617,7 +617,7 @@ public class CheckTokenEndpointTests {
         setAccessToken(tokenServices.createAccessToken(authentication));
         Claims result = endpoint.checkToken(getAccessToken(), Collections.emptyList());
         assertNotNull("iss field is not present", result.getIss());
-        assertEquals("http://some.other.issuer/oauth/token", result.getIss());
+        assertEquals("http://some.other.issuer", result.getIss());
     }
 
     @Test
@@ -630,7 +630,7 @@ public class CheckTokenEndpointTests {
             setAccessToken(tokenServices.createAccessToken(authentication));
             Claims result = endpoint.checkToken(getAccessToken(), Collections.emptyList());
             assertNotNull("iss field is not present", result.getIss());
-            assertEquals("http://subdomain.some.other.issuer/oauth/token", result.getIss());
+            assertEquals("http://subdomain.some.other.issuer", result.getIss());
         } finally {
             IdentityZoneHolder.clear();
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -149,7 +149,7 @@ public class UaaTokenServicesTests {
     public static final String REFRESH_TOKEN = "refresh_token";
     public static final String IMPLICIT = "implicit";
     public static final String CLIENT_AUTHORITIES = "read,update,write,openid";
-    public static final String ISSUER_URI = "http://localhost:8080/uaa/oauth/token";
+    public static final String ISSUER_URI = "http://localhost:8080/uaa";
     public static final String READ = "read";
     public static final String WRITE = "write";
     public static final String DELETE = "delete";
@@ -509,7 +509,7 @@ public class UaaTokenServicesTests {
 
         this.assertCommonClientAccessTokenProperties(accessToken);
         assertThat(accessToken, validFor(is(3600)));
-        assertThat(accessToken, issuerUri(is("http://"+subdomain+".localhost:8080/uaa/oauth/token")));
+        assertThat(accessToken, issuerUri(is("http://"+subdomain+".localhost:8080/uaa")));
         assertThat(accessToken.getRefreshToken(), is(nullValue()));
         validateExternalAttributes(accessToken);
 
@@ -708,7 +708,7 @@ public class UaaTokenServicesTests {
         assertEquals(refreshedAccessToken.getRefreshToken().getValue(), accessToken.getRefreshToken().getValue());
 
         this.assertCommonUserAccessTokenProperties(refreshedAccessToken);
-        assertThat(refreshedAccessToken, issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa/oauth/token")));
+        assertThat(refreshedAccessToken, issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa")));
         assertThat(refreshedAccessToken, scope(is(requestedAuthScopes)));
         assertThat(refreshedAccessToken, validFor(is(3600)));
         validateExternalAttributes(accessToken);
@@ -1165,14 +1165,14 @@ public class UaaTokenServicesTests {
         OAuth2AccessToken accessToken = tokenServices.createAccessToken(authentication);
 
         this.assertCommonUserAccessTokenProperties(accessToken);
-        assertThat(accessToken, issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa/oauth/token")));
+        assertThat(accessToken, issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa")));
         assertThat(accessToken, scope(is(requestedAuthScopes)));
         assertThat(accessToken, validFor(is(3600)));
         assertThat(accessToken.getRefreshToken(), is(not(nullValue())));
 
         OAuth2RefreshToken refreshToken = accessToken.getRefreshToken();
         this.assertCommonUserRefreshTokenProperties(refreshToken);
-        assertThat(refreshToken, OAuth2RefreshTokenMatchers.issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa/oauth/token")));
+        assertThat(refreshToken, OAuth2RefreshTokenMatchers.issuerUri(is("http://test-zone-subdomain.localhost:8080/uaa")));
         assertThat(refreshToken, OAuth2RefreshTokenMatchers.validFor(is(9600)));
 
         this.assertCommonEventProperties(accessToken, userId, buildJsonString(requestedAuthScopes));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -2716,7 +2716,7 @@ public class TokenMvcMockTests extends AbstractTokenMockMvcTests {
             .andReturn();
         String claimsJSON = JwtHelper.decode(JsonUtils.readValue(result.getResponse().getContentAsString(), OAuthToken.class).accessToken).getClaims();
         Claims claims = JsonUtils.readValue(claimsJSON, Claims.class);
-        assertEquals(claims.getIss(), "http://" + subdomain.toLowerCase() + ".localhost:8080/uaa/oauth/token");
+        assertEquals(claims.getIss(), "http://" + subdomain.toLowerCase() + ".localhost:8080/uaa");
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
@@ -319,7 +319,7 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
         IdentityZone zone = createZone(id, HttpStatus.CREATED, identityClientToken);
         assertEquals(id, zone.getId());
         assertEquals(id.toLowerCase(), zone.getSubdomain());
-        checkAuditEventListener(1, AuditEventType.IdentityZoneCreatedEvent, zoneModifiedEventListener, IdentityZone.getUaa().getId(), "http://localhost:8080/uaa/oauth/token", "identity");
+        checkAuditEventListener(1, AuditEventType.IdentityZoneCreatedEvent, zoneModifiedEventListener, IdentityZone.getUaa().getId(), "http://localhost:8080/uaa", "identity");
     }
 
     @Test
@@ -944,7 +944,7 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
         assertEquals("zones.write", created.getAdditionalInformation().get(ClientConstants.CREATED_WITH));
         assertEquals(Collections.singletonList(UAA), created.getAdditionalInformation().get(ClientConstants.ALLOWED_PROVIDERS));
         assertEquals("bar", created.getAdditionalInformation().get("foo"));
-        checkAuditEventListener(1, AuditEventType.ClientCreateSuccess, clientCreateEventListener, id, "http://localhost:8080/uaa/oauth/token", "identity");
+        checkAuditEventListener(1, AuditEventType.ClientCreateSuccess, clientCreateEventListener, id, "http://localhost:8080/uaa", "identity");
 
         for (String url : Arrays.asList("", "/")) {
             getMockMvc().perform(
@@ -959,7 +959,7 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
                 .accept(APPLICATION_JSON))
             .andExpect(status().isOk());
 
-        checkAuditEventListener(1, AuditEventType.ClientDeleteSuccess, clientDeleteEventListener, id, "http://localhost:8080/uaa/oauth/token", "identity");
+        checkAuditEventListener(1, AuditEventType.ClientDeleteSuccess, clientDeleteEventListener, id, "http://localhost:8080/uaa", "identity");
     }
 
     @Test
@@ -1093,12 +1093,12 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
         IdentityZone identityZone = creationResult.getIdentityZone();
 
         checkZoneAuditEventInUaa(1, AuditEventType.IdentityZoneCreatedEvent);
-        checkAuditEventListener(1, AuditEventType.GroupCreatedEvent, groupModifiedEventListener, IdentityZone.getUaa().getId(), "http://localhost:8080/uaa/oauth/token", "identity");
-        checkAuditEventListener(1, AuditEventType.ClientCreateSuccess, clientCreateEventListener, identityZone.getId(), "http://localhost:8080/uaa/oauth/token", creationResult.getZoneAdminUser().getId());
+        checkAuditEventListener(1, AuditEventType.GroupCreatedEvent, groupModifiedEventListener, IdentityZone.getUaa().getId(), "http://localhost:8080/uaa", "identity");
+        checkAuditEventListener(1, AuditEventType.ClientCreateSuccess, clientCreateEventListener, identityZone.getId(), "http://localhost:8080/uaa", creationResult.getZoneAdminUser().getId());
 
         String scimAdminToken = testClient.getClientCredentialsOAuthAccessToken("admin", "admin-secret", "scim.write,scim.read", subdomain);
         ScimUser user = createUser(scimAdminToken, subdomain);
-        checkAuditEventListener(1, AuditEventType.UserCreatedEvent, userModifiedEventListener, identityZone.getId(), "http://" + subdomain + ".localhost:8080/uaa/oauth/token", "admin");
+        checkAuditEventListener(1, AuditEventType.UserCreatedEvent, userModifiedEventListener, identityZone.getId(), "http://" + subdomain + ".localhost:8080/uaa", "admin");
 
         user.setUserName("updated-username@test.com");
         MockHttpServletRequestBuilder put = put("/Users/" + user.getId())
@@ -1113,7 +1113,7 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
             .andExpect(jsonPath("$.userName").value(user.getUserName()))
             .andReturn();
 
-        checkAuditEventListener(2, AuditEventType.UserModifiedEvent, userModifiedEventListener, identityZone.getId(), "http://" + subdomain + ".localhost:8080/uaa/oauth/token", "admin");
+        checkAuditEventListener(2, AuditEventType.UserModifiedEvent, userModifiedEventListener, identityZone.getId(), "http://" + subdomain + ".localhost:8080/uaa", "admin");
         user = JsonUtils.readValue(result.getResponse().getContentAsString(), ScimUser.class);
         List<ScimUser> users = getUsersInZone(subdomain, scimAdminToken);
         assertTrue(users.contains(user));
@@ -1130,7 +1130,7 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
             .andExpect(jsonPath("$.id").value(user.getId()))
             .andReturn();
 
-        checkAuditEventListener(3, AuditEventType.UserDeletedEvent, userModifiedEventListener, identityZone.getId(), "http://" + subdomain + ".localhost:8080/uaa/oauth/token", "admin");
+        checkAuditEventListener(3, AuditEventType.UserDeletedEvent, userModifiedEventListener, identityZone.getId(), "http://" + subdomain + ".localhost:8080/uaa", "admin");
         users = getUsersInZone(subdomain, scimAdminToken);
         assertEquals(0, users.size());
     }
@@ -1305,7 +1305,7 @@ public class IdentityZoneEndpointsMockMvcTests extends InjectedMockContextTest {
     }
 
     private <T extends AbstractUaaEvent> void checkZoneAuditEventInUaa(int eventCount, AuditEventType eventType) {
-        checkAuditEventListener(eventCount, eventType, zoneModifiedEventListener, IdentityZone.getUaa().getId(), "http://localhost:8080/uaa/oauth/token", "identity");
+        checkAuditEventListener(eventCount, eventType, zoneModifiedEventListener, IdentityZone.getUaa().getId(), "http://localhost:8080/uaa", "identity");
     }
 
     private <T extends AbstractUaaEvent> void checkAuditEventListener(int eventCount, AuditEventType eventType, TestApplicationEventListener<T> eventListener, String identityZoneId, String issuer, String subject) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsMockMvcTests.java
@@ -30,7 +30,7 @@ public class OpenIdConnectEndpointsMockMvcTests extends InjectedMockContextTest 
 
         OpenIdConfiguration openIdConfiguration = JsonUtils.readValue(response.getContentAsString(), OpenIdConfiguration.class);
         assertNotNull(openIdConfiguration);
-        assertEquals("http://subdomain.localhost:8080/uaa/oauth/token",openIdConfiguration.getIssuer());
+        assertEquals("http://subdomain.localhost:8080/uaa",openIdConfiguration.getIssuer());
         assertEquals("http://subdomain.localhost/oauth/authorize",openIdConfiguration.getAuthUrl());
         assertEquals("http://subdomain.localhost/oauth/token",openIdConfiguration.getTokenUrl());
         assertArrayEquals(new String[]{"client_secret_basic"}, openIdConfiguration.getTokenAMR());


### PR DESCRIPTION
Right now, the iss claim in a JWT points to the OAuth endpoint used to
get the token.  This makes OIDC integration impossible because the iss
claim must match the issuer property of the OIDC configuration document.
With this change, we no longer append "oauth/token" to the issuer URL.

**Note:** I realize that OIDC support isn't official or complete but after
discussing this in Slack with @sreetummidi, I figured I would whip up a
PR to get the conversation started.  I will supply more detail into why this
PR came about in the comments below.
