### PR TITLE
Fix OIDC well-known endpoint to be in compliance with spec

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/OpenIdConnectEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/OpenIdConnectEndpoints.java
@@ -15,7 +15,7 @@ public class OpenIdConnectEndpoints {
 
     private String issuer;
 
-    @RequestMapping(value = "/.well-known/openid-configuration")
+    @RequestMapping(value = "/oauth/token/.well-known/openid-configuration")
     public ResponseEntity<OpenIdConfiguration> getOpenIdConfiguration(HttpServletRequest request) throws URISyntaxException {
         OpenIdConfiguration conf = new OpenIdConfiguration(getServerContextPath(request), getTokenEndpoint());
         return new ResponseEntity<>(conf, OK);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCacheTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCacheTests.java
@@ -56,7 +56,7 @@ public class ExpiringUrlCacheTests {
         cache = new ExpiringUrlCache(EXPIRING_TIME_MILLIS, ticker, 2);
         template = mock(RestTemplate.class);
         when(template.getForObject(any(URI.class), any())).thenReturn(content, new byte[1024]);
-        uri = "http://localhost:8080/uaa/.well-known/openid-configuration";
+        uri = "http://localhost:8080/uaa/oauth/token/.well-known/openid-configuration";
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthIdentityProviderConfigValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthIdentityProviderConfigValidatorTest.java
@@ -33,7 +33,7 @@ public class XOAuthIdentityProviderConfigValidatorTest {
         definition.setTokenUrl(null);
         definition.setTokenKeyUrl(null);
         definition.setTokenKey(null);
-        ((OIDCIdentityProviderDefinition)definition).setDiscoveryUrl(new URL("http://localhost:8080/uaa/.well-known/openid-configuration"));
+        ((OIDCIdentityProviderDefinition)definition).setDiscoveryUrl(new URL("http://localhost:8080/uaa/oauth/token/.well-known/openid-configuration"));
         validator = new XOAuthIdentityProviderConfigValidator();
         validator.validate(definition);
     }

--- a/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
@@ -194,6 +194,17 @@
         <csrf disabled="true"/>
     </http>
 
+    <http name="wellKnown"
+          pattern="/oauth/token/.well-known/**"
+          disable-url-rewriting="true"
+          entry-point-ref="loginEntryPoint"
+          use-expressions="false"
+          xmlns="http://www.springframework.org/schema/security"
+          authentication-manager-ref="emptyAuthenticationManager">
+        <intercept-url pattern="/**" access="IS_AUTHENTICATED_ANONYMOUSLY" />
+        <csrf disabled="true"/>
+    </http>
+
     <!--/oauth/token with any match -->
     <http name="tokenEndpointSecurity" create-session="stateless" authentication-manager-ref="clientAuthenticationManager" use-expressions="false"
         pattern="/oauth/token/**" entry-point-ref="basicAuthenticationEntryPoint" xmlns="http://www.springframework.org/schema/security">

--- a/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
@@ -27,16 +27,6 @@
         <csrf disabled="true"/>
     </http>
 
-    <http name="wellKnown"
-          pattern="/.well-known/**"
-          disable-url-rewriting="true"
-          entry-point-ref="loginEntryPoint"
-          use-expressions="false"
-          xmlns="http://www.springframework.org/schema/security">
-      <intercept-url pattern="/**" access="IS_AUTHENTICATED_ANONYMOUSLY" />
-      <csrf disabled="true"/>
-    </http>
-
     <oauth:resource-server id="openidResourceAuthenticationFilter" token-services-ref="tokenServices"
         resource-id="openid" entry-point-ref="oauthAuthenticationEntryPoint" />
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantMockMvcTests.java
@@ -193,6 +193,7 @@ public class JwtBearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
         createAuth0Provider(IdentityZone.getUaa(),
                             "73hk1Cjb49KaDrLjvaU0OU7C2Tyof7pd",
                             "https://cf-identity-eng.auth0.com/.well-known/openid-configuration");
+// TODO                     "https://cf-identity-eng.auth0.com/oauth/token/.well-known/openid-configuration");
 
         ClientDetails client = createJwtBearerClient(theZone);
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsDocs.java
@@ -20,6 +20,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 public class OpenIdConnectEndpointsDocs extends InjectedMockContextTest {
 
+    final static String WELL_KNOWN_ENDPOINT = "/oauth/token/.well-known/openid-configuration";
+
     @Test
     public void getWellKnownOpenidConf() throws Exception {
 
@@ -43,9 +45,10 @@ public class OpenIdConnectEndpointsDocs extends InjectedMockContextTest {
             fieldWithPath("ui_locales_supported").description("Languages and scripts supported for the user interface.")
         );
 
+
         getMockMvc().perform(
-            get("/.well-known/openid-configuration")
-            .servletPath("/.well-known/openid-configuration")
+            get(WELL_KNOWN_ENDPOINT)
+            .servletPath(WELL_KNOWN_ENDPOINT)
             .accept(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andDo(document("{ClassName}/{methodName}",

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/OpenIdConnectEndpointsMockMvcTests.java
@@ -26,6 +26,8 @@ public class OpenIdConnectEndpointsMockMvcTests extends InjectedMockContextTest 
 
     private IdentityZone identityZone;
 
+    static final String WELL_KNOWN_PATH = "/oauth/token/.well-known/openid-configuration";
+
     @Before
     public void setUp() throws Exception {
         identityZone = createOtherIdentityZone("subdomain", getMockMvc(), getWebApplicationContext());
@@ -38,9 +40,9 @@ public class OpenIdConnectEndpointsMockMvcTests extends InjectedMockContextTest 
 
     @Test
     public void testWellKnownEndpoint() throws Exception {
-        MockHttpServletResponse response = getMockMvc().perform(get("/.well-known/openid-configuration")
+        MockHttpServletResponse response = getMockMvc().perform(get(WELL_KNOWN_PATH)
             .with(new SetServerNameRequestPostProcessor("subdomain.localhost"))
-            .servletPath("/.well-known/openid-configuration")
+            .servletPath(WELL_KNOWN_PATH)
             .accept(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn().getResponse();
@@ -68,9 +70,9 @@ public class OpenIdConnectEndpointsMockMvcTests extends InjectedMockContextTest 
     public void testUserInfoEndpointIsCorrect() throws Exception {
         SetServerNameRequestPostProcessor inZone = new SetServerNameRequestPostProcessor("subdomain.localhost");
 
-        MockHttpServletResponse response = getMockMvc().perform(get("/.well-known/openid-configuration")
+        MockHttpServletResponse response = getMockMvc().perform(get(WELL_KNOWN_PATH)
             .with(inZone)
-            .servletPath("/.well-known/openid-configuration")
+            .servletPath(WELL_KNOWN_PATH)
             .accept(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn().getResponse();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserInfoEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserInfoEndpointMockMvcTests.java
@@ -103,8 +103,8 @@ public class UserInfoEndpointMockMvcTests extends InjectedMockContextTest {
 
     @Test
     public void testGetUserInfoEndpointFromWellKnownConfiguration() throws Exception {
-        MockHttpServletResponse response = getMockMvc().perform(get("/.well-known/openid-configuration")
-            .servletPath("/.well-known/openid-configuration")
+        MockHttpServletResponse response = getMockMvc().perform(get("/oauth/token/.well-known/openid-configuration")
+            .servletPath("/oauth/token/.well-known/openid-configuration")
             .accept(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andReturn().getResponse();


### PR DESCRIPTION
This change provides a fix for issue #652 
As per the [spec](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation), `issuer` value returned by the config should be identical to the `<issuer_url>` used to obtain the config (ex: `<issuer_url>/.well-known/openid-configuration`) and the `iss` claim in the id_token