### PR TITLE
When acting as a SAML SP allow configuration of RequestedAuthnContext

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
@@ -62,6 +62,7 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
     public SamlIdentityProviderDefinition clone() {
         List<String> emailDomain = getEmailDomain() != null ? new ArrayList<>(getEmailDomain()) : null;
         List<String> externalGroupsWhitelist = getExternalGroupsWhitelist() != null ? new ArrayList<>(getExternalGroupsWhitelist()) : null;
+        List<String> authnContext = getAuthnContext() != null ? new ArrayList<>(getAuthnContext()) : null;
         Map<String, Object> attributeMappings = getAttributeMappings() != null ? new HashMap(getAttributeMappings()) : null;
         SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition();
         def.setMetaDataLocation(metaDataLocation);

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
@@ -55,6 +55,7 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
     private String iconUrl;
     private ExternalGroupMappingMode groupMappingMode = ExternalGroupMappingMode.EXPLICITLY_MAPPED;
     private boolean skipSslValidation = false;
+    private List<String> authnContext;
 
     public SamlIdentityProviderDefinition() {}
 
@@ -82,6 +83,7 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
         def.setSocketFactoryClassName(getSocketFactoryClassName());
         def.setSkipSslValidation(isSkipSslValidation());
         def.setStoreCustomAttributes(isStoreCustomAttributes());
+        def.setAuthnContext(authnContext);
         return def;
     }
 
@@ -145,6 +147,15 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
 
     public SamlIdentityProviderDefinition setNameID(String nameID) {
         this.nameID = nameID;
+        return this;
+    }
+
+    public List<String> getAuthnContext() {
+        return authnContext;
+    }
+
+    public SamlIdentityProviderDefinition setAuthnContext(List<String> authnContext) {
+        this.authnContext = authnContext;
         return this;
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfigurator.java
@@ -123,6 +123,8 @@ public class BootstrapSamlIdentityProviderConfigurator implements InitializingBe
             Boolean addShadowUserOnLogin = (Boolean)((Map)entry.getValue()).get("addShadowUserOnLogin");
             Boolean skipSslValidation = (Boolean)((Map)entry.getValue()).get("skipSslValidation");
             Boolean storeCustomAttributes = (Boolean)((Map)entry.getValue()).get(STORE_CUSTOM_ATTRIBUTES_NAME);
+            List<String> authnContext = (List<String>) saml.getOrDefault("authnContext", Collections.<String>emptyList());
+
             if (storeCustomAttributes == null) {
                 storeCustomAttributes = true; //default value
             }
@@ -165,6 +167,7 @@ public class BootstrapSamlIdentityProviderConfigurator implements InitializingBe
             def.setZoneId(hasText(zoneId) ? zoneId : IdentityZone.getUaa().getId());
             def.setAddShadowUserOnLogin(addShadowUserOnLogin==null?true:addShadowUserOnLogin);
             def.setSkipSslValidation(skipSslValidation);
+            def.setAuthnContext(authnContext);
             toBeFetchedProviders.add(def);
         }
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfigurator.java
@@ -123,7 +123,7 @@ public class BootstrapSamlIdentityProviderConfigurator implements InitializingBe
             Boolean addShadowUserOnLogin = (Boolean)((Map)entry.getValue()).get("addShadowUserOnLogin");
             Boolean skipSslValidation = (Boolean)((Map)entry.getValue()).get("skipSslValidation");
             Boolean storeCustomAttributes = (Boolean)((Map)entry.getValue()).get(STORE_CUSTOM_ATTRIBUTES_NAME);
-            List<String> authnContext = (List<String>) saml.getOrDefault("authnContext", Collections.<String>emptyList());
+            List<String> authnContext = (List<String>) saml.get("authnContext");
 
             if (storeCustomAttributes == null) {
                 storeCustomAttributes = true; //default value

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
@@ -160,6 +160,13 @@ public class LoginSamlAuthenticationProvider extends SAMLAuthenticationProvider 
 
         Set<String> filteredExternalGroups = filterSamlAuthorities(samlConfig, samlAuthorities);
         MultiValueMap<String, String> userAttributes = retrieveUserAttributes(samlConfig, (SAMLCredential) result.getCredentials());
+
+        if (samlConfig.getAuthnContext() != null) {
+            if (Collections.disjoint(userAttributes.get(AUTHENTICATION_CONTEXT_CLASS_REFERENCE), samlConfig.getAuthnContext())) {
+                throw new BadCredentialsException("Identity Provider did not authenticate with the requested AuthnContext.");
+            }
+        }
+
         UaaUser user = createIfMissing(samlPrincipal, addNew, authorities, userAttributes);
         UaaPrincipal principal = new UaaPrincipal(user);
         UaaAuthentication resultUaaAuthentication = new LoginSamlAuthenticationToken(principal, result).getUaaAuthentication(user.getAuthorities(), filteredExternalGroups, userAttributes);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlEntryPoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlEntryPoint.java
@@ -50,6 +50,10 @@ public class LoginSamlEntryPoint extends SAMLEntryPoint {
                 if (def.getAssertionConsumerIndex()>=0) {
                     options.setAssertionConsumerIndex(def.getAssertionConsumerIndex());
                 }
+
+                if (!def.getAuthnContext().isEmpty()) {
+                    options.setAuthnContexts(def.getAuthnContext());
+                }
             }
         }
         return options;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlEntryPoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlEntryPoint.java
@@ -51,7 +51,7 @@ public class LoginSamlEntryPoint extends SAMLEntryPoint {
                     options.setAssertionConsumerIndex(def.getAssertionConsumerIndex());
                 }
 
-                if (!def.getAuthnContext().isEmpty()) {
+                if (def.getAuthnContext() != null) {
                     options.setAuthnContexts(def.getAuthnContext());
                 }
             }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfiguratorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfiguratorTests.java
@@ -151,7 +151,12 @@ public class BootstrapSamlIdentityProviderConfiguratorTests {
         "      assertionConsumerIndex: 0\n" +
         "      idpMetadata: http://simplesamlphp.uaa-acceptance.cf-app.com/saml2/idp/metadata.php\n" +
         "      metadataTrustCheck: false\n" +
-        "      nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\n"
+        "      nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\n" +
+        "    custom-authncontext:\n" +
+        "      authnContext: [\"custom-context\", \"another-context\"]\n" +
+        "      idpMetadata: |\n" +
+        "        " + testXmlFileData.replace("\n","\n        ") + "\n"
+
 //        +"    incomplete-provider:\n" +
 //        "      idpMetadata: http://localhost:8081/openam/saml2/jsp/exportmetadata.jsp?entityid=http://localhost:8081/openam\n"
         ;
@@ -198,14 +203,14 @@ public class BootstrapSamlIdentityProviderConfiguratorTests {
     public void testAddProviderDefinition() throws Exception {
         bootstrap.setIdentityProviders(sampleData);
         bootstrap.afterPropertiesSet();
-        testGetIdentityProviderDefinitions(3, false);
+        testGetIdentityProviderDefinitions(4, false);
     }
 
 
 
     @Test
     public void testGetIdentityProviderDefinitions() throws Exception {
-        testGetIdentityProviderDefinitions(3);
+        testGetIdentityProviderDefinitions(4);
     }
 
     protected void testGetIdentityProviderDefinitions(int count) throws Exception {
@@ -236,6 +241,7 @@ public class BootstrapSamlIdentityProviderConfiguratorTests {
                     assertTrue(idp.isMetadataTrustCheck());
                     assertTrue(idp.getEmailDomain().containsAll(asList("test.com", "test.org")));
                     assertTrue(idp.isStoreCustomAttributes());
+                    assertTrue(idp.getAuthnContext().isEmpty());
                     break;
                 }
                 case "okta-local-2" : {
@@ -270,6 +276,13 @@ public class BootstrapSamlIdentityProviderConfiguratorTests {
                     assertFalse(idp.isStoreCustomAttributes());
                     break;
                 }
+                case "custom-authncontext" : {
+                    assertEquals(2, idp.getAuthnContext().size());
+                    assertEquals("custom-context", idp.getAuthnContext().get(0));
+                    assertEquals("another-context", idp.getAuthnContext().get(1));
+                    break;
+                }
+
                 default:
                     fail();
             }
@@ -282,12 +295,12 @@ public class BootstrapSamlIdentityProviderConfiguratorTests {
         bootstrap.setLegacyIdpIdentityAlias("okta-local-3");
         bootstrap.setLegacyShowSamlLink(true);
         bootstrap.setLegacyNameId("urn:oasis:names:tc:SAML:2.0:nameid-format:persistent");
-        testGetIdentityProviderDefinitions(4);
+        testGetIdentityProviderDefinitions(5);
     }
 
     @Test
     public void testGetIdentityProviders() throws Exception {
-        testGetIdentityProviderDefinitions(3);
+        testGetIdentityProviderDefinitions(4);
     }
 
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfiguratorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderConfiguratorTests.java
@@ -241,7 +241,7 @@ public class BootstrapSamlIdentityProviderConfiguratorTests {
                     assertTrue(idp.isMetadataTrustCheck());
                     assertTrue(idp.getEmailDomain().containsAll(asList("test.com", "test.org")));
                     assertTrue(idp.isStoreCustomAttributes());
-                    assertTrue(idp.getAuthnContext().isEmpty());
+                    assertEquals(null, idp.getAuthnContext());
                     break;
                 }
                 case "okta-local-2" : {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfiguratorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfiguratorTests.java
@@ -155,6 +155,11 @@ public class SamlIdentityProviderConfiguratorTests {
                     assertEquals("http://simplesamlphp.uaa-acceptance.cf-app.com/saml2/idp/metadata.php", provider.getEntityID());
                     break;
                 }
+                case "custom-authncontext" : {
+                    ComparableProvider provider = (ComparableProvider) configurator.getExtendedMetadataDelegateFromCache(def).getDelegate();
+                    assertEquals("http://www.okta.com/k2lvtem0VAJDMINKEYJW", provider.getEntityID());
+                    break;
+                }
                 default: fail(String.format("Unknown provider %s", def.getIdpEntityAlias()));
             }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
@@ -192,6 +192,18 @@ public class SamlIdentityProviderDefinitionTests {
         assertEquals("test.com", def.getEmailDomain().get(0));
     }
 
+    @Test
+    public void testDefaultAuthnContext() {
+        SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition();
+        assertTrue(def.getAuthnContext().isEmpty());
+    }
+
+    @Test
+    public void testSetAuthnContext() {
+        SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition();
+        def.setAuthnContext(Arrays.asList("a-custom-context"));
+        assertEquals("a-custom-context", def.getAuthnContext().get(0));
+    }
 
     @Test
     public void testGetSocketFactoryClassName() throws Exception {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
@@ -195,7 +195,7 @@ public class SamlIdentityProviderDefinitionTests {
     @Test
     public void testDefaultAuthnContext() {
         SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition();
-        assertTrue(def.getAuthnContext().isEmpty());
+        assertEquals(null, def.getAuthnContext());
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
@@ -371,6 +371,7 @@ public class IdentityProviderEndpointsDocs extends InjectedMockContextTest {
             fieldWithPath("config.iconUrl").optional(null).type(STRING).description("Reserved for future use"),
             fieldWithPath("config.socketFactoryClassName").optional(null).description("Either `\"org.apache.commons.httpclient.protocol.DefaultProtocolSocketFactory\"` or" +
                 "`\"org.apache.commons.httpclient.contrib.ssl.EasySSLProtocolSocketFactory\"` depending on if the `metaDataLocation` of type `URL` is HTTP or HTTPS, respectively"),
+            fieldWithPath("config.authnContext").optional(null).type(ARRAY).description("List of AuthnContextClassRef to include in the SAMLRequest. If not specified no AuthnContext will be requested."),
             ADD_SHADOW_USER_ON_LOGIN,
             EXTERNAL_GROUPS_WHITELIST,
             ATTRIBUTE_MAPPING,

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
@@ -600,6 +600,33 @@ public class LoginSamlAuthenticationProviderTests extends JdbcTestBase {
     }
 
     @Test
+    public void authnContext_isvalidated_fail() throws Exception {
+        providerDefinition.setAuthnContext(Arrays.asList("some-context", "another-context"));
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider);
+
+        try {
+            getAuthentication();
+            fail("Expected authentication to throw BadCredentialsException");
+        } catch (BadCredentialsException ex) {
+
+        }
+    }
+
+    @Test
+    public void authnContext_isvalidated_good() throws Exception {
+        providerDefinition.setAuthnContext(Arrays.asList(AuthnContext.PASSWORD_AUTHN_CTX));
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider);
+
+        try {
+            getAuthentication();
+        } catch (BadCredentialsException ex) {
+            fail("Expected authentication to succeed");
+        }
+    }
+
+    @Test
     public void shadowAccountNotCreated_givenShadowAccountCreationDisabled() throws Exception {
         Map<String,Object> attributeMappings = new HashMap<>();
         attributeMappings.put("given_name", "firstName");


### PR DESCRIPTION
This PR allows for setting a `RequestedAuthnContext` in the SAMLRequest generated when UAA is operating as a SAML SP.  This is accomplished by adding a new property to `login.saml.providers` named `authnContext`.

For example:
```yaml
login:
  saml:
    providers:
      cloud.gov:
        authnContext:
        - foo
        - bar
        - baz
        idpMetadata: |
           ...
```
Would produce a SAMLRequest with this `RequestedAuthnContext`:
```xml
<saml2p:RequestedAuthnContext Comparison="exact">
	<saml2:AuthnContextClassRef xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">foo</saml2:AuthnContextClassRef>
	<saml2:AuthnContextClassRef xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">bar</saml2:AuthnContextClassRef>
	<saml2:AuthnContextClassRef xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">baz</saml2:AuthnContextClassRef>
</saml2p:RequestedAuthnContext>
```
If this value is not provided, the previous default behavior of not including any `RequestedAuthnContext` in the request is preserved.

**Update:** This PR now includes validation of the context returned by the IDP.

I'm not an expert in Java or the UAA codebase so feedback is appreciated 😁 
