### PR TITLE
Reload login when CSRF token expires

### DIFF
--- a/server/src/main/resources/templates/web/login.html
+++ b/server/src/main/resources/templates/web/login.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<head>
+    <meta http-equiv="refresh" th:content="${@loginCookieCsrfRepository.getCookieMaxAge()}" />
+</head>
 <div class="island" layout:fragment="page-content">
     <h1 th:text="${T(org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder).uaa ? 'Welcome!':'Welcome to '+zone_name+'!'}">Welcome!</h1>
     <div class="island-content">

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
@@ -253,6 +253,12 @@ public class LoginIT {
     }
 
     @Test
+    public void testLoginPageReloadBasedOnCsrf() {
+        webDriver.get(baseUrl + "/login");
+        assertTrue(webDriver.getPageSource().contains("http-equiv=\"refresh\""));
+    }
+
+    @Test
     public void userLockedoutAfterFailedAttempts() throws Exception {
         String userEmail = createAnotherUser();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -345,6 +345,17 @@ public class LoginMockMvcTests extends InjectedMockContextTest {
         assertNotEquals(csrf1.getValue(), csrf2.getValue());
     }
 
+    @Test
+    public void testLoginPageReloadOnCsrfExpiry() throws Exception {
+        CookieBasedCsrfTokenRepository cookieBasedCsrfTokenRepository = webApplicationContext.getBean(CookieBasedCsrfTokenRepository.class);
+        cookieBasedCsrfTokenRepository.setCookieMaxAge(3);
+
+        MvcResult mvcResult = getMockMvc()
+                .perform(get("/login"))
+                .andReturn();
+        assertThat("", mvcResult.getResponse().getContentAsString(), containsString("http-equiv=\"refresh\" content=\"3\""));
+    }
+
     protected void setDisableInternalAuth(boolean disable) throws Exception {
        MockMvcUtils.setDisableInternalAuth(getWebApplicationContext(), getUaa().getId(), disable);
     }


### PR DESCRIPTION
When login page is left open until the point of expiry of CSRF token and the user goes on to submit their credentials, they are shown with the CSRF error `Invalid login attempt, request does not meet our security standards, please try again`. This can be avoided by performing a client-side page reload using `meta-refresh` when the CSRF token expires.