### PR TITLE
update flyway5 to allow openjdk9+ to build

### DIFF
--- a/shared_versions.gradle
+++ b/shared_versions.gradle
@@ -10,7 +10,7 @@ ext {
   commonsHttpClientVersion = '4.5.3'
   commonsLoggingVersion = '1.2'
   esapiVersion = '2.1.0.1'
-  flywayVersion = '4.2.0'
+  flywayVersion = '5.1.4'
   googleauthVersion = '1.1.2'
   guavaVersion = '24.1.1-jre'
   hamcrestVersion = '1.3'


### PR DESCRIPTION
I accidentally tried to build UAA using `java -version` 10 and got the error at https://github.com/flyway/flyway/issues/1545

The fix is to upgrade to flyway 5.