### PR TITLE
Fix BaseURL generation when hostname matches URL

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -115,7 +115,7 @@ public abstract class UaaUrlUtils {
         //for example http://localhost:8080/uaa or http://login.identity.cf-app.com
         String requestURL = request.getRequestURL().toString();
         return hasText(request.getServletPath()) ?
-            requestURL.substring(0, requestURL.indexOf(request.getServletPath())) :
+            requestURL.substring(0, requestURL.lastIndexOf(request.getServletPath())) :
             requestURL;
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
@@ -69,6 +69,46 @@ public class UaaUrlUtilsTest {
     }
 
     @Test
+    public void testGetBaseURL() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("login.domain");
+        request.setRequestURI("/something");
+        request.setServletPath("/something");
+        ServletRequestAttributes attrs = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attrs);
+
+        assertEquals("http://login.domain", UaaUrlUtils.getBaseURL(request));
+    }
+
+    @Test
+    public void testGetBaseURLWhenPathMatchesHostname() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("login.domain");
+        request.setRequestURI("/login");
+        request.setServletPath("/login");
+        ServletRequestAttributes attrs = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attrs);
+
+        assertEquals("http://login.domain", UaaUrlUtils.getBaseURL(request));
+    }
+
+    @Test
+    public void testGetBaseURLOnLocalhost() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setRequestURI("/uaa/something");
+        request.setServletPath("/something");
+        ServletRequestAttributes attrs = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(attrs);
+
+        assertEquals("http://localhost:8080/uaa", UaaUrlUtils.getBaseURL(request));
+    }
+
+    @Test
     public void test_ZoneAware_UaaUrl() throws Exception {
         IdentityZone zone = MultitenancyFixture.identityZone("id","subdomain");
         IdentityZoneHolder.set(zone);


### PR DESCRIPTION
As reported in cloudfoundry/uaa#562, when the login hostname begins with login,
then generation of the redirect_uri sent to OIDC providers should look like
this before urlencoding:

https://login.domain/login/callback/ALIAS

instead it looks like this:

https://login/callback/ALIAS

Which causes the Google OIDC provider to reject the request due to a non-whitelisted redirect_uri.

This fixes that bug and also adds tests.