### PR TITLE
Remove unnecessary use of synchronized

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
@@ -578,19 +578,8 @@ public class ClientAdminEndpoints implements InitializingBean {
 
     private void incrementErrorCounts(Exception e) {
         String series = UaaStringUtils.getErrorName(e);
-        AtomicInteger value = errorCounts.get(series);
-        if (value == null) {
-            synchronized (errorCounts) {
-                value = errorCounts.get(series);
-                if (value == null) {
-                    value = new AtomicInteger();
-                    errorCounts.put(series, value);
-                }
-            }
-        }
-        value.incrementAndGet();
+        errorCounts.computeIfAbsent(series, k -> new AtomicInteger()).incrementAndGet();
     }
-
 
 
     private void checkPasswordChangeIsAllowed(ClientDetails clientDetails, String oldSecret) {


### PR DESCRIPTION
Using the native Java concurrent types AtomicInteger and
ConcurrentHashMap makes it unnecessary to also use the `synchronized`
keyword.

The example in the atomicvars guide shows how AtomicInteger can be used
for a simple counter:

    https://docs.oracle.com/javase/tutorial/essential/concurrency/atomicvars.html