### PR TITLE
Minimal server.xml for UAA image

### DIFF
--- a/k8s/image/tomcat/conf/server.xml
+++ b/k8s/image/tomcat/conf/server.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8'?>
+<Server port='-1'>
+  <Service name='Catalina'>
+    <Connector port='8080' bindOnInit='true' connectionTimeout='20000' maxHttpHeaderSize='14336'/>
+
+    <Engine defaultHost='localhost' name='Catalina'>
+      <Valve className='org.apache.catalina.valves.RemoteIpValve' protocolHeader='x-forwarded-proto'/>
+      <Valve className='org.cloudfoundry.tomcat.logging.access.CloudFoundryAccessLoggingValve'
+             pattern='[ACCESS] %{org.apache.catalina.AccessLog.RemoteAddr}r %l %t %D %F %B %S vcap_request_id:%{X-Vcap-Request-Id}i'
+             enabled='${access.logging.enabled}'/>
+      <Host name='localhost'
+            failCtxIfServletStartFails='true'>
+        <Listener className='org.cloudfoundry.tomcat.lifecycle.ApplicationStartupFailureDetectingLifecycleListener'/>
+      </Host>
+    </Engine>
+  </Service>
+</Server>


### PR DESCRIPTION
This server.xml should represent the minimal configuration necessary for the UAA to successfully run. Tomcat behavior cannot be configured yet and logging will go to the console for now.

Configuration of the UAA, however, is possible by providing the location of the UAA config file via one of the supported environment variables.