### PR TITLE
`enforceDomains` option based on `emailDomain`

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractIdentityProviderDefinition.java
@@ -23,10 +23,12 @@ import java.util.Map;
 public class AbstractIdentityProviderDefinition {
     public static final String EMAIL_DOMAIN_ATTR = "emailDomain";
     public static final String PROVIDER_DESCRIPTION = "providerDescription";
+    public static final String ENFORCE_DOMAINS = "enforceDomains";
 
     private List<String> emailDomain;
     private Map<String,Object> additionalConfiguration;
     private String providerDescription;
+    private boolean enforceDomains;
 
     public List<String> getEmailDomain() {
         return emailDomain;
@@ -52,6 +54,14 @@ public class AbstractIdentityProviderDefinition {
 
     public void setProviderDescription(String description) {
         this.providerDescription = description;
+    }
+
+    public boolean isEnforceDomains() {
+        return enforceDomains;
+    }
+
+    public void setEnforceDomains(Boolean enforceDomains) {
+        this.enforceDomains = Boolean.TRUE.equals(enforceDomains);
     }
 
     @Override

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/LdapIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/LdapIdentityProviderDefinition.java
@@ -50,6 +50,7 @@ public class LdapIdentityProviderDefinition extends ExternalIdentityProviderDefi
     public static final String LDAP_BASE_USER_DN_PATTERN = LDAP_PREFIX + "base.userDnPattern";
     public static final String LDAP_BASE_USER_DN_PATTERN_DELIMITER = LDAP_PREFIX + "base.userDnPatternDelimiter";
     public static final String LDAP_EMAIL_DOMAIN = LDAP_PREFIX + EMAIL_DOMAIN_ATTR;
+    public static final String LDAP_ENFORCE_DOMAINS = LDAP_PREFIX + ENFORCE_DOMAINS;
     public static final String LDAP_STORE_CUSTOM_ATTRIBUTES = LDAP_PREFIX + STORE_CUSTOM_ATTRIBUTES_NAME;
     public static final String LDAP_EXTERNAL_GROUPS_WHITELIST = LDAP_PREFIX + "externalGroupsWhitelist";
     public static final String LDAP_GROUP_FILE_GROUPS_AS_SCOPES = "ldap/ldap-groups-as-scopes.xml";
@@ -109,6 +110,7 @@ public class LdapIdentityProviderDefinition extends ExternalIdentityProviderDefi
             LDAP_BASE_USER_DN_PATTERN,
             LDAP_BASE_USER_DN_PATTERN_DELIMITER,
             LDAP_EMAIL_DOMAIN,
+            LDAP_ENFORCE_DOMAINS,
             LDAP_EXTERNAL_GROUPS_WHITELIST,
             LDAP_GROUPS_AUTO_ADD,
             LDAP_GROUPS_FILE,
@@ -143,6 +145,7 @@ public class LdapIdentityProviderDefinition extends ExternalIdentityProviderDefi
         LDAP_PROPERTY_TYPES.put(LDAP_BASE_USER_DN_PATTERN, String.class);
         LDAP_PROPERTY_TYPES.put(LDAP_BASE_USER_DN_PATTERN_DELIMITER, String.class);
         LDAP_PROPERTY_TYPES.put(LDAP_EMAIL_DOMAIN, List.class);
+        LDAP_PROPERTY_TYPES.put(LDAP_ENFORCE_DOMAINS, Boolean.class);
         LDAP_PROPERTY_TYPES.put(LDAP_EXTERNAL_GROUPS_WHITELIST, List.class);
         LDAP_PROPERTY_TYPES.put(LDAP_GROUPS_AUTO_ADD, Boolean.class);
         LDAP_PROPERTY_TYPES.put(LDAP_GROUPS_FILE, String.class);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/EmailDomainNotAllowedException.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/EmailDomainNotAllowedException.java
@@ -1,0 +1,13 @@
+package org.cloudfoundry.identity.uaa.authentication;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class EmailDomainNotAllowedException extends AuthenticationException {
+    public EmailDomainNotAllowedException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public EmailDomainNotAllowedException(String msg) {
+        super(msg);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
@@ -100,6 +100,7 @@ public class OauthIDPWrapperFactoryBean {
         idpDefinition.setRelyingPartyId((String) idpDefinitionMap.get("relyingPartyId"));
         idpDefinition.setRelyingPartySecret((String) idpDefinitionMap.get("relyingPartySecret"));
         idpDefinition.setEmailDomain((List<String>) idpDefinitionMap.get("emailDomain"));
+        idpDefinition.setEnforceDomains((Boolean) idpDefinitionMap.get("enforceDomains"));
         idpDefinition.setShowLinkText(idpDefinitionMap.get("showLinkText") == null ? true : (boolean) idpDefinitionMap.get("showLinkText"));
         idpDefinition.setAddShadowUserOnLogin(idpDefinitionMap.get("addShadowUserOnLogin") == null ? true : (boolean) idpDefinitionMap.get("addShadowUserOnLogin"));
         idpDefinition.setStoreCustomAttributes(idpDefinitionMap.get(STORE_CUSTOM_ATTRIBUTES_NAME) == null ? true : (boolean) idpDefinitionMap.get(STORE_CUSTOM_ATTRIBUTES_NAME));

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/LdapUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/LdapUtils.java
@@ -53,6 +53,7 @@ public final class LdapUtils {
         setIfNotNull(LdapIdentityProviderDefinition.LDAP_BASE_USER_DN_PATTERN, definition.getUserDNPattern(), properties);
         setIfNotNull(LdapIdentityProviderDefinition.LDAP_BASE_USER_DN_PATTERN_DELIMITER, definition.getUserDNPatternDelimiter(), properties);
         setIfNotNull(LdapIdentityProviderDefinition.LDAP_EMAIL_DOMAIN, definition.getEmailDomain(), properties);
+        setIfNotNull(LdapIdentityProviderDefinition.LDAP_ENFORCE_DOMAINS, definition.isEnforceDomains(), properties);
         setIfNotNull(LdapIdentityProviderDefinition.LDAP_EXTERNAL_GROUPS_WHITELIST, definition.getExternalGroupsWhitelist(), properties);
         setIfNotNull(LdapIdentityProviderDefinition.LDAP_GROUPS_AUTO_ADD, definition.isAutoAddGroups(), properties);
         setIfNotNull(LdapIdentityProviderDefinition.LDAP_GROUPS_FILE, definition.getLdapGroupFile(), properties);
@@ -94,6 +95,10 @@ public final class LdapUtils {
 
         if (ldapConfig.get(LdapIdentityProviderDefinition.LDAP_EMAIL_DOMAIN)!=null) {
             definition.setEmailDomain((List<String>) ldapConfig.get(LdapIdentityProviderDefinition.LDAP_EMAIL_DOMAIN));
+        }
+
+        if (ldapConfig.get(LdapIdentityProviderDefinition.LDAP_ENFORCE_DOMAINS)!=null) {
+            definition.setEnforceDomains((Boolean) ldapConfig.get(LdapIdentityProviderDefinition.LDAP_ENFORCE_DOMAINS));
         }
 
         if (ldapConfig.get(LdapIdentityProviderDefinition.LDAP_EXTERNAL_GROUPS_WHITELIST)!=null) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/AbstractExternalLoginAuthenticationManagerBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/AbstractExternalLoginAuthenticationManagerBuilder.java
@@ -1,0 +1,152 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.authentication.manager.ExternalLoginAuthenticationManager;
+import org.cloudfoundry.identity.uaa.authentication.manager.LdapLoginAuthenticationManager;
+import org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.user.UaaUser;
+import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public abstract class AbstractExternalLoginAuthenticationManagerBuilder <BuilderType extends AbstractExternalLoginAuthenticationManagerBuilder>{
+    // defaults
+    boolean enforceDomains = false;
+    boolean addShadowUser = true;
+    boolean storeCustomAttributes = true;
+    List<String> emailDomain;
+
+    String origin = "default_origin";
+    IdentityProviderProvisioning idProviderProvisioning;
+    IdentityProvider identityProvider;
+    ExternalIdentityProviderDefinition providerDefinition;
+    UaaUserDatabase uaaUserDatabase = mock(UaaUserDatabase.class);
+    List<UaaUser> uaaUsers = new ArrayList<>();
+    List<UaaUser> initiallyMissingUaaUsers = new ArrayList<>();
+    ApplicationEventPublisher applicationEventPublisher = null;
+
+
+
+    protected abstract BuilderType me();
+
+    public BuilderType withProvider(IdentityProvider identityProvider) {
+        this.identityProvider = identityProvider;
+        return me();
+    }
+
+    public BuilderType enforceDomains(boolean enforceDomains) {
+        this.enforceDomains = enforceDomains;
+        return me();
+    }
+
+    public BuilderType addShadowUser(boolean addShadowUser) {
+        this.addShadowUser = addShadowUser;
+        return me();
+    }
+
+    public BuilderType withIdProviderProvisioning(IdentityProviderProvisioning idProviderProvisioning) {
+        this.idProviderProvisioning = idProviderProvisioning;
+        return me();
+    }
+
+    public BuilderType withOrigin(String origin) {
+        this.origin = origin;
+        return me();
+    }
+
+    public BuilderType withProviderDefinition(ExternalIdentityProviderDefinition providerDefinition) {
+        this.providerDefinition = providerDefinition;
+        return me();
+    }
+
+    protected ExternalLoginAuthenticationManager build(ExternalLoginAuthenticationManager manager) {
+        if (idProviderProvisioning != null) {
+            when(idProviderProvisioning.retrieveByOrigin(eq(origin), anyString())).thenReturn(identityProvider);
+        }
+        when(identityProvider.getConfig()).thenReturn(providerDefinition);
+
+        when(providerDefinition.isEnforceDomains()).thenReturn(enforceDomains);
+        when(providerDefinition.isAddShadowUserOnLogin()).thenReturn(addShadowUser);
+        when(providerDefinition.isStoreCustomAttributes()).thenReturn(storeCustomAttributes);
+        when(providerDefinition.getEmailDomain()).thenReturn(emailDomain);
+
+        manager.setUserDatabase(uaaUserDatabase);
+        manager.setOrigin(origin);
+        manager.setApplicationEventPublisher(applicationEventPublisher);
+        for (UaaUser uaaUser : uaaUsers) {
+            when(uaaUserDatabase.retrieveUserById(eq(uaaUser.getId()))).thenReturn(uaaUser);
+            when(uaaUserDatabase.retrieveUserByName(eq(uaaUser.getUsername()), eq(origin))).thenReturn(uaaUser);
+        }
+
+        for (UaaUser uaaUser : initiallyMissingUaaUsers) {
+            when(uaaUserDatabase.retrieveUserById(eq(uaaUser.getId()))).thenReturn(uaaUser);
+            when(uaaUserDatabase.retrieveUserByName(eq(uaaUser.getUsername()), eq(origin)))
+                    .thenReturn(null)
+                    .thenReturn(uaaUser);
+        }
+
+        return manager;
+    }
+
+    <T extends ExternalLoginAuthenticationManager> T buildManagerType(Class<T> managerType) {
+        try {
+            Constructor<T> constructor = managerType.getConstructor(IdentityProviderProvisioning.class);
+            T manager = constructor.newInstance(idProviderProvisioning);
+            build(manager);
+            return manager;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public BuilderType withUaaUserDB(UaaUserDatabase userDb) {
+        this.uaaUserDatabase = userDb;
+        return me();
+    }
+
+    public BuilderType withUaaUser(UaaUser user) {
+        uaaUsers.add(user);
+        return me();
+    }
+
+    public BuilderType withUaaUser(UaaUserBuilder uaaUserBuilder) {
+        uaaUsers.add(uaaUserBuilder.build());
+        return me();
+    }
+
+    /**
+     * user visible only after the 1st call to retrieveUserByName.
+     * user is always visible for other retreive calls.
+     * @param uaaUserBuilder
+     * @return
+     */
+    public BuilderType withInitiallyMissingUaaUser(UaaUserBuilder uaaUserBuilder) {
+        initiallyMissingUaaUsers.add(uaaUserBuilder.build());
+        return me();
+    }
+
+    public BuilderType withApplicationEventPublisher(ApplicationEventPublisher publisher) {
+        this.applicationEventPublisher = publisher;
+        return me();
+    }
+
+    public BuilderType storeCustomAttributes(boolean storeCustomAttributes) {
+        this.storeCustomAttributes = storeCustomAttributes;
+        return me();
+    }
+
+    public BuilderType withEmailDomain(List<String> emailDomains) {
+        this.emailDomain = emailDomains;
+        return me();
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/AuthenticationBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/AuthenticationBuilder.java
@@ -1,0 +1,79 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.cloudfoundry.identity.uaa.authentication.manager.builders.UserDetailsBuilder.aUserDetails;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AuthenticationBuilder<T extends Authentication> {
+    private T authentication;
+
+    private AuthenticationBuilder(T authenticationMock) {
+        authentication = authenticationMock;
+    }
+
+    public static AuthenticationBuilder<Authentication> anAuthentication() {
+        return new AuthenticationBuilder(mock(Authentication.class)).withPrincipal(aUserDetails());
+    }
+
+    public static AuthenticationBuilder<UaaAuthentication> aUaaAuthentication() {
+        // defaults
+        MultiValueMap<String, String> userAttributes = new LinkedMultiValueMap<>();
+        userAttributes.put("1", Arrays.asList("1"));
+        userAttributes.put("2", Arrays.asList("2", "3"));
+
+        Set<String> groups = new HashSet<>(Arrays.asList("role1", "role2", "role3"));
+
+        return new AuthenticationBuilder(mock(UaaAuthentication.class))
+                .withUserAttributes(userAttributes)
+                .withExternalGroups(groups);
+    }
+
+    public T build() {
+        return authentication;
+    }
+
+    public AuthenticationBuilder<T> withPrincipal(UserDetailsBuilder userDetailsBuilder) {
+        when(authentication.getPrincipal()).thenReturn(userDetailsBuilder.build());
+        return this;
+    }
+
+    public AuthenticationBuilder<T> withPrincipal(Object principal) {
+        when(authentication.getPrincipal()).thenReturn(principal);
+        return this;
+    }
+
+    public AuthenticationBuilder<T> withPrincipal(UaaPrincipalBuilder builder) {
+        when(authentication.getPrincipal()).thenReturn(builder.build());
+        return this;
+    }
+
+    public AuthenticationBuilder<T> withDetails(UaaAuthenticationDetails uaaAuthenticationDetails) {
+        when(authentication.getDetails()).thenReturn(uaaAuthenticationDetails);
+        return this;
+    }
+
+    public AuthenticationBuilder<T> withDetails(UaaAuthenticationDetailsBuilder uaaAuthenticationDetailsBuilder) {
+        when(authentication.getDetails()).thenReturn(uaaAuthenticationDetailsBuilder.build());
+        return this;
+    }
+
+    public AuthenticationBuilder<T> withUserAttributes(MultiValueMap<String, String> userAttributes) {
+        when(((UaaAuthentication) authentication).getUserAttributes()).thenReturn(userAttributes);
+        return this;
+    }
+
+    public AuthenticationBuilder<T> withExternalGroups(Set<String> groups) {
+        when(((UaaAuthentication) authentication).getExternalGroups()).thenReturn(groups);
+        return this;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/ExtendedLdapUserImplBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/ExtendedLdapUserImplBuilder.java
@@ -1,0 +1,34 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.provider.ldap.extension.ExtendedLdapUserImpl;
+import org.springframework.security.ldap.userdetails.LdapUserDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExtendedLdapUserImplBuilder {
+    private Map<String, String[]> ldapAttrs = new HashMap<>();
+    private LdapUserDetails ldapUserDetails;
+    private String mailAttributeName;
+
+    public static ExtendedLdapUserImplBuilder anExtendedLdapUserImpl() {
+        return new ExtendedLdapUserImplBuilder();
+    }
+
+    public ExtendedLdapUserImplBuilder withMailAttribute(String attributeName, String attributeValue) {
+        ldapAttrs.put(attributeName, new String[]{attributeValue});
+        this.mailAttributeName = attributeName;
+        return this;
+    }
+
+    public ExtendedLdapUserImplBuilder withLdapUserDetails(LdapUserDetails ldapUserDetails) {
+        this.ldapUserDetails = ldapUserDetails;
+        return this;
+    }
+
+    public ExtendedLdapUserImpl build() {
+        ExtendedLdapUserImpl extendedLdapUserDetails = new ExtendedLdapUserImpl(ldapUserDetails, ldapAttrs);
+        extendedLdapUserDetails.setMailAttributeName(mailAttributeName);
+        return extendedLdapUserDetails;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/ExternalLoginAuthenticationManagerBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/ExternalLoginAuthenticationManagerBuilder.java
@@ -1,0 +1,25 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.authentication.manager.ExternalLoginAuthenticationManager;
+import org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+
+import static org.mockito.Mockito.mock;
+
+public class ExternalLoginAuthenticationManagerBuilder extends AbstractExternalLoginAuthenticationManagerBuilder<ExternalLoginAuthenticationManagerBuilder> {
+    protected ExternalLoginAuthenticationManagerBuilder me() {
+        return this;
+    }
+
+    public static ExternalLoginAuthenticationManagerBuilder aManager() {
+        return new ExternalLoginAuthenticationManagerBuilder()
+                .withIdProviderProvisioning(mock(IdentityProviderProvisioning.class))
+                .withProviderDefinition(mock(ExternalIdentityProviderDefinition.class))
+                .withProvider(mock(IdentityProvider.class));
+    }
+
+    public ExternalLoginAuthenticationManager build() {
+        return buildManagerType(ExternalLoginAuthenticationManager.class);
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/LdapLoginAuthenticationManagerBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/LdapLoginAuthenticationManagerBuilder.java
@@ -1,0 +1,28 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.authentication.manager.ExternalLoginAuthenticationManager;
+import org.cloudfoundry.identity.uaa.authentication.manager.LdapLoginAuthenticationManager;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.LdapIdentityProviderDefinition;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import static org.mockito.Mockito.mock;
+
+public class LdapLoginAuthenticationManagerBuilder extends AbstractExternalLoginAuthenticationManagerBuilder<LdapLoginAuthenticationManagerBuilder> {
+    protected LdapLoginAuthenticationManagerBuilder me() {
+        return this;
+    }
+
+    public static LdapLoginAuthenticationManagerBuilder anLdapManager() {
+        return new LdapLoginAuthenticationManagerBuilder()
+                .withIdProviderProvisioning(mock(IdentityProviderProvisioning.class))
+                .withProviderDefinition(mock(LdapIdentityProviderDefinition.class))
+                .withProvider(mock(IdentityProvider.class));
+    }
+
+    public ExternalLoginAuthenticationManager build() {
+        return buildManagerType(LdapLoginAuthenticationManager.class);
+    }
+
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UaaAuthenticationDetailsBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UaaAuthenticationDetailsBuilder.java
@@ -1,0 +1,38 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UaaAuthenticationDetailsBuilder {
+    private UaaAuthenticationDetails uaaAuthenticationDetails = mock(UaaAuthenticationDetails.class);
+
+    private UaaAuthenticationDetailsBuilder() {
+        // defaults
+        when(uaaAuthenticationDetails.getSessionId()).thenReturn("default_session_id");
+    }
+
+    public static UaaAuthenticationDetailsBuilder aUaaAuthenticationDetails() {
+        return new UaaAuthenticationDetailsBuilder();
+    }
+
+    public UaaAuthenticationDetailsBuilder withOrigin(String origin) {
+        when(uaaAuthenticationDetails.getOrigin()).thenReturn(origin);
+        return this;
+    }
+
+    public UaaAuthenticationDetailsBuilder withClientId(String clientId) {
+        when(uaaAuthenticationDetails.getClientId()).thenReturn(clientId);
+        return this;
+    }
+
+    public UaaAuthenticationDetailsBuilder withSessionId(String sessionId) {
+        when(uaaAuthenticationDetails.getSessionId()).thenReturn(sessionId);
+        return this;
+    }
+
+    public UaaAuthenticationDetails build() {
+        return uaaAuthenticationDetails;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UaaPrincipalBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UaaPrincipalBuilder.java
@@ -1,0 +1,23 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UaaPrincipalBuilder {
+    private UaaPrincipal uaaPrincipal = mock(UaaPrincipal.class);
+
+    public static UaaPrincipalBuilder aUaaPrincipal() {
+        return new UaaPrincipalBuilder();
+    }
+
+    public UaaPrincipal build() {
+        return uaaPrincipal;
+    }
+
+    public UaaPrincipalBuilder withId(String id) {
+        when(uaaPrincipal.getId()).thenReturn(id);
+        return this;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UaaUserBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UaaUserBuilder.java
@@ -1,0 +1,54 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.user.UaaUser;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class UaaUserBuilder {
+    private String username = "default_username";
+    private String password = "default_password";
+    private String origin = "default_origin";
+    private String email = "default@email.com";
+    private String userId = "default_userId";
+
+    public static UaaUserBuilder aUaaUser() {
+        return new UaaUserBuilder();
+    }
+
+    public UaaUserBuilder withUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    public UaaUserBuilder withPassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public UaaUserBuilder withEmail(String email) {
+        this.email = email;
+        return this;
+    }
+
+    public UaaUserBuilder withOrigin(String origin) {
+        this.origin = origin;
+        return this;
+    }
+
+    public UaaUserBuilder withId(String userId) {
+        this.userId = userId;
+        return this;
+    }
+
+    public UaaUser build() {
+        UaaUser user = mock(UaaUser.class);
+        when(user.getUsername()).thenReturn(username);
+        when(user.getId()).thenReturn(userId);
+        when(user.getOrigin()).thenReturn(origin);
+        when(user.getEmail()).thenReturn(email);
+        when(user.getPassword()).thenReturn(password);
+
+        return user;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UserDetailsBuilder.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/builders/UserDetailsBuilder.java
@@ -1,0 +1,73 @@
+package org.cloudfoundry.identity.uaa.authentication.manager.builders;
+
+import org.cloudfoundry.identity.uaa.provider.ldap.ExtendedLdapUserDetails;
+import org.cloudfoundry.identity.uaa.user.Mailable;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.ldap.userdetails.LdapUserDetails;
+
+import static org.mockito.Mockito.*;
+
+public class UserDetailsBuilder<T extends UserDetails> {
+    private T userDetails;
+
+    private UserDetailsBuilder(T mockedUserDetails) {
+        userDetails = mockedUserDetails;
+
+        // defaults
+        when(userDetails.getUsername()).thenReturn("default_username");
+        when(userDetails.getPassword()).thenReturn("default_password");
+        when(userDetails.getAuthorities()).thenReturn(null);
+        when(userDetails.isAccountNonExpired()).thenReturn(true);
+        when(userDetails.isAccountNonLocked()).thenReturn(true);
+        when(userDetails.isCredentialsNonExpired()).thenReturn(true);
+        when(userDetails.isEnabled()).thenReturn(true);
+    }
+
+    public static UserDetailsBuilder<UserDetails> aUserDetails() {
+        return new UserDetailsBuilder<>(
+                mock(UserDetails.class)
+        );
+    }
+
+    public static UserDetailsBuilder<UserDetails> aMailableUserDetails() {
+        return new UserDetailsBuilder<>(
+                mock(UserDetails.class, withSettings().extraInterfaces(Mailable.class))
+        );
+    }
+
+    public static UserDetailsBuilder<LdapUserDetails> anLdapUserDetails() {
+        return new UserDetailsBuilder<>(
+                mock(LdapUserDetails.class)
+        );
+    }
+
+    public static UserDetailsBuilder<ExtendedLdapUserDetails> aMailableExtendedLdapUserDetails() {
+        return new UserDetailsBuilder<>(
+                mock(ExtendedLdapUserDetails.class, withSettings().extraInterfaces(Mailable.class))
+        );
+    }
+
+    public T build() {
+        return userDetails;
+    }
+
+    public UserDetailsBuilder<T> withUsername(String username) {
+        when(userDetails.getUsername()).thenReturn(username);
+        return this;
+    }
+
+    public UserDetailsBuilder<T> withPassword(String password) {
+        when(userDetails.getPassword()).thenReturn(password);
+        return this;
+    }
+
+    public UserDetailsBuilder<T> withEmailAddress(String email) {
+        when(((Mailable) userDetails).getEmailAddress()).thenReturn(email);
+        return this;
+    }
+    public UserDetailsBuilder<T> withDn(String dn) {
+        when(((LdapUserDetails)userDetails).getDn()).thenReturn(dn);
+        return this;
+    }
+
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
@@ -43,6 +43,7 @@ public class OauthIdentityProviderDefinitionFactoryBeanTest {
         idpDefinitionMap.put("tokenUrl", "http://token.url");
         idpDefinitionMap.put("tokenKeyUrl", "http://token-key.url");
         idpDefinitionMap.put("clientAuthInBody", false);
+        idpDefinitionMap.put("enforceDomains", false);
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsDocs.java
@@ -128,6 +128,7 @@ public class IdentityProviderEndpointsDocs extends InjectedMockContextTest {
     private static final FieldDescriptor EXTERNAL_GROUPS_WHITELIST = fieldWithPath("config.externalGroupsWhitelist").optional(null).type(ARRAY).description("List of external groups that will be included in the ID Token if the `roles` scope is requested.");
     private static final FieldDescriptor PROVIDER_DESC = fieldWithPath("config.providerDescription").optional(null).type(STRING).description("Human readable name/description of this provider");
     private static final FieldDescriptor EMAIL_DOMAIN = fieldWithPath("config.emailDomain").optional(null).type(ARRAY).description("List of email domains associated with the provider for the purpose of associating users to the correct origin upon invitation. If empty list, no invitations are accepted. Wildcards supported.");
+    private static final FieldDescriptor ENFORCE_DOMAINS = fieldWithPath("config.enforceDomains").optional(false).type(BOOLEAN).description("Only allow login for users having their email matching one of the domains specified by the `emailDomains` property. If `enforceDomains` is `true` and `emailDomains` is empty, no user will be able to login using this Identity Provider.");
     private static final FieldDescriptor ACTIVE = fieldWithPath("active").optional(null).description(ACTIVE_DESC);
     private static final FieldDescriptor NAME = fieldWithPath("name").required().description(NAME_DESC);
     private static final FieldDescriptor CONFIG = fieldWithPath("config").required().description("Various configuration properties for the identity provider.");
@@ -157,6 +158,7 @@ public class IdentityProviderEndpointsDocs extends InjectedMockContextTest {
         NAME,
         PROVIDER_DESC,
         EMAIL_DOMAIN,
+        ENFORCE_DOMAINS,
         ACTIVE,
         ADD_SHADOW_USER,
         STORE_CUSTOM_ATTRIBUTES

--- a/uaa/src/test/resources/test/bootstrap/all-properties-set.yml
+++ b/uaa/src/test/resources/test/bootstrap/all-properties-set.yml
@@ -152,6 +152,7 @@ login:
         authUrl: http://my-auth.com
         emailDomain:
         - example.com
+        enforceDomains: false
         issuer: http://issuer-my-token.com
         linkText: My Oauth Provider
         relyingPartyId: uaa


### PR DESCRIPTION
Implemented https://www.pivotaltracker.com/n/projects/997278/stories/152248593

- Added a boolean `enforceDomains` identityProvider property to restrict or not the logging in users based on their email address domain matching with the existing `emailDomain` identityProvider property.
- Refactored the ExternalLoginAuthenticationManagerTest test class to make it easier to add the tests related to that new feature. All the existing tests were kept and their logic unchanged.
- Added a bunch of Builders to help with tests readability and maintainability (only used in ExternalLoginAuthenticationManagerTest)

Default general behavior is the same: `enforceDomains` is false by default.