### PR TITLE
Remove null check on UserAuthenticationFailureEvent

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/event/UserAuthenticationFailureEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/event/UserAuthenticationFailureEvent.java
@@ -16,7 +16,6 @@ import org.cloudfoundry.identity.uaa.audit.AuditEvent;
 import org.cloudfoundry.identity.uaa.audit.AuditEventType;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.springframework.security.core.Authentication;
-import org.springframework.util.Assert;
 
 /**
  * Event which indicates that a user authentication failed.
@@ -30,16 +29,11 @@ public class UserAuthenticationFailureEvent extends AbstractUaaAuthenticationEve
 
     public UserAuthenticationFailureEvent(UaaUser user, Authentication authentication) {
         super(authentication);
-        Assert.notNull(user, "UaaUser object cannot be null");
         this.user = user;
     }
 
     @Override
     public AuditEvent getAuditEvent() {
-        if (user == null) {
-            return createAuditRecord("<UNKNOWN>", AuditEventType.UserNotFound, getOrigin(getAuthenticationDetails()),
-                            user.getUsername());
-        }
         return createAuditRecord(user.getId(), AuditEventType.UserAuthenticationFailure,
                         getOrigin(getAuthenticationDetails()), user.getUsername());
     }


### PR DESCRIPTION
If this null check was ever true the `user.getUsername()` call would
raise a NullPointerException.

These events only occur when user passwords don't match, more precisely
the event is only created here:

    org/cloudfoundry/identity/uaa/authentication/manager/AuthzAuthenticationManager.java:107

In this case the user object has already been null checked.