### PR TITLE
Fix/saml login with incorrect attributes

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
@@ -358,7 +358,12 @@ public class LoginSamlAuthenticationProvider extends SAMLAuthenticationProvider 
         }
         if (haveUserAttributesChanged(user, userWithSamlAttributes)) {
             userModified = true;
-            user = user.modifyAttributes(userWithSamlAttributes.getEmail(), userWithSamlAttributes.getGivenName(), userWithSamlAttributes.getFamilyName(), userWithSamlAttributes.getPhoneNumber());
+
+            String email = userWithSamlAttributes.getEmail().contains("@unknown.org") ? user.getEmail() : userWithSamlAttributes.getEmail();
+            String givenName = userWithSamlAttributes.getGivenName();
+            String familyName = userWithSamlAttributes.getFamilyName();
+            String phoneNumber = userWithSamlAttributes.getPhoneNumber();
+            user = user.modifyAttributes(email, givenName, familyName, phoneNumber);
         }
         publish(
             new ExternalGroupAuthorizationEvent(
@@ -394,19 +399,14 @@ public class LoginSamlAuthenticationProvider extends SAMLAuthenticationProvider 
             if (name.contains("@")) {
                 if (name.split("@").length == 2 && !name.startsWith("@") && !name.endsWith("@")) {
                     email = name;
-                } else {
-                    email = name.replaceAll("@", "") + "@unknown.org";
                 }
+              else {
+                  email = name.replaceAll("@", "") + "@unknown.org";
+              }
             }
             else {
                 email = name + "@unknown.org";
             }
-        }
-        if (givenName == null) {
-            givenName = email.split("@")[0];
-        }
-        if (familyName == null) {
-            familyName = email.split("@")[1];
         }
         return new UaaUser(
         new UaaUserPrototype()

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
@@ -103,6 +103,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -740,7 +741,7 @@ public class LoginSamlAuthenticationProviderTests extends JdbcTestBase {
     }
 
     @Test
-    public void shadowUser_GetsCreatedWithDefaultValues_IfAttributeNotMapped() throws Exception {
+    public void shadowUserGetsCreatedWithDefaultValuesIfAttributeNotMapped() throws Exception {
         Map<String,Object> attributeMappings = new HashMap<>();
         attributeMappings.put("surname", "lastName");
         attributeMappings.put("email", "emailAddress");
@@ -750,8 +751,59 @@ public class LoginSamlAuthenticationProviderTests extends JdbcTestBase {
 
         UaaAuthentication authentication = getAuthentication();
         UaaUser user = userDatabase.retrieveUserByName("marissa-saml", OriginKeys.SAML);
-        assertEquals("marissa.bloggs", user.getGivenName());
-        assertEquals("test.com", user.getFamilyName());
+        assertEquals(null, user.getGivenName());
+        assertEquals(null, user.getFamilyName());
+        assertEquals("marissa.bloggs@test.com", user.getEmail());
+        assertEquals("No custom attributes have been mapped", 0, authentication.getUserAttributes().size());
+    }
+
+    @Test
+    public void shadowUserGetsCreatedWithAppropriateValuesIfAttributeNotMapped() throws Exception {
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider, IdentityZoneHolder.get().getId());
+
+        UaaAuthentication authentication = getAuthentication();
+        UaaUser user = userDatabase.retrieveUserByName("marissa-saml", OriginKeys.SAML);
+        assertEquals(null, user.getGivenName());
+        assertEquals(null, user.getFamilyName());
+        assertEquals("marissa-saml@unknown.org", user.getEmail());
+        assertEquals("No custom attributes have been mapped", 0, authentication.getUserAttributes().size());
+    }
+
+    @Test
+    public void shadowUserWhitelistedWithUsernameSameAsEmailOverwrittenIfAttributetMappedInCorrectly() throws Exception {
+        createSamlUser("marissa.bloggs@test.com", "marissa.bloggs@test.com", "Marissa", "Bloggs");
+        credential = getUserCredential("marissa.bloggs@test.com", "Marissa", "Bloggs", "marissa.bloggs@test.com", "1234567890");
+        when(consumer.processAuthenticationResponse(any())).thenReturn(credential);
+        Map<String,Object> attributeMappings = new HashMap<>();
+        attributeMappings.put("surname", "lastName");
+        attributeMappings.put("email", "incorrect_email");
+        providerDefinition.setAttributeMappings(attributeMappings);
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider, IdentityZoneHolder.get().getId());
+
+        UaaAuthentication authentication = getAuthentication();
+        UaaUser user = userDatabase.retrieveUserByName("marissa.bloggs@test.com", OriginKeys.SAML);
+        assertEquals(null, user.getGivenName());
+        assertEquals(null, user.getFamilyName());
+        assertEquals("marissa.bloggs@test.com", user.getEmail());
+        assertEquals("No custom attributes have been mapped", 0, authentication.getUserAttributes().size());
+    }
+
+    @Test
+    public void shadowUserWhitelistedOverwrittenIfAttributetMappedInCorrectly() throws Exception {
+        createSamlUser("marissa-saml", "marissa.bloggs@test.com", "Marissa", "Bloggs");
+        Map<String,Object> attributeMappings = new HashMap<>();
+        attributeMappings.put("surname", "lastName");
+        attributeMappings.put("email", "incorrect_email");
+        providerDefinition.setAttributeMappings(attributeMappings);
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider, IdentityZoneHolder.get().getId());
+
+        UaaAuthentication authentication = getAuthentication();
+        UaaUser user = userDatabase.retrieveUserByName("marissa-saml", OriginKeys.SAML);
+        assertEquals(null, user.getGivenName());
+        assertEquals(null, user.getFamilyName());
         assertEquals("marissa.bloggs@test.com", user.getEmail());
         assertEquals("No custom attributes have been mapped", 0, authentication.getUserAttributes().size());
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
@@ -121,6 +121,7 @@ import static org.springframework.util.StringUtils.hasText;
 
 public class IntegrationTestUtils {
 
+    public static final String ZONE_NAME_TEMPLATE = "The Twiglet Zone[%s]";
 
     public static ScimUser createUnapprovedUser(ServerRunning serverRunning) throws Exception {
         String userName = "bob-" + new RandomValueStringGenerator().generate();
@@ -1017,7 +1018,7 @@ public class IntegrationTestUtils {
         IdentityZone identityZone = new IdentityZone();
         identityZone.setId(id);
         identityZone.setSubdomain(subdomain);
-        identityZone.setName("The Twiglet Zone[" + id + "]");
+        identityZone.setName(String.format(ZONE_NAME_TEMPLATE, id));
         identityZone.setDescription("Like the Twilight Zone but tastier[" + id + "].");
         identityZone.setConfig(config);
         return identityZone;


### PR DESCRIPTION
Use Case: SAML Federation with External IDP assuming Shadow users pre provisioned
Team not sure of Attributes on the External IDP and thus configures the external IDP in UAA with incorrect attributeMappings.

Current Behavior:  UAA while consuming the SAML Assertion for IDP with misconfigured attributeMappings, defaults the uaaUser with email,givenName and familyName like 
    (Either: userName@unknown.org, userName and “unknown” for givenName/familyName  OR if the userName is an email :: email: userName givenName: userNameportionbefore@ familyName:emailDomainPart)

Desired Behavior: UAA while consuming SAML Assertion for IDP with misconfigured attributeMappings, **would not overwrite the existing attributes(email,givenName and familyName) with the defaults(mentioned above in Current Behaviour) and rather set those to null for the shadow user.**