### PR TITLE
Escape the correct regex characters

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/util/UaaStringUtils.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/util/UaaStringUtils.java
@@ -143,7 +143,7 @@ public class UaaStringUtils {
      * @return a regular expression string that will only match exact literals
      */
     public static String escapeRegExCharacters(String s) {
-        return escapeRegExCharacters(s, "([^a-zA-z0-9 ])");
+        return escapeRegExCharacters(s, "([^a-zA-Z0-9 ])");
     }
 
     /**


### PR DESCRIPTION
There is a typo in the regex pattern consisting of characters that don't need to be escaped. The pattern "A-z" actually includes all the characters between the uppercase A and lowercase Z, namely "[", "\", "]", "^", "_", and "`". Without this fix, those characters are treated as regex characters instead of string literals.