### PR TITLE
omit not needed libs

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     exclude(group: 'org.owasp.esapi', module: 'esapi')
     exclude(group: 'ca.juliusdavies', module: 'not-yet-commons-ssl')
     exclude(group: "org.apache.velocity", module: 'velocity')
+    exclude(group: 'org.beanshell', module: 'beanshell')
   }
   compile group: 'org.apache.velocity', name: 'velocity-engine-core', version: '2.0'
 


### PR DESCRIPTION
omit bsh-core-2.0b4.jar because of CVE-2016-2510
