### PR TITLE
Fix type for claim az_attr

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/Claims.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/Claims.java
@@ -62,7 +62,7 @@ public class Claims {
     @JsonProperty(ClaimConstants.GRANT_TYPE)
     private String grantType;
     @JsonProperty(ClaimConstants.ADDITIONAL_AZ_ATTR)
-    private String azAttr;
+    private Map<String,String> azAttr;
     @JsonProperty(ClaimConstants.AZP)
     private String azp;
     @JsonProperty(ClaimConstants.AUTH_TIME)
@@ -232,11 +232,11 @@ public class Claims {
         this.grantType = grantType;
     }
 
-    public String getAzAttr() {
+    public Map<String,String> getAzAttr() {
         return azAttr;
     }
 
-    public void setAzAttr(String azAttr) {
+    public void setAzAttr(Map<String,String> azAttr) {
         this.azAttr = azAttr;
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpoint.java
@@ -166,7 +166,7 @@ public class CheckTokenEndpoint implements InitializingBean {
         try {
             claims = JsonUtils.readValue(tokenJwt.getClaims(), Claims.class);
         } catch (JsonUtils.JsonUtilException e) {
-            throw new IllegalStateException("Cannot read token claims", e);
+            throw new InvalidTokenException("Cannot read token claims", e);
         }
 
         return claims;


### PR DESCRIPTION
Documentation says that with authorities additional claims
can be added into JWT.
However with /check_token this fails because of invalid json
object if you add here a string map.
See:
https://github.com/cloudfoundry/uaa/blob/master/docs/UAA-APIs.rst

Example:
authorities={"az_attr":{"external_group":"domain\\group1","external_id":"abcd1234"}}