### PR TITLE
Fix array out of bounds exception in case of wrong email format

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManager.java
@@ -160,7 +160,7 @@ public class LoginAuthenticationManager implements AuthenticationManager, Applic
         }
         String familyName = info.get("family_name");
         if (familyName == null) {
-            familyName = email.split("@")[1];
+            familyName = (email.split("@").length > 1 ? email.split("@")[1] : email);
         }
         return new UaaUser(
             userId,


### PR DESCRIPTION
A quick bug fix for an ArrayOutOfBoundsException we encountered. I don't know why the family name is extracted from the email, but I have no insight to this project. Hence I tried to touch as few code as possible. 