### PR TITLE
Encode cookies to be compliant with Tomcat 8.5x

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/AccountSavingAuthenticationSuccessHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/AccountSavingAuthenticationSuccessHandler.java
@@ -9,7 +9,8 @@
  *     separate copyright notices and license terms. Your use of these
  *     subcomponents is subject to the terms and conditions of the
  *     subcomponent's license, as noted in the LICENSE file.
- *******************************************************************************/package org.cloudfoundry.identity.uaa.login;
+ *******************************************************************************/
+package org.cloudfoundry.identity.uaa.login;
 
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
@@ -60,8 +61,7 @@ public class AccountSavingAuthenticationSuccessHandler implements Authentication
         savedAccountOption.setOrigin(uaaPrincipal.getOrigin());
         savedAccountOption.setUserId(uaaPrincipal.getId());
         savedAccountOption.setUsername(uaaPrincipal.getName());
-        Cookie savedAccountCookie = new Cookie("Saved-Account-" + uaaPrincipal.getId(), JsonUtils.writeValueAsString(savedAccountOption));
-
+        Cookie savedAccountCookie = new Cookie("Saved-Account-" + uaaPrincipal.getId(), encodeCookieValue(JsonUtils.writeValueAsString(savedAccountOption)));
         savedAccountCookie.setPath(request.getContextPath() + "/login");
         savedAccountCookie.setHttpOnly(true);
         savedAccountCookie.setSecure(request.isSecure());
@@ -72,16 +72,21 @@ public class AccountSavingAuthenticationSuccessHandler implements Authentication
 
         CurrentUserInformation currentUserInformation = new CurrentUserInformation();
         currentUserInformation.setUserId(uaaPrincipal.getId());
-        Cookie currentUserCookie;
-        try {
-            currentUserCookie = new Cookie("Current-User", URLEncoder.encode(JsonUtils.writeValueAsString(currentUserInformation), UTF_8.name()));
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException(e);
-        }
+        Cookie currentUserCookie = new Cookie("Current-User", encodeCookieValue(JsonUtils.writeValueAsString(currentUserInformation)));
         currentUserCookie.setMaxAge(365*24*60*60);
         currentUserCookie.setHttpOnly(false);
         currentUserCookie.setPath(request.getContextPath());
 
         response.addCookie(currentUserCookie);
+    }
+
+    private static String encodeCookieValue(String inValue) throws IllegalArgumentException {
+        String out = null;
+        try {
+            out = URLEncoder.encode(inValue, UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return out;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.login;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.identity.uaa.authentication.AuthzAuthenticationRequest;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
@@ -107,6 +109,8 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
  */
 @Controller
 public class LoginInfoEndpoint {
+
+    private static Log logger = LogFactory.getLog(LoginInfoEndpoint.class);
 
     public static final String NotANumber = OriginKeys.NotANumber;
     public static final String CREATE_ACCOUNT_LINK = "createAccountLink";
@@ -256,6 +260,7 @@ public class LoginInfoEndpoint {
         try {
             out = URLDecoder.decode(inValue, UTF_8.name());
         } catch (Exception e) {
+            logger.debug("URLDecoder.decode failed for " + inValue, e);
             return "";
         }
         return out;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/AccountSavingAuthenticationSuccessHandlerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/AccountSavingAuthenticationSuccessHandlerTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.web.authentication.SavedRequestAwareAuthenti
 import javax.servlet.ServletException;
 import javax.servlet.http.Cookie;
 import java.io.IOException;
+import java.net.URLEncoder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -60,6 +61,7 @@ public class AccountSavingAuthenticationSuccessHandlerTest {
 
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void whenSuccessfullyAuthenticated_accountGetsSavedViaCookie() throws IOException, ServletException {
         Date yesterday = new Date(System.currentTimeMillis()-(1000*60*60*24));
@@ -104,7 +106,7 @@ public class AccountSavingAuthenticationSuccessHandlerTest {
         expectedCookieValue.setEmail(user.getEmail());
         expectedCookieValue.setOrigin(user.getOrigin());
 
-        assertEquals(JsonUtils.writeValueAsString(expectedCookieValue), cookieValue);
+        assertEquals(URLEncoder.encode(JsonUtils.writeValueAsString(expectedCookieValue)), cookieValue);
         assertEquals(true, accountOptionCookie.isHttpOnly());
         assertEquals(365*24*60*60, accountOptionCookie.getMaxAge());
         assertEquals("/login", accountOptionCookie.getPath());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -56,6 +56,7 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -66,6 +67,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.cloudfoundry.identity.uaa.login.LoginInfoEndpoint.OAUTH_LINKS;
 import static org.cloudfoundry.identity.uaa.login.LoginInfoEndpoint.SHOW_LOGIN_LINKS;
 import static org.cloudfoundry.identity.uaa.util.UaaUrlUtils.addSubdomainToUrl;
@@ -172,13 +174,14 @@ public class LoginInfoEndpointTests {
         savedAccount.setEmail("bob@example.com");
         savedAccount.setUserId("xxxx");
         savedAccount.setOrigin("uaa");
-        Cookie cookie1 = new Cookie("Saved-Account-xxxx", JsonUtils.writeValueAsString(savedAccount));
+
+        Cookie cookie1 = new Cookie("Saved-Account-xxxx", URLEncoder.encode(JsonUtils.writeValueAsString(savedAccount), UTF_8.name()));
 
         savedAccount.setUsername("tim");
         savedAccount.setEmail("tim@example.org");
         savedAccount.setUserId("zzzz");
         savedAccount.setOrigin("ldap");
-        Cookie cookie2 = new Cookie("Saved-Account-zzzz", JsonUtils.writeValueAsString(savedAccount));
+        Cookie cookie2 = new Cookie("Saved-Account-zzzz", URLEncoder.encode(JsonUtils.writeValueAsString(savedAccount), UTF_8.name()));
 
         request.setCookies(cookie1, cookie2);
         endpoint.loginForHtml(model, null, request);
@@ -201,6 +204,24 @@ public class LoginInfoEndpointTests {
         assertEquals("tim@example.org", savedAccount1.getEmail());
         assertEquals("ldap", savedAccount1.getOrigin());
         assertEquals("zzzz", savedAccount1.getUserId());
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testSavedAccountsInvalidCookie() throws Exception {
+        LoginInfoEndpoint endpoint = getEndpoint();
+        assertThat(model, not(hasKey("savedAccounts")));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SavedAccountOption savedAccount = new SavedAccountOption();
+
+        savedAccount.setUsername("bob");
+        savedAccount.setEmail("bob@example.com");
+        savedAccount.setUserId("xxxx");
+        savedAccount.setOrigin("uaa");
+
+        Cookie cookie1 = new Cookie("Saved-Account-xxxx", "%2");
+
+        request.setCookies(cookie1);
+        endpoint.loginForHtml(model, null, request);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -206,6 +206,50 @@ public class LoginInfoEndpointTests {
         assertEquals("zzzz", savedAccount1.getUserId());
     }
 
+    @Test
+    public void testSavedAccountsEncodedAndUnEncoded() throws Exception {
+        LoginInfoEndpoint endpoint = getEndpoint();
+        assertThat(model, not(hasKey("savedAccounts")));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        SavedAccountOption savedAccount = new SavedAccountOption();
+
+        savedAccount.setUsername("bill");
+        savedAccount.setEmail("bill@example.com");
+        savedAccount.setUserId("xxxx");
+        savedAccount.setOrigin("uaa");
+        // write Cookie1 without URLencode into value, situation before this correction
+        Cookie cookie1 = new Cookie("Saved-Account-xxxx", JsonUtils.writeValueAsString(savedAccount));
+
+        savedAccount.setUsername("bill");
+        savedAccount.setEmail("bill@example.com");
+        savedAccount.setUserId("xxxx");
+        savedAccount.setOrigin("uaa");
+        // write Cookie2 with URLencode into value, situation after this correction
+        Cookie cookie2 = new Cookie("Saved-Account-zzzz", URLEncoder.encode(JsonUtils.writeValueAsString(savedAccount), UTF_8.name()));
+
+        request.setCookies(cookie1, cookie2);
+        endpoint.loginForHtml(model, null, request);
+
+        assertThat(model, hasKey("savedAccounts"));
+        assertThat(model.get("savedAccounts"), instanceOf(List.class));
+        List<SavedAccountOption> savedAccounts = (List<SavedAccountOption>) model.get("savedAccounts");
+        assertThat(savedAccounts, hasSize(2));
+        // evaluate that both cookies can be parsed out has have same values
+        SavedAccountOption savedAccount0 = savedAccounts.get(0);
+        assertThat(savedAccount0, notNullValue());
+        assertEquals("bill", savedAccount0.getUsername());
+        assertEquals("bill@example.com", savedAccount0.getEmail());
+        assertEquals("uaa", savedAccount0.getOrigin());
+        assertEquals("xxxx", savedAccount0.getUserId());
+
+        SavedAccountOption savedAccount1 = savedAccounts.get(1);
+        assertThat(savedAccount1, notNullValue());
+        assertEquals("bill", savedAccount1.getUsername());
+        assertEquals("bill@example.com", savedAccount1.getEmail());
+        assertEquals("uaa", savedAccount1.getOrigin());
+        assertEquals("xxxx", savedAccount1.getUserId());
+    }
+
     @Test(expected=NullPointerException.class)
     public void testSavedAccountsInvalidCookie() throws Exception {
         LoginInfoEndpoint endpoint = getEndpoint();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -2001,7 +2001,7 @@ public class LoginMockMvcTests extends InjectedMockContextTest {
         savedAccount.setUsername("test@example.org");
         getMockMvc().perform(get("/login")
             .session(session)
-            .cookie(new Cookie("Saved-Account-12345678", JsonUtils.writeValueAsString(savedAccount)))
+            .cookie(new Cookie("Saved-Account-12345678", URLEncoder.encode(JsonUtils.writeValueAsString(savedAccount))))
             .header("Accept", TEXT_HTML)
             .with(new SetServerNameRequestPostProcessor(zone.getSubdomain() + ".localhost")))
             .andExpect(status().isOk())

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/PasswordResetEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/PasswordResetEndpointMockMvcTests.java
@@ -34,6 +34,7 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -189,6 +190,7 @@ public class PasswordResetEndpointMockMvcTests extends InjectedMockContextTest {
             .andExpect(savedAccountCookie(user));
     }
 
+    @SuppressWarnings("deprecation")
     private ResultMatcher savedAccountCookie(ScimUser user) {
         return result -> {
             SavedAccountOption savedAccountOption = new SavedAccountOption();
@@ -197,7 +199,7 @@ public class PasswordResetEndpointMockMvcTests extends InjectedMockContextTest {
             savedAccountOption.setOrigin(user.getOrigin());
             savedAccountOption.setUserId(user.getId());
             String cookieName = "Saved-Account-" + user.getId();
-            cookie().value(cookieName, JsonUtils.writeValueAsString(savedAccountOption)).match(result);
+            cookie().value(cookieName, URLEncoder.encode(JsonUtils.writeValueAsString(savedAccountOption))).match(result);
             cookie().maxAge(cookieName, 365*24*60*60);
         };
     }


### PR DESCRIPTION
 * fix #563
 * Encode Cookie Saved-Account-xx in AccountSaving
 * Decode Cookie Saved-Account-xx in LoginInfoEndpoint
 * Add test for invalid cookie