### PR TITLE
user delete in other zone does not remove members correctly

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
@@ -316,7 +316,7 @@ public class ScimUserEndpoints implements InitializingBean, ApplicationEventPubl
         int version = etag == null ? -1 : getVersion(userId, etag);
         ScimUser user = getUser(userId, httpServletResponse);
         checkIsEditAllowed(user.getOrigin(), request);
-        membershipManager.removeMembersByMemberId(userId, IdentityZoneHolder.get().getId(), IdentityZoneHolder.get().getId());
+        membershipManager.removeMembersByMemberId(userId, user.getOrigin(), IdentityZoneHolder.get().getId());
         scimUserProvisioning.delete(userId, version, IdentityZoneHolder.get().getId());
         scimDeletes.incrementAndGet();
         if (publisher != null) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -590,6 +590,30 @@ public class ScimUserEndpointsTests {
         validateGroupMembers(groupEndpoints.getGroup(g.getId(), new MockHttpServletResponse()), exGuy.getId(), false);
     }
 
+
+    @Test
+    public void deleteUserInZoneUpdatesGroupMembership() {
+        IdentityZone zone = new IdentityZone();
+        zone.setId("not-uaa");
+        zone.setSubdomain("not-uaa");
+        zone.setName("not-uaa");
+        zone.setDescription("not-uaa");
+        IdentityZoneHolder.set(zone);
+
+        ScimUser exGuy = new ScimUser(null, "deleteme3", "Expendable", "Guy");
+        exGuy.addEmail("exguy3@imonlyheretobedeleted.com");
+        exGuy = dao.createUser(exGuy, "exguyspassword", IdentityZoneHolder.get().getId());
+        assertEquals(IdentityZoneHolder.get().getId(), exGuy.getZoneId());
+
+        ScimGroup g = new ScimGroup(null,"test1",IdentityZoneHolder.get().getId());
+        g.setMembers(asList(new ScimGroupMember(exGuy.getId())));
+        g = groupEndpoints.createGroup(g, new MockHttpServletResponse());
+        validateGroupMembers(g, exGuy.getId(), true);
+
+        endpoints.deleteUser(exGuy.getId(), "*", new MockHttpServletRequest(), new MockHttpServletResponse());
+        validateGroupMembers(groupEndpoints.getGroup(g.getId(), new MockHttpServletResponse()), exGuy.getId(), false);
+    }
+
     private void validateGroupMembers(ScimGroup g, String mId, boolean expected) {
         boolean isMember = false;
         for (ScimGroupMember m : g.getMembers()) {


### PR DESCRIPTION
Currently deleting a user in an identity zone will not correctly delete the group membership associated with that user. This fixes that and adds a test for the use case.