### PR TITLE
Add tokenKeyUrl to sample Google OIDC config

### DIFF
--- a/docs/google-oidc-provider.md
+++ b/docs/google-oidc-provider.md
@@ -16,6 +16,7 @@ Please refer to 'https://accounts.google.com/.well-known/openid-configuration' f
           type: oidc1.0
           authUrl: https://accounts.google.com/o/oauth2/v2/auth
           tokenUrl: https://www.googleapis.com/oauth2/v4/token
+          tokenKeyUrl: https://www.googleapis.com/oauth2/v3/certs
           issuer: https://accounts.google.com
           redirectUrl: http://localhost:8080/uaa
           scopes:


### PR DESCRIPTION
This might fix #565

Prior to our v251 to v253 CF upgrade, logging in with google OpenID Connect seemed to be working, however once we'd upgraded to v253 we encountered the error: "There was an error when authenticating against the external identity provider: Could not verify token signature."

As suggested in #565 , a tokenKeyURL has been added, and this appears to make the problem go away. 

I'm unclear if it is intentional that `tokenKeyUrl` is now required. There didn't appear to be anything in the release notes describing the config changes that needed to be made.
