### PR TITLE
Create a consolidated docker image for CI

### DIFF
--- a/ci/image/Dockerfile
+++ b/ci/image/Dockerfile
@@ -1,0 +1,173 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl jq git lsb-release unzip vim sudo \
+    apt-transport-https apt-utils ca-certificates gnupg \
+    && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    # unzip used once
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=true
+
+# JAVA
+ENV JAVA_HOME /usr/lib/jvm/java-bellsoft-amd64
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+RUN JAVA_MAJOR_VERSION="11" \
+    && JDK_METADATA="jdk-metadata.json" \
+    && curl -sLo "${JDK_METADATA}" "https://api.bell-sw.com/v1/liberica/releases?version-modifier=latest&os=linux&release-type=lts&bitness=64&package-type=tar.gz&bundle-type=jdk&arch=x86" \
+    && JDK_VERSION="$(jq -r ".[] | select(.featureVersion | contains("${JAVA_MAJOR_VERSION}")).version" "${JDK_METADATA}")" \
+    && JDK_ARCHIVE_URL="$(jq -r ".[] | select(.featureVersion | contains("${JAVA_MAJOR_VERSION}")).downloadUrl" "${JDK_METADATA}")" \
+    && JDK_ARCHIVE="$(basename "${JDK_ARCHIVE_URL}")" \
+    && curl -sLo "${JDK_ARCHIVE}" "${JDK_ARCHIVE_URL}" \
+    && mkdir -p "${JAVA_HOME}" \
+    && tar -xf "${JDK_ARCHIVE}" -C "${JAVA_HOME}" --strip-components=1 \
+    && rm -rf "${JDK_ARCHIVE}" "${JDK_METADATA}" \
+    && "${JAVA_HOME}"/bin/java -version
+#/JAVA
+
+# CHROME; see https://github.com/justinribeiro/dockerfiles/blob/c87217ebfeced3f0088f6559b799ed85f495ddff/chrome-headless/Dockerfile#L31-L51
+RUN curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+	&& echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
+	google-chrome-stable \
+	fontconfig \
+	fonts-ipafont-gothic \
+	fonts-wqy-zenhei \
+	fonts-thai-tlwg \
+	fonts-kacst \
+	fonts-symbola \
+	fonts-noto \
+    libgconf-2-4 \
+    libxss1 \
+    libasound2 \
+    libnss3-tools \
+    && apt-get install -y --no-install-recommends libosmesa6 \
+        && ln -s /usr/lib/x86_64-linux-gnu/libOSMesa.so.8 \
+                 /opt/google/chrome/libosmesa.so \
+    && apt-get install -y --no-install-recommends libatk-bridge2.0-0 \
+        && ln -s /usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0 \
+                 /opt/google/chrome/ \
+    && apt-get install -y --no-install-recommends libgtk-3-0 \
+        && ln -s /usr/lib/x86_64-linux-gnu/libgtk-3.so.0 \
+                 /opt/google/chrome/ \
+    && apt-get install -y --no-install-recommends libgdk3.0-cil \
+        && ln -s /usr/lib/x86_64-linux-gnu/libgdk-3.so.0 \
+                 /opt/google/chrome/ \
+    && export CHROMEDRIVER_VERSION=$(curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_$(google-chrome --version | cut -f 3 -d ' ' | cut -f 1,2,3 -d '.')) \
+    && curl -sfLO https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip \
+    && unzip chromedriver_linux64.zip -d /usr/bin/ \
+    && rm chromedriver_linux64.zip \
+    && ln -s /usr/bin/chromedriver /usr/local/bin/ \
+    && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    # ^ TODO: WHY IS THE BINARY NEEDED IN TWO PLACES?
+#/CHROME
+
+# LDAP; see https://help.ubuntu.com/lts/serverguide/openldap-server.html
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gnutls-bin slapd ldap-utils ssl-cert \
+    && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && certtool --generate-privkey > /etc/ssl/private/cakey.pem \
+    && echo "cn = Pivotal Software Test"    >> /etc/ssl/ca.info \
+    && echo "  ca"                          >> /etc/ssl/ca.info \
+    && echo "  cert_signing_key"            >> /etc/ssl/ca.info \
+    && certtool --generate-self-signed --load-privkey /etc/ssl/private/cakey.pem --template /etc/ssl/ca.info --outfile /etc/ssl/certs/cacert.pem \
+    && certtool --generate-privkey --bits 1024 --outfile /etc/ssl/private/ldap01_slapd_key.pem \
+    && echo "organization = Pivotal Software Test"  >> /etc/ssl/ldap01.info \
+    && echo "    cn = ldap01.example.com"           >> /etc/ssl/ldap01.info \
+    && echo "    tls_www_server"                    >> /etc/ssl/ldap01.info \
+    && echo "    encryption_key"                    >> /etc/ssl/ldap01.info \
+    && echo "    signing_key"                       >> /etc/ssl/ldap01.info \
+    && echo "    expiration_days = 3650"            >> /etc/ssl/ldap01.info \
+    && certtool --generate-certificate --load-privkey /etc/ssl/private/ldap01_slapd_key.pem --load-ca-certificate /etc/ssl/certs/cacert.pem --load-ca-privkey /etc/ssl/private/cakey.pem --template /etc/ssl/ldap01.info --outfile /etc/ssl/certs/ldap01_slapd_cert.pem \
+    && adduser openldap ssl-cert \
+    && chgrp ssl-cert /etc/ssl/private/ldap01_slapd_key.pem \
+    && chmod 0640 /etc/ssl/private/ldap01_slapd_key.pem \
+    && echo "dn: cn=config"                                                     >> /etc/ssl/certinfo.ldif \
+    && echo "changetype: modify"                                                >> /etc/ssl/certinfo.ldif \
+    && echo "add: olcTLSCACertificateFile"                                      >> /etc/ssl/certinfo.ldif \
+    && echo "olcTLSCACertificateFile: /etc/ssl/certs/cacert.pem"                >> /etc/ssl/certinfo.ldif \
+    && echo "-"                                                                 >> /etc/ssl/certinfo.ldif \
+    && echo "add: olcTLSCertificateFile"                                        >> /etc/ssl/certinfo.ldif \
+    && echo "olcTLSCertificateFile: /etc/ssl/certs/ldap01_slapd_cert.pem"       >> /etc/ssl/certinfo.ldif \
+    && echo "-"                                                                 >> /etc/ssl/certinfo.ldif \
+    && echo "add: olcTLSCertificateKeyFile"                                     >> /etc/ssl/certinfo.ldif \
+    && echo "olcTLSCertificateKeyFile: /etc/ssl/private/ldap01_slapd_key.pem"   >> /etc/ssl/certinfo.ldif \
+    && service slapd start \
+    && ldapmodify -Y EXTERNAL -H ldapi:/// -f /etc/ssl/certinfo.ldif \
+    && sed -i "s/^SLAPD_SERVICES.*/SLAPD_SERVICES=\"ldap\:\/\/\/ ldapi\:\/\/\/ ldaps\:\/\/\/\"/g" /etc/default/slapd \
+    && echo "#!/usr/bin/env bash"                                               >> /bin/start-slapd \
+    && echo "set -eu -o pipefail"                                               >> /bin/start-slapd \
+    && echo "echo '# docker build will not persist /etc/hosts'  >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '# ------------- UAA DNS ------------- #'     >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 oidcloginit.localhost'             >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 testzone1.localhost'               >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 testzone2.localhost'               >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 testzone3.localhost'               >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 testzone4.localhost'               >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 testzoneinactive.localhost'        >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '127.0.0.1 testzonedoesnotexist.localhost'    >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "echo '# ------------- UAA DNS ------------- #'     >> /etc/hosts"  >> /bin/start-slapd \
+    && echo "pgrep slapd || service slapd start"                                >> /bin/start-slapd \
+    && chmod 0755 /bin/start-slapd
+#/LDAP
+
+# DATABASES
+# DATABASES-POSTGRESQL
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    postgresql postgresql-contrib \
+    && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && echo "#!/usr/bin/env bash"                                               >> /bin/start-postgresql \
+    && echo "set -eu -o pipefail"                                               >> /bin/start-postgresql \
+    && echo "service postgresql start"                                          >> /bin/start-postgresql \
+    && echo "while ! sudo -u postgres psql -c 'select 1'; do sleep 1; done;"    >> /bin/start-postgresql \
+    && chmod 0755 /bin/start-postgresql
+#/DATABASES-POSTGRESQL
+
+# DATABASES-MYSQL-OR-PERCONA
+RUN export PERCONA_DEB="percona-release_latest.$(lsb_release -sc)_all.deb" \
+    && curl -sLo ${PERCONA_DEB} https://repo.percona.com/apt/${PERCONA_DEB} \
+    && dpkg -i ${PERCONA_DEB} && rm ${PERCONA_DEB} \
+    && apt-get update && apt-get install -y --no-install-recommends \
+# MYSQL - collides with PERCONA
+    mysql-server \
+# MYSQL - collides with PERCONA
+# PERCONA - collides with MYSQL
+#    percona-server-server-5.7 mysql-client \
+#/PERCONA - collides with MYSQL
+    && apt-get autoremove -yqq && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && sudo mysql_ssl_rsa_setup --uid=mysql \
+    && echo "#!/usr/bin/env bash"                                                   >> /bin/start-mysql \
+    && echo "set -eu -o pipefail"                                                   >> /bin/start-mysql \
+    && echo "find /var/lib/mysql -type f -exec touch {} \; && service mysql start"  >> /bin/start-mysql \
+    && echo "while ! mysql -e 'select 1'; do sleep 1; done;"                        >> /bin/start-mysql \
+    && chmod 0755 /bin/start-mysql
+# DATABASES-MYSQL-OR-PERCONA
+#/DATABASES
+
+# PROJECT_SETUP
+ENV DB_NAME=uaa
+ENV DB_USER=root
+ENV DB_PASS=changeme
+ENV NUM_DBS=24
+
+RUN /bin/start-mysql \
+    && echo "[mysql]"               >> "${HOME}/.my.cnf" \
+    && echo "password=${DB_PASS}"   >> "${HOME}/.my.cnf" \
+    && mysql -e "ALTER USER '${DB_USER}'@'localhost' IDENTIFIED WITH mysql_native_password BY '${DB_PASS}';" \
+    # -----------^ change root from `auth_socket` to `mysql_native_password` so that `-h 127.0.0.1` works
+    && mysql -e "CREATE DATABASE ${DB_NAME} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;" \
+    && for i in $(seq 1 ${NUM_DBS}); do mysql -e "CREATE DATABASE ${DB_NAME}_${i} DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;" ; done
+
+RUN /bin/start-postgresql \
+    && sudo -u postgres psql -c "CREATE USER ${DB_USER} WITH SUPERUSER PASSWORD '${DB_PASS}';" \
+    && sudo -u postgres createdb "${DB_USER}" \
+    && sudo -u postgres createdb "${DB_NAME}" \
+    && for i in $(seq 1 ${NUM_DBS}); do sudo -u postgres createdb "${DB_NAME}_${i}" ; done
+
+COPY ldap_db_init.ldif copy_of-uaa_src_main_resources_ldap_init.ldif /ldap/
+RUN /bin/start-slapd \
+    && ldapadd -Y EXTERNAL -H ldapi:/// -f /ldap/ldap_db_init.ldif \
+    && ldapadd -x -D 'cn=admin,dc=test,dc=com' -w password -f /ldap/copy_of-uaa_src_main_resources_ldap_init.ldif \
+    && rm -rf /ldap/
+#/PROJECT_SETUP

--- a/ci/image/copy_of-uaa_src_main_resources_ldap_init.ldif
+++ b/ci/image/copy_of-uaa_src_main_resources_ldap_init.ldif
@@ -1,0 +1,326 @@
+dn: dc=test,dc=com
+changetype: add
+objectClass: top
+objectClass: dcObject
+objectClass: domain
+
+dn: ou=Users,dc=test,dc=com
+changetype: add
+objectClass: organizationalUnit
+ou: Users
+
+dn: cn=admin,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: admin
+sn: Administrator
+userPassword: adminsecret
+uid: 3378a03c-fc8c-46b6-8a76-f67f9d7a7b4a
+mail: admin@test.com
+givenname: Bob
+initials: X
+telephonenumber: 8885550987
+streetAddress: 1111 Admin St
+l: Adminton
+st: California
+postalCode: 94119
+
+dn: cn=marissa,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa
+userPassword: koala
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db1
+mail: marissa@test.com
+sn: Marissa
+
+dn: cn=slash/username,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: slash/username
+userPassword: koala
+uid: 20f459e0-e30b-4d1f-998c-3ded7fff9db1
+mail: slash-username@test.com
+sn: Marissa
+
+dn: cn=slash/贺琳,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: slash/贺琳
+userPassword: koala
+uid: 20f459e0-e30b-4d1f-998c-3ded7fff9db1
+mail: slash-username2@test.com
+sn: Marissa
+
+dn: cn=琳贺,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: 琳贺
+userPassword: koala
+uid: 20f459e0-e30b-4d1f-998c-3ded7fff9db1
+mail: username3@test.com
+sn: Marissa
+
+dn: cn=marissa2,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa2
+userPassword: ldap
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db2
+mail: marissa2@test.com
+sn: Marissa2
+
+dn: cn=marissa3,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: customUaaUser
+cn: marissa3
+userPassword: ldap3
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db3
+mail: marissa3@test.com
+sn: Lastnamerton
+givenname: Marissa
+initials: M
+telephonenumber: 8885550986
+streetAddress: 1111 Marissa St
+l: Marissaville
+st: Florida
+postalCode: 32561
+costCenter: Denver,CO
+uaaManager: John the Sloth
+uaaManager: Kari the Ant Eater
+emailVerified: false
+memberOf: cn=developers,ou=scopes,dc=test,dc=com
+
+dn: cn=marissa4,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa4
+userPassword: ldap4
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db4
+mail: marissa4@test.com
+sn: Marissa4
+
+dn: cn=marissa5,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa5
+userPassword: ldap5
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db5
+mail: marissa5@test.com
+sn: Marissa5
+
+dn: cn=marissa6,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa6
+userPassword: ldap6
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db6
+mail: marissa6@test.com
+sn: Marissa6
+
+dn: cn=marissa7,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa7
+userPassword: ldap7
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db7
+sn: Marissa7
+
+dn: cn=marissa8,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa8
+userPassword: ldap8
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db8
+sn: Marissa8
+
+dn: cn=marissa9,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: customUaaUser
+cn: marissa9
+mail: marissa9@test.com
+userPassword: ldap9
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769db9
+sn: Marissa9
+costCenter: Denver,CO
+uaaManager: John the Sloth
+uaaManager: Kari the Ant Eater
+givenname: Marissa
+initials: M
+telephonenumber: 8885550986
+mail: marissa9-custom@test.com
+emailVerified: true
+memberOf: cn=developers,ou=scopes,dc=test,dc=com
+
+dn: cn=marissa10,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: customUaaUser
+cn: marissa10
+userPassword: ldap10
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769d10
+sn: Marissa10
+costCenter: Denver,CO
+uaaManager: John the Sloth
+uaaManager: Kari the Ant Eater
+emailVerified: true
+memberOf: cn=developers,ou=scopes,dc=test,dc=com
+memberOf: cn=superusers,ou=scopes,dc=test,dc=com
+
+dn: cn=marissa 11,ou=Users,dc=test,dc=com
+changetype: add
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+cn: marissa 11
+userPassword: ldap11
+uid: 20f459e0-e30b-4d1f-998c-3ded7f769d10
+sn: Marissa11
+
+###############################################################################
+#        BEGIN GROUP TO SCOPE MAPPING
+###############################################################################
+#scopes as groups mapping - this is the search base
+
+dn: ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: organizationalUnit
+ou: scopes
+
+#This groups contains scopes as comma separated list in the description attribute
+dn: cn=admins,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: admins
+description: uaa.admin,cloud_controller.read
+member: cn=admin,ou=Users,dc=test,dc=com
+member: cn=marissa3,ou=Users,dc=test,dc=com
+
+dn: cn=marissagroup1,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: marissagroup1
+description: foobar # the description field is required for ldap-groups-as-scopes.xml, but not for ldap-groups-map-to-scopes.xml
+member: cn=marissa,ou=Users,dc=test,dc=com
+
+dn: cn=marissagroup2,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: marissagroup2
+description: foobar # the description field is required for ldap-groups-as-scopes.xml, but not for ldap-groups-map-to-scopes.xml
+member: cn=marissa,ou=Users,dc=test,dc=com
+
+#This groups contains scope as the cn attribute
+dn: cn=uaa.admin,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: uaa.admin
+member: cn=admin,ou=Users,dc=test,dc=com
+member: cn=marissa3,ou=Users,dc=test,dc=com
+
+dn: cn=thirdmarissa,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: thirdmarissa
+description: thirdmarissa
+member: cn=marissa3,ou=Users,dc=test,dc=com
+
+dn: cn=developers,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: developers
+description: test.read
+member: cn=operators,ou=scopes,dc=test,dc=com
+member: cn=marissa6,ou=Users,dc=test,dc=com
+
+dn: cn=operators,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: operators
+description: test.write
+member: cn=superusers,ou=scopes,dc=test,dc=com
+member: cn=marissa5,ou=Users,dc=test,dc=com
+
+dn: cn=superusers,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: superusers
+description: test.everything
+member: cn=marissa4,ou=Users,dc=test,dc=com
+
+dn: cn=otherusers,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: otherusers
+description: test.everything
+member: cn=marissa8,ou=Users,dc=test,dc=com
+
+# Invalid referral cause PartialResultsException
+
+dn: cn=Referral1,ou=scopes,dc=test,dc=com
+changetype: add
+objectclass: referral
+objectclass: extensibleObject
+member: cn=marissa8,ou=Users,dc=test,dc=com
+ref: ldap://localhost:43389/cn=otherusers1,ou=scopes,dc=test,dc=com
+
+#This groups contains scopes as comma separated list in the description attribute
+dn: cn=marissaniner,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: marissaniner
+description: marissaniner
+member: cn=marissa9,ou=Users,dc=test,dc=com
+
+#This groups contains scopes as comma separated list in the description attribute
+dn: cn=marissaniner2,ou=scopes,dc=test,dc=com
+changetype: add
+objectClass: groupOfNames
+objectClass: top
+cn: marissaniner2
+description: marissaniner2
+member: cn=marissa9,ou=Users,dc=test,dc=com
+
+###############################################################################
+#        END GROUP TO SCOPE MAPPING
+###############################################################################

--- a/ci/image/ldap_db_init.ldif
+++ b/ci/image/ldap_db_init.ldif
@@ -1,0 +1,84 @@
+# Load modules for database type
+dn: cn=module,cn=config
+objectclass: olcModuleList
+cn: module
+olcModuleLoad: back_bdb.la
+
+# Create directory database
+dn: olcDatabase=bdb,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcBdbConfig
+olcDatabase: bdb
+# Domain name (e.g. home.local)
+olcSuffix: dc=test,dc=com
+# Location on system where database is stored
+olcDbDirectory: /var/lib/ldap
+# Manager of the database
+olcRootDN: cn=admin,dc=test,dc=com
+olcRootPW: {SSHA}XerHS1s6xgIHpLrR9hCvelH7grepkqiv
+# Indices in database to speed up searches
+olcDbIndex: uid pres,eq
+olcDbIndex: cn,sn,mail pres,eq,approx,sub
+olcDbIndex: objectClass eq
+# Allow users to change their own password
+# Allow anonymous to authenticate against the password
+# Allow admin to change any password
+olcAccess: to attrs=userPassword
+  by self write
+  by anonymous auth
+  by dn.base="cn=admin,dc=test,dc=com" write
+  by dn.base="cn=admin,ou=Users,dc=test,dc=com" read
+  by * none
+# Allow users to change their own record
+# Allow anyone to read directory
+olcAccess: to *
+  by self write
+  by dn.base="cn=admin,dc=test,dc=com" write
+  by * read
+
+dn: cn=schema,cn=config
+changetype: modify
+add: olcAttributeTypes
+olcAttributeTypes: (
+  1.3.6.1.4.1.35015.1.2.4
+  NAME 'costCenter'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ )
+
+dn: cn=schema,cn=config
+changetype: modify
+add: olcAttributeTypes
+olcAttributeTypes: (
+  1.3.6.1.4.1.35015.1.2.5
+  NAME 'uaaManager'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ )
+
+dn: cn=schema,cn=config
+changetype: modify
+add: olcAttributeTypes
+olcAttributeTypes: (
+  1.3.6.1.4.1.35015.1.2.6
+  NAME 'memberOf'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ )
+
+dn: cn=schema,cn=config
+changetype: modify
+add: olcAttributeTypes
+olcAttributeTypes: (
+  1.3.6.1.4.1.35015.1.2.7
+  NAME 'emailVerified'
+  SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+ )
+
+dn: cn=schema,cn=config
+changetype: modify
+add: olcObjectClasses
+olcObjectClasses: (
+  1.3.6.1.4.1.35015.1.2.8
+  NAME 'customUaaUser'
+  SUP top
+  AUXILIARY
+  MUST (uaaManager $ costCenter $ emailVerified $ memberOf)
+ )

--- a/scripts/docker_run
+++ b/scripts/docker_run
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+UAA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+DOCKER_IMAGE=${DOCKER_IMAGE-cfidentity/uaa-consolidated}
+echo "Using docker image: ${DOCKER_IMAGE}"
+
+uaa_work_dir="/root/uaa"
+
+docker_run() {
+  local run_command="docker run ${*}"
+  cat <<COMMAND
+Running:
+  ${run_command}
+COMMAND
+
+  command pushd "${UAA_DIR}"    > /dev/null # silence output
+  ${run_command}
+  command popd                  > /dev/null # silence output
+}
+
+docker_run --tty --interactive \
+  --workdir "${uaa_work_dir}" \
+  --volume "${UAA_DIR}":"${uaa_work_dir}" \
+  --env DB=${DB-hsqldb} \
+  "${DOCKER_IMAGE}" \
+  "${@}"

--- a/scripts/generate-docs
+++ b/scripts/generate-docs
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+UAA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+"${UAA_DIR}/scripts/gradle" generateDocs

--- a/scripts/gradle
+++ b/scripts/gradle
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+UAA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+db_variant() {
+    local db_type="${1}"
+
+    if [[ "${db_type}" = "percona" ]]; then
+        echo "mysql"
+    else
+        echo "${db_type}"
+    fi
+}
+
+gradle() {
+  local gradle_command="./gradlew ${*}"
+  cat <<COMMAND
+Running:
+  ${gradle_command}
+COMMAND
+
+  command pushd "${UAA_DIR}"    > /dev/null # silence output
+  ${gradle_command}
+  command popd                  > /dev/null # silence output
+}
+
+db="$(db_variant "${DB-hsqldb}")"
+TESTENV="${TESTENV-${db},default}"
+
+if [[ -x /bin/start-slapd ]]; then /bin/start-slapd; fi
+if [[ -x "/bin/start-${db}" ]]; then "/bin/start-${db}"; fi
+
+gradle --stacktrace \
+    --exclude-task :cloudfoundry-identity-samples:assemble \
+    "-Dspring.profiles.active=${TESTENV}" \
+    "${@}"

--- a/scripts/integration-tests
+++ b/scripts/integration-tests
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+UAA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+"${UAA_DIR}/scripts/gradle" integrationTest "${@}"

--- a/scripts/jasmine-tests
+++ b/scripts/jasmine-tests
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+UAA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+pushd "${UAA_DIR}"
+  npm install
+  npm test
+popd

--- a/scripts/unit-tests
+++ b/scripts/unit-tests
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+UAA_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+"${UAA_DIR}/scripts/gradle" test "${@}"


### PR DESCRIPTION
- add `scripts/docker_run`
  - this passes `${DB}` for switching db variant, default is `hsqldb`
- add `scripts/gradle` to unify test dependency startup
  - all test scripts call into this script
- deletions
  - `scripts/ldap/install-ldap.sh`
  - => replaced by ldap setup in Dockerfile
  - `run-integration-tests.sh`
  - => use `scripts/docker_run scripts/integration-tests.sh`
  - `run-unit-tests.sh`
  - => use `scripts/docker_run scripts/unit-tests.sh`

[#168655249]