### PR TITLE
Added "Accept-Language", "en-US" to PhantomJS

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
@@ -1,6 +1,7 @@
 /*******************************************************************************
  *     Cloud Foundry
  *     Copyright (c) [2009-2016] Pivotal Software, Inc. All Rights Reserved.
+ *     Copyright (c) 2017 Siemens AG - method webDriver() added PhantomJS language locale
  *
  *     This product is licensed to you under the Apache License, Version 2.0 (the "License").
  *     You may not use this product except in compliance with the License.
@@ -51,6 +52,8 @@ public class DefaultIntegrationTestConfig {
     public PhantomJSDriver webDriver() {
         DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
         desiredCapabilities.setCapability(PhantomJSDriverService.PHANTOMJS_CLI_ARGS, new String[] {"--web-security=no", "--ignore-ssl-errors=yes"});
+        //added PhantomJS language local to make integration tests system independent
+        desiredCapabilities.setCapability(PhantomJSDriverService.PHANTOMJS_PAGE_CUSTOMHEADERS_PREFIX + "Accept-Language", "en-US");
         PhantomJSDriver driver = new PhantomJSDriver(desiredCapabilities);
         driver.manage().timeouts().implicitlyWait(15, TimeUnit.SECONDS);
         driver.manage().timeouts().pageLoadTimeout(20, TimeUnit.SECONDS);


### PR DESCRIPTION
Tests do not run successfully on machines configured for a language locale different from "en-US". To make the tests independent of the system language, explicitly specify the "Accept-Language" header for the PantomJSDriverService to "en-US".