### PR TITLE
Purge expired session from in memory map

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/PurgeableSessionMap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/PurgeableSessionMap.java
@@ -1,0 +1,28 @@
+package org.cloudfoundry.identity.uaa.web.beans;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.session.Session;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.stream.Collectors.toList;
+
+@Component
+class PurgeableSessionMap extends ConcurrentHashMap<String, Session> {
+    private final static Logger logger = LoggerFactory.getLogger(PurgeableSessionMap.class);
+
+    @Scheduled(fixedDelayString = "${servlet-session-purge-delay:900000}")
+    public void purge() {
+        List<Session> expired = expired();
+        expired.forEach(s -> remove(s.getId()));
+        logger.debug(String.format("Purged %s sessions", expired.size()));
+    }
+
+    public List<Session> expired() {
+        return values().stream().filter(Session::isExpired).collect(toList());
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaMemorySessionConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaMemorySessionConfig.java
@@ -7,14 +7,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.*;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.lang.NonNull;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.session.MapSessionRepository;
 import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
-
-import java.util.concurrent.ConcurrentHashMap;
 
 @Configuration
 @Conditional(UaaMemorySessionConfig.MemoryConfigured.class)
 @EnableSpringHttpSession
+@EnableScheduling
 public class UaaMemorySessionConfig extends UaaSessionConfig {
 
     private final static Logger logger = LoggerFactory.getLogger(UaaMemorySessionConfig.class);
@@ -29,8 +29,11 @@ public class UaaMemorySessionConfig extends UaaSessionConfig {
     }
 
     @Bean
-    public MapSessionRepository sessionRepository(final @Value("${servlet.idle-timeout:1800}") int idleTimeout) {
-        MapSessionRepository sessionRepository = new MapSessionRepository(new ConcurrentHashMap<>());
+    public MapSessionRepository sessionRepository(
+            final @Value("${servlet.idle-timeout:1800}") int idleTimeout,
+            @Autowired PurgeableSessionMap purgeableSessionMap
+    ) {
+        MapSessionRepository sessionRepository = new MapSessionRepository(purgeableSessionMap);
         sessionRepository.setDefaultMaxInactiveInterval(idleTimeout);
         return sessionRepository;
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/PurgeableSessionMapTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/PurgeableSessionMapTest.java
@@ -1,0 +1,44 @@
+package org.cloudfoundry.identity.uaa.web.beans;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.session.Session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PurgeableSessionMapTest {
+    private static final String SESSION_ID = "id";
+    private PurgeableSessionMap sessions;
+
+    @BeforeEach
+    void setUp() {
+        sessions = new PurgeableSessionMap();
+    }
+
+    @Test
+    void doesNotDeleteActiveSessions() {
+        sessions.put(SESSION_ID, createSession(SESSION_ID, false));
+
+        sessions.purge();
+        assertThat(sessions).hasSize(1);
+        assertThat(sessions).containsKey(SESSION_ID);
+    }
+
+    @Test
+    void deletesActiveSessions() {
+        sessions.put(SESSION_ID, createSession(SESSION_ID, true));
+
+        sessions.purge();
+        assertThat(sessions).hasSize(0);
+    }
+
+    private Session createSession(String id, boolean expired) {
+        Session session = mock(Session.class);
+        when(session.getId()).thenReturn(id);
+        when(session.isExpired()).thenReturn(expired);
+
+        return session;
+    }
+}


### PR DESCRIPTION
This PR addresses:
https://github.com/cloudfoundry/uaa/issues/1150

Prior to this commit, configuring the UAA to manage sessions in memory
resulted in the use of `MapSessionRepository` to manage sessions.
`MapSessionRepository` does not automatically remove expired sessions
from its backing map.

And neither did the UAA, resulting in a memory leak.

Now, register a scheduled task to remove expired sessions. The tasks
frequency can be configured via the `servlet.session-purge-delay`
property.