### PR TITLE
Prevent UnknownFormatConversionException from being thrown

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditService.java
@@ -114,7 +114,7 @@ public class LoggingAuditService implements UaaAuditService {
         String logMessage = String.format("%s ('%s'): principal=%s, origin=[%s], identityZoneId=[%s]", auditEvent.getType().name(), auditEvent.getData(),
                 auditEvent.getPrincipalId(), auditEvent.getOrigin(), auditEvent.getIdentityZoneId());
         if (auditEvent.getAuthenticationType() != null) {
-            logMessage = String.format(logMessage + ", authenticationType=[%s]", auditEvent.getAuthenticationType());
+            logMessage = String.format("%s, authenticationType=[%s]", logMessage, auditEvent.getAuthenticationType());
         }
         log(logMessage);
     }


### PR DESCRIPTION
logMessage string variable could contain the '%' symbol which will be unintentionally parsed by the string formatter resulting in an UnknownFormatConversionException being thrown.