### PR TITLE
Fixes issue where migrations fail using MySQL8

### DIFF
--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V1_5_2__initial_db.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V1_5_2__initial_db.sql
@@ -73,7 +73,7 @@ CREATE TABLE authz_approvals (
   primary key (userName, clientId, scope)
 ) ;
 
-CREATE TABLE groups (
+CREATE TABLE `groups` (
   id VARCHAR(36) not null primary key,
   displayName VARCHAR(255) not null,
   created TIMESTAMP default current_timestamp not null,


### PR DESCRIPTION
When using use-external-db.yml in cf-deployment, and with MySQL8 engine, this query fails during running initial setup complaining about syntax error. Escaping the table name seems to fix it.