### PR TITLE
OIDC token endpoint needs to support client authorization in either POST body or Basic auth

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractXOAuthIdentityProviderDefinition.java
@@ -29,6 +29,7 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
     private String tokenKey;
     private String linkText;
     private boolean showLinkText = true;
+    private boolean clientAuthInBody = false;
     private boolean skipSslValidation;
     private String relyingPartyId;
     private String relyingPartySecret;
@@ -78,6 +79,15 @@ public abstract class AbstractXOAuthIdentityProviderDefinition<T extends Abstrac
 
     public T setLinkText(String linkText) {
         this.linkText = linkText;
+        return (T) this;
+    }
+
+    public boolean isClientAuthInBody() {
+        return clientAuthInBody;
+    }
+
+    public T setClientAuthInBody(boolean clientAuthInBody) {
+        this.clientAuthInBody = clientAuthInBody;
         return (T) this;
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationManager.java
@@ -471,8 +471,14 @@ public class XOAuthAuthenticationManager extends ExternalLoginAuthenticationMana
         body.add("redirect_uri", codeToken.getRedirectUrl());
 
         HttpHeaders headers = new HttpHeaders();
-        String clientAuthHeader = getClientAuthHeader(config);
-        headers.add("Authorization", clientAuthHeader);
+
+        if(config.isClientAuthInBody()) {
+            body.add("client_id", config.getRelyingPartyId());
+            body.add("client_secret", config.getRelyingPartySecret());
+        } else {
+            String clientAuthHeader = getClientAuthHeader(config);
+            headers.add("Authorization", clientAuthHeader);
+        }
         headers.add("Accept", "application/json");
 
         URI requestUri;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
@@ -444,7 +444,9 @@ public class IdentityProviderEndpointsDocs extends InjectedMockContextTest {
             fieldWithPath("config.scopes").optional(null).type(ARRAY).description("What scopes to request on a call to the external OAuth provider"),
             fieldWithPath("config.checkTokenUrl").optional(null).type(OBJECT).description("Reserved for future OAuth use."),
             fieldWithPath("config.responseType").optional("code").type(STRING).description("Response type for the authorize request, will be sent to OAuth server, defaults to `code`"),
-            ADD_SHADOW_USER_ON_LOGIN,
+            fieldWithPath("config.clientAuthInBody").optional(false).type(BOOLEAN).description("(Advanced) Passes client credentials for token call in body instad of as Basic Authorization header."),
+
+                ADD_SHADOW_USER_ON_LOGIN,
             EXTERNAL_GROUPS,
             ATTRIBUTE_MAPPING,
             fieldWithPath("config.attributeMappings.user_name").optional("preferred_username").type(STRING).description("Map `user_name` to the attribute for username in the provider assertion."),
@@ -512,6 +514,7 @@ public class IdentityProviderEndpointsDocs extends InjectedMockContextTest {
             fieldWithPath("config.scopes").optional(null).type(ARRAY).description("What scopes to request on a call to the external OAuth/OpenID provider. For example, can provide " +
                                                                                       "`openid`, `roles`, or `profile` to request ID token, scopes populated in the ID token external groups attribute mappings, or the user profile information, respectively."),
             fieldWithPath("config.checkTokenUrl").optional(null).type(OBJECT).description("Reserved for future OAuth/OIDC use."),
+            fieldWithPath("config.clientAuthInBody").optional(false).type(BOOLEAN).description("(Advanced) Passes client credentials for token call in body instad of as Basic Authorization header."),
             fieldWithPath("config.userInfoUrl").optional(null).type(OBJECT).description("Reserved for future OIDC use.  This can be left blank if a discovery URL is provided. If both are provided, this property overrides the discovery URL."),
             fieldWithPath("config.responseType").optional("code").type(STRING).description("Response type for the authorize request, defaults to `code`, but can be `code id_token` if the OIDC server can return an id_token as a query parameter in the redirect."),
             ADD_SHADOW_USER_ON_LOGIN,


### PR DESCRIPTION
As per [spec](https://tools.ietf.org/html/rfc6749#section-2.3.1), client credentials can be specified using either methods.