### PR TITLE
UAA as a SAML IDP: Add attribute inResponseTo to the saml2p:Response …

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/IdpWebSsoProfileImplTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/IdpWebSsoProfileImplTest.java
@@ -137,6 +137,8 @@ public class IdpWebSsoProfileImplTest {
 
         AuthnRequest request = (AuthnRequest) context.getInboundSAMLMessage();
         Response response = (Response) context.getOutboundSAMLMessage();
+        assertEquals(request.getID(), response.getInResponseTo());
+
         Assertion assertion = response.getAssertions().get(0);
         Subject subject = assertion.getSubject();
         assertEquals("marissa", subject.getNameID().getValue());


### PR DESCRIPTION
…element

Signed-off-by: Raymond <raymond.lemon@ge.com>

Summary Of Changes:

- Add  attribute `InResponseTo` to `saml2p:Response` to go with the corresponding inResponseTo attribute on the `saml2:SubjectConfirmationData`.
- Add assertion to SAML IDP test to validate the inResponseTo against the saml authentication requestId.





