### PR TITLE
Allow underscores in subdomain section

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -77,7 +77,7 @@ public abstract class UaaUrlUtils {
     private static final Pattern allowedRedirectUriPattern = Pattern.compile(
         "^http(\\*|s)?://" +            //URL starts with 'www.' or 'http://' or 'https://' or 'http*://
         "(.*:.*@)?" +                   //username/password in URL
-        "(([a-zA-Z0-9\\-\\*]+\\.)*" +   //subdomains
+        "(([a-zA-Z0-9\\-\\*_]+\\.)*" +   //subdomains
         "[a-zA-Z0-9\\-]+\\.)?" +        //hostname
         "[a-zA-Z0-9\\-]+" +             //tld
         "(:[0-9]+)?(/.*|$)"             //port and path

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
@@ -70,6 +70,7 @@ public class UaaUrlUtilsTest {
         "https://subsub.sub.valid.com/**",
         "https://valid.com/path/*/path",
         "http://sub.valid.com/*/with/path**",
+        "http://sub_with_underscore.valid.com/*/with/path**",
         "http*://sub.valid.com/*/with/path**",
         "http*://*.valid.com/*/with/path**",
         "http://*.valid.com/*/with/path**",


### PR DESCRIPTION
A client using ` authorization_code ` and with a redirect url that has underscore in it `eg: my_fancy_app.domain.com/oauth/token ` would get an error stating `invalid_client ` .

This pull request should fix it.