### PR TITLE
Do not update identical client secret

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
@@ -425,8 +425,8 @@ public class ClientAdminEndpoints implements InitializingBean, ApplicationEventP
                 clientId = change[i].getClientId();
                 clientDetails[i] = new ClientDetailsModification(clientDetailsService.retrieve(clientId, IdentityZoneHolder.get().getId()));
                 boolean oldPasswordOk = authenticateClient(clientId, change[i].getOldSecret());
-                if (!change[i].getSecret().equals(change[i].getOldSecret())) {
-                    clientDetailsValidator.getClientSecretValidator().validate(change[i].getSecret());
+                clientDetailsValidator.getClientSecretValidator().validate(change[i].getSecret());
+                if (!authenticateClient(clientId, change[i].getSecret())) {
                     clientRegistrationService.updateClientSecret(clientId, change[i].getSecret(), IdentityZoneHolder.get().getId());
                     clientSecretChanges.incrementAndGet();
                 }
@@ -547,13 +547,13 @@ public class ClientAdminEndpoints implements InitializingBean, ApplicationEventP
                 break;
 
             default:
-                if (!change.getSecret().equals(change.getOldSecret())) {
-                    clientDetailsValidator.getClientSecretValidator().validate(change.getSecret());
+                clientDetailsValidator.getClientSecretValidator().validate(change.getSecret());
+                if (authenticateClient(client_id, change.getSecret())) {
+                    result = new ActionResult("ok", "nothing to do");
+                } else {
                     clientRegistrationService.updateClientSecret(client_id, change.getSecret(), IdentityZoneHolder.get().getId());
                     result = new ActionResult("ok", "secret updated");
                     clientSecretChanges.incrementAndGet();
-                } else {
-                    result = new ActionResult("ok", "nothing to do");
                 }
         }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsTests.java
@@ -646,6 +646,27 @@ public class ClientAdminEndpointsTests {
     }
 
     @Test
+    public void testChangeSecretIdentical() throws Exception {
+        Authentication auth = mock(Authentication.class);
+        when(auth.isAuthenticated()).thenReturn(true);
+        when(authenticationManager.authenticate(any(Authentication.class))).thenReturn(auth);
+
+        when(clientDetailsService.retrieve(detail.getClientId(), IdentityZoneHolder.get().getId())).thenReturn(detail);
+        SecurityContextAccessor sca = mock(SecurityContextAccessor.class);
+        when(sca.getClientId()).thenReturn(detail.getClientId());
+        when(sca.isClient()).thenReturn(true);
+        setSecurityContextAccessor(sca);
+
+        SecretChangeRequest change = new SecretChangeRequest();
+        String secret = detail.getClientSecret();
+        change.setOldSecret(secret);
+        change.setSecret(secret);
+        int clientSecretChanges = endpoints.getClientSecretChanges();
+        endpoints.changeSecret(detail.getClientId(), change);
+        assertEquals(clientSecretChanges, endpoints.getClientSecretChanges());
+    }
+
+    @Test
     public void testAddSecret() {
         SecurityContextAccessor sca = mock(SecurityContextAccessor.class);
         when(sca.getClientId()).thenReturn("bar");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsTests.java
@@ -629,7 +629,7 @@ public class ClientAdminEndpointsTests {
     public void testChangeSecret() throws Exception {
         Authentication auth = mock(Authentication.class);
         when(auth.isAuthenticated()).thenReturn(true);
-        when(authenticationManager.authenticate(any(Authentication.class))).thenReturn(auth);
+        when(authenticationManager.authenticate(any(Authentication.class))).thenReturn(auth).thenThrow(new BadCredentialsException("Invalid client secret"));
 
         when(clientDetailsService.retrieve(detail.getClientId(), IdentityZoneHolder.get().getId())).thenReturn(detail);
         SecurityContextAccessor sca = mock(SecurityContextAccessor.class);


### PR DESCRIPTION
When updating a client secret with an identical value, the client secret hash changes. As a consequence, all issued client tokens become invalid ("revocable signature mismatch"). If the client secret doesn't change, then a client token should remain valid as long as the token has not been revoked.