### PR TITLE
Use issuer.uri from zone configuration

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneConfiguration.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneConfiguration.java
@@ -39,6 +39,7 @@ public class IdentityZoneConfiguration {
     private boolean accountChooserEnabled;
     private UserConfig userConfig = new UserConfig();
     private MfaConfig mfaConfig = new MfaConfig();
+    private String issuer;
 
     public IdentityZoneConfiguration() {}
 
@@ -136,5 +137,15 @@ public class IdentityZoneConfiguration {
 
     public void setUserConfig(UserConfig userConfig) {
         this.userConfig = userConfig;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public String getIssuer() {
+        return issuer;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public void setIssuer(String issuer) {
+        this.issuer = issuer;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -396,6 +396,37 @@ public class UaaTokenServicesTests {
         assertCommonEventProperties(accessToken, CLIENT_ID, tokenSupport.expectedJson);
     }
 
+    @Test
+    public void testCreateAccessTokenForAnotherIssuer() throws URISyntaxException {
+
+        String subdomain = "test-zone-subdomain";
+        IdentityZone identityZone = getIdentityZone(subdomain);
+        identityZone.setConfig(
+            JsonUtils.readValue(
+                "{\"issuer\": \"http://uaamaster:8080/uaa\"}",
+                IdentityZoneConfiguration.class
+            )
+        );
+        tokenSupport.copyClients(IdentityZoneHolder.get().getId(), identityZone.getId());
+        IdentityZoneHolder.set(identityZone);
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest(CLIENT_ID,tokenSupport.clientScopes);
+        authorizationRequest.setResourceIds(new HashSet<>(tokenSupport.resourceIds));
+        Map<String, String> azParameters = new HashMap<>(authorizationRequest.getRequestParameters());
+        azParameters.put(GRANT_TYPE, CLIENT_CREDENTIALS);
+        authorizationRequest.setRequestParameters(azParameters);
+
+        OAuth2Authentication authentication = new OAuth2Authentication(authorizationRequest.createOAuth2Request(), null);
+
+        tokenServices.setIssuer("http://uaaslave:8080/uaa");
+        OAuth2AccessToken accessToken = tokenServices.createAccessToken(authentication);
+
+        assertCommonClientAccessTokenProperties(accessToken);
+        assertThat(accessToken, validFor(is(tokenSupport.accessTokenValidity)));
+        assertThat(accessToken, issuerUri(is("http://uaamaster:8080/uaa/oauth/token")));
+        assertThat(accessToken, zoneId(is(IdentityZoneHolder.get().getId())));
+        assertThat(accessToken.getRefreshToken(), is(nullValue()));
+        validateExternalAttributes(accessToken);
+    }
 
     @Test
     public void test_refresh_token_is_opaque_when_requested() {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointDocs.java
@@ -149,6 +149,8 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
     private static final String SERVICE_PROVIDER_ID = "cloudfoundry-saml-login";
     private static final String MFA_CONFIG_ENABLED_DESC = "Set `true` to enable Multi-factor Authentication (MFA) for the current zone. Defaults to `false`";
     private static final String MFA_CONFIG_PROVIDER_NAME_DESC = "The unique `name` of the MFA provider to use for this zone.";
+    private static final String ZONE_ISSUER_DESC = "Issuer of this zone";
+    private static final String DEFAULT_ISSUER_URI = "http://localhost:8080/uaa";
 
     @Before
     public void setUp() throws Exception {
@@ -183,6 +185,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
         samlConfig.setPrivateKey(SERVICE_PROVIDER_KEY);
         samlConfig.setPrivateKeyPassword(SERVICE_PROVIDER_KEY_PASSWORD);
         samlConfig.setEntityID(SERVICE_PROVIDER_ID);
+        identityZone.getConfig().setIssuer(DEFAULT_ISSUER_URI);
         identityZone.getConfig().setSamlConfig(samlConfig);
         IdentityZoneConfiguration brandingConfig = setBranding(identityZone.getConfig());
         identityZone.setConfig(brandingConfig);
@@ -241,6 +244,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
 
             fieldWithPath("config.idpDiscoveryEnabled").description(IDP_DISCOVERY_ENABLED_FLAG).attributes(key("constraints").value("Optional")),
             fieldWithPath("config.accountChooserEnabled").description(ACCOUNT_CHOOSER_ENABLED_FLAG).attributes(key("constraints").value("Optional")),
+            fieldWithPath("config.issuer").description(ZONE_ISSUER_DESC).attributes(key("constraints").value("Optional")),
 
             fieldWithPath("config.branding.companyName").description(BRANDING_COMPANY_NAME_DESC).attributes(key("constraints").value("Optional")),
             fieldWithPath("config.branding.productLogo").description(BRANDING_PRODUCT_LOGO_DESC).attributes(key("constraints").value("Optional")),
@@ -397,6 +401,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
 
             fieldWithPath("[].config.idpDiscoveryEnabled").description(IDP_DISCOVERY_ENABLED_FLAG),
             fieldWithPath("[].config.accountChooserEnabled").description(ACCOUNT_CHOOSER_ENABLED_FLAG),
+            fieldWithPath("[].config.issuer").description(ZONE_ISSUER_DESC),
 
             fieldWithPath("[].config.branding.companyName").description(BRANDING_COMPANY_NAME_DESC).attributes(key("constraints").value("Optional")),
             fieldWithPath("[].config.branding.productLogo").description(BRANDING_PRODUCT_LOGO_DESC).attributes(key("constraints").value("Optional")),
@@ -474,6 +479,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
         samlConfig.setPrivateKeyPassword(SERVICE_PROVIDER_KEY_PASSWORD);
         samlConfig.setCertificate(SERVICE_PROVIDER_CERTIFICATE);
         samlConfig.setEntityID(SERVICE_PROVIDER_ID);
+        updatedIdentityZone.getConfig().setIssuer(DEFAULT_ISSUER_URI);
         updatedIdentityZone.getConfig().setSamlConfig(samlConfig);
         IdentityZoneConfiguration brandingConfig = setBranding(updatedIdentityZone.getConfig());
         updatedIdentityZone.setConfig(brandingConfig);
@@ -531,6 +537,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
 
             fieldWithPath("config.idpDiscoveryEnabled").description(IDP_DISCOVERY_ENABLED_FLAG).attributes(key("constraints").value("Optional")),
             fieldWithPath("config.accountChooserEnabled").description(ACCOUNT_CHOOSER_ENABLED_FLAG).attributes(key("constraints").value("Optional")),
+            fieldWithPath("config.issuer").description(ZONE_ISSUER_DESC).attributes(key("constraints").value("Optional")),
 
             fieldWithPath("config.branding.companyName").description(BRANDING_COMPANY_NAME_DESC).attributes(key("constraints").value("Optional")),
             fieldWithPath("config.branding.productLogo").description(BRANDING_PRODUCT_LOGO_DESC).attributes(key("constraints").value("Optional")),
@@ -631,6 +638,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
         samlConfig.setPrivateKeyPassword(SERVICE_PROVIDER_KEY_PASSWORD);
         samlConfig.setEntityID(SERVICE_PROVIDER_ID);
         identityZone.getConfig().setSamlConfig(samlConfig);
+        identityZone.getConfig().setIssuer(DEFAULT_ISSUER_URI);
         identityZone.setId(id);
         identityZone.setSubdomain(StringUtils.hasText(id) ? id : new RandomValueStringGenerator().generate());
         identityZone.setName("The Twiglet Zone");
@@ -697,6 +705,7 @@ public class IdentityZoneEndpointDocs extends InjectedMockContextTest {
 
             fieldWithPath("config.idpDiscoveryEnabled").description(IDP_DISCOVERY_ENABLED_FLAG),
             fieldWithPath("config.accountChooserEnabled").description(ACCOUNT_CHOOSER_ENABLED_FLAG),
+            fieldWithPath("config.issuer").description(ZONE_ISSUER_DESC),
             fieldWithPath("config.branding.companyName").description(BRANDING_COMPANY_NAME_DESC),
             fieldWithPath("config.branding.productLogo").description(BRANDING_PRODUCT_LOGO_DESC),
             fieldWithPath("config.branding.squareLogo").description(BRANDING_SQUARE_LOGO_DESC),


### PR DESCRIPTION
    The default zone uses a YAML configuration entry, which remains as it is
    Add test for new property

Old:

    The other zones use automatically a generated issuer.uri which enforce an indivdual trust configuration for each Zone of UAA

New:

    Move issuer.uri to Config in zone configuration and make use of the property if the entry is not null
    This allows that a zone can have an own configured issuer.uri 
    Allows to combine the trust of different zones to one trust, simply using same issuer
