### PR TITLE
Saml Provider: ensure username update

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
@@ -356,6 +356,7 @@ public class LoginSamlAuthenticationProvider extends SAMLAuthenticationProvider 
         } catch (UsernameNotFoundException e) {
             UaaUser uaaUser = userDatabase.retrieveUserByEmail(userWithSamlAttributes.getEmail(), samlPrincipal.getOrigin());
             if (uaaUser != null) {
+                userModified = true;
                 user = uaaUser.modifyUsername(samlPrincipal.getName());
             } else {
                 if (!addNew) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.authentication.event.IdentityProviderAuthenticationSuccessEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.AuthEvent;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -90,12 +91,17 @@ import org.springframework.security.saml.context.SAMLMessageContext;
 import org.springframework.security.saml.log.SAMLLogger;
 import org.springframework.security.saml.metadata.ExtendedMetadata;
 import org.springframework.security.saml.websso.WebSSOProfileConsumer;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.context.request.ServletWebRequest;
 
+import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.FAMILY_NAME_ATTRIBUTE_NAME;
+import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.GIVEN_NAME_ATTRIBUTE_NAME;
+import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EMAIL_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.GROUP_ATTRIBUTE_NAME;
+import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.PHONE_NUMBER_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.USER_ATTRIBUTE_PREFIX;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.not;
@@ -586,6 +592,36 @@ public class LoginSamlAuthenticationProviderTests extends JdbcTestBase {
         UaaUser user = userDatabase.retrieveUserByName("marissa-saml", OriginKeys.SAML);
         assertEquals("Marissa-changed", user.getGivenName());
         assertEquals("marissa.bloggs@change.org", user.getEmail());
+    }
+
+    @Test
+    public void update_existingUser_if_username_different() throws Exception {
+        Map<String,Object> attributeMappings = new HashMap<>();
+        attributeMappings.put("given_name", "firstName");
+        attributeMappings.put("family_name", "lastName");
+        attributeMappings.put("email", "emailAddress");
+        attributeMappings.put("phone_number", "phone");
+        providerDefinition.setAttributeMappings(attributeMappings);
+        provider.setConfig(providerDefinition);
+        providerProvisioning.update(provider, IdentityZoneHolder.get().getId());
+
+        getAuthentication();
+
+        UaaUser originalUser = userDatabase.retrieveUserByEmail("marissa.bloggs@test.com", OriginKeys.SAML);
+        assertNotNull(originalUser);
+        assertEquals("marissa-saml", originalUser.getUsername());
+
+        LinkedMultiValueMap<String, String> attributes = new LinkedMultiValueMap<String, String>();
+        attributes.add(GIVEN_NAME_ATTRIBUTE_NAME, "Marissa");
+        attributes.add(FAMILY_NAME_ATTRIBUTE_NAME, "Bloggs");
+        attributes.add(EMAIL_ATTRIBUTE_NAME, "marissa.bloggs@test.com");
+        attributes.add(PHONE_NUMBER_ATTRIBUTE_NAME, "1234567890");
+
+        UaaPrincipal samlPrincipal = new UaaPrincipal(OriginKeys.NotANumber, "marissa-saml-changed", "marissa.bloggs@test.com", OriginKeys.SAML, "marissa-saml-changed", IdentityZoneHolder.get().getId());
+        UaaUser user = authprovider.createIfMissing(samlPrincipal, false, new ArrayList<SimpleGrantedAuthority>(), attributes);
+
+        assertNotNull(user);
+        assertEquals("marissa-saml-changed", user.getUsername());
     }
 
     @Test


### PR DESCRIPTION
**Scenario**

* User created with Identity Provider (SAML)
* User logon (UAA)
* User deleted (on provider)
* User created again with same email address and new user id (SAML)
* User logon (UAA)

**Actual behavior**

The shadow user is found by email. If no other attributes have changed, the user record will NOT be updated since the `userModified` flag is not set in this case. The token issued from UAA contains a wrong/outdated user identifier.

**Expected behavior**

The shadow user is found by email and the record is updated with the new user id.

**Change**

* set `userModified` when the user has been found via email and `modifyUsername` is called
* add test to verify the described behavior