### PR TITLE
Fix the problem with WAS (IBM WebSphere) 9

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/XOAuthAuthenticationFilter.java
@@ -73,7 +73,7 @@ public class XOAuthAuthenticationFilter implements Filter {
     }
 
     public boolean authenticationWasSuccessful(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String origin = URIUtil.getName(request.getServletPath());
+        String origin = URIUtil.getName(String.valueOf(request.getRequestURL()));
         String code = request.getParameter("code");
         String idToken = request.getParameter("id_token");
         String accessToken = request.getParameter("access_token");


### PR DESCRIPTION
In IBM WebSphere 9, this getServletPath() returns a blank String, and with a blank origin, UAA is unable to successfully authenticate.
This getRequestURL() works fine for both Tomcat and WAS 9.