### PR TITLE
Fix to process expired codes periodically

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -216,7 +216,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
         //check if we should expire again
         if ((System.currentTimeMillis()-last) > getExpirationTime()) {
             //avoid concurrent deletes from the same UAA - performance improvement
-            if (lastClean.compareAndSet(last, last+getExpirationTime())) {
+            if (lastClean.compareAndSet(last, System.currentTimeMillis())) {
                 try {
                     JdbcTemplate template = new JdbcTemplate(dataSource);
                     int expired = template.update(SQL_EXPIRE_STATEMENT, System.currentTimeMillis());


### PR DESCRIPTION
This change fixes a bug that was causing expired codes to be processed almost every time rather than periodically based on an expiration time, as it was designed. Without doing this the code will more likely encounter the dead locks under significant load.