### PR TITLE
Fix documentation of additional authorization attributes

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -200,7 +200,7 @@ Support for additional authorization attributes
 
 Additional user defined claims can be added to the token by sending them in the token request. The format of the request is as follows::
 
-        authorities={"additionalAuthorizationAttributes":{"external_group":"domain\\group1","external_id":"abcd1234"}}
+        authorities={"az_attr":{"external_group":"domain\\group1","external_id":"abcd1234"}}
 
 A sample password grant request is as follows::
 
@@ -208,7 +208,7 @@ A sample password grant request is as follows::
         Host: localhost:8080
         Accept: application/json
         Authorization: Basic YXBwOmFwcGNsaWVudHNlY3JldA==
-        "grant_type=password&username=marissa&password=koala&authorities=%7B%22additionalAuthorizationAttributes%22%3A%7B%22external_group%22%3A%22domain%5C%5Cgroup1%22%2C%20%22external_id%22%3A%22abcd1234%22%7D%7D%0A"
+        "grant_type=password&username=marissa&password=koala&authorities=%7B%22az_attr%22%3A%7B%22external_group%22%3A%22domain%5C%5Cgroup1%22%2C%20%22external_id%22%3A%22abcd1234%22%7D%7D%0A"
 
 The access token will contain an az_attr claim like::
 


### PR DESCRIPTION
The JSON object should be named "az_attr" instead of "additionalAuthorizationAttributes". See the following code:

https://github.com/cloudfoundry/uaa/blob/fe946fdc871027fcea9278e97c09cbf270831cf4/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java#L840