### PR TITLE
Add and update migrations to ensure all tables have a primary key

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/db/mysql/V4_9_2__AddPrimaryKeysIfMissing.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/db/mysql/V4_9_2__AddPrimaryKeysIfMissing.java
@@ -1,0 +1,22 @@
+package org.cloudfoundry.identity.uaa.db.mysql;
+
+import org.flywaydb.core.api.migration.spring.SpringJdbcMigration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+
+public class V4_9_2__AddPrimaryKeysIfMissing implements SpringJdbcMigration {
+
+    private final String checkPrimaryKeyExists = "SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND CONSTRAINT_NAME = 'PRIMARY'";
+
+    @Override
+    public void migrate(JdbcTemplate jdbcTemplate) throws Exception {
+        String[] tables = {"group_membership", "external_group_mapping", "oauth_code", "sec_audit"};
+        for (String table : tables) {
+            int count = jdbcTemplate.queryForObject(checkPrimaryKeyExists, Integer.class, jdbcTemplate.getDataSource().getConnection().getCatalog(), table);
+            if (count == 0) {
+                String sql = "ALTER TABLE " + table + " ADD COLUMN `id` int(11) unsigned PRIMARY KEY AUTO_INCREMENT";
+                jdbcTemplate.execute(sql);
+            }
+        }
+    }
+}

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_4_1_1__Add_primary_keys.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_4_1_1__Add_primary_keys.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_code ADD COLUMN `id` int(11) unsigned PRIMARY KEY AUTO_INCREMENT;
+ALTER TABLE sec_audit ADD COLUMN `id` int(11) unsigned PRIMARY KEY AUTO_INCREMENT;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_4_1__Zonify_Group_Memberships.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V2_4_1__Zonify_Group_Memberships.sql
@@ -13,10 +13,12 @@
 
 ALTER TABLE group_membership ADD COLUMN identity_zone_id varchar(36) DEFAULT 'uaa';
 ALTER TABLE group_membership DROP PRIMARY KEY;
+ALTER TABLE group_membership ADD COLUMN `id` int(11) unsigned PRIMARY KEY AUTO_INCREMENT;
 
 ALTER TABLE external_group_mapping ADD COLUMN identity_zone_id varchar(36);
 ALTER TABLE external_group_mapping ADD COLUMN origin varchar(36);
 ALTER TABLE external_group_mapping DROP PRIMARY KEY;
+ALTER TABLE external_group_mapping ADD COLUMN `id` int(11) unsigned PRIMARY KEY AUTO_INCREMENT;
 
 UPDATE group_membership SET identity_zone_id = (SELECT identity_zone_id FROM users where users.id = group_membership.member_id);
 UPDATE group_membership SET identity_zone_id = (SELECT 'uaa' FROM groups where groups.id = group_membership.member_id);


### PR DESCRIPTION
The mysql clustered database in cf-deployment has previously allowed tables without primary keys, although this is not recommended. This will be changed soon to enforce primary keys as the lack of primary keys can cause issues with the clustered database. This pull request is intended as a starting point for conversation and potentially for cross-team efforts to address the issue of tables without primary keys.

With primary key enforcement enabled, older UAA migrations that update tables without primary keys will fail. Because of this we've modified older migrations to add the missing primary keys. We also added a new migration at the end that will add the primary keys on deployments that are upgrading and have already run the older migrations.

Important points:
- These are currently only for the mysql database. Although the primary keys are not needed for the other database engines as far as we know, they should probably be added there to keep the schemas in sync.
- Migration `V2_4_1_1__Add_primary_keys.sql` was added in the past, but no work was done to update the `schema_version` table to say that it was run. We saw that adding migrations to the `schema_version` table was done in `V4_0_4__FixFailedBackPortMigrations`. However, we saw that this "older migration" was simply skipped and did not cause errors, so we saw no reason to manually add it to the `schema_version` table.