### PR TITLE
Update google-oidc-provider.md

### DIFF
--- a/docs/google-oidc-provider.md
+++ b/docs/google-oidc-provider.md
@@ -27,6 +27,7 @@ Please refer to 'https://accounts.google.com/.well-known/openid-configuration' f
           addShadowUserOnLogin: true
           relyingPartyId: REPLACE_WITH_CLIENT_ID
           relyingPartySecret: REPLACE_WITH_CLIENT_SECRET
+          clientAuthInBody: true
           skipSslValidation: false
           attributeMappings:
             user_name: email


### PR DESCRIPTION
Sometime today (2018-09-27) something appears to have changed at Google such that passing a basic auth header no longer works to authenticate a client ID/secret.

Passing in the body of the request (which matches most other Google libraries) seems to work just fine.