### PR TITLE
Fix array out of bounds exception in case of bogus email format

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManager.java
@@ -160,7 +160,7 @@ public class LoginAuthenticationManager implements AuthenticationManager, Applic
         }
         String familyName = info.get("family_name");
         if (familyName == null) {
-            familyName = email.split("@")[1];
+            familyName = (email.split("@").length > 1 ? email.split("@")[1] : email);
         }
         return new UaaUser(
             userId,

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManagerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/LoginAuthenticationManagerTests.java
@@ -15,6 +15,7 @@ package org.cloudfoundry.identity.uaa.authentication.manager;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertNotNull;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -190,4 +191,20 @@ public class LoginAuthenticationManagerTests {
         Assert.assertEquals(1, publisher.getEventCount());
         Assert.assertEquals("foo", publisher.getLatestEvent().getUser().getUsername());
     }
+
+    @Test
+    public void testNoOutOfBoundsInCaseOfWrongEmailFormat() {
+        // use an email without the '@' sign and provide no name and familyname to trigger the potential bug
+        String username = "newuser";
+        String email = "noAtSign";
+        AuthzAuthenticationRequest req1 = UaaAuthenticationTestFactory.getAuthenticationRequest(username, true);
+        Map<String,String> info = new HashMap<>(req1.getInfo());
+        info.put("email", email);
+        UaaUser u1 = manager.getUser(req1, info);
+        assertNotNull(u1);
+        assertEquals(username, u1.getUsername());
+        assertNotNull(u1.getFamilyName());
+        assertNotNull(u1.getGivenName());
+    }
+
 }


### PR DESCRIPTION
A quick bug fix for an ArrayOutOfBoundsException we encountered. I don't know why the family name is extracted from the email, but I have no insight to this project. Hence I tried to touch as few code as possible.

Found with the help of Holger Koser.

An integration test is included. In case you want to manually reproduce the error, try the following steps.

Given $TOKEN contains a valid token for user login, the following http request led to an error:

curl 'https://uaa.cf...../authenticate' -d "source=login&origin=ldap&username=newuser&add_new=true&email=wrongformat" -H 'Accept: application/json' -H "Authorization: bearer $TOKEN" -s -k

Response: {“error":"error"}

Upon inspecting the server logs we found:

RemoteAuthenticationEndpoint: Failed to authenticate user 
java.lang.ArrayIndexOutOfBoundsException: 1
at org.cloudfoundry.identity.uaa.authentication.manager.LoginAuthenticationManager.getUser(LoginAuthenticationManager.java:159)
at org.cloudfoundry.identity.uaa.authentication.manager.LoginAuthenticationManager.authenticate(LoginAuthenticationManager.java:83)
at org.cloudfoundry.identity.uaa.authentication.RemoteAuthenticationEndpoint.authenticate(RemoteAuthenticationEndpoint.java:123)
at sun.reflect.GeneratedMethodAccessor304.invoke(Unknown Source)
...