### PR TITLE
Fix MemberNotFoundException after external authorizations

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimGroupMembershipManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimGroupMembershipManager.java
@@ -68,6 +68,18 @@ public interface ScimGroupMembershipManager extends Queryable<ScimGroupMember> {
     Set<ScimGroup> getGroupsWithMember(String memberId, boolean transitive) throws ScimResourceNotFoundException;
 
     /**
+     * Retrieve all groups that the given member belongs to
+     *
+     * @param memberId
+     * @param filter
+     * @param transitive true means indirect/transitive membership is also
+     *            processed (nested groups)
+     * @return
+     * @throws ScimResourceNotFoundException
+     */
+    Set<ScimGroup> getGroupsWithMember(String memberId, String filter, boolean transitive) throws ScimResourceNotFoundException;
+
+    /**
      * Retrieve a particular member's membership details
      *
      * @param groupId


### PR DESCRIPTION
The delete of existing group memberships when receiving an ExternalGroupAuthorizationEvent can cause a MemberNotFoundException when multiple threads are authenticating the same user. This can
happen because one thread has already done the delete and is adding the external group memberships while another thread is deleting them. The first thread does a get on each group membership it adds and that get will fail with an exception if the row doesn't exist.

This isn't too difficult to happen under load because this code path is invoked not just for web logins but also when obtaining a token using a password grant.

This change fixes the problem by only deleting and adding any changes to the group memberships. Thus after the first login, there will rarely be deletes and inserts, which is more efficient also.