### PR TITLE
[Don't Merge Yet] Chores/cleanup yaml servlet profile initializer

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -59,7 +59,7 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
     private static final String DEFAULT_YAML_KEY = "environmentYamlKey";
 
-    private String yamlEnvironmentVariableName = "UAA_CONFIG_YAML";
+    private static final String YAML_ENVIRONMENT_VARIABLE_NAME = "UAA_CONFIG_YAML";
 
     private SystemEnvironmentAccessor environmentAccessor = new SystemEnvironmentAccessor() {
     };
@@ -125,7 +125,7 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
     private Resource getYamlFromEnvironmentVariable() {
         if (environmentAccessor != null) {
-            String data = environmentAccessor.getEnvironmentVariable(getYamlEnvironmentVariableName());
+            String data = environmentAccessor.getEnvironmentVariable(YAML_ENVIRONMENT_VARIABLE_NAME);
             if (hasText(data)) {
                 //validate the Yaml? We don't do that for the others
                 return new InMemoryResource(data);
@@ -201,14 +201,6 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
                 environment.setActiveProfiles(commaDelimitedListToStringArray(systemProfiles));
             }
         }
-    }
-
-    String getYamlEnvironmentVariableName() {
-        return yamlEnvironmentVariableName;
-    }
-
-    void setYamlEnvironmentVariableName(String yamlEnvironmentVariableName) {
-        this.yamlEnvironmentVariableName = yamlEnvironmentVariableName;
     }
 
     void setEnvironmentAccessor(SystemEnvironmentAccessor environmentAccessor) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -23,13 +23,9 @@ import javax.servlet.ServletContext;
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.springframework.util.StringUtils.commaDelimitedListToStringArray;
@@ -69,14 +65,14 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
         WebApplicationContextUtils.initServletPropertySources(applicationContext.getEnvironment().getPropertySources(),
                 servletContext, applicationContext.getServletConfig());
 
-        List<Resource> resources = Set.of("uaa.yml", "login.yml")
+        List<Resource> resources = List.of("uaa.yml", "login.yml")
                 .stream()
                 .map(ClassPathResource::new)
                 .filter(ClassPathResource::exists)
                 .collect(Collectors.toList());
 
         //add default locations first
-        Set<String> locations = Set.of(
+        List<String> locations = List.of(
                 "${APPLICATION_CONFIG_URL}",
                 "file:${APPLICATION_CONFIG_FILE}",
                 "${LOGIN_CONFIG_URL}",
@@ -126,7 +122,7 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
     private List<Resource> getResource(final ServletContext servletContext,
                                        final ConfigurableWebApplicationContext applicationContext,
-                                       final Set<String> configFileLocations) {
+                                       final List<String> configFileLocations) {
         List<Resource> resources = new LinkedList<>();
         for (String location : configFileLocations) {
             location = applicationContext.getEnvironment().resolvePlaceholders(location);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -77,6 +77,8 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
         //add default locations first
         Set<String> locations = Set.of(
+                "${APPLICATION_CONFIG_URL}",
+                "file:${APPLICATION_CONFIG_FILE}",
                 "${LOGIN_CONFIG_URL}",
                 "file:${LOGIN_CONFIG_PATH}/login.yml",
                 "file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml",

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -51,10 +51,6 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
     private static final String PROFILE_CONFIG_FILE_LOCATIONS = "environmentConfigLocations";
 
-    private static final String[] DEFAULT_PROFILE_CONFIG_FILE_LOCATIONS = new String[]{
-            "${APPLICATION_CONFIG_URL}",
-            "file:${APPLICATION_CONFIG_FILE}"};
-
     private static final String DEFAULT_YAML_KEY = "environmentYamlKey";
 
     private static final String YAML_ENVIRONMENT_VARIABLE_NAME = "UAA_CONFIG_YAML";
@@ -133,7 +129,7 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
     private List<Resource> getResource(ServletContext servletContext, ConfigurableWebApplicationContext applicationContext,
                                        String locations) {
         List<Resource> resources = new LinkedList<>();
-        String[] configFileLocations = locations == null ? DEFAULT_PROFILE_CONFIG_FILE_LOCATIONS : StringUtils
+        String[] configFileLocations = locations == null ? new String[] {"file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml"} : StringUtils
                 .commaDelimitedListToStringArray(locations);
         for (String location : configFileLocations) {
             location = applicationContext.getEnvironment().resolvePlaceholders(location);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -49,8 +49,6 @@ import static org.springframework.util.StringUtils.isEmpty;
  */
 public class YamlServletProfileInitializer implements ApplicationContextInitializer<ConfigurableWebApplicationContext> {
 
-    private static final String PROFILE_CONFIG_FILE_LOCATIONS = "environmentConfigLocations";
-
     private static final String DEFAULT_YAML_KEY = "environmentYamlKey";
 
     private static final String YAML_ENVIRONMENT_VARIABLE_NAME = "UAA_CONFIG_YAML";
@@ -69,8 +67,6 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
         WebApplicationContextUtils.initServletPropertySources(applicationContext.getEnvironment().getPropertySources(),
                 servletContext, applicationContext.getServletConfig());
 
-        ServletConfig servletConfig = applicationContext.getServletConfig();
-        String locations = servletConfig == null ? null : servletConfig.getInitParameter(PROFILE_CONFIG_FILE_LOCATIONS);
         List<Resource> resources = new ArrayList<>();
 
         //add default locations first
@@ -82,6 +78,7 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
             }
         }
 
+        String locations = "${LOGIN_CONFIG_URL},file:${LOGIN_CONFIG_PATH}/login.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml,${UAA_CONFIG_URL},file:${UAA_CONFIG_FILE},file:${UAA_CONFIG_PATH}/uaa.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml";
         resources.addAll(getResource(servletContext, applicationContext, locations));
 
         Resource yamlFromEnv = getYamlFromEnvironmentVariable();
@@ -91,7 +88,6 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
         if (resources.isEmpty()) {
             servletContext.log("No YAML environment properties from servlet.  Defaulting to servlet context.");
-            locations = servletContext.getInitParameter(PROFILE_CONFIG_FILE_LOCATIONS);
             resources.addAll(getResource(servletContext, applicationContext, locations));
         }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -51,8 +51,6 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
 
     private static final String PROFILE_CONFIG_FILE_LOCATIONS = "environmentConfigLocations";
 
-    private static final String PROFILE_CONFIG_FILE_DEFAULT = "environmentConfigDefaults";
-
     private static final String[] DEFAULT_PROFILE_CONFIG_FILE_LOCATIONS = new String[]{
             "${APPLICATION_CONFIG_URL}",
             "file:${APPLICATION_CONFIG_FILE}"};
@@ -80,13 +78,11 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
         List<Resource> resources = new ArrayList<>();
 
         //add default locations first
-        Set<String> defaultLocation = StringUtils.commaDelimitedListToSet(servletConfig == null ? null : servletConfig.getInitParameter(PROFILE_CONFIG_FILE_DEFAULT));
-        if (defaultLocation != null && defaultLocation.size() > 0) {
-            for (String s : defaultLocation) {
-                Resource defaultResource = new ClassPathResource(s);
-                if (defaultResource.exists()) {
-                    resources.add(defaultResource);
-                }
+        Set<String> defaultLocation = Set.of("uaa.yml", "login.yml");
+        for (String s : defaultLocation) {
+            Resource defaultResource = new ClassPathResource(s);
+            if (defaultResource.exists()) {
+                resources.add(defaultResource);
             }
         }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/extensions/SystemPropertiesCleanupExtension.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/extensions/SystemPropertiesCleanupExtension.java
@@ -1,0 +1,40 @@
+package org.cloudfoundry.identity.uaa.extensions;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class SystemPropertiesCleanupExtension implements BeforeAllCallback, AfterAllCallback {
+
+    private final Set<String> properties;
+
+    public SystemPropertiesCleanupExtension(String... props) {
+        this.properties = Arrays.stream(props).collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()));
+
+        properties.forEach(s -> store.put(s, System.getProperty(s)));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()));
+
+        properties.forEach(key -> {
+                    String value = store.get(key, String.class);
+                    if (value == null) {
+                        System.clearProperty(key);
+                    } else {
+                        System.setProperty(key, value);
+                    }
+                }
+        );
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/extensions/SystemPropertiesCleanupExtension.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/extensions/SystemPropertiesCleanupExtension.java
@@ -1,14 +1,14 @@
 package org.cloudfoundry.identity.uaa.extensions;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class SystemPropertiesCleanupExtension implements BeforeAllCallback, AfterAllCallback {
+public class SystemPropertiesCleanupExtension implements BeforeEachCallback, AfterEachCallback {
 
     private final Set<String> properties;
 
@@ -17,14 +17,14 @@ public class SystemPropertiesCleanupExtension implements BeforeAllCallback, Afte
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    public void beforeEach(ExtensionContext context) {
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()));
 
         properties.forEach(s -> store.put(s, System.getProperty(s)));
     }
 
     @Override
-    public void afterAll(ExtensionContext context) {
+    public void afterEach(ExtensionContext context) {
         ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()));
 
         properties.forEach(key -> {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
@@ -149,8 +149,7 @@ class YamlServletProfileInitializerTest {
 
     @Test
     void loadServletConfiguredResource() {
-        when(servletConfig.getInitParameter("environmentConfigLocations")).thenReturn("foo.yml");
-        when(context.getResource(ArgumentMatchers.eq("foo.yml"))).thenReturn(
+        when(context.getResource(ArgumentMatchers.eq("${LOGIN_CONFIG_URL}"))).thenReturn(
                 new ByteArrayResource("foo: bar\nspam:\n  foo: baz-from-config".getBytes()));
 
         initializer.initialize(context);
@@ -161,8 +160,7 @@ class YamlServletProfileInitializerTest {
 
     @Test
     void loadContextConfiguredResource() {
-        when(servletContext.getInitParameter("environmentConfigLocations")).thenReturn("foo.yml");
-        when(context.getResource(ArgumentMatchers.eq("foo.yml"))).thenReturn(
+        when(context.getResource(ArgumentMatchers.eq("${LOGIN_CONFIG_URL}"))).thenReturn(
                 new ByteArrayResource("foo: bar\nspam:\n  foo: baz-from-context".getBytes()));
 
         initializer.initialize(context);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
@@ -225,24 +225,12 @@ class YamlServletProfileInitializerTest {
     }
 
     @Test
-    void readingYamlFromEnvironment_WithNullVariableName() {
-        readingYamlFromEnvironment(null);
-    }
-
-    @Test
-    void readingYamlFromEnvironment_WithNonNullVariableName() {
-        readingYamlFromEnvironment("Renaming environment variable");
-    }
-
-    private void readingYamlFromEnvironment(String variableName) {
-        if (hasText(variableName)) {
-            initializer.setYamlEnvironmentVariableName(variableName);
-        }
+    void readingYamlFromEnvironment() {
         SystemEnvironmentAccessor env = new SystemEnvironmentAccessor() {
             @Override
             public String getEnvironmentVariable(String name) {
-                return name.equals(initializer.getYamlEnvironmentVariableName()) ?
-                        "uaa.url: http://uaa.test.url/\n" +
+                return "UAA_CONFIG_YAML".equals(name) ?
+                        "uaa.url: http://uaa.test-from-env.url/\n" +
                                 "login.url: http://login.test.url/\n" +
                                 "smtp:\n" +
                                 "  host: mail.server.host\n" +
@@ -254,7 +242,7 @@ class YamlServletProfileInitializerTest {
         initializer.initialize(context);
         assertEquals("mail.server.host", environment.getProperty("smtp.host"));
         assertEquals("3535", environment.getProperty("smtp.port"));
-        assertEquals("http://uaa.test.url/", environment.getProperty("uaa.url"));
+        assertEquals("http://uaa.test-from-env.url/", environment.getProperty("uaa.url"));
         assertEquals("http://login.test.url/", environment.getProperty("login.url"));
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
@@ -64,10 +64,11 @@ class YamlServletProfileInitializerTest {
     private ServletContext mockServletContext;
 
     @RegisterExtension
+    @SuppressWarnings("unused")
     static final SystemPropertiesCleanupExtension systemPropertiesCleanupExtension = new SystemPropertiesCleanupExtension(
             "APPLICATION_CONFIG_FILE",
-            "APPLICATION_CONFIG_URL");
-
+            "APPLICATION_CONFIG_URL",
+            "spring.profiles.active");
 
     @BeforeEach
     void setup() {
@@ -270,6 +271,13 @@ class YamlServletProfileInitializerTest {
     @ExtendWith(MockitoExtension.class)
     @Nested
     class ApplySpringProfiles {
+
+        @RegisterExtension
+        @SuppressWarnings("unused")
+        final SystemPropertiesCleanupExtension systemPropertiesCleanupExtension = new SystemPropertiesCleanupExtension(
+                "APPLICATION_CONFIG_FILE",
+                "APPLICATION_CONFIG_URL",
+                "spring.profiles.active");
 
         private MockEnvironment environment;
         private MockServletContext context;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
@@ -5,11 +5,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.extensions.SpringProfileCleanupExtension;
+import org.cloudfoundry.identity.uaa.extensions.SystemPropertiesCleanupExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
@@ -61,6 +63,12 @@ class YamlServletProfileInitializerTest {
     @Mock
     private ServletContext mockServletContext;
 
+    @RegisterExtension
+    static final SystemPropertiesCleanupExtension systemPropertiesCleanupExtension = new SystemPropertiesCleanupExtension(
+            "APPLICATION_CONFIG_FILE",
+            "APPLICATION_CONFIG_URL");
+
+
     @BeforeEach
     void setup() {
         initializer = new YamlServletProfileInitializer();
@@ -70,12 +78,6 @@ class YamlServletProfileInitializerTest {
         when(mockConfigurableWebApplicationContext.getServletContext()).thenReturn(mockServletContext);
         when(mockConfigurableWebApplicationContext.getEnvironment()).thenReturn(environment);
         when(mockConfigurableWebApplicationContext.getResource(anyString())).thenReturn(null);
-    }
-
-    @AfterEach
-    void tearDown() {
-        System.clearProperty("APPLICATION_CONFIG_FILE");
-        System.clearProperty("APPLICATION_CONFIG_URL");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializerTest.java
@@ -12,8 +12,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.PropertySource;
 import org.springframework.core.env.StandardEnvironment;
@@ -42,34 +43,34 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.util.StringUtils.hasText;
 
 @ExtendWith(PollutionPreventionExtension.class)
 @ExtendWith(SpringProfileCleanupExtension.class)
 @ExtendWith(LoggerContextCleanupExtension.class)
+@ExtendWith(MockitoExtension.class)
 class YamlServletProfileInitializerTest {
 
     private YamlServletProfileInitializer initializer;
-    private ConfigurableWebApplicationContext mockConfigurableWebApplicationContext;
     private ConfigurableEnvironment environment;
+    @Mock
+    private ConfigurableWebApplicationContext mockConfigurableWebApplicationContext;
+    @Mock
     private ServletConfig mockServletConfig;
+    @Mock
     private ServletContext mockServletContext;
 
     @BeforeEach
     void setup() {
         initializer = new YamlServletProfileInitializer();
-        mockConfigurableWebApplicationContext = mock(ConfigurableWebApplicationContext.class);
         environment = new StandardServletEnvironment();
-        mockServletConfig = mock(ServletConfig.class);
-        mockServletContext = mock(ServletContext.class);
 
         when(mockConfigurableWebApplicationContext.getServletConfig()).thenReturn(mockServletConfig);
         when(mockConfigurableWebApplicationContext.getServletContext()).thenReturn(mockServletContext);
         when(mockConfigurableWebApplicationContext.getEnvironment()).thenReturn(environment);
-        when(mockServletContext.getContextPath()).thenReturn("/context");
+        when(mockConfigurableWebApplicationContext.getResource(anyString())).thenReturn(null);
     }
 
     @AfterEach
@@ -275,6 +276,8 @@ class YamlServletProfileInitializerTest {
 
     @ExtendWith(PollutionPreventionExtension.class)
     @ExtendWith(SpringProfileCleanupExtension.class)
+    @ExtendWith(LoggerContextCleanupExtension.class)
+    @ExtendWith(MockitoExtension.class)
     @Nested
     class ApplySpringProfiles {
 
@@ -286,6 +289,7 @@ class YamlServletProfileInitializerTest {
             initializer = new YamlServletProfileInitializer();
             environment = new MockEnvironment();
             context = new MockServletContext();
+            reset(mockConfigurableWebApplicationContext);
         }
 
         @Test

--- a/uaa/src/main/webapp/WEB-INF/web.xml
+++ b/uaa/src/main/webapp/WEB-INF/web.xml
@@ -88,10 +88,6 @@
             <param-value>org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer</param-value>
         </init-param>
         <init-param>
-            <param-name>environmentConfigDefaults</param-name>
-            <param-value>uaa.yml,login.yml</param-value>
-        </init-param>
-        <init-param>
             <param-name>environmentConfigLocations</param-name>
             <param-value>
                 ${LOGIN_CONFIG_URL},file:${LOGIN_CONFIG_PATH}/login.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml,${UAA_CONFIG_URL},file:${UAA_CONFIG_FILE},file:${UAA_CONFIG_PATH}/uaa.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml

--- a/uaa/src/main/webapp/WEB-INF/web.xml
+++ b/uaa/src/main/webapp/WEB-INF/web.xml
@@ -87,12 +87,6 @@
             <param-name>contextInitializerClasses</param-name>
             <param-value>org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer</param-value>
         </init-param>
-        <init-param>
-            <param-name>environmentConfigLocations</param-name>
-            <param-value>
-                ${LOGIN_CONFIG_URL},file:${LOGIN_CONFIG_PATH}/login.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml,${UAA_CONFIG_URL},file:${UAA_CONFIG_FILE},file:${UAA_CONFIG_PATH}/uaa.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml
-            </param-value>
-        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.login;
 
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.extensions.SpringProfileCleanupExtension;
+import org.cloudfoundry.identity.uaa.extensions.SystemPropertiesCleanupExtension;
 import org.cloudfoundry.identity.uaa.impl.config.IdentityZoneConfigurationBootstrap;
 import org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer;
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
@@ -15,10 +16,7 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.SamlConfig;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -36,12 +34,9 @@ import org.springframework.web.servlet.ViewResolver;
 
 import javax.servlet.RequestDispatcher;
 import java.io.File;
-import java.util.Arrays;
 import java.util.EventListener;
 import java.util.List;
 import java.util.Scanner;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -49,37 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-class SystemPropertiesCleanupExtension implements BeforeAllCallback, AfterAllCallback {
-
-    private final Set<String> properties;
-
-    SystemPropertiesCleanupExtension(String... props) {
-        this.properties = Arrays.stream(props).collect(Collectors.toUnmodifiableSet());
-    }
-
-    @Override
-    public void beforeAll(ExtensionContext context) {
-        ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()));
-
-        properties.forEach(s -> store.put(s, System.getProperty(s)));
-    }
-
-    @Override
-    public void afterAll(ExtensionContext context) {
-        ExtensionContext.Store store = context.getStore(ExtensionContext.Namespace.create(context.getRequiredTestClass()));
-
-        properties.forEach(key -> {
-                    String value = store.get(key, String.class);
-                    if (value == null) {
-                        System.clearProperty(key);
-                    } else {
-                        System.setProperty(key, value);
-                    }
-                }
-        );
-    }
-}
 
 @ExtendWith(PollutionPreventionExtension.class)
 @ExtendWith(SpringProfileCleanupExtension.class)


### PR DESCRIPTION
Simplify `YamlServletProfileInitializer` by hardcoding servlet initialization parameters.

This does bring in behavioral changes specific to direct OSS UAA users (not BOSH release users [see 1]).

`YamlServletProfileInitializer` has several levels of indirection to support init params in `web.xml`. However, these params are hardcoded and not configurable, meaning that the indirection can be simplified by inlining. 

## Former behavior:
1) Load from `uaa.yml,login.yml`
1) Then try to add from 
```
  - ${LOGIN_CONFIG_URL}
  - file:${LOGIN_CONFIG_PATH}/login.yml
  - file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml
  - ${UAA_CONFIG_URL}
  - file:${UAA_CONFIG_FILE}
  - file:${UAA_CONFIG_PATH}/uaa.yml
  - file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml
```
1) If (1) & (2) didn't yield any results, load from 
```
  - ${APPLICATION_CONFIG_URL}
  - file:${APPLICATION_CONFIG_FILE}
```
1) If still no results, try (2) and (3) again.
1) Note that there would always be results from (1) because `uaa.yml` is packaged with the WAR file.

## New behavior:
1) Load from `uaa.yml,login.yml`
2) Load from all of:
```
  - ${APPLICATION_CONFIG_URL}
  - file:${APPLICATION_CONFIG_FILE}
  - ${LOGIN_CONFIG_URL}
  - file:${LOGIN_CONFIG_PATH}/login.yml
  - file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml
  - ${UAA_CONFIG_URL}
  - file:${UAA_CONFIG_FILE}
  - file:${UAA_CONFIG_PATH}/uaa.yml
  - file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml
```
3) Note that properties from later files loaded take precedence over properties from earlier files.

### Notes
[1] The UAA BOSH release only seems to care about `file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml`, as configured at https://github.com/cloudfoundry/uaa-release/blob/ed3111886628e41caf0acc3b388a8f297a2a4aa7/jobs/uaa/templates/config/bpm.yml.erb#L7