### PR TITLE
Fixed query string (first param should be appended using ? instead of &) - fix #600

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpoint.java
@@ -347,7 +347,7 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint {
             }
             return new ModelAndView(
                 new RedirectView(
-                    appendAccessToken(authorizationRequest, accessToken, authentication, true),
+                    appendAccessToken(authorizationRequest, accessToken, authentication),
                     false,
                     true,
                     false
@@ -391,8 +391,7 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint {
 
     private String appendAccessToken(AuthorizationRequest authorizationRequest,
                                      OAuth2AccessToken accessToken,
-                                     Authentication authUser,
-                                     boolean fragment) {
+                                     Authentication authUser) {
 
         String requestedRedirect = authorizationRequest.getRedirectUri();
         if (accessToken == null) {
@@ -441,17 +440,15 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint {
         }
 
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(requestedRedirect);
-        if (fragment) {
-            String existingFragment = builder.build(true).getFragment();
-            if (StringUtils.hasText(existingFragment)) {
-                existingFragment = existingFragment + "&" + url.toString();
-            } else {
-                existingFragment = url.toString();
-            }
-            builder.fragment(existingFragment);
+
+        String existingFragment = builder.build(true).getFragment();
+        if (StringUtils.hasText(existingFragment)) {
+            existingFragment = existingFragment + "?" + url.toString();
         } else {
-            builder.query(url.toString());
+            existingFragment = url.toString();
         }
+        builder.fragment(existingFragment);
+
         // Do not include the refresh token (even if there is one)
         return builder.build(true).toUriString();
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -2106,7 +2106,9 @@ public class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         String locationToken = locationParts[1];
 
         assertEquals(redirectUri.split("#")[0], locationUri);
-        String[] locationParams = locationToken.split("&");
+        String[] locationPath = locationToken.split("\\?");
+        int paramIndex = locationPath.length == 2 ? 1 : 0;
+        String[] locationParams = locationPath[paramIndex].split("&");
         assertThat(Arrays.asList(locationParams), hasItem(is("token_type=bearer")));
         assertThat(Arrays.asList(locationParams), hasItem(startsWith("access_token=")));
     }


### PR DESCRIPTION
This will fix #600 

Would be interesting to know why nobody yet had this issue, as it seems that it is in there since 2015

Furthermore I removed boolean fragment as it is always true. If this is not wanted let me know and I revert it.