### PR TITLE
update javax.validation 

### DIFF
--- a/shared_versions.gradle
+++ b/shared_versions.gradle
@@ -47,7 +47,7 @@ ext {
   tomcatVersion = '8.5.23'
   tomcatJdbcPoolVersion = '8.5.23'
   tomcatContainerId = 'tomcat8x'
-  validationAPIVersion = '1.0.0.GA'
+  validationAPIVersion = '2.0.1.Final'
   velocityVersion = '2.0'
   xalanVersion = '2.7.2'
   zxingVersion = '3.3.1'


### PR DESCRIPTION
since version 1.0.0 is not compatible with hibernate 4.3.x

follow-up to https://github.com/cloudfoundry/uaa/pull/832