### PR TITLE
Add table of contents to MD files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,31 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [CloudFoundry User Account and Authentication (UAA) Server](#cloudfoundry-user-account-and-authentication-uaa-server)
+  - [Co-ordinates](#co-ordinates)
+  - [Quick Start](#quick-start)
+    - [Deploy to Cloud Foundry](#deploy-to-cloud-foundry)
+    - [Demo of command line usage on local server](#demo-of-command-line-usage-on-local-server)
+    - [Running local system against default MySQL and PostgreSQL settings (and Flyway migration script information)](#running-local-system-against-default-mysql-and-postgresql-settings-and-flyway-migration-script-information)
+    - [Demo of command line usage on run.pivotal.io](#demo-of-command-line-usage-on-runpivotalio)
+  - [Integration tests](#integration-tests)
+    - [Custom YAML Configuration](#custom-yaml-configuration)
+    - [Using Gradle to test with postgresql or mysql](#using-gradle-to-test-with-postgresql-or-mysql)
+  - [Inventory](#inventory)
+    - [Organization of Code](#organization-of-code)
+  - [UAA Server](#uaa-server)
+    - [Use Cases](#use-cases)
+    - [Configuration](#configuration)
+    - [User Account Data](#user-account-data)
+  - [The API Sample Application](#the-api-sample-application)
+  - [The App Sample Application](#the-app-sample-application)
+    - [Use Cases](#use-cases-1)
+- [Contributing to the UAA](#contributing-to-the-uaa)
+  - [Acknowledgements](#acknowledgements)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
 # CloudFoundry User Account and Authentication (UAA) Server
 

--- a/docs/UAA-LDAP.md
+++ b/docs/UAA-LDAP.md
@@ -1,3 +1,41 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [User Account and Authentication LDAP Integration](#user-account-and-authentication-ldap-integration)
+- [Overview](#overview)
+- [Authentication](#authentication)
+  - [Chained Authentication](#chained-authentication)
+  - [UAA Authentication](#uaa-authentication)
+  - [LDAP Authentication](#ldap-authentication)
+    - [Ldap Search and Bind](#ldap-search-and-bind)
+    - [Ldap Bind](#ldap-bind)
+    - [Ldap Search and Compare](#ldap-search-and-compare)
+  - [Ldap Authentication Configuration](#ldap-authentication-configuration)
+    - [Overview](#overview-1)
+      - [Selecting an authentication method](#selecting-an-authentication-method)
+        - [Configuring Simple Bind](#configuring-simple-bind)
+        - [Configuring Search and Bind](#configuring-search-and-bind)
+        - [Configuring Search and Compare](#configuring-search-and-compare)
+- [LDAP Group Mapping](#ldap-group-mapping)
+  - [Scopes](#scopes)
+  - [Selecting a Group Mapping](#selecting-a-group-mapping)
+    - [No Group Integration](#no-group-integration)
+    - [LDAP Groups as Scopes](#ldap-groups-as-scopes)
+    - [LDAP Groups to Scopes](#ldap-groups-to-scopes)
+  - [Group Mapping Configuration](#group-mapping-configuration)
+    - [No Group Integration Configuration](#no-group-integration-configuration)
+    - [Ldap Groups as Scopes Configuration](#ldap-groups-as-scopes-configuration)
+    - [Ldap Groups to Scopes Configuration](#ldap-groups-to-scopes-configuration)
+    - [Populating External Group Mappings](#populating-external-group-mappings)
+- [LDAP Email integration](#ldap-email-integration)
+  - [Generating an email address if LDAP mail attribute is empty](#generating-an-email-address-if-ldap-mail-attribute-is-empty)
+  - [Overriding the LDAP email address](#overriding-the-ldap-email-address)
+- [Samples](#samples)
+- [Configuration References](#configuration-references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ==================================================
 User Account and Authentication LDAP Integration
 ==================================================

--- a/docs/UAA-Security.md
+++ b/docs/UAA-Security.md
@@ -1,3 +1,35 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [UAA Security Features and Configuration](#uaa-security-features-and-configuration)
+  - [User Accounts](#user-accounts)
+    - [Security Metadata](#security-metadata)
+    - [Bootstrap](#bootstrap)
+    - [Account lockout policy](#account-lockout-policy)
+  - [OAuth Client Applications](#oauth-client-applications)
+    - [Security Metadata](#security-metadata-1)
+    - [Bootstrap](#bootstrap-1)
+    - [Demo Environment](#demo-environment)
+    - [VCAP Dev Setup](#vcap-dev-setup)
+  - [Token Scope Rules](#token-scope-rules)
+    - [User Tokens](#user-tokens)
+    - [Client Tokens](#client-tokens)
+  - [UAA Resources](#uaa-resources)
+    - [Token Management](#token-management)
+    - [Client Registration](#client-registration)
+    - [Client Secret Mangagement](#client-secret-mangagement)
+    - [Password Change](#password-change)
+    - [User Account Management](#user-account-management)
+    - [Username from ID Queries](#username-from-id-queries)
+    - [User Profiles](#user-profiles)
+    - [Groups & Membership Management](#groups-&-membership-management)
+    - [Token Resources for Providers](#token-resources-for-providers)
+    - [Management Information](#management-information)
+    - [Login Prompts](#login-prompts)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # UAA Security Features and Configuration
 
 It is the responsibility of a Resource Server to extract information

--- a/docs/UAA-Tokens.md
+++ b/docs/UAA-Tokens.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [User Account and Authentication - A note on Tokens](#user-account-and-authentication---a-note-on-tokens)
+- [Overview](#overview)
+- [Getting Started](#getting-started)
+  - [Users and Clients and other actors](#users-and-clients-and-other-actors)
+  - [Grant types](#grant-types)
+  - [Scopes](#scopes)
+    - [Client authorities, UAA groups and scopes](#client-authorities-uaa-groups-and-scopes)
+    - [Wildcard scopes](#wildcard-scopes)
+  - [Token enhancers](#token-enhancers)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ==================================================
 User Account and Authentication - A note on Tokens
 ==================================================

--- a/docs/google-oidc-provider.md
+++ b/docs/google-oidc-provider.md
@@ -1,3 +1,11 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Registering google as external OAuth provider in UAA](#registering-google-as-external-oauth-provider-in-uaa)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Registering google as external OAuth provider in UAA
  
 Google can be setup as an OIDC provider for UAA. 

--- a/docs/keystone.md
+++ b/docs/keystone.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installing Keystone](#installing-keystone)
+- [Creating a test user (no tenant/domain)](#creating-a-test-user-no-tenantdomain)
+- [Getting an user token, version 2,  (simple authentication)](#getting-an-user-token-version-2--simple-authentication)
+- [Getting an user token, version 3,  (simple authentication)](#getting-an-user-token-version-3--simple-authentication)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 
 Installing Keystone
 ==================================

--- a/docs/login/Login-APIs.md
+++ b/docs/login/Login-APIs.md
@@ -1,3 +1,24 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Login Server APIs](#login-server-apis)
+  - [Overview](#overview)
+  - [Login Form: ``GET /login``](#login-form-get-login)
+  - [Form Login: `POST /login.do`](#form-login-post-logindo)
+  - [Logout: `GET /logout.do`](#logout-get-logoutdo)
+  - [OAuth2 Endpoints](#oauth2-endpoints)
+    - [Start Authorization: `GET /oauth/authorize`](#start-authorization-get-oauthauthorize)
+    - [Obtain Authorization Code: `POST /oauth/authorize`](#obtain-authorization-code-post-oauthauthorize)
+    - [Token Endpoint: `POST /oauth/token`](#token-endpoint-post-oauthtoken)
+  - [Login Info: `GET /login`](#login-info-get-login)
+  - [Healthz: `GET /healthz`](#healthz-get-healthz)
+  - [Varz: `GET /varz`](#varz-get-varz)
+  - [Autologin](#autologin)
+    - [Obtain Autologin Code: `POST /autologin`](#obtain-autologin-code-post-autologin)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 - [Login Server APIs](#login-server-apis)
 	- [Overview](#overview)
 	- [Login Form: ``GET /login``](#login-form-get-login)

--- a/docs/login/Okta-README.md
+++ b/docs/login/Okta-README.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Introduction](#introduction)
+- [Pivotal Preview and Standalone Login Server](#pivotal-preview-and-standalone-login-server)
+  - [Step 1](#step-1)
+  - [Step 2](#step-2)
+- [Pivotal Preview - Configure Custom Application](#pivotal-preview---configure-custom-application)
+  - [Step 1](#step-1-1)
+  - [Step 2](#step-2-1)
+  - [Step 3](#step-3)
+  - [Step 4](#step-4)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ##Introduction
 This document outlines a very simple SAML integration between Okta and the
 Cloud Foundry UAA.

--- a/docs/login/OpenAM-README.md
+++ b/docs/login/OpenAM-README.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Introduction](#introduction)
+  - [Step 1](#step-1)
+  - [Step 2](#step-2)
+  - [Step 3](#step-3)
+  - [Step 4](#step-4)
+  - [Step 5](#step-5)
+  - [Step 6](#step-6)
+  - [Step 7](#step-7)
+  - [Step 8](#step-8)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ##Introduction
 This document outlines a very simple SAML integration between the OpenAM server and the 
 Cloud Foundry UAA.

--- a/docs/login/Setup-Local-Notifications-service.md
+++ b/docs/login/Setup-Local-Notifications-service.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+  - [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Step 1](#step-1)
+- [Step 2](#step-2)
+- [Step 3](#step-3)
+- [Step 4](#step-4)
+- [Step 5](#step-5)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ##Introduction
 This document outlines how to setup a local notifications service.
 

--- a/samples/login/README.md
+++ b/samples/login/README.md
@@ -1,3 +1,17 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Login Sample Application](#login-sample-application)
+  - [Quick start](#quick-start)
+  - [Customizing the application](#customizing-the-application)
+    - [Using a different token server](#using-a-different-token-server)
+    - [Customizing the user interface](#customizing-the-user-interface)
+    - [Logging](#logging)
+  - [Playing with the entire flow](#playing-with-the-entire-flow)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Login Sample Application
 
 This login application is a sample for how you can set up your own custom login user interface using the UAA as a backend Identity Provider. The application also supports different openid identity providers. The application is written in ruby and uses the sinatra framework. You may choose to embed it along with your code to provide a customized look and feel for the login interface using the UAA as an identity provider and a token server to issue Oauth access tokens.

--- a/uaa/slate/CHANGELOG.md
+++ b/uaa/slate/CHANGELOG.md
@@ -1,3 +1,14 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Changelog](#changelog)
+  - [Version 1.2](#version-12)
+  - [Version 1.1](#version-11)
+  - [Version 1.0](#version-10)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Changelog
 
 ## Version 1.2

--- a/uaa/slate/README.md
+++ b/uaa/slate/README.md
@@ -1,3 +1,19 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Slate](#slate)
+  - [Features](#features)
+  - [Getting Started with Slate](#getting-started-with-slate)
+    - [Prerequisites](#prerequisites)
+    - [Getting Set Up](#getting-set-up)
+  - [Examples of Slate in the Wild](#examples-of-slate-in-the-wild)
+  - [Need Help? Found a bug?](#need-help-found-a-bug)
+  - [Contributors](#contributors)
+  - [Special Thanks](#special-thanks)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 Slate
 ========
 


### PR DESCRIPTION
A lot of the markdown files are quite lengthy. It is nice to have a ToC to get an overview of what is in it. I used `doctoc` to generate them.
Not sure if this the way the project wants to go, but it would be nice to have auto-generated ToCs.