### PR TITLE
Add input validation for az_attr

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -837,11 +837,13 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     private Map<String, String> getAdditionalAuthorizationAttributes(String authoritiesJson) {
         if (StringUtils.hasLength(authoritiesJson)) {
             try {
-                @SuppressWarnings("unchecked")
                 Map<String, Object> authorities = JsonUtils.readValue(authoritiesJson, new TypeReference<Map<String, Object>>() {});
-                @SuppressWarnings("unchecked")
+                Object az_attr = authorities.get("az_attr");
+                if(az_attr == null)
+                    return null;
+                // validate az_attr content with Map<String, String>>
                 Map<String, String> additionalAuthorizationAttributes =
-                    (Map<String, String>) authorities.get("az_attr");
+                    JsonUtils.readValue(JsonUtils.writeValueAsBytes(az_attr), new TypeReference<Map<String, String>>() {});
 
                 return additionalAuthorizationAttributes;
             } catch (Throwable t) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
@@ -971,7 +971,7 @@ public class CheckTokenEndpointTests {
         assertEquals(result.getAzAttr(),azAttributes);
     }
 
-    @Test(expected = InvalidTokenException.class)
+    @Test
     public void testInvalidAuthoritiesNested() throws Exception {
         Map<String, Object> nestedAttributes = new HashMap<>();
         nestedAttributes.put("nested_group", "true");
@@ -987,7 +987,8 @@ public class CheckTokenEndpointTests {
         authentication = new OAuth2Authentication(authorizationRequest.createOAuth2Request(),
             UaaAuthenticationTestFactory.getAuthentication(userId, userName, "olds@vmware.com"));
         setAccessToken(tokenServices.createAccessToken(authentication));
-        endpoint.checkToken(getAccessToken(), Collections.emptyList(), request);
+        Claims result = endpoint.checkToken(getAccessToken(), Collections.emptyList(), request);
+        assertNull(result.getAzAttr());
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CheckTokenEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CheckTokenEndpointIntegrationTests.java
@@ -316,12 +316,11 @@ public class CheckTokenEndpointIntegrationTests {
 
         @SuppressWarnings("rawtypes")
         ResponseEntity<Map> tokenResponse = serverRunning.postForMap("/check_token", formData, tokenHeaders);
-        assertEquals(HttpStatus.BAD_REQUEST, tokenResponse.getStatusCode());
+        assertEquals(HttpStatus.OK, tokenResponse.getStatusCode());
 
         @SuppressWarnings("unchecked")
         Map<String, String> map = tokenResponse.getBody();
-        assertEquals("invalid_token", map.get("error"));
-        assertTrue(map.containsKey("error_description"));
+        assertNull(map.get("az_attr"));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
In addition to pull request #729 add a type check for az_attr
and prevent write if type is not valid.
Remark: with PR #729 the validation already fails if az_attr claim
has not correct type, however now we prevent that a JWT is created with
an invalid az_attr input.

The result JWT does not contain the az_attr claim if type check fails