### PR TITLE
Prepare YamlServletProfileInitializer for Spring Boot

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/web.xml
+++ b/uaa/src/main/webapp/WEB-INF/web.xml
@@ -87,16 +87,6 @@
             <param-name>contextInitializerClasses</param-name>
             <param-value>org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer</param-value>
         </init-param>
-        <init-param>
-            <param-name>environmentConfigDefaults</param-name>
-            <param-value>uaa.yml,login.yml</param-value>
-        </init-param>
-        <init-param>
-            <param-name>environmentConfigLocations</param-name>
-            <param-value>
-                ${LOGIN_CONFIG_URL},file:${LOGIN_CONFIG_PATH}/login.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/login.yml,${UAA_CONFIG_URL},file:${UAA_CONFIG_FILE},file:${UAA_CONFIG_PATH}/uaa.yml,file:${CLOUDFOUNDRY_CONFIG_PATH}/uaa.yml
-            </param-value>
-        </init-param>
         <load-on-startup>1</load-on-startup>
     </servlet>
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/BootstrapTests.java
@@ -205,15 +205,17 @@ class BootstrapTests {
     private static ConfigurableApplicationContext getServletContext(
             final String profiles,
             final String uaaYamlPath) {
-        String[] yamlFiles = new String[]{"required_configuration.yml", uaaYamlPath};
+        System.setProperty("LOGIN_CONFIG_URL", "classpath:required_configuration.yml");
+        System.setProperty("UAA_CONFIG_URL", "classpath:" + uaaYamlPath);
 
         abstractRefreshableWebApplicationContext.setServletContext(mockServletContext);
         MockServletConfig servletConfig = new MockServletConfig(mockServletContext);
-        servletConfig.addInitParameter("environmentConfigLocations", StringUtils.arrayToCommaDelimitedString(yamlFiles));
         abstractRefreshableWebApplicationContext.setServletConfig(servletConfig);
 
         YamlServletProfileInitializer initializer = new YamlServletProfileInitializer();
         initializer.initialize(abstractRefreshableWebApplicationContext);
+        System.clearProperty("LOGIN_CONFIG_URL");
+        System.clearProperty("UAA_CONFIG_URL");
 
         if (profiles != null) {
             abstractRefreshableWebApplicationContext.getEnvironment().setActiveProfiles(StringUtils.commaDelimitedListToStringArray(profiles));


### PR DESCRIPTION
YamlServletProfileInitializer relies on hard-coded configuration in web.xml. This migrates that configuration into YamlServletProfileInitializer directly since it's not configurable.

Also, YamlServletProfileInitializer relies on the servlet config. This will not be available in the Spring Boot lifecycle, so provide workarounds when possible.

- Hardcode init params
- Use STDOUT/STDERR instead of `servletContext.log()`
- Allow context path to default to "/" (this may be refactored for Spring Boot)

[#169991138]