### PR TITLE
Prevent unnecessary exceptions from being thrown and showing up in logs

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -173,14 +173,12 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
     }
 
     protected SCIMFilter scimFilter(String filter) throws SCIMException {
-        SCIMFilter scimFilter;
-        try {
-            scimFilter = SCIMFilter.parse(filter);
-        } catch (SCIMException e) {
-            logger.debug("Attempting legacy scim filter conversion for [" + filter + "]", e);
-            filter = filter.replaceAll("'","\"");
-            scimFilter = SCIMFilter.parse(filter);
-        }
+        if(filter.indexOf("'") != -1) {
+    		filter = filter.replaceAll("'","\"");
+    		logger.debug("Attempting legacy scim filter conversion for [" + filter + "]");
+    	}
+        
+        SCIMFilter scimFilter = SCIMFilter.parse(filter);
         validateFilterAttributes(scimFilter, VALID_ATTRIBUTE_NAMES);
         return scimFilter;
     }


### PR DESCRIPTION
Previous logic would not check to see if invalid char's were present in the string until after an exception was thrown.  This led to many unnecessary and misleading exceptions showing up in the debug logs.