### PR TITLE
Update gradle-docker-plugin depedency version

### DIFF
--- a/docker.gradle
+++ b/docker.gradle
@@ -23,7 +23,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.bmuschko:gradle-docker-plugin:3.0.8'
+    classpath 'com.bmuschko:gradle-docker-plugin:3.0.11'
   }
 }
 


### PR DESCRIPTION
This update allows Gradle to work with the latest Docker versions.