### PR TITLE
For cloudfoundry/uaa#666

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/EnvironmentMapFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/EnvironmentMapFactoryBean.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.List;
+
 
 /**
  * Factory for Maps that reads from the Spring context {@link Environment} where

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/EnvironmentMapFactoryBeanTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/EnvironmentMapFactoryBeanTests.java
@@ -13,72 +13,281 @@
 package org.cloudfoundry.identity.uaa.config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-import java.util.Enumeration;
+import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import org.cloudfoundry.identity.uaa.impl.config.EnvironmentMapFactoryBean;
 import org.cloudfoundry.identity.uaa.impl.config.NestedMapPropertySource;
 import org.junit.Test;
 import org.springframework.core.env.StandardEnvironment;
-import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author Dave Syer
  * 
  */
-public class EnvironmentMapFactoryBeanTests {
+public class EnvironmentMapFactoryBeanTests
+{
 
     @Test
-    public void testDefaultProperties() throws Exception {
+    public void testDefaultProperties() throws Exception
+    {
         EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
-        factory.setDefaultProperties(getProperties("foo=foo"));
+        factory.setDefaultProperties(getProperties("{\"foo\":\"foo\"}"));
         Map<String, ?> properties = factory.getObject();
         assertEquals("foo", properties.get("foo"));
     }
 
     @Test
-    public void testRawPlaceholderProperties() throws Exception {
+    public void testRawPlaceholderProperties() throws Exception
+    {
         EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
-        factory.setDefaultProperties(getProperties("foo=${bar}"));
+        factory.setDefaultProperties(getProperties("{\"foo\":\"${bar}\"}"));
         Map<String, ?> properties = factory.getObject();
         assertEquals("${bar}", properties.get("foo"));
     }
 
     @Test
-    public void testPlaceholderProperties() throws Exception {
+    public void testPlaceholderProperties() throws Exception
+    {
         EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
         StandardEnvironment environment = new StandardEnvironment();
-        environment.getPropertySources().addLast(new NestedMapPropertySource("override", getProperties("bar=${spam}")));
+        environment.getPropertySources()
+                .addLast(new NestedMapPropertySource("override", getProperties("{\"bar\":\"${spam}\"}")));
         factory.setEnvironment(environment);
-        factory.setDefaultProperties(getProperties("foo=baz"));
+        factory.setDefaultProperties(getProperties("{\"foo\":\"baz\"}"));
         Map<String, ?> properties = factory.getObject();
         assertEquals("baz", properties.get("foo"));
         assertEquals("${spam}", properties.get("bar"));
     }
 
     @Test
-    public void testOverrideProperties() throws Exception {
+    public void testOverrideProperties() throws Exception
+    {
         EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
-        factory.setDefaultProperties(getProperties("foo=foo"));
+        factory.setDefaultProperties(getProperties("{\"foo\":\"foo\"}"));
         StandardEnvironment environment = new StandardEnvironment();
-        environment.getPropertySources().addLast(new NestedMapPropertySource("override", getProperties("foo=bar")));
+        environment.getPropertySources()
+                .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":\"bar\"}")));
         factory.setEnvironment(environment);
         Map<String, ?> properties = factory.getObject();
         assertEquals("bar", properties.get("foo"));
     }
-
-    private Map<String, ?> getProperties(String input) {
-        HashMap<String, Object> result = new HashMap<String, Object>();
-        Properties properties = StringUtils.splitArrayElementsIntoProperties(
-                        StringUtils.commaDelimitedListToStringArray(input), "=");
-        for (Enumeration<?> keys = properties.propertyNames(); keys.hasMoreElements();) {
-            String key = (String) keys.nextElement();
-            result.put(key, properties.getProperty(key));
-        }
-        return result;
+    
+    @Test
+    public void testPlaceholderResolutionForSimpleValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        System.setProperty("some_env", "some_env_value");
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":\"${some_env}\"}")));
+        
+        
+        factory.setEnvironment(environment);
+        
+        Map<String, ?> properties = factory.getObject();
+        assertEquals("some_env_value", properties.get("foo"));
+    }
+    
+    
+    @Test
+    public void testPlaceholderResolutionForListValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        System.setProperty("some_env", "some_env_value");
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":[\"${some_env}\",\"bar2\"]}")));
+        
+        
+        factory.setEnvironment(environment);
+        
+        Map<String, ?> properties = factory.getObject();
+        Object val = properties.get("foo");
+        assertTrue("The value must be of type list",val instanceof List);
+        
+        @SuppressWarnings("rawtypes")
+        List asList = (List)val;
+        assertEquals("some_env_value", asList.get(0));
     }
 
+    @Test
+    public void testPlaceholderResolutionForMapValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        System.setProperty("some_env", "some_env_value");
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"fake-client\":{\"key1\": \"${some_env}\"}}")));
+        
+        
+        factory.setEnvironment(environment);
+        
+        Map<String, ?> properties = factory.getObject();
+        Object val = properties.get("fake-client");
+        assertTrue("The value must be of type list",val instanceof Map);
+        
+        @SuppressWarnings("rawtypes")
+        Map asMap = (Map)val;
+        assertEquals("some_env_value", asMap.get("key1"));
+    }
+
+    @Test
+    public void testPlaceholderResolutionForNoEnvSimpleValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        System.setProperty("some_env", "some_env_value");
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":\"${spam}\"}")));
+        
+        
+        factory.setEnvironment(environment);
+        
+        Map<String, ?> properties = factory.getObject();
+        assertEquals("${spam}", properties.get("foo"));
+    }
+    
+    
+    @Test
+    public void testPlaceholderResolutionForNoEnvListValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        System.setProperty("some_env", "some_env_value");
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":[\"${spam}\",\"bar2\"]}")));
+        
+        
+        factory.setEnvironment(environment);
+        
+        Map<String, ?> properties = factory.getObject();
+        Object val = properties.get("foo");
+        assertTrue("The value must be of type list",val instanceof List);
+        
+        @SuppressWarnings("rawtypes")
+        List asList = (List)val;
+        assertEquals("${spam}", asList.get(0));
+    }
+
+    @Test
+    public void testPlaceholderResolutionForNoEnvMapValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        System.setProperty("some_env", "some_env_value");
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"fake-client\":{\"key1\": \"${spam}\"}}")));
+        
+        
+        factory.setEnvironment(environment);
+        
+        Map<String, ?> properties = factory.getObject();
+        Object val = properties.get("fake-client");
+        assertTrue("The value must be of type map",val instanceof Map);
+        
+        @SuppressWarnings("rawtypes")
+        Map asMap = (Map)val;
+        assertEquals("${spam}", asMap.get("key1"));
+    }
+
+    @Test
+    public void testPlaceholderResolutionForSimpleNullValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":null}")));
+
+        factory.setEnvironment(environment);
+
+        Map<String, ?> properties = factory.getObject();
+        assertNull(properties.get("foo"));
+    }
+    
+    
+    @Test
+    public void testPlaceholderResolutionForListNullValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"foo\":[null,\"bar2\"]}")));
+
+        factory.setEnvironment(environment);
+
+        Map<String, ?> properties = factory.getObject();
+        Object val = properties.get("foo");
+        assertTrue("The value must be of type list",val instanceof List);
+        
+        @SuppressWarnings("rawtypes")
+        List asList = (List)val;
+        assertNull(asList.get(0));
+    }
+
+    @Test
+    public void testPlaceholderResolutionForMapNullValue() throws Exception
+    {
+        EnvironmentMapFactoryBean factory = new EnvironmentMapFactoryBean();
+        
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources()
+        .addLast(new NestedMapPropertySource("override", getProperties("{\"fake-client\":{\"key1\": null}}")));
+
+        factory.setEnvironment(environment);
+
+        Map<String, ?> properties = factory.getObject();
+        Object val = properties.get("fake-client");
+        assertTrue("The value must be of type list",val instanceof Map);
+        
+        @SuppressWarnings("rawtypes")
+        Map asMap = (Map)val;
+        assertNull(asMap.get("key1"));
+    }
+
+    @SuppressWarnings("rawtypes")
+    private Map<String, ?> getProperties(String input)
+            throws JsonParseException, JsonMappingException, IOException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(input, new TypeReference<HashMap>()
+        {
+        });
+    }
+    
+    public static void main(String[] args) throws JsonProcessingException
+    {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String,String> map = new HashMap<>();
+        
+        map.put("key", null);
+        
+        System.out.println(mapper.writeValueAsString(map));
+    }
 }


### PR DESCRIPTION
*Problem:* Currently the `environment.resolvePlaceholders` is called only for the type string. In reality the values are of type Map, List.
*Fix:* Added logic to resolve the values.
*Reference:* https://github.com/cloudfoundry/uaa/issues/666