### PR TITLE
UaaTokenStore: Don't fall over when failing to expire oauth codes

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
@@ -215,12 +216,14 @@ public class UaaTokenStore implements AuthorizationCodeServices {
         //check if we should expire again
         if ((System.currentTimeMillis()-last) > getExpirationTime()) {
             //avoid concurrent deletes from the same UAA - performance improvement
-            if (lastClean.compareAndSet(last, last+getExpirationTime())) {
+            if (lastClean.compareAndSet(last, last+getExpirationTime())) try {
                 JdbcTemplate template = new JdbcTemplate(dataSource);
                 int expired = template.update(SQL_EXPIRE_STATEMENT, System.currentTimeMillis());
                 logger.debug("[oauth_code] Removed "+expired+" expired entries.");
                 expired = template.update(SQL_CLEAN_STATEMENT, new Timestamp(System.currentTimeMillis()-LEGACY_CODE_EXPIRATION_TIME));
                 logger.debug("[oauth_code] Removed "+expired+" old entries.");
+            } catch (DeadlockLoserDataAccessException e) {
+                logger.debug("[oauth code] Deadlock trying to expire entries, ignored.");
             }
         }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStoreTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStoreTests.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.dao.DeadlockLoserDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -44,6 +45,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.sql.Timestamp;
@@ -314,6 +316,27 @@ public class UaaTokenStoreTests extends JdbcTestBase {
         }
     }
 
+    @Test
+    public void testCleanUpExpiredTokensDeadlockLoser() throws Exception {
+        Connection con = dataSource.getConnection();
+        try {
+            Connection expirationLoser = (Connection) Proxy.newProxyInstance(getClass().getClassLoader(),
+                    new Class[]{Connection.class},
+                    new ExpirationLoserConnection(con));
+
+            SameConnectionDataSource sameConnectionDataSource = new SameConnectionDataSource(expirationLoser);
+
+            store = new UaaTokenStore(sameConnectionDataSource, 1);
+            int count = 10;
+            for (int i=0; i<count; i++) {
+                String code = store.createAuthorizationCode(clientAuthentication);
+                try { store.consumeAuthorizationCode(code); } catch (InvalidGrantException e) {}
+            }
+        } finally {
+            con.close();
+            store = new UaaTokenStore(dataSource);
+        }
+    }
 
 
     public class SameConnectionDataSource implements DataSource {
@@ -384,6 +407,53 @@ public class UaaTokenStoreTests extends JdbcTestBase {
             } else {
                 return method.invoke(con, args);
             }
+        }
+    }
+
+    public class ExpirationLoserConnection implements InvocationHandler {
+        static final String CLOSE_VAL = "close";
+        static final String PREPARE_VAL = "prepareStatement";
+        private final Connection con;
+
+        protected class ExpirationLoserPreparedStatement implements InvocationHandler {
+            static final String UPDATE_VAL = "executeUpdate";
+            private final PreparedStatement stmt;
+
+            ExpirationLoserPreparedStatement(PreparedStatement stmt) {
+                this.stmt = stmt;
+            }
+
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                if (UPDATE_VAL.equals(method.getName())) {
+                    throw new DeadlockLoserDataAccessException("Deadlock in update (emulated)", null);
+                }
+                return method.invoke(stmt, args);
+            }
+        }
+
+        ExpirationLoserConnection(Connection con) {
+            this.con = con;
+        }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            switch (method.getName()) {
+                case CLOSE_VAL:
+                    // This breaks things
+                    return null;
+                case PREPARE_VAL:
+                    if (args.length > 0) {
+                        String sql = (String) args[0];
+                        if (sql.startsWith("delete from oauth_code where expiresat ")) {
+                            PreparedStatement stmt = (PreparedStatement) method.invoke(con, args);
+                            return Proxy.newProxyInstance(getClass().getClassLoader(),
+                                    new Class[]{PreparedStatement.class},
+                                    new ExpirationLoserPreparedStatement(stmt));
+                        }
+                    }
+            }
+            return method.invoke(con, args);
         }
     }
 


### PR DESCRIPTION
MySQL does row-level locking, which means when we delete expired oauth codes in parallel we can sometimes hit a harmless deadlock (where the two delete updates execute across the rows in different order simultaneously).  This is not an issue as the winning update will expire tokens as appropriate, plus the tokens are checked for expiry on use.

This was encountered when repeatedly running multiple instances of `cf ssh` in parallel on a Cloud Foundry deployment using a single non-HA UAA instance (backed by a single non-HA MySQL database).

Thanks for building UAA!