### PR TITLE
Change getAuthorities to reduce number of executed SQL-Statements

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabase.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabase.java
@@ -13,6 +13,7 @@
 package org.cloudfoundry.identity.uaa.user;
 
 
+import org.apache.commons.lang.ArrayUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
@@ -27,6 +28,7 @@ import org.springframework.util.StringUtils;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -52,9 +54,6 @@ public class JdbcUaaUserDatabase implements UaaUserDatabase {
 
 
     public static final String DEFAULT_USER_BY_ID_QUERY = "select " + USER_FIELDS + "from users where id = ? and active=? and identity_zone_id=?";
-
-
-    private String AUTHORITIES_QUERY = "select g.id,g.displayName from groups g, group_membership m where g.id = m.group_id and m.member_id = ? and g.identity_zone_id=?";
 
     private JdbcTemplate jdbcTemplate;
 
@@ -162,24 +161,41 @@ public class JdbcUaaUserDatabase implements UaaUserDatabase {
 
         private String getAuthorities(final String userId) {
             Set<String> authorities = new HashSet<>();
-            getAuthorities(authorities, userId);
+            getAuthorities(authorities, Arrays.asList(userId));
             authorities.addAll(defaultAuthorities);
             return StringUtils.collectionToCommaDelimitedString(new HashSet<>(authorities));
         }
 
-        protected void getAuthorities(Set<String> authorities, final String memberId) {
+        protected void getAuthorities(Set<String> authorities, final List<String> memberIdList) {
             List<Map<String, Object>> results;
+            if(memberIdList.size() == 0) {
+                return;
+            }
+            StringBuffer dynamicAuthoritiesQuery = new StringBuffer("select g.id,g.displayName from groups g, group_membership m where g.id = m.group_id  and g.identity_zone_id=? and m.member_id in (");
+            for(int i=0;i<memberIdList.size()-1;i++)
+            {
+                dynamicAuthoritiesQuery.append("?,");
+            }
+            dynamicAuthoritiesQuery.append("?);");
+
+            Object[] parameterList = ArrayUtils.addAll(new Object[]{IdentityZoneHolder.get().getId()},memberIdList.toArray());
             try {
-                results = jdbcTemplate.queryForList(AUTHORITIES_QUERY, memberId, IdentityZoneHolder.get().getId());
-                for (Map<String,Object> record : results) {
+                results = jdbcTemplate.queryForList(dynamicAuthoritiesQuery.toString(), parameterList);
+                List<String> newMemberIdList = new ArrayList<>();
+
+                for(int i=0;i<results.size();i++)
+                {
+                    Map<String,Object> record = results.get(i);
                     String displayName = (String)record.get("displayName");
                     String groupId = (String)record.get("id");
                     if (!authorities.contains(displayName)) {
                         authorities.add(displayName);
-                        getAuthorities(authorities, groupId);
+                        newMemberIdList.add(groupId);
                     }
                 }
+                getAuthorities(authorities,newMemberIdList);
             } catch (EmptyResultDataAccessException ex) {
+                return;
             }
         }
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabase.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabase.java
@@ -179,24 +179,21 @@ public class JdbcUaaUserDatabase implements UaaUserDatabase {
             dynamicAuthoritiesQuery.append("?);");
 
             Object[] parameterList = ArrayUtils.addAll(new Object[]{IdentityZoneHolder.get().getId()},memberIdList.toArray());
-            try {
-                results = jdbcTemplate.queryForList(dynamicAuthoritiesQuery.toString(), parameterList);
-                List<String> newMemberIdList = new ArrayList<>();
 
-                for(int i=0;i<results.size();i++)
-                {
-                    Map<String,Object> record = results.get(i);
-                    String displayName = (String)record.get("displayName");
-                    String groupId = (String)record.get("id");
-                    if (!authorities.contains(displayName)) {
-                        authorities.add(displayName);
-                        newMemberIdList.add(groupId);
-                    }
+            results = jdbcTemplate.queryForList(dynamicAuthoritiesQuery.toString(), parameterList);
+            List<String> newMemberIdList = new ArrayList<>();
+
+            for(int i=0;i<results.size();i++)
+            {
+                Map<String,Object> record = results.get(i);
+                String displayName = (String)record.get("displayName");
+                String groupId = (String)record.get("id");
+                if (!authorities.contains(displayName)) {
+                    authorities.add(displayName);
+                    newMemberIdList.add(groupId);
                 }
-                getAuthorities(authorities,newMemberIdList);
-            } catch (EmptyResultDataAccessException ex) {
-                return;
             }
+            getAuthorities(authorities,newMemberIdList);
         }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabaseTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabaseTests.java
@@ -223,6 +223,19 @@ public class JdbcUaaUserDatabaseTests extends JdbcTestBase {
     }
 
     @Test
+    public void getUserWithMultipleExtraAuthorities() {
+        addAuthority("additional", JOE_ID);
+        addAuthority("anotherOne", JOE_ID);
+        UaaUser joe = db.retrieveUserByName("joe", OriginKeys.UAA);
+        assertTrue("authorities does not contain uaa.user",
+                joe.getAuthorities().contains(new SimpleGrantedAuthority("uaa.user")));
+        assertTrue("authorities does not contain additional",
+                joe.getAuthorities().contains(new SimpleGrantedAuthority("additional")));
+        assertTrue("authorities does not contain anotherOne",
+                joe.getAuthorities().contains(new SimpleGrantedAuthority("anotherOne")));
+    }
+
+    @Test
     public void getUserWithNestedAuthoritiesWorks() {
         UaaUser joe = db.retrieveUserByName("joe", OriginKeys.UAA);
         assertThat(joe.getAuthorities(),


### PR DESCRIPTION
Any time a user is retrieved using this class, the getAuthorities method is executed to retrieve all of the user's direct and indirect group memberships recursively. 
As mentioned in #463 by my colleague @mwdb the number of SQL queries used to do this grows with the number of scopes assigned.
As the methods are called very frequently, this highly increases the load on the database. With this PR the number of SQL queries is reduced. According to our performance tests this highly increases the performance of the database. 
