### PR TITLE
Fix circular view path errors on login

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -41,6 +41,8 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -59,6 +61,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -228,7 +231,16 @@ public class LoginInfoEndpoint {
     }
 
     @RequestMapping(value = {"/login"}, headers = "Accept=text/html, */*")
-    public String loginForHtml(Model model, Principal principal, HttpServletRequest request) {
+    public String loginForHtml(
+        Model model, Principal principal, HttpServletRequest request,
+        @RequestHeader(value = "Accept", required = false) List<MediaType> headers)
+        throws HttpMediaTypeNotAcceptableException
+    {
+        boolean match = headers == null ? true : headers.stream().anyMatch(
+        mediaType -> mediaType.isCompatibleWith(MediaType.TEXT_HTML));
+        if (!match) {
+            throw new HttpMediaTypeNotAcceptableException(request.getHeader(HttpHeaders.ACCEPT));
+        }
 
         Cookie[] cookies = request.getCookies();
         List<SavedAccountOptionModel> savedAccounts = getSavedAccounts(cookies, SavedAccountOptionModel.class);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -183,7 +183,7 @@ public class LoginInfoEndpointTests {
         Cookie cookie2 = new Cookie("Saved-Account-zzzz", JsonUtils.writeValueAsString(savedAccount));
 
         request.setCookies(cookie1, cookie2);
-        endpoint.loginForHtml(model, null, request, Arrays.asList(MediaType.TEXT_XML));
+        endpoint.loginForHtml(model, null, request, Arrays.asList(MediaType.TEXT_HTML));
 
         assertThat(model, hasKey("savedAccounts"));
         assertThat(model.get("savedAccounts"), instanceOf(List.class));
@@ -214,7 +214,7 @@ public class LoginInfoEndpointTests {
         IdentityZoneHolder.set(zone);
         LoginInfoEndpoint endpoint = getEndpoint();
         assertFalse(model.containsAttribute("zone_name"));
-        endpoint.loginForHtml(model, null, new MockHttpServletRequest(), Arrays.asList(MediaType.TEXT_XML));
+        endpoint.loginForHtml(model, null, new MockHttpServletRequest(), Arrays.asList(MediaType.TEXT_HTML));
         assertEquals("some_other_zone", model.asMap().get("zone_name"));
     }
 
@@ -636,7 +636,7 @@ public class LoginInfoEndpointTests {
 
         when(identityProviderProvisioning.retrieveAll(anyBoolean(), anyString())).thenReturn(Collections.singletonList(identityProvider));
         LoginInfoEndpoint endpoint = getEndpoint();
-        endpoint.loginForHtml(model, null, new MockHttpServletRequest(), Arrays.asList(MediaType.TEXT_XML));
+        endpoint.loginForHtml(model, null, new MockHttpServletRequest(), Arrays.asList(MediaType.TEXT_HTML));
 
         assertThat(model.get(SHOW_LOGIN_LINKS), equalTo(true));
     }


### PR DESCRIPTION
The login endpoint should return text/html by default if no Accept header is specified, or if the client specifies */*. However, requests to UAA with an unexpected media type in the Accept header can get redirected to the login page and will result in a 500 status code and the following error:

Circular view path [login]: would dispatch back to the current handler URL [/uaa/login] again. Check your ViewResolver setup! (Hint: This may be the result of an unspecified view, due to default view name generation.)

This is because the loginForHtml endpoint accepts */* but when spring goes to render the page it can't find an appropriate view. The fix to this is to take an additional parameter with the Accept media types
and check to see if it is compatible.