### PR TITLE
Feature/rememberme

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/SamlLoginRememberMeAwareFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/SamlLoginRememberMeAwareFilter.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ *     Cloud Foundry 
+ *     Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *
+ *     This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ *     You may not use this product except in compliance with the License.
+ *
+ *     This product includes a number of subcomponents with
+ *     separate copyright notices and license terms. Your use of these
+ *     subcomponents is subject to the terms and conditions of the
+ *     subcomponent's license, as noted in the LICENSE file.
+ *******************************************************************************/
 package org.cloudfoundry.identity.uaa.authentication.rememberme;
 
 import java.io.IOException;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/SamlLoginRememberMeAwareFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/SamlLoginRememberMeAwareFilter.java
@@ -1,0 +1,73 @@
+package org.cloudfoundry.identity.uaa.authentication.rememberme;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
+
+/**
+ * The RME cookie will be automatically set when the SAML authentication succeed.
+ * 
+ * @author Stephane CIZERON
+ *
+ */
+public class SamlLoginRememberMeAwareFilter implements Filter {
+
+	private Boolean enabledForSaml;
+	
+	public SamlLoginRememberMeAwareFilter() {
+	 this(Boolean.TRUE);
+	}
+	
+	public SamlLoginRememberMeAwareFilter(Boolean enabled) {
+		this.enabledForSaml = (enabled != null) ? enabled : Boolean.TRUE;
+	}
+	
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		chain.doFilter(this.enabledForSaml ? new RememberMeRequestWrapper((HttpServletRequest) request) : request, response);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) throws ServletException {
+		this.enabledForSaml = Boolean.valueOf(filterConfig.getInitParameter("enabledForSaml"));
+	}
+	
+	@Override
+	public void destroy() {
+	}
+	
+	/**
+	 * This request wrapper returns true when the RememberService needs to detect if the RME is desired.
+	 * 
+	 */
+	public class RememberMeRequestWrapper extends HttpServletRequestWrapper {
+
+		private static final String ENABLED = "true";
+
+		/**
+		 * 
+		 * @param request
+		 */
+		public RememberMeRequestWrapper(HttpServletRequest request) {
+			super(request);
+		}
+	
+		@Override
+       public String getParameter(String name) {
+           if (AbstractRememberMeServices.DEFAULT_PARAMETER.equals(name)) {
+               return ENABLED;
+           } 
+           return super.getParameter(name);
+       }
+	}
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/UaaTokenBasedRememberMeServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/UaaTokenBasedRememberMeServices.java
@@ -1,0 +1,203 @@
+package org.cloudfoundry.identity.uaa.authentication.rememberme;
+
+import java.io.UnsupportedEncodingException;
+import java.security.GeneralSecurityException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Date;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.cloudfoundry.identity.uaa.account.UaaUserDetails;
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+import org.cloudfoundry.identity.uaa.user.UaaUser;
+import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
+import org.springframework.security.web.authentication.rememberme.InvalidCookieException;
+import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException;
+
+/**
+ * Custom implementation allowing to set a RME cookie which contains 3 items : the encrypted user id, the expiry time and a hashed token.
+ * The hashed token contains the user iid, the expiry time, the user agent and the key spring-security component.
+ *  
+ * @author Stephane CIZERON
+ */
+public class UaaTokenBasedRememberMeServices extends AbstractRememberMeServices {
+
+	// ~ Static fields/initializers
+	// =====================================================================================
+	private static final String UTF_8_CHARSET = "UTF-8";
+
+	private static final String SECRET_KEY_SPEC_ALGORITHM = "AES";
+	
+	private static final String CIPHER_TRANSFORMATION = "AES/CBC/PKCS5Padding";
+
+	private static final String MESSAGE_DIGEST_ALGORITHM = "SHA-256";
+
+	private static final String USER_AGENT_HEADER_NAME = "User-Agent";
+
+	private static final int COOKIE_TOKENS = 3;
+	
+	// ~ Instance fields
+	// ================================================================================================	
+	private UaaUserDatabase uaaUserDatabase;
+	
+	private SecretKeySpec secret;
+	
+	private IvParameterSpec ivParameterSpec;
+	
+	/**
+	 * 
+	 * @param key
+	 * @param aesKey
+	 * @param uaaUserDatabase
+	 */
+	protected UaaTokenBasedRememberMeServices(String key,  String aesKey, String aesIv, UaaUserDatabase uaaUserDatabase) {
+		// an userDetailsService instance is expected by AbstractRememberMeServices and must be not null but we don't use it
+		super(key, new UserDetailsService() {
+			@Override
+			public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+				return null;
+			}
+		});
+		
+		logger.debug("Init " + getClass().getName() + " with aesKey: " + aesKey + " and aesIv: " + aesIv);
+		
+		this.uaaUserDatabase = uaaUserDatabase;
+		this.secret = new SecretKeySpec(Hex.decode(aesKey), SECRET_KEY_SPEC_ALGORITHM);
+		this.ivParameterSpec = new IvParameterSpec(Hex.decode(aesIv));
+	}
+
+	@Override
+	protected void onLoginSuccess(HttpServletRequest request, HttpServletResponse response,
+			Authentication successfulAuthentication) {
+		UaaPrincipal uaaPrincipal = (UaaPrincipal) successfulAuthentication.getPrincipal();
+		UaaUser uaaUser = this.uaaUserDatabase.retrieveUserById(uaaPrincipal.getId());
+		long expiryTime = System.currentTimeMillis() + 1000L * getTokenValiditySeconds();
+		String signatureValue = makeTokenSignature(uaaUser.getId(), expiryTime, uaaUser.getModified(), request.getHeader(USER_AGENT_HEADER_NAME));
+		try {
+			setCookie(new String[] { encrypt(uaaPrincipal.getId()), Long.toString(expiryTime), signatureValue },
+					getTokenValiditySeconds(), request, response);
+		} catch (UnsupportedEncodingException | GeneralSecurityException e) {
+			logger.error("Error while trying to set the " + getCookieName() + " cookie", e);
+		}
+	}
+
+	@Override
+	protected UserDetails processAutoLoginCookie(String[] cookieTokens, HttpServletRequest request,
+			HttpServletResponse response) throws RememberMeAuthenticationException, UsernameNotFoundException {
+		if (cookieTokens == null || cookieTokens.length != COOKIE_TOKENS) {
+			throw new InvalidCookieException("Cookie token did not contain " + COOKIE_TOKENS
+					+ " tokens, but contained '" + Arrays.asList(cookieTokens) + "'");
+		}
+
+		long tokenExpiryTime;
+
+		try {
+			tokenExpiryTime = new Long(cookieTokens[1]).longValue();
+		} catch (NumberFormatException nfe) {
+			throw new InvalidCookieException(
+					"Cookie token[1] did not contain a valid number (contained '"
+							+ cookieTokens[1] + "')");
+		}
+
+		if (tokenExpiryTime < System.currentTimeMillis()) {
+			throw new InvalidCookieException("Cookie token[1] has expired (expired on '"
+					+ new Date(tokenExpiryTime) + "'; current time is '" + new Date()
+					+ "')");
+		}		
+		
+		String userId = null;
+		UaaUser retrieveUserById = null;
+		
+		try {
+			userId = decrypt(cookieTokens[0]);
+			retrieveUserById = this.uaaUserDatabase.retrieveUserById(userId);
+		} catch (UnsupportedEncodingException | GeneralSecurityException e) {
+			throw new InvalidCookieException(String.format("Cookie token[0] contains an invalid user id '%s'", userId));
+		}
+		
+		if (retrieveUserById == null) {
+			throw new InvalidCookieException(String.format("Cookie token[0] contains an unknown user id '%s'", userId));
+		}
+		
+		String expectedTokenSignature = makeTokenSignature(retrieveUserById.getId(), tokenExpiryTime
+				, retrieveUserById.getModified()
+				, request.getHeader(USER_AGENT_HEADER_NAME));
+		
+		if (!expectedTokenSignature.equals(cookieTokens[2])) {
+			throw new InvalidCookieException("Cookie token[2] contained signature '"
+					+ cookieTokens[2] + "' but expected '" + expectedTokenSignature + "'");
+		}
+		
+		return new UaaUserDetails(retrieveUserById);
+	}
+	
+	@Override
+	protected Authentication createSuccessfulAuthentication(HttpServletRequest request, UserDetails user) {
+		UaaUserDetails uaaUserDetails = (UaaUserDetails) user;
+		UaaPrincipal uaaPrincipal = new UaaPrincipal(uaaUserDetails.getUser());
+		return new RememberMeAuthenticationToken(getKey(), uaaPrincipal, user.getAuthorities());
+	}
+	
+	/**
+	 * Decrypt the incoming string parameter
+	 * 
+	 * @param data
+	 * @return
+	 * @throws UnsupportedEncodingException
+	 * @throws GeneralSecurityException
+	 */
+	private String decrypt(String data) throws UnsupportedEncodingException, GeneralSecurityException {
+		Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+		cipher.init(Cipher.DECRYPT_MODE, this.secret, this.ivParameterSpec);
+		return new String(cipher.doFinal(Base64.getDecoder().decode(data.getBytes(UTF_8_CHARSET))), UTF_8_CHARSET);
+	}
+
+	/**
+	 * Encrypt the incoming string parameter 
+	 *
+	 * @param data
+	 * @return
+	 * @throws UnsupportedEncodingException
+	 * @throws GeneralSecurityException
+	 */
+	private String encrypt(String data) throws UnsupportedEncodingException, GeneralSecurityException {
+		Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+		cipher.init(Cipher.ENCRYPT_MODE, this.secret, this.ivParameterSpec);
+		return new String(Base64.getEncoder().encode(cipher.doFinal(data.getBytes(UTF_8_CHARSET))), UTF_8_CHARSET);
+	}
+	
+    /**
+     * Calculates the digital signature to be put in the cookie :SHA256("userid:tokenExpiryTime:modified:userAgent:key")
+     *  
+	 * @param id
+	 * @param tokenExpiryTime
+	 * @param modified
+	 * @param userAgent
+	 * @return
+	 */
+	private String makeTokenSignature(String id, long tokenExpiryTime, Date modified, String userAgent) {
+		try {
+			String data = String.format("%s:%d:%d:%s:%s", id, tokenExpiryTime, modified.getTime(), userAgent != null ? userAgent : "", getKey());
+			MessageDigest digest = MessageDigest.getInstance(MESSAGE_DIGEST_ALGORITHM);
+			return new String(Hex.encode(digest.digest(data.getBytes(UTF_8_CHARSET))));
+		} catch (NoSuchAlgorithmException e) {
+			throw new IllegalStateException("No " + MESSAGE_DIGEST_ALGORITHM + " algorithm available!");
+		} catch (UnsupportedEncodingException e) {
+			throw new IllegalStateException("An error has occured while making the token signature", e);
+		}
+	}
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/UaaTokenBasedRememberMeServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/rememberme/UaaTokenBasedRememberMeServices.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ *     Cloud Foundry 
+ *     Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *
+ *     This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ *     You may not use this product except in compliance with the License.
+ *
+ *     This product includes a number of subcomponents with
+ *     separate copyright notices and license terms. Your use of these
+ *     subcomponents is subject to the terms and conditions of the
+ *     subcomponent's license, as noted in the LICENSE file.
+ *******************************************************************************/
 package org.cloudfoundry.identity.uaa.authentication.rememberme;
 
 import java.io.UnsupportedEncodingException;
@@ -86,7 +98,7 @@ public class UaaTokenBasedRememberMeServices extends AbstractRememberMeServices 
 		UaaPrincipal uaaPrincipal = (UaaPrincipal) successfulAuthentication.getPrincipal();
 		UaaUser uaaUser = this.uaaUserDatabase.retrieveUserById(uaaPrincipal.getId());
 		long expiryTime = System.currentTimeMillis() + 1000L * getTokenValiditySeconds();
-		String signatureValue = makeTokenSignature(uaaUser.getId(), expiryTime, uaaUser.getModified(), request.getHeader(USER_AGENT_HEADER_NAME));
+		String signatureValue = makeTokenSignature(uaaPrincipal.getId(), expiryTime, uaaUser.getModified(), request.getHeader(USER_AGENT_HEADER_NAME));
 		try {
 			setCookie(new String[] { encrypt(uaaPrincipal.getId()), Long.toString(expiryTime), signatureValue },
 					getTokenValiditySeconds(), request, response);

--- a/server/src/main/resources/login-ui.xml
+++ b/server/src/main/resources/login-ui.xml
@@ -241,6 +241,11 @@
             <util:list>
                 <ref bean="currentUserCookieDestructor"/>
                 <ref bean="samlLogoutHandler"/>
+                <bean class="org.springframework.security.web.authentication.logout.CookieClearingLogoutHandler">
+               		<constructor-arg index="0">
+                		<util:list><value>remember-me</value></util:list>
+                	</constructor-arg>
+               	</bean>
             </util:list>
         </constructor-arg>
     </bean>
@@ -268,6 +273,7 @@
                     <constructor-arg index="0">
                         <util:list>
                             <value>JSESSIONID</value>
+                            <value>remember-me</value>
                         </util:list>
                     </constructor-arg>
                 </bean>
@@ -287,6 +293,7 @@
           xmlns="http://www.springframework.org/schema/security">
         <intercept-url pattern="/login**" access="IS_AUTHENTICATED_ANONYMOUSLY"/>
         <intercept-url pattern="/login/idp_discovery" access="IS_AUTHENTICATED_ANONYMOUSLY"/>
+        <intercept-url pattern="/oauth/authorize" access="IS_AUTHENTICATED_REMEMBERED,IS_AUTHENTICATED_FULLY" />
         <intercept-url pattern="/**" access="IS_AUTHENTICATED_FULLY"/>
         <form-login login-page="/login"
                     username-parameter="username"
@@ -305,8 +312,19 @@
               request-matcher-ref="uiCookeCsrfRequestMatcher"/>
         <access-denied-handler error-page="/login?error=invalid_login_request"/>
         <request-cache ref="clientRedirectStateCache"/>
+        <remember-me services-ref="uaaTokenBasedRememberMeServices" key="#{@rememberMeKey}"/>
     </http>
-
+    
+    <bean id="rememberMeKey" class="java.lang.String"><constructor-arg index="0" value="4DDC2E4BAB5CE81C8CB0471F7184BA741AFECCB6AC45F024105A0606212F58E2"/></bean>
+    
+    <bean id="uaaTokenBasedRememberMeServices" class="org.cloudfoundry.identity.uaa.authentication.rememberme.UaaTokenBasedRememberMeServices">
+	 <constructor-arg index="0" ref="rememberMeKey"/>
+	 <constructor-arg index="1" value="${rememberMe.aes128cbcKey:79491918F8C3EAA525424C296D90B3C8}"/>
+	 <constructor-arg index="2" value="${rememberMe.aes128cbcIv:C75984A550C4CD81ACD44AF92BB91CAB}"/>
+	 <constructor-arg index="3" ref="userDatabase"/>
+	 <property name="tokenValiditySeconds" value="${rememberMe.validitySeconds:1209600}"/>
+    </bean>
+   
     <http name="deleteSavedAccountSecurity" pattern="/delete_saved_account**" create-session="stateless"
           entry-point-ref="basicAuthenticationEntryPoint"
           authentication-manager-ref="clientAuthenticationManager" use-expressions="false"

--- a/server/src/main/resources/templates/web/login.html
+++ b/server/src/main/resources/templates/web/login.html
@@ -15,6 +15,9 @@
                    th:attr="autocomplete=${(prompt.value[0] == 'password') ? 'off' : null}"
                    th:autofocus="${iter.index} == 0"
                    class="form-control"/>
+            <div style="float: left;">
+             <input type="checkbox" style="display:inline-block" name="remember-me" value="true" checked="checked"/><label for="remember-me" style="margin-left: 5px"  th:text="#{'prompt.rememberme'}">Se souvenir de moi</label>
+            </div>
             <input type="submit" value="Sign in" class="island-button"/>
             <input th:if="${session.SPRING_SECURITY_SAVED_REQUEST}"
                    th:unless="${form_redirect_uri}"

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/rememberme/SamlLoginRememberMeAwareFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/rememberme/SamlLoginRememberMeAwareFilterTests.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *     Cloud Foundry 
+ *     Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *
+ *     This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ *     You may not use this product except in compliance with the License.
+ *
+ *     This product includes a number of subcomponents with
+ *     separate copyright notices and license terms. Your use of these
+ *     subcomponents is subject to the terms and conditions of the
+ *     subcomponent's license, as noted in the LICENSE file.
+ *******************************************************************************/
+package org.cloudfoundry.identity.uaa.authentication.rememberme;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockFilterConfig;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * 
+ * @author Stephane CIZERON
+ *
+ */
+public class SamlLoginRememberMeAwareFilterTests {
+
+	private SamlLoginRememberMeAwareFilter filter;
+
+	@Test
+	public void enabledFromConstructor() throws IOException, ServletException {
+		this.filter = new SamlLoginRememberMeAwareFilter(Boolean.TRUE);
+		MockFilterChain chain = doFilter();
+		assertEnabled(chain);
+	}
+
+	@Test
+	public void disabledFromConstructor() throws IOException, ServletException {
+		this.filter = new SamlLoginRememberMeAwareFilter(Boolean.FALSE);
+		MockFilterChain chain = doFilter();
+		assertDisabled(chain);
+	}
+	
+	@Test
+	public void enabledFromFilterConfig() throws ServletException, IOException {
+		this.filter = new SamlLoginRememberMeAwareFilter();
+		MockFilterConfig filterConfig = new MockFilterConfig();
+		filterConfig.addInitParameter("enabledForSaml", "true");
+		this.filter.init(filterConfig);
+		MockFilterChain chain = doFilter();
+		assertEnabled(chain);
+	}
+	
+	@Test
+	public void disabledFromFilterConfig() throws ServletException, IOException {
+		this.filter = new SamlLoginRememberMeAwareFilter();
+		MockFilterConfig filterConfig = new MockFilterConfig();
+		this.filter.init(filterConfig);
+		MockFilterChain chain = doFilter();
+		assertDisabled(chain);
+	}
+	
+	/**
+	 * 
+	 * @param chain
+	 */
+	private void assertEnabled(MockFilterChain chain) {
+		Assert.assertThat("the original request is wrapped",
+				chain.getRequest() instanceof SamlLoginRememberMeAwareFilter.RememberMeRequestWrapper,
+				CoreMatchers.is(true));
+		Assert.assertThat("the original request is wrapped and returns \"true\" when getting \"remember-me\" parameter",
+				chain.getRequest().getParameter("remember-me"), CoreMatchers.is("true"));
+	}
+
+	/**
+	 * 
+	 * @param chain
+	 */
+	private void assertDisabled(MockFilterChain chain) {
+		Assert.assertThat("the original request is not wrapped",
+				chain.getRequest() instanceof SamlLoginRememberMeAwareFilter.RememberMeRequestWrapper,
+				CoreMatchers.is(false));
+		Assert.assertThat("the original request has no \"remember-me\" parameter",
+				chain.getRequest().getParameter("remember-me"), CoreMatchers.nullValue());
+	}
+
+	/**
+	 * 
+	 * @return
+	 * @throws IOException
+	 * @throws ServletException
+	 */
+	private MockFilterChain doFilter() throws IOException, ServletException {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain chain = new MockFilterChain();
+		this.filter.doFilter(request, response, chain);
+		return chain;
+	}
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/rememberme/UaaTokenBasedRememberMeServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/rememberme/UaaTokenBasedRememberMeServicesTests.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ *     Cloud Foundry 
+ *     Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *
+ *     This product is licensed to you under the Apache License, Version 2.0 (the "License").
+ *     You may not use this product except in compliance with the License.
+ *
+ *     This product includes a number of subcomponents with
+ *     separate copyright notices and license terms. Your use of these
+ *     subcomponents is subject to the terms and conditions of the
+ *     subcomponent's license, as noted in the LICENSE file.
+ *******************************************************************************/
+package org.cloudfoundry.identity.uaa.authentication.rememberme;
+
+import java.util.Date;
+
+import javax.servlet.http.Cookie;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+import org.cloudfoundry.identity.uaa.user.UaaUser;
+import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.core.Authentication;
+
+/**
+ * 
+ * @author Stephane CIZERON
+ *
+ */
+public class UaaTokenBasedRememberMeServicesTests {
+
+	private UaaTokenBasedRememberMeServices rememberMeServices;
+	
+	private UaaUserDatabase uaaUserDatabase;
+	
+	@org.junit.Before
+	public void newContext() {
+		this.uaaUserDatabase = Mockito.mock(UaaUserDatabase.class);
+		this.rememberMeServices = new UaaTokenBasedRememberMeServices("123", "79491918F8C3EAA525424C296D90B3C8", "C75984A550C4CD81ACD44AF92BB91CAB", this.uaaUserDatabase);
+		this.rememberMeServices.setTokenValiditySeconds(50*365*24*60*60); // it will expire in 50 years, so we have time ...
+
+	}
+	
+	/**
+	 * we assert that the remember me is part of the response
+	 */
+	@Test 
+	public void onLoginSuccess() {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		request.setParameter("remember-me", "true");
+		request.setParameter("User-Agent","my-user-agent");
+		
+		Authentication successfulAuthentication = Mockito.mock(Authentication.class);
+		UaaPrincipal uaaPrincipal = Mockito.mock(UaaPrincipal.class);
+		UaaUser uaaUser = Mockito.mock(UaaUser.class);
+		Mockito.when(uaaUser.getModified()).thenReturn(new Date(1322018752992l));
+		Mockito.when(successfulAuthentication.getPrincipal()).thenReturn(uaaPrincipal);
+		Mockito.when(uaaPrincipal.getId()).thenReturn("d0f52125-1c30-42c4-93d4-5ab6cff9be68");
+		Mockito.when(this.uaaUserDatabase.retrieveUserById(Mockito.eq("d0f52125-1c30-42c4-93d4-5ab6cff9be68"))).thenReturn(uaaUser);
+		
+		// when
+		this.rememberMeServices.loginSuccess(request, response, successfulAuthentication);
+		
+		// then
+		Assert.assertThat(response.getCookie("remember-me"), CoreMatchers.notNullValue());
+		Assert.assertThat(response.getCookie("remember-me").getValue(), CoreMatchers.notNullValue());
+	}
+	
+	@Test
+	public void autoLogin() {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		Cookie cookie = new Cookie("remember-me", "T1pkNzJscnU3ZytzQno0LzVqTkFXcTEvTVhSbERGMDRSdWxKU3JMQ1N2TkJVUVE1WDEzem5QL3g5YVdEZExLVjozMDU2ODcyNDQ0MDA2OmVjOTI5MTUwMzRlMzEwOTI0NGVjNjZkYWQ2OGE2ZDhmZTM5ZjFmNWM1MmU1YzYxZDU4MzRiNzNjMjBlMjAzYjg");
+		request.setCookies(cookie);
+		
+		UaaUser uaaUser = Mockito.mock(UaaUser.class);
+		Mockito.when(uaaUser.getId()).thenReturn("d0f52125-1c30-42c4-93d4-5ab6cff9be68");
+		Mockito.when(uaaUser.getModified()).thenReturn(new Date(1322018752992l));
+		Mockito.when(uaaUser.getUsername()).thenReturn("marissa");
+		Mockito.when(uaaUser.getPassword()).thenReturn("koala");
+		Mockito.when(this.uaaUserDatabase.retrieveUserById(Mockito.eq("d0f52125-1c30-42c4-93d4-5ab6cff9be68"))).thenReturn(uaaUser);
+	
+		// when		
+		Authentication authentication = this.rememberMeServices.autoLogin(request, response);
+		
+		// then 
+		Assert.assertThat(authentication, CoreMatchers.notNullValue());
+		Assert.assertThat(authentication instanceof RememberMeAuthenticationToken, CoreMatchers.is(true));
+		Assert.assertThat(authentication.getPrincipal() instanceof UaaPrincipal, CoreMatchers.is(true));
+		Assert.assertThat(((UaaPrincipal)authentication.getPrincipal()).getId(), CoreMatchers.is("d0f52125-1c30-42c4-93d4-5ab6cff9be68"));
+	}
+
+	@Test
+	public void noRememberMeCookie()  {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		// when		
+		Authentication authentication = this.rememberMeServices.autoLogin(request, response);
+		// then
+		Assert.assertThat(authentication, CoreMatchers.nullValue());
+	}
+
+	
+	@Test
+	public void invalidCookie()  {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();	
+		Cookie cookie = new Cookie("remember-me", "invalid");
+		request.setCookies(cookie);
+
+		// when		
+		Authentication authentication = this.rememberMeServices.autoLogin(request, response);
+
+		// then
+		Assert.assertThat(authentication, CoreMatchers.nullValue());
+		Assert.assertThat(response.getCookie("remember-me"), CoreMatchers.notNullValue());
+		Assert.assertThat(response.getCookie("remember-me").getMaxAge(), CoreMatchers.is(0));
+	}
+	
+	@Test
+	public void unknowUser()  {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		Cookie cookie = new Cookie("remember-me", "T1pkNzJscnU3ZytzQno0LzVqTkFXcTEvTVhSbERGMDRSdWxKU3JMQ1N2TkJVUVE1WDEzem5QL3g5YVdEZExLVjozMDU2ODcyNDQ0MDA2OmVjOTI5MTUwMzRlMzEwOTI0NGVjNjZkYWQ2OGE2ZDhmZTM5ZjFmNWM1MmU1YzYxZDU4MzRiNzNjMjBlMjAzYjg");
+		request.setCookies(cookie);
+
+		// when		
+		Authentication authentication = this.rememberMeServices.autoLogin(request, response);
+
+		// then
+		Assert.assertThat(authentication, CoreMatchers.nullValue());
+		Assert.assertThat(response.getCookie("remember-me"), CoreMatchers.notNullValue());
+		Assert.assertThat(response.getCookie("remember-me").getMaxAge(), CoreMatchers.is(0));
+	}
+}

--- a/uaa/src/main/resources/messages.properties
+++ b/uaa/src/main/resources/messages.properties
@@ -19,6 +19,7 @@ scope.cloud_controller_service_permissions.read=Verify user permission to manage
 
 prompt.username=Email / Username
 prompt.password=Password
+prompt.rememberme=Remember Me
 
 email_change.success=Email address successfully verified.
 email_change.non-uaa-origin=Sorry, your email cannot be changed from here.

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -440,9 +440,9 @@
         <property name="logoutDisableRedirectParameter" value="${logout.redirect.parameter.disable:true}"/>
         <property name="prompts" ref="prompts"/>
         <property name="branding" value="#{@config['login']['branding']}" />
-        <property name="samlSpPrivateKey" value="${login.serviceProviderKey}" />
-        <property name="samlSpPrivateKeyPassphrase" value="${login.serviceProviderKeyPassword}" />
-        <property name="samlSpCertificate" value="${login.serviceProviderCertificate}" />
+        <property name="samlSpPrivateKey" value="#{'${login.serviceProviderKey:' + @defaultSamlKey + '}'}" />
+        <property name="samlSpPrivateKeyPassphrase" value="${login.serviceProviderKeyPassword:password}" />
+        <property name="samlSpCertificate" value="#{'${login.serviceProviderCertificate:' + @defaultSamlCert + '}'}" />
     </bean>
 
     <bean id="ldapLoginAuthenticationMgr" class="org.cloudfoundry.identity.uaa.authentication.manager.LdapLoginAuthenticationManager">

--- a/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
@@ -15,8 +15,10 @@
 
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:security="http://www.springframework.org/schema/security"
+       xmlns:util="http://www.springframework.org/schema/util"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.0.xsd
+              http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-4.0.xsd
               http://www.springframework.org/schema/security http://www.springframework.org/schema/security/spring-security-4.1.xsd">
 
 
@@ -28,13 +30,17 @@
 
         <bean id="samlSecurityContextPersistenceFilter" class="org.springframework.security.web.context.SecurityContextPersistenceFilter"/>
 
+		<bean id="samlLoginRememberMeAwareFilter" class="org.cloudfoundry.identity.uaa.authentication.rememberme.SamlLoginRememberMeAwareFilter">
+			<constructor-arg index="0" value="${rememberMe.enabledForSaml:true}"/>
+		</bean>
+
         <bean id="samlFilter" class="org.springframework.security.web.FilterChainProxy">
             <security:filter-chain-map request-matcher="ant">
                 <security:filter-chain pattern="/saml/login/**" filters="samlEntryPoint" />
                 <security:filter-chain pattern="/saml/logout/**" filters="samlLogoutFilter" />
                 <security:filter-chain pattern="/saml/metadata/**" filters="metadataDisplayFilter" />
                 <security:filter-chain pattern="/saml/idp/metadata/**" filters="idpMetadataDisplayFilter" />
-                <security:filter-chain pattern="/saml/SSO/**" filters="samlSecurityContextPersistenceFilter,samlWebSSOProcessingFilter" />
+                <security:filter-chain pattern="/saml/SSO/**" filters="samlLoginRememberMeAwareFilter,samlSecurityContextPersistenceFilter,samlWebSSOProcessingFilter" />
                 <security:filter-chain pattern="/saml/SingleLogout/**" filters="samlLogoutProcessingFilter" />
                 <security:filter-chain pattern="/saml/discovery/**" filters="samlIDPDiscovery" />
                 <!--<security:filter-chain pattern="/oauth/authorize/**" filters="exceptionTranslationFilter" />-->
@@ -43,6 +49,61 @@
 
         <!-- Logger for SAML messages and events -->
         <bean id="samlLogger" class="org.springframework.security.saml.log.SAMLDefaultLogger" />
+
+        <!--<bean id="samlLoginServerKeyManagerFactory" class="org.cloudfoundry.identity.uaa.provider.saml.SamlKeyManagerFactory -->
+        <!--<constructor-arg type="java.lang.String" value="#{'${login.serviceProviderKey:' + @defaultSamlKey + '}'}" />-->
+            <!--<constructor-arg type="java.lang.String" value="${login.serviceProviderKeyPassword:password}" />-->
+            <!--<constructor-arg type="java.lang.String" value="#{'${login.serviceProviderCertificate:' + @defaultSamlCert + '}'}" />-->
+        <!--</bean>-->
+
+        <bean id="defaultSamlCert" class="java.lang.String">
+            <constructor-arg>
+                <value>
+<![CDATA[-----BEGIN CERTIFICATE-----
+MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO
+MAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEO
+MAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5h
+cnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwx
+CzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAM
+BgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAb
+BgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GN
+ADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39W
+qS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOw
+znoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4Ha
+MIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGc
+gBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYD
+VQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYD
+VQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJh
+QGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ
+0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxC
+KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK
+RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=
+-----END CERTIFICATE-----]]>
+                </value>
+            </constructor-arg>
+        </bean>
+
+        <bean id="defaultSamlKey" class="java.lang.String">
+            <constructor-arg>
+                <value>
+<![CDATA[-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5
+L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vA
+fpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQAB
+AoGAVOj2Yvuigi6wJD99AO2fgF64sYCm/BKkX3dFEw0vxTPIh58kiRP554Xt5ges
+7ZCqL9QpqrChUikO4kJ+nB8Uq2AvaZHbpCEUmbip06IlgdA440o0r0CPo1mgNxGu
+lhiWRN43Lruzfh9qKPhleg2dvyFGQxy5Gk6KW/t8IS4x4r0CQQD/dceBA+Ndj3Xp
+ubHfxqNz4GTOxndc/AXAowPGpge2zpgIc7f50t8OHhG6XhsfJ0wyQEEvodDhZPYX
+kKBnXNHzAkEAyCA76vAwuxqAd3MObhiebniAU3SnPf2u4fdL1EOm92dyFs1JxyyL
+gu/DsjPjx6tRtn4YAalxCzmAMXFSb1qHfwJBAM3qx3z0gGKbUEWtPHcP7BNsrnWK
+vw6By7VC8bk/ffpaP2yYspS66Le9fzbFwoDzMVVUO/dELVZyBnhqSRHoXQcCQQCe
+A2WL8S5o7Vn19rC0GVgu3ZJlUrwiZEVLQdlrticFPXaFrn3Md82ICww3jmURaKHS
+N+l4lnMda79eSp3OMmq9AkA0p79BvYsLshUJJnvbk76pCjR28PK4dV1gSDUEqQMB
+qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/
+-----END RSA PRIVATE KEY-----]]>
+                </value>
+            </constructor-arg>
+        </bean>
 
         <!-- Entry point to initialize authentication, default values taken from
             properties file -->
@@ -152,6 +213,7 @@
             <property name="authenticationFailureHandler" ref="samlLoginFailureHandler" />
             <property name="contextProvider" ref="basicContextProvider" />
             <property name="SAMLProcessor" ref="processor" />
+            <property name="rememberMeServices" ref="uaaTokenBasedRememberMeServices"/>
         </bean>
 
         <!-- Logout handler terminating local session -->
@@ -170,6 +232,7 @@
             <constructor-arg ref="samlLogoutHandlers" />
             <property name="contextProvider" ref="redirectSavingSamlContextProvider" />
         </bean>
+
 
         <!-- Filter processing incoming logout messages -->
         <!-- First argument determines URL user will be redirected to after successful


### PR DESCRIPTION
Here is a remember me implementation, based on a hashed token.
The remember feature is enabled for the login form and can be enabled for the saml providers.
When the feature is enabled for SAML, when the SAML authentication response is succeed, the cookie will  be set automatically.