### PR TITLE
Fix/zone aware client lockout

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/JdbcAuditService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/JdbcAuditService.java
@@ -43,6 +43,11 @@ public class JdbcAuditService implements UaaAuditService {
                         "principal_id=? and created > ? order by created desc", new AuditEventRowMapper(), principal,
                         new Timestamp(after));
     }
+    
+
+    public List<AuditEvent> find(String principal, long after, String IdentityzoneId) {
+        return find(principal, after);
+    }
 
     @Override
     public void log(AuditEvent auditEvent) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/JdbcAuditService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/JdbcAuditService.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.audit;
 
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 
@@ -39,14 +40,13 @@ public class JdbcAuditService implements UaaAuditService {
 
     @Override
     public List<AuditEvent> find(String principal, long after) {
-        return template.query("select event_type, principal_id, origin, event_data, created, identity_zone_id from sec_audit where " +
-                        "principal_id=? and created > ? order by created desc", new AuditEventRowMapper(), principal,
-                        new Timestamp(after));
+        return find(principal, after, IdentityZoneHolder.get().getId());
     }
-    
 
-    public List<AuditEvent> find(String principal, long after, String IdentityzoneId) {
-        return find(principal, after);
+    public List<AuditEvent> find(String principalId, long after, String identityZoneId) {
+        return template.query("select event_type, principal_id, origin, event_data, created, identity_zone_id from sec_audit where " +
+            "principal_id=? and identity_zone_id=? and created > ? order by created desc", new AuditEventRowMapper(), principalId
+            , identityZoneId, new Timestamp(after));
     }
 
     @Override

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/audit/JdbcFailedLoginCountingAuditServiceTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/audit/JdbcFailedLoginCountingAuditServiceTests.java
@@ -112,6 +112,23 @@ public class JdbcFailedLoginCountingAuditServiceTests extends JdbcTestBase {
         assertEquals("testman", events.get(0).getData());
         assertEquals("1.1.1.1", events.get(0).getOrigin());
     }
+    
+
+    @Test
+    public void clientAuthenticationFailureAuditIsZoneAware() throws Exception {
+        auditService.log(getAuditEvent(ClientAuthenticationFailure, "client", "testman"));
+        Thread.sleep(100);
+        auditService.log(getAuditEvent(ClientAuthenticationFailure, "client", "testman"));
+        Thread.sleep(100);
+        auditService.log(getAuditEventForAltZone(ClientAuthenticationFailure, "client", "testman"));
+        Thread.sleep(100);
+        auditService.log(getAuditEventForAltZone(ClientAuthenticationFailure, "client", "testman"));
+        List<AuditEvent> events = auditService.find("client", 0, "test-zone");
+        assertEquals(2, events.size());
+        assertEquals("client", events.get(0).getPrincipalId());
+        assertEquals("testman", events.get(0).getData());
+        assertEquals("1.1.1.1", events.get(0).getOrigin());
+    }
 
     @Test
     public void clientAuthenticationFailureDeletesOldData() throws Exception {
@@ -142,6 +159,10 @@ public class JdbcFailedLoginCountingAuditServiceTests extends JdbcTestBase {
 
     private AuditEvent getAuditEvent(AuditEventType type, String principal, String data) {
         return new AuditEvent(type, principal, authDetails, data, System.currentTimeMillis(), IdentityZone.getUaa().getId());
+    }
+    
+    private AuditEvent getAuditEventForAltZone(AuditEventType type, String principal, String data) {
+        return new AuditEvent(type, principal, authDetails, data, System.currentTimeMillis(), "test-zone");
     }
 
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -155,6 +155,7 @@ public class LoginMockMvcTests extends InjectedMockContextTest {
     private XmlWebApplicationContext webApplicationContext;
     private IdentityZoneConfiguration originalConfiguration;
     private IdentityZoneConfiguration identityZoneConfiguration;
+    
 
     @Before
     public void setUpContext() throws Exception {


### PR DESCRIPTION
client lockout policy was not zone aware, so clients with the same client id across zones would share lockout counters and times. This pull request fixes it.
To replicate: checkout master, start uaa, add 2 identity zones. Attempt to get admin token 5 times in zone 1 with wrong credentials, get locked out of admin client. target zone 2, attempt to get admin token with correct credentials, admin will still be locked out.