### PR TITLE
Feature/bypass 20second integration test startup time

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.2.0'
     compile group: 'org.hsqldb', name: 'hsqldb', version: "2.5.0"
 
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.18'
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.24'
 
     compile libraries.springSecurityLdap
     compile libraries.springLdapCore

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/AliasSupportingTypeDescription.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/AliasSupportingTypeDescription.java
@@ -1,0 +1,29 @@
+package org.cloudfoundry.identity.uaa.impl.config;
+
+import org.yaml.snakeyaml.TypeDescription;
+import org.yaml.snakeyaml.introspector.Property;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by taitz.
+ */
+class AliasSupportingTypeDescription extends TypeDescription {
+
+    private final Map<String, Property> aliases = new HashMap<>();
+
+    AliasSupportingTypeDescription(Class<?> clazz) {
+        super(clazz);
+    }
+
+    @Override
+    public Property getProperty(String name) {
+        return aliases.containsKey(name) ? aliases.get(name) : super.getProperty(name);
+    }
+
+    public void put(String alias, Property property) {
+        aliases.put(alias, property);
+    }
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/CustomPropertyConstructor.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/CustomPropertyConstructor.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.impl.config;
 
+import org.springframework.util.Assert;
+import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
@@ -30,12 +32,22 @@ import java.util.Map;
 public class CustomPropertyConstructor extends Constructor {
     private final Map<Class<?>, Map<String, Property>> properties = new HashMap<Class<?>, Map<String, Property>>();
     private final PropertyUtils propertyUtils = new PropertyUtils();
+    private final Map<Class<?>, AliasSupportingTypeDescription> typeDescriptions = new HashMap<>();
 
     public CustomPropertyConstructor(Class<?> theRoot) {
         super(theRoot);
+        TypeDescription typeDescription = createTypeDescription(theRoot);
+        addTypeDescription(typeDescription);
         yamlClassConstructors.put(NodeId.mapping, new CustomPropertyConstructMapping());
     }
 
+    TypeDescription createTypeDescription(Class<?> clazz) {
+        Assert.isTrue(!typeDescriptions.containsKey(clazz), "type description for " + clazz.getSimpleName() + " already exists");
+        AliasSupportingTypeDescription typeDescription = new AliasSupportingTypeDescription(clazz);
+        typeDescriptions.put(clazz, typeDescription);
+        return typeDescription;
+    }
+    
     /**
      * Adds an alias for a Javabean property name on a particular type.
      * The values of YAML keys with the alias name will be mapped to the
@@ -54,7 +66,16 @@ public class CustomPropertyConstructor extends Constructor {
             properties.put(type, typeMap);
         }
 
-        typeMap.put(alias, propertyUtils.getProperty(type, name));
+        Property property = propertyUtils.getProperty(type, name);
+        typeMap.put(alias, property);
+        addAliasToTypeDescription(alias, type, property);
+    }
+
+    private void addAliasToTypeDescription(String alias, Class<?> type, Property property) {
+        AliasSupportingTypeDescription typeDescription = typeDescriptions.get(type);
+        if (typeDescription != null) {
+            typeDescription.put(alias, property);
+        }
     }
 
     class CustomPropertyConstructMapping extends ConstructMapping {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/CustomPropertyConstructor.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/CustomPropertyConstructor.java
@@ -17,7 +17,6 @@ import org.yaml.snakeyaml.introspector.Property;
 import org.yaml.snakeyaml.introspector.PropertyUtils;
 import org.yaml.snakeyaml.nodes.NodeId;
 
-import java.beans.IntrospectionException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,17 +54,13 @@ public class CustomPropertyConstructor extends Constructor {
             properties.put(type, typeMap);
         }
 
-        try {
-            typeMap.put(alias, propertyUtils.getProperty(type, name));
-        } catch (IntrospectionException e) {
-            throw new RuntimeException(e);
-        }
+        typeMap.put(alias, propertyUtils.getProperty(type, name));
     }
 
     class CustomPropertyConstructMapping extends ConstructMapping {
 
         @Override
-        protected Property getProperty(Class<?> type, String name) throws IntrospectionException {
+        protected Property getProperty(Class<?> type, String name) {
             Property p = lookupProperty(type, name);
 
             return p != null ? p : super.getProperty(type, name);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/UaaConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/UaaConfiguration.java
@@ -238,23 +238,23 @@ public class UaaConfiguration {
         public UaaConfigConstructor() {
             super(UaaConfiguration.class);
 
-            TypeDescription oauthDesc = new TypeDescription(OAuth.class);
+            TypeDescription oauthDesc = createTypeDescription(OAuth.class);
             oauthDesc.putMapPropertyType("clients", String.class, OAuthClient.class);
             addTypeDescription(oauthDesc);
 
-            TypeDescription clientDesc = new TypeDescription(Client.class);
+            TypeDescription clientDesc = createTypeDescription(Client.class);
             clientDesc.putListPropertyType(ClientConstants.AUTO_APPROVE, String.class);
             addTypeDescription(clientDesc);
 
-            TypeDescription oauthClientDesc = new TypeDescription(OAuthClient.class);
+            TypeDescription oauthClientDesc = createTypeDescription(OAuthClient.class);
             oauthClientDesc.putListPropertyType(ClientConstants.AUTO_APPROVE, String.class);
             addTypeDescription(oauthClientDesc);
 
-            TypeDescription claimsDesc = new TypeDescription(Claims.class);
+            TypeDescription claimsDesc = createTypeDescription(Claims.class);
             claimsDesc.putListPropertyType("exclusions", String.class);
             addTypeDescription(clientDesc);
 
-            TypeDescription policyDesc = new TypeDescription(Policy.class);
+            TypeDescription policyDesc = createTypeDescription(Policy.class);
             policyDesc.putMapPropertyType("keys", String.class, KeySpec.class);
             addTypeDescription(policyDesc);
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/yml/YamlProcessorTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/yml/YamlProcessorTest.java
@@ -1,0 +1,46 @@
+package org.cloudfoundry.identity.uaa.yml;
+
+import org.cloudfoundry.identity.uaa.integration.feature.ImplicitGrantIT;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Stopwatch;
+import org.springframework.core.io.DefaultResourceLoader;
+import org.springframework.core.io.Resource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Created by taitz.
+ */
+public class YamlProcessorTest {
+
+    @Rule
+    public Stopwatch stopwatch = new Stopwatch() {
+    };
+
+
+    /**
+     * Integration tests using spring, such as {@link ImplicitGrantIT}, have been taking around 20 seconds to start up.
+     * This is due to the {@link Yaml} parser having a hard time parsing uaa.yml, which contains very long comments.
+     * This test ensures that the parser will parse swiftly.
+     */
+    @Test
+    public void loadAll_yamlIsFullOfLongComments_yamlLoadsInUnderASecond() throws IOException {
+        DefaultResourceLoader loader = new DefaultResourceLoader();
+        Resource resource = loader.getResource("uaa.yml");
+        InputStream inputStream = resource.getInputStream();
+        Yaml yaml = new Yaml();
+
+        Iterable<Object> objects = yaml.loadAll(inputStream);
+        for (Object o : objects) {
+            System.out.println(o);
+        }
+
+        assertEquals(1, stopwatch.runtime(SECONDS), 1);
+    }
+}


### PR DESCRIPTION
By moving comments out of uaa.yml, the 20 second integration test startup time is overcome.