### PR TITLE
oidc: Use standard JWA algorithm names in /token_key(s)

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -2925,7 +2925,7 @@ Response body     *example* ::
 
                     {
                         "kid":"keyIdSymmetric",
-                        "alg":"HMACSHA256",
+                        "alg":"HS256",
                         "value":"FYSDKJHfgdUydsFJSHDFKAJHDSF"
                     }
 
@@ -2933,7 +2933,7 @@ Response body     *example* ::
                     Content-Type: text/plain
                     {
                         "kid":"keyIdRSA",
-                        "alg":"SHA256withRSA",
+                        "alg":"RS256",
                         "value":"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0m59l2u9iDnMbrXHfqkO\nrn2dVQ3vfBJqcDuFUK03d+1PZGbVlNCqnkpIJ8syFppW8ljnWweP7+LiWpRoz0I7\nfYb3d8TjhV86Y997Fl4DBrxgM6KTJOuE/uxnoDhZQ14LgOU2ckXjOzOdTsnGMKQB\nLCl0vpcXBtFLMaSbpv1ozi8h7DJyVZ6EnFQZUWGdgTMhDrmqevfx95U/16c5WBDO\nkqwIn7Glry9n9Suxygbf8g5AzpWcusZgDLIIZ7JTUldBb8qU2a0Dl4mvLZOn4wPo\njfj9Cw2QICsc5+Pwf21fP+hzf+1WSRHbnYv8uanRO0gZ8ekGaghM/2H6gqJbo2nI\nJwIDAQAB\n-----END PUBLIC KEY-----",
                         "kty":"RSA",
                         "use":"sig",
@@ -2947,7 +2947,7 @@ The algorithm ("alg") tells the caller how to use the value (it is the
 result of algorithm method in the `Signer` implementation used in the
 token endpoint).  In this case it is an HMAC (symmetric) key, but you
 might also see an asymmetric RSA public key with algorithm
-"SHA256withRSA").
+"RS256").
 
 Get Token Signing Keys: ``GET /token_keys``
 ---------------------------------------------
@@ -2965,7 +2965,7 @@ Response body     *example* ::
                     [
                         {
                             "kid":"keyId1",
-                            "alg":"SHA256withRSA",
+                            "alg":"RS256",
                             "value":"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0m59l2u9iDnMbrXHfqkO\nrn2dVQ3vfBJqcDuFUK03d+1PZGbVlNCqnkpIJ8syFppW8ljnWweP7+LiWpRoz0I7\nfYb3d8TjhV86Y997Fl4DBrxgM6KTJOuE/uxnoDhZQ14LgOU2ckXjOzOdTsnGMKQB\nLCl0vpcXBtFLMaSbpv1ozi8h7DJyVZ6EnFQZUWGdgTMhDrmqevfx95U/16c5WBDO\nkqwIn7Glry9n9Suxygbf8g5AzpWcusZgDLIIZ7JTUldBb8qU2a0Dl4mvLZOn4wPo\njfj9Cw2QICsc5+Pwf21fP+hzf+1WSRHbnYv8uanRO0gZ8ekGaghM/2H6gqJbo2nI\nJwIDAQAB\n-----END PUBLIC KEY-----",
                             "kty":"RSA",
                             "use":"sig",
@@ -2974,7 +2974,7 @@ Response body     *example* ::
                         },
                         {
                             "kid":"keyId2",
-                            "alg":"SHA256withRSA",
+                            "alg":"RS256",
                             "value":"-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0m59l2u9iDnMbrXHfqkO\nrn2dVQ3vfBJqcDuFUK03d+1PZGbVlNCqnkpIJ8syFppW8ljnWweP7+LiWpRoz0I7\nfYb3d8TjhV86Y997Fl4DBrxgM6KTJOuE/uxnoDhZQ14LgOU2ckXjOzOdTsnGMKQB\nLCl0vpcXBtFLMaSbpv1ozi8h7DJyVZ6EnFQZUWGdgTMhDrmqevfx95U/16c5WBDO\nkqwIn7Glry9n9Suxygbf8g5AzpWcusZgDLIIZ7JTUldBb8qU2a0Dl4mvLZOn4wPo\njfj9Cw2QICsc5+Pwf21fP+hzf+1WSRHbnYv8uanRO0gZ8ekGaghM/2H6gqJbo2nI\nJwIDAQAB\n-----END PUBLIC KEY-----",
                             "kty":"RSA",
                             "use":"sig",

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration.java
@@ -13,7 +13,7 @@ public class OpenIdConfiguration {
     @JsonProperty("token_endpoint_auth_methods_supported")
     private String[] tokenAMR = new String[]{"client_secret_basic"};
     @JsonProperty("token_endpoint_auth_signing_alg_values_supported")
-    private String[] tokenEndpointAuthSigningValues = new String[]{"SHA256withRSA", "HMACSHA256"};
+    private String[] tokenEndpointAuthSigningValues = new String[]{"RS256", "HS256"};
     @JsonProperty("userinfo_endpoint")
     private String userInfoUrl;
     @JsonProperty("scopes_supported")
@@ -21,7 +21,7 @@ public class OpenIdConfiguration {
     @JsonProperty("response_types_supported")
     private String[] responseTypes = new String[]{"code", "code id_token", "id_token", "token id_token"};
     @JsonProperty("id_token_signing_alg_values_supported")
-    private String[] idTokenSigningAlgValues = new String[]{"SHA256withRSA", "HMACSHA256"};
+    private String[] idTokenSigningAlgValues = new String[]{"RS256", "HS256"};
     @JsonProperty("id_token_encryption_alg_values_supported")
     private String[] requestObjectSigningAlgValues = new String[]{"none"};
     @JsonProperty("claim_types_supported")

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenKeyEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenKeyEndpoint.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.oauth;
 
+import static org.cloudfoundry.identity.uaa.oauth.jwt.JwtAlgorithms.sigAlg;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.identity.uaa.oauth.token.VerificationKeyResponse;
@@ -64,7 +66,7 @@ public class TokenKeyEndpoint {
 
     public static VerificationKeyResponse getVerificationKeyResponse(KeyInfo key) {
         VerificationKeyResponse result = new VerificationKeyResponse();
-        result.setAlgorithm(key.getSigner().algorithm());
+        result.setAlgorithm(sigAlg(key.getSigner().algorithm()));
         result.setKey(key.getVerifierKey());
         //new values per OpenID and JWK spec
         result.setType(key.getType());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtAlgorithms.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtAlgorithms.java
@@ -44,7 +44,7 @@ public class JwtAlgorithms {
 
     }
 
-    static String sigAlg(String javaName){
+    public static String sigAlg(String javaName){
         String alg = javaToSigAlgs.get(javaName);
 
         if (alg == null) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/TokenKeyEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/TokenKeyEndpointTests.java
@@ -66,7 +66,7 @@ public class TokenKeyEndpointTests {
     public void sharedSecretIsReturnedFromTokenKeyEndpoint() throws Exception {
         configureKeysForDefaultZone(Collections.singletonMap("someKeyId", "someKey"));
         VerificationKeyResponse response = tokenKeyEndpoint.getKey(validUaaResource);
-        assertEquals("HMACSHA256", response.getAlgorithm());
+        assertEquals("HS256", response.getAlgorithm());
         assertEquals("someKey", response.getKey());
         assertEquals("someKeyId", response.getId());
         assertEquals("MAC", response.getType());
@@ -88,7 +88,7 @@ public class TokenKeyEndpointTests {
     @Test(expected = AccessDeniedException.class)
     public void sharedSecretCannotBeAnonymouslyRetrievedFromTokenKeyEndpoint() throws Exception {
         configureKeysForDefaultZone(Collections.singletonMap("anotherKeyId", "someKey"));
-        assertEquals("{alg=HMACSHA256, value=someKey}",
+        assertEquals("{alg=HS256, value=someKey}",
             tokenKeyEndpoint.getKey(
                 new AnonymousAuthenticationToken("anon", "anonymousUser", AuthorityUtils
                     .createAuthorityList("ROLE_ANONYMOUS"))).toString());
@@ -102,7 +102,7 @@ public class TokenKeyEndpointTests {
         String serialized = JsonUtils.writeValueAsString(response);
 
         Map<String, String> deserializedMap = JsonUtils.readValue(serialized, Map.class);
-        assertEquals("HMACSHA256", deserializedMap.get("alg"));
+        assertEquals("HS256", deserializedMap.get("alg"));
         assertEquals("someKey", deserializedMap.get("value"));
         assertEquals("MAC", deserializedMap.get("kty"));
         assertEquals("sig", deserializedMap.get("use"));
@@ -134,7 +134,7 @@ public class TokenKeyEndpointTests {
         assertEquals(response.getModulus(), Base64Utils.encodeToUrlSafeString(Base64Utils.decodeFromUrlSafeString(response.getModulus())));
         assertEquals(response.getExponent(), Base64Utils.encodeToUrlSafeString(Base64Utils.decodeFromUrlSafeString(response.getExponent())));
 
-        assertEquals("SHA256withRSA", response.getAlgorithm());
+        assertEquals("RS256", response.getAlgorithm());
         assertEquals("key1", response.getId());
         assertEquals("RSA", response.getType());
         assertEquals("sig", response.getUse());
@@ -148,7 +148,7 @@ public class TokenKeyEndpointTests {
 
         VerificationKeyResponse response = tokenKeyEndpoint.getKey(validUaaResource);
 
-        assertEquals("HMACSHA256", response.getAlgorithm());
+        assertEquals("HS256", response.getAlgorithm());
         assertEquals("someKey", response.getKey());
         assertEquals("someKeyId", response.getId());
         assertEquals("MAC", response.getType());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
@@ -232,7 +232,7 @@ public class TokenKeyEndpointMockMvcTests extends InjectedMockContextTest {
         //optional - algorithm of key
         assertNotNull(alg);
         assertTrue(alg instanceof String);
-        assertEquals("SHA256withRSA", alg);
+        assertEquals("RS256", alg);
 
         Object kid = key.get("kid");
         //optional - indicates the id for a certain key

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsMockMvcTests.java
@@ -34,11 +34,11 @@ public class OpenIdConnectEndpointsMockMvcTests extends InjectedMockContextTest 
         assertEquals("http://subdomain.localhost/oauth/authorize",openIdConfiguration.getAuthUrl());
         assertEquals("http://subdomain.localhost/oauth/token",openIdConfiguration.getTokenUrl());
         assertArrayEquals(new String[]{"client_secret_basic"}, openIdConfiguration.getTokenAMR());
-        assertArrayEquals(new String[]{"SHA256withRSA", "HMACSHA256"}, openIdConfiguration.getTokenEndpointAuthSigningValues());
+        assertArrayEquals(new String[]{"RS256", "HS256"}, openIdConfiguration.getTokenEndpointAuthSigningValues());
         assertEquals("http://subdomain.localhost/userInfo", openIdConfiguration.getUserInfoUrl());
         assertArrayEquals(new String[]{"openid", "profile", "email", "phone"}, openIdConfiguration.getScopes());
         assertArrayEquals(new String[]{"code", "code id_token", "id_token", "token id_token"}, openIdConfiguration.getResponseTypes());
-        assertArrayEquals(new String[]{"SHA256withRSA", "HMACSHA256"}, openIdConfiguration.getIdTokenSigningAlgValues());
+        assertArrayEquals(new String[]{"RS256", "HS256"}, openIdConfiguration.getIdTokenSigningAlgValues());
         assertArrayEquals(new String[]{"normal"}, openIdConfiguration.getClaimTypesSupported());
         assertArrayEquals(new String[]{"sub", "user_name", "origin", "iss", "auth_time", "amr", "acr", "client_id",
             "aud", "zid", "grant_type", "user_id", "azp", "scope", "exp", "iat", "jti", "rev_sig", "cid", "given_name", "family_name", "phone_number", "email"}, openIdConfiguration.getClaimsSupported());


### PR DESCRIPTION
The JWA specification has a list of algorithms and the registered "alg"
name to be used in the `/token_key(s)` documents:

* https://tools.ietf.org/html/rfc7518#page-6

Per this document, for HMAC and RSA there are clearly defined "alg"
values to be used.  This commit updates the code used to generate the
`/token_key(s)` documents to use the JWA algorithm names instead of the
algorithm names provided by Spring Security.  The purpose of this was to
make it so that JWK/JWS libraries coding to the specification can "just
work" instead of having to have UAA-specific code to translate the
currently provided Spring Security algorithm names to the standard JWA
algorithm names.

Fixes #282