### PR TITLE
Initial support for Facebook external IdP using signed_request

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationFilter.java
@@ -68,7 +68,8 @@ public class XOAuthAuthenticationFilter implements Filter {
         String code = request.getParameter("code");
         String idToken = request.getParameter("id_token");
         String accessToken = request.getParameter("access_token");
-        return hasText(code) || hasText(idToken) || hasText(accessToken);
+        String signedRequest = request.getParameter("signed_request");
+        return hasText(code) || hasText(idToken) || hasText(accessToken) || hasText(signedRequest);
     }
 
     public boolean authenticationWasSuccessful(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -76,8 +77,10 @@ public class XOAuthAuthenticationFilter implements Filter {
         String code = request.getParameter("code");
         String idToken = request.getParameter("id_token");
         String accessToken = request.getParameter("access_token");
+        String signedRequest = request.getParameter("signed_request");
+
         String redirectUrl = request.getRequestURL().toString();
-        XOAuthCodeToken codeToken = new XOAuthCodeToken(code, origin, redirectUrl, idToken, accessToken);
+        XOAuthCodeToken codeToken = new XOAuthCodeToken(code, origin, redirectUrl, idToken, accessToken, signedRequest);
         codeToken.setDetails(new UaaAuthenticationDetails(request));
         try {
             Authentication authentication = xOAuthAuthenticationManager.authenticate(codeToken);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
@@ -61,6 +61,9 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -322,7 +325,10 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
 
     private String getResponseType(AbstractXOAuthIdentityProviderDefinition config) {
         if (RawXOAuthIdentityProviderDefinition.class.isAssignableFrom(config.getClass())) {
-            return "token";
+            if ("signed_request".equals(config.getResponseType()))
+                return "signed_request";
+            else
+                return "token";
         } else if (OIDCIdentityProviderDefinition.class.isAssignableFrom(config.getClass())) {
             return "id_token";
         } else {
@@ -342,19 +348,62 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
             return null;
         }
 
-        JsonWebKeySet tokenKey = getTokenKeyFromOAuth(config);
+        if ("signed_request".equals(config.getResponseType())) {
+            String signedRequest = idToken;
+            String secret = config.getRelyingPartySecret();
+            logger.debug("Validating signed_request: " + signedRequest);
+            //split request into signature and data
+            String[] signedRequests = signedRequest.split("\\.", 2);
+            //parse signature
+            String signature = signedRequests[0];
+            //parse data and convert to json object
+            String data = signedRequests[1];
+            Map<String, Object> jsonData = null;
+            try {
+                jsonData = JsonUtils.readValue(new String(Base64.decodeBase64(data), "UTF-8"), new TypeReference<Map<String,Object>>() {});
+                //check signature algorithm
+                if(!jsonData.get("algorithm").equals("HMAC-SHA256")) {
+                    logger.debug("Unknown algorithm was used to sign request! No claims returned.");
+                    return null;
+                }
+                //check if data is signed correctly
+                if(!hmacSHA256(signedRequests[1], secret).equals(signature)) {
+                    logger.debug("Signature is not correct, possibly the data was tampered with! No claims returned.");
+                    return null;
+                }
+                //logger.debug("Deserializing id_token claims: " + decodeIdToken.getClaims());
+                return jsonData;
+            } catch (UnsupportedEncodingException e) {
+                logger.error(e);
+                return null;
+            } catch (Exception e) {
+                logger.error(e);
+                return null;
+            }
+        } else {
+            JsonWebKeySet tokenKey = getTokenKeyFromOAuth(config);
 
-        logger.debug("Validating id_token");
-        TokenValidation validation = validate(idToken)
-            .checkSignature(new ChainedSignatureVerifier(tokenKey))
-            .checkIssuer((StringUtils.isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()))
-            .checkAudience(config.getRelyingPartyId())
-            .checkExpiry()
-            .throwIfInvalid();
-        logger.debug("Decoding id_token");
-        Jwt decodeIdToken = validation.getJwt();
-        logger.debug("Deserializing id_token claims");
-        return JsonUtils.readValue(decodeIdToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+            logger.debug("Validating id_token");
+            TokenValidation validation = validate(idToken)
+                    .checkSignature(new ChainedSignatureVerifier(tokenKey))
+                    .checkIssuer((StringUtils.isEmpty(config.getIssuer()) ? config.getTokenUrl().toString() : config.getIssuer()))
+                    .checkAudience(config.getRelyingPartyId())
+                    .checkExpiry()
+                    .throwIfInvalid();
+            logger.debug("Decoding id_token");
+            Jwt decodeIdToken = validation.getJwt();
+            logger.debug("Deserializing id_token claims: " + decodeIdToken.getClaims());
+            return JsonUtils.readValue(decodeIdToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+        }
+    }
+
+    //HmacSHA256 implementation
+    private String hmacSHA256(String data, String key) throws Exception {
+        SecretKeySpec secretKey = new SecretKeySpec(key.getBytes("UTF-8"), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(secretKey);
+        byte[] hmacData = mac.doFinal(data.getBytes("UTF-8"));
+        return new String(Base64.encodeBase64URLSafe(hmacData), "UTF-8");
     }
 
     private JsonWebKeySet<JsonWebKey> getTokenKeyFromOAuth(AbstractXOAuthIdentityProviderDefinition config) {
@@ -390,11 +439,20 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
             logger.debug("XOauthCodeToken contains id_token, not exchanging code.");
             return codeToken.getIdToken();
         }
+        if (StringUtils.hasText(codeToken.getSignedRequest()) && "signed_request".equals(getResponseType(config))) {
+            logger.debug("XOauthCodeToken contains signed_request, not exchanging code.");
+            return codeToken.getSignedRequest();
+        }
         MultiValueMap<String, String> body = new LinkedMaskingMultiValueMap<>("code");
         body.add("grant_type", "authorization_code");
         body.add("response_type", getResponseType(config));
         body.add("code", codeToken.getCode());
         body.add("redirect_uri", codeToken.getRedirectUrl());
+
+        //DRE: Add client_id and secret for Salesforce
+        logger.debug("Adding new client_id and client_secret for token exchange");
+        body.add("client_id", config.getRelyingPartyId());
+        body.add("client_secret", config.getRelyingPartySecret());
 
         HttpHeaders headers = new HttpHeaders();
         String clientAuthHeader = getClientAuthHeader(config);
@@ -423,7 +481,8 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
                               }
                     );
             logger.debug(String.format("Request completed with status:%s", responseEntity.getStatusCode()));
-            return responseEntity.getBody().get(ID_TOKEN);
+            //DRE: Read proper field from response depending on configuration (id_token, signed_request etc)
+            return responseEntity.getBody().get(getResponseType(config));
         } catch (HttpServerErrorException | HttpClientErrorException ex) {
             throw ex;
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthCodeToken.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthCodeToken.java
@@ -25,6 +25,8 @@ public class XOAuthCodeToken implements Authentication {
     private String redirectUrl;
     private String idToken;
     private String accessToken;
+    //DRE: Support for Facebook implementation of OAuth using signed_request
+    private String signedRequest;
     private UaaAuthenticationDetails details;
 
     public XOAuthCodeToken(String code, String origin, String redirectUrl) {
@@ -33,14 +35,15 @@ public class XOAuthCodeToken implements Authentication {
         this.redirectUrl = redirectUrl;
     }
 
-    public XOAuthCodeToken(String code, String origin, String redirectUrl, String idToken, String accessToken) {
+    public XOAuthCodeToken(String code, String origin, String redirectUrl, String idToken, String accessToken, String signedRequest) {
         this(code, origin, redirectUrl);
         this.idToken = idToken;
         this.accessToken = accessToken;
+        this.signedRequest = signedRequest;
     }
 
-    public XOAuthCodeToken(String code, String origin, String redirectUrl, String idToken, String accessToken, UaaAuthenticationDetails details) {
-        this(code, origin, redirectUrl, idToken, accessToken);
+    public XOAuthCodeToken(String code, String origin, String redirectUrl, String idToken, String accessToken, String signedRequest, UaaAuthenticationDetails details) {
+        this(code, origin, redirectUrl, idToken, accessToken, signedRequest);
         this.details = details;
     }
 
@@ -121,4 +124,14 @@ public class XOAuthCodeToken implements Authentication {
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
     }
+
+    public String getSignedRequest() {
+        return signedRequest;
+    }
+
+    public void setSignedRequest(String signedRequest) {
+        this.signedRequest = signedRequest;
+    }
+
+
 }


### PR DESCRIPTION
Here is basic support for Facebook as external IdP using their implementation of signed_request (based on OAuth). 
Corresponding login configuration:
facebook:
        type: oauth2.0
        authUrl: https://www.facebook.com/dialog/oauth
        tokenUrl: https://graph.facebook.com/oauth/access_token
        responseType: signed_request
        issuer: https://www.facebook.com
        scopes:
          - public_profile
          - email
        linkText: Login with Facebook
        showLinkText: true
        addShadowUserOnLogin: true
        relyingPartyId: <redacted>
        relyingPartySecret: <redacted>
        skipSslValidation: true
        attributeMappings:
          user_name: user_id