### PR TITLE
use isBlank form apache instead of isEmpty for hsqldb

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
@@ -14,6 +14,7 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.identity.uaa.codestore.ExpiringCode;
@@ -24,7 +25,6 @@ import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
-import org.hsqldb.lib.StringUtil;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -184,7 +184,7 @@ public class PasscodeAuthenticationFilter extends BackwardsCompatibleTokenEndpoi
                 }
 
                 String passcode = expiringCodeAuthentication.getPasscode();
-                if (StringUtil.isEmpty(passcode)) {
+                if (StringUtils.isBlank(passcode)) {
                     throw new InsufficientAuthenticationException("Passcode information is missing.");
                 }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
@@ -14,7 +14,6 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.cloudfoundry.identity.uaa.codestore.ExpiringCode;
@@ -35,6 +34,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
+import org.springframework.util.StringUtils;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -184,7 +184,7 @@ public class PasscodeAuthenticationFilter extends BackwardsCompatibleTokenEndpoi
                 }
 
                 String passcode = expiringCodeAuthentication.getPasscode();
-                if (StringUtils.isBlank(passcode)) {
+                if (StringUtils.isEmpty(passcode)) {
                     throw new InsufficientAuthenticationException("Passcode information is missing.");
                 }
 


### PR DESCRIPTION
The use of this method from hsqldb causes problem if jar is not available
The dependent library is not needed for usage if mysql or postgesql therefore we removed it.
However with this dependency it is a hard requirement which should not be the case.

If you check the internals of isEmpty of hsqldb then it is the same if you call isBlank from apache
see also
http://technohandle.blogspot.de/2011/01/stringutilsisemtpty-vs.html