### PR TITLE
Add form_redirect_uri to login page during reload

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -39,6 +39,7 @@ import org.cloudfoundry.identity.uaa.util.JsonUtils.JsonUtilException;
 import org.cloudfoundry.identity.uaa.util.MapCollector;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
+import org.cloudfoundry.identity.uaa.web.UaaSavedRequestAwareAuthenticationSuccessHandler;
 import org.cloudfoundry.identity.uaa.zone.ClientServicesExtension;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -451,6 +452,11 @@ public class LoginInfoEndpoint {
 
             if(discoveryNeeded) {
                 return "idp_discovery/email";
+            }
+
+            String formRedirectUri = request.getParameter(UaaSavedRequestAwareAuthenticationSuccessHandler.FORM_REDIRECT_PARAMETER);
+            if(hasText(formRedirectUri)) {
+                model.addAttribute(UaaSavedRequestAwareAuthenticationSuccessHandler.FORM_REDIRECT_PARAMETER, formRedirectUri);
             }
 
             return "login";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -286,6 +287,21 @@ public class LoginIT {
         String regex = "Version: \\S+, Commit: \\w{7}, Timestamp: .+, UAA: " + baseUrl;
         assertTrue(webDriver.findElement(By.cssSelector(".footer .copyright")).getAttribute("title").matches(regex));
     }
+
+    @Test
+    public void testLoginReloadRetainsFormRedirect() {
+
+        String redirectUri = "http://expected.com";
+        webDriver.get(baseUrl + "/oauth/authorize?client_id=test&redirect_uri="+redirectUri);
+        ((JavascriptExecutor)webDriver).executeScript("document.getElementsByName('X-Uaa-Csrf')[0].value=''");
+        webDriver.manage().deleteCookieNamed("JSESSIONID");
+
+        webDriver.findElement(By.xpath("//input[@value='Sign in']")).click();
+
+        assertThat(webDriver.getCurrentUrl(), Matchers.containsString("/login"));
+        assertThat(webDriver.findElement(By.name("form_redirect_uri")).getAttribute("value"), Matchers.containsString("redirect_uri="+redirectUri));
+
+}
 
     private String createAnotherUser() {
         String userEmail = "user" + new SecureRandom().nextInt() + "@example.com";


### PR DESCRIPTION
When the user session expires, this `form_redirect_uri` is used to retain the context. But, the value is lost when login page is reloaded due to any error (ie incorrect password, csrf). This fix adds the value to the model if present in the original request