### PR TITLE
Use zonifed cors configuration if configured.

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/CorsConfiguration.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/CorsConfiguration.java
@@ -15,6 +15,7 @@ package org.cloudfoundry.identity.uaa.zone;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static org.springframework.http.HttpHeaders.ACCEPT;
@@ -105,5 +106,24 @@ public class CorsConfiguration {
 
     public void setMaxAge(int maxAge) {
         this.maxAge = maxAge;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CorsConfiguration that = (CorsConfiguration) o;
+        return allowedCredentials == that.allowedCredentials &&
+                maxAge == that.maxAge &&
+                Objects.equals(allowedOrigins, that.allowedOrigins) &&
+                Objects.equals(allowedUris, that.allowedUris) &&
+                Objects.equals(allowedHeaders, that.allowedHeaders) &&
+                Objects.equals(allowedMethods, that.allowedMethods);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(allowedOrigins, allowedUris, allowedHeaders, allowedMethods, allowedCredentials, maxAge);
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/TimeLimitRegexMatcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/TimeLimitRegexMatcher.java
@@ -1,0 +1,71 @@
+package org.cloudfoundry.identity.uaa.security.web;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TimeLimitRegexMatcher {
+    private static final long TIMEOUT_IN_MILLIS = 200L;
+
+    public static Matcher matcher(Pattern pattern, CharSequence charSequence) {
+        if (!(charSequence instanceof TimeLimitedCharSequence)) {
+            charSequence = new TimeLimitedCharSequence(
+                    charSequence,
+                    TIMEOUT_IN_MILLIS,
+                    pattern,
+                    charSequence
+            );
+        }
+
+        return pattern.matcher(charSequence);
+    }
+
+    public static class RegExTimeoutException extends RuntimeException {
+        public RegExTimeoutException(String message) {
+            super(message);
+        }
+    }
+
+    private static class TimeLimitedCharSequence implements CharSequence {
+        private final CharSequence charSequence;
+        private final long timeoutInMillis;
+        private final long timeoutTimestamp;
+        private final Pattern pattern;
+        private final CharSequence originalCharSequence;
+
+        public TimeLimitedCharSequence(CharSequence charSequence, long timeoutInMillis, Pattern pattern, CharSequence originalCharSequence) {
+            super();
+            this.charSequence = charSequence;
+            this.timeoutInMillis = timeoutInMillis;
+            this.timeoutTimestamp = System.currentTimeMillis() + timeoutInMillis;
+            this.pattern = pattern;
+            this.originalCharSequence = originalCharSequence;
+        }
+
+        @Override
+        public int length() {
+            return charSequence.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            if(System.currentTimeMillis() > timeoutTimestamp) {
+                throw new RegExTimeoutException("Regular expression timeout after "
+                        + timeoutInMillis + "ms for [ "
+                        + pattern.pattern() + " ] operating on [ "
+                        + originalCharSequence + " ]");
+            }
+            return charSequence.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return new TimeLimitedCharSequence(
+                charSequence.subSequence(start, end), timeoutTimestamp - System.currentTimeMillis(), pattern, originalCharSequence
+            );
+        }
+
+        public String toString() {
+            return charSequence.toString();
+        }
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/CorsFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/CorsFilterTests.java
@@ -101,6 +101,32 @@ public class CorsFilterTests {
     }
 
     @Test
+    public void test_isAllowedRequestUri_Reaches_Max_Timeout() {
+        String uri = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaax";
+        CorsFilter filter = new CorsFilter();
+        filter.setCorsAllowedUris(Arrays.asList("((a*b*)*) | ((a*)*)", "((a*c*)*) | ((a*)*)", "((a*d*)*) | ((a*)*)"));
+        filter.initialize();
+        long startTime = System.currentTimeMillis();
+        assertFalse(filter.isAllowedRequestUri(uri, filter.getDefaultConfiguration()));
+        long executionTime = System.currentTimeMillis() - startTime;
+        //execution time will always be just slightly larger than total cors timeout so add 15 ms to account for that.
+        assertTrue(executionTime <= CorsFilter.CORS_MATCH_TIMEOUT + 10L);
+    }
+
+    @Test
+    public void test_isAllowedRequestOrigin_Reaches_Max_Timeout() {
+        String origin = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaax";
+        CorsFilter filter = new CorsFilter();
+        filter.setCorsAllowedOrigins(Arrays.asList("((a*b*)*) | ((a*)*)", "((a*c*)*) | ((a*)*)", "((a*d*)*) | ((a*)*)"));
+        filter.initialize();
+        long startTime = System.currentTimeMillis();
+        assertFalse(filter.isAllowedOrigin(origin, filter.getDefaultConfiguration()));
+        long executionTime = System.currentTimeMillis() - startTime;
+        //execution time will always be just slightly larger than total cors timeout so add 10 ms to account for that.
+        assertTrue(executionTime <= CorsFilter.CORS_MATCH_TIMEOUT + 10L);
+    }
+
+    @Test
     public void testRequestExpectStandardCorsResponse() throws ServletException, IOException {
         CorsFilter corsFilter = createConfiguredCorsFilter();
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/TimeLimitRegexMatcherTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/TimeLimitRegexMatcherTest.java
@@ -1,0 +1,24 @@
+package org.cloudfoundry.identity.uaa.security.web;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+
+public class TimeLimitRegexMatcherTest {
+
+    @Test(expected = TimeLimitRegexMatcher.RegExTimeoutException.class)
+    public void testTimeLimitRegexMatcherTimeout() {
+        Pattern pattern = Pattern.compile("((a*b*)*) | ((a*)*)");
+        String largeString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaax";
+        TimeLimitRegexMatcher.matcher(pattern, largeString).find();
+    }
+
+    @Test
+    public void testTimeLimitRegexMatcherMatches() {
+        Pattern pattern = Pattern.compile("a*");
+        String largeString = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaax";
+        assertTrue(TimeLimitRegexMatcher.matcher(pattern, largeString).find());
+    }
+}

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -245,13 +245,13 @@
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(1)}" />
                 <entry value-ref="utf8ConversionFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(2)}" />
-                <entry value-ref="corsFilter"
-                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(3)}" />
                 <entry value-ref="limitedModeUaaFilter"
-                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(4)}" />
+                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(3)}" />
                 <entry value-ref="identityZoneResolvingFilter"
-                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(5)}"/>
+                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(4)}"/>
                 <!-- Add in a flag that removes id_token from /oauth/authorize requests-->
+                <entry value-ref="corsFilter"
+                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(5)}" />
                 <entry value-ref="disableIdTokenResponseFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(6)}"/>
                 <!-- Zone switcher goes *after* class OAuth2AuthenticationProcessingFilter as it requires a token to be present to work -->

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ZonifiedCorsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ZonifiedCorsIntegrationTests.java
@@ -1,0 +1,70 @@
+package org.cloudfoundry.identity.uaa.integration;
+
+import org.cloudfoundry.identity.uaa.ServerRunning;
+import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
+import org.cloudfoundry.identity.uaa.zone.CorsConfiguration;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+
+public class ZonifiedCorsIntegrationTests {
+    @Rule
+    public ServerRunning serverRunning = ServerRunning.isRunning();
+
+    private static String baseUrl = "http://localhost:8080/uaa";
+
+
+    @Test
+    public void testZonifiedCorsFilter() {
+        String zoneId = "testzone3";
+
+        RestTemplate identityClient = IntegrationTestUtils.getClientCredentialsTemplate(
+                IntegrationTestUtils.getClientCredentialsResource(baseUrl, new String[]{"zones.write", "zones.read", "scim.zones"}, "identity", "identitysecret")
+        );
+        IdentityZoneConfiguration config = new IdentityZoneConfiguration();
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOrigins(Arrays.asList("other.com$"));
+        config.getCorsPolicy().setDefaultConfiguration(corsConfiguration);
+        IntegrationTestUtils.createZoneOrUpdateSubdomain(identityClient, baseUrl, zoneId, zoneId, config);
+        String zoneUrl = baseUrl.replace("localhost",zoneId+".localhost");
+
+        RestTemplate template = new RestTemplate();
+        //set request factory so restricted headers will be sent
+        template.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        HttpHeaders failHeaders = new HttpHeaders();
+        failHeaders.add(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        failHeaders.add(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, AUTHORIZATION + ", " + ACCEPT + ", " + CONTENT_TYPE);
+        failHeaders.add(HttpHeaders.ORIGIN, "wrong.com");
+        HttpEntity<String> failEntity = new HttpEntity<>(null, failHeaders);
+        try {
+            template.exchange(zoneUrl + "/userinfo", HttpMethod.OPTIONS, failEntity, String.class);
+            Assert.fail("Expected HttpClientErrorException to be thrown with a 403.");
+        } catch(HttpClientErrorException e) {
+            assertEquals(HttpStatus.FORBIDDEN, e.getStatusCode());
+        }
+
+        HttpHeaders successHeaders = new HttpHeaders();
+        successHeaders.add(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD, "GET");
+        successHeaders.add(HttpHeaders.ACCESS_CONTROL_REQUEST_HEADERS, AUTHORIZATION + ", " + ACCEPT + ", " + CONTENT_TYPE);
+        successHeaders.add(HttpHeaders.ORIGIN, "other.com");
+        HttpEntity<String> successEntity = new HttpEntity<>(null, successHeaders);
+        ResponseEntity<String> response = template.exchange(zoneUrl + "/userinfo", HttpMethod.OPTIONS, successEntity, String.class);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+}


### PR DESCRIPTION
Currently, the identity zone configuration offers the ability to set a cors policy per zone. However, that cors policy is never used. Instead, the global cors policy is always used. This pull request uses the cors policy in the identity zone configuration if it differs from the global one. Additionally, since zonified cors policy is based on user input, we set a timeout for a long running regex match as well as a max timeout for matching with all patterns. In order to implement zonified cors policy, it was necessary to switch the filter order slightly so that the cors filter could access the correct policy for a given zone. 