### PR TITLE
Make UaaLoginHint Serializable

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaLoginHint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaLoginHint.java
@@ -23,7 +23,7 @@ public class UaaLoginHint implements Serializable {
         }
     }
 
-    private UaaLoginHint() {
+    public UaaLoginHint() {
     }
 
     public UaaLoginHint(String origin) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaLoginHint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaLoginHint.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.URLDecoder;
 
-public class UaaLoginHint {
+public class UaaLoginHint implements Serializable {
     private String origin;
     private static ObjectMapper mapper = new ObjectMapper();
 


### PR DESCRIPTION
UaaLoginHint is an attribute of UaaAuthenticationDetails, which itself is Serializable and part of an UaaAuthentication. This is stored in the SecurityContext and ultimately the HTTP session. These should all be serializable to avoid issues with session repositories that require serialization (e.g. for replication).