### PR TITLE
Fix for startup failure when inactive service providers exist in the database

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfigurator.java
@@ -23,7 +23,6 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.opensaml.common.xml.SAMLConstants;
 import org.opensaml.saml2.core.NameIDType;
-import org.opensaml.saml2.metadata.NameIDFormat;
 import org.opensaml.saml2.metadata.SPSSODescriptor;
 import org.opensaml.saml2.metadata.provider.MetadataProviderException;
 import org.opensaml.xml.parse.BasicParserPool;
@@ -202,14 +201,19 @@ public class SamlServiceProviderConfigurator {
     public synchronized ExtendedMetadataDelegate removeSamlServiceProvider(String entityId) {
         Map<String, SamlServiceProviderHolder> serviceProviders = getOrCreateSamlServiceProviderMapForZone(
                 IdentityZoneHolder.get());
-        return serviceProviders.remove(entityId).getExtendedMetadataDelegate();
+
+        SamlServiceProviderHolder samlServiceProviderHolder =  serviceProviders.remove(entityId);
+        return samlServiceProviderHolder == null ? null : samlServiceProviderHolder.getExtendedMetadataDelegate();
     }
 
     public ExtendedMetadataDelegate getExtendedMetadataDelegateFromCache(String entityId)
             throws MetadataProviderException {
         Map<String, SamlServiceProviderHolder> serviceProviders = getOrCreateSamlServiceProviderMapForZone(
                 IdentityZoneHolder.get());
-        return serviceProviders.get(entityId).getExtendedMetadataDelegate();
+
+        SamlServiceProviderHolder samlServiceProviderHolder =  serviceProviders.get(entityId);
+        return samlServiceProviderHolder == null ? null : samlServiceProviderHolder.getExtendedMetadataDelegate();
+        
     }
 
     public ExtendedMetadataDelegate getExtendedMetadataDelegate(SamlServiceProvider provider)

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfiguratorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfiguratorTest.java
@@ -15,6 +15,7 @@ import org.cloudfoundry.identity.uaa.provider.saml.ComparableProvider;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -158,4 +159,15 @@ public class SamlServiceProviderConfiguratorTest {
         }
         t.cancel();
     }
+    
+    @Test
+    public void testGetNonExistentServiceProviderMetadata() throws Exception {
+       Assert.assertNull(conf.getExtendedMetadataDelegateFromCache("non-existent-entity-id"));
+    }
+    
+    @Test
+    public void testRemoveNonExistentServiceProviderMetadata() throws Exception {
+       Assert.assertNull(conf.removeSamlServiceProvider("non-existent-entity-id"));
+    }
+ 
 }


### PR DESCRIPTION
Without this change, SamlServiceProviderConfigurator.java throws NPE which fails bean initialization when there are inactive service providers in the DB:

`2016-09-27T11:23:59.10-0700 [App/0]      OUT java.lang.NullPointerException
2016-09-27T11:23:59.10-0700 [App/0]      OUT    at org.cloudfoundry.identity.uaa.provider.saml.idp.SamlServiceProviderConfigurator.removeSamlServiceProvider(SamlServiceProviderConfigurator.java:183)
2016-09-27T11:23:59.10-0700 [App/0]      OUT    at org.cloudfoundry.identity.uaa.provider.saml.idp.ZoneAwareIdpMetadataManager.removeSamlServiceProvider(ZoneAwareIdpMetadataManager.java:167)
2016-09-27T11:23:59.10-0700 [App/0]      OUT    at org.cloudfoundry.identity.uaa.provider.saml.idp.ZoneAwareIdpMetadataManager.refreshAllProviders(ZoneAwareIdpMetadataManager.java:141)
2016-09-27T11:23:59.10-0700 [App/0]      OUT    at org.cloudfoundry.identity.uaa.provider.saml.idp.ZoneAwareIdpMetadataManager.refreshAllProviders(ZoneAwareIdpMetadataManager.java:112)
2016-09-27T11:23:59.10-0700 [App/0]      OUT    at org.cloudfoundry.identity.uaa.provider.saml.idp.ZoneAwareIdpMetadataManager.checkAllProviders(ZoneAwareIdpMetadataManager.java:106)`