### PR TITLE
Extend scope and authorities fields for oauth clients

### DIFF
--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_9_1__Extend_client_scopes_authorities.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_9_1__Extend_client_scopes_authorities.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_client_details ALTER COLUMN scope CLOB;
+ALTER TABLE oauth_client_details ALTER COLUMN authorities CLOB;
+ALTER TABLE revocable_tokens ALTER COLUMN scope CLOB;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_9_1__Extend_client_scopes_authorities.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_9_1__Extend_client_scopes_authorities.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_client_details MODIFY scope LONGTEXT;
+ALTER TABLE oauth_client_details MODIFY authorities LONGTEXT;
+ALTER TABLE revocable_tokens MODIFY scope LONGTEXT;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_9_1__Extend_client_scopes_authorities.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_9_1__Extend_client_scopes_authorities.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_client_details ALTER COLUMN scope TYPE TEXT;
+ALTER TABLE oauth_client_details ALTER COLUMN authorities TYPE TEXT;
+ALTER TABLE revocable_tokens ALTER COLUMN scope TYPE TEXT;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/sqlserver/V4_9_1__Extend_client_scopes_authorities.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/sqlserver/V4_9_1__Extend_client_scopes_authorities.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_client_details ALTER COLUMN scope NVARCHAR(MAX);
+ALTER TABLE oauth_client_details ALTER COLUMN authorities NVARCHAR(MAX);
+ALTER TABLE revocable_tokens ALTER COLUMN scope NVARCHAR(MAX);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/db/ClientDetailsSupportsExtendedAuthoritesAndScopes.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/db/ClientDetailsSupportsExtendedAuthoritesAndScopes.java
@@ -14,21 +14,20 @@
  */
 package org.cloudfoundry.identity.uaa.db;
 
-import org.cloudfoundry.identity.uaa.test.JdbcTestBase;
-import org.junit.Test;
-import org.springframework.mock.env.MockEnvironment;
-import org.springframework.util.StringUtils;
+import static org.hamcrest.Matchers.isIn;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.util.Arrays;
 
-import static org.hamcrest.Matchers.isIn;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import org.cloudfoundry.identity.uaa.test.JdbcTestBase;
+import org.junit.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.util.StringUtils;
 
 public class ClientDetailsSupportsExtendedAuthoritesAndScopes extends JdbcTestBase {
 
@@ -60,7 +59,7 @@ public class ClientDetailsSupportsExtendedAuthoritesAndScopes extends JdbcTestBa
                 int columnSize = rs.getInt("COLUMN_SIZE");
                 if (tableName.equalsIgnoreCase(rstableName) && (scopeColumnName.equalsIgnoreCase(rscolumnName)
                         || authoritiesColumnName.equalsIgnoreCase(rscolumnName))) {
-                    assertEquals(String.format("Table: %s Column: %s should be 4000 in size.", rstableName, rscolumnName), 4000,  columnSize);
+                    assertTrue(String.format("Table: %s Column: %s should be over 4000 chars", rstableName, rscolumnName), columnSize > 4000);
                     foundTable = true;
                     if(scopeColumnName.equalsIgnoreCase(rscolumnName)) {
                         foundColumnScope = true;
@@ -71,7 +70,7 @@ public class ClientDetailsSupportsExtendedAuthoritesAndScopes extends JdbcTestBa
 
                     String columnType = rs.getString("TYPE_NAME");
                     assertNotNull(String.format("Table: %s Column: %s should have a column type", rstableName, rscolumnName), columnType);
-                    assertThat(String.format("Table: %s Column: %s should be varchar or nvarchar", rstableName, rscolumnName), columnType.toLowerCase(), isIn(Arrays.asList("varchar","nvarchar")));
+                    assertThat(String.format("Table: %s Column: %s should be text, longtext, nvarchar or clob", rstableName, rscolumnName), columnType.toLowerCase(), isIn(Arrays.asList("text","longtext","nvarchar","clob")));
                 } else {
                     continue;
                 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/db/RevocableTokenTableTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/db/RevocableTokenTableTest.java
@@ -39,7 +39,7 @@ public class RevocableTokenTableTest extends JdbcTestBase {
         new TestColumn("response_type", "varchar/nvarchar", 25),
         new TestColumn("issued_at", "bigint/int8", 64),
         new TestColumn("expires_at", "bigint/int8", 64),
-        new TestColumn("scope", "varchar/nvarchar", 4000),
+        new TestColumn("scope", "text/longtext/nvarchar/clob", 0),
         new TestColumn("data", "nvarchar/longvarchar/mediumtext", 0),
         new TestColumn("identity_zone_id", "varchar/nvarchar", 36)
     );
@@ -66,7 +66,7 @@ public class RevocableTokenTableTest extends JdbcTestBase {
     public boolean testColumn(List<TestColumn> columns, String name, String type, int size) {
         for (TestColumn c : columns) {
             if (c.name.equalsIgnoreCase(name)) {
-                return ("varchar".equalsIgnoreCase(type) || "nvarchar".equalsIgnoreCase(type)) && !"data".equalsIgnoreCase(name) ?
+                return ("varchar".equalsIgnoreCase(type) || "nvarchar".equalsIgnoreCase(type)) && !("data".equalsIgnoreCase(name) || "scope".equalsIgnoreCase(name)) ?
                     c.type.toLowerCase().contains(type.toLowerCase()) && c.size == size :
                     c.type.toLowerCase().contains(type.toLowerCase());
             }


### PR DESCRIPTION
Hi,

as discussed, we want to extend the fields storing scopes and authorities for oauth clients. 
As simply doubling it is not supported by all databases, I decided to go for text-types, which are also used e.g. for identity_zone config.
