### PR TITLE
Chores/matcher cleanup

### DIFF
--- a/k8s/test/container_matcher_test.go
+++ b/k8s/test/container_matcher_test.go
@@ -1,0 +1,52 @@
+package k8s_test
+
+import (
+	"fmt"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+type ContainerMatcher struct {
+	fields map[string]types.GomegaMatcher
+
+	container *coreV1.Container
+	executed  types.GomegaMatcher
+}
+
+func NewContainerMatcher() *ContainerMatcher {
+	return &ContainerMatcher{map[string]types.GomegaMatcher{}, nil, nil}
+}
+
+func (matcher *ContainerMatcher) WithName(name string) *ContainerMatcher {
+	matcher.fields["Name"] = gomega.Equal(name)
+
+	return matcher
+}
+
+func (matcher *ContainerMatcher) Match(actual interface{}) (bool, error) {
+	container, ok := actual.(coreV1.Container)
+	if !ok {
+		return false, fmt.Errorf("Expected a container. Got\n%s", format.Object(actual, 1))
+	}
+
+	matcher.container = &container
+	matcher.executed = gstruct.MatchFields(gstruct.IgnoreExtras, matcher.fields)
+	return matcher.executed.Match(container)
+}
+
+func (matcher *ContainerMatcher) FailureMessage(actual interface{}) string {
+	return fmt.Sprintf(
+		"At least one container should match: \n%s",
+		matcher.executed.FailureMessage(&matcher.container),
+	)
+}
+
+func (matcher *ContainerMatcher) NegatedFailureMessage(actual interface{}) string {
+	return fmt.Sprintf(
+		"No container should match: \n%s",
+		matcher.executed.FailureMessage(&matcher.container),
+	)
+}

--- a/k8s/test/deployment_matcher_test.go
+++ b/k8s/test/deployment_matcher_test.go
@@ -1,0 +1,48 @@
+package k8s_test
+
+import (
+	"fmt"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	appV1 "k8s.io/api/apps/v1"
+)
+
+type PodMatcherConfig func(*PodMatcher)
+
+type DeploymentMatcher struct {
+	pod *PodMatcher
+
+	executed types.GomegaMatcher
+}
+
+func RepresentingDeployment() *DeploymentMatcher {
+	return &DeploymentMatcher{NewPodMatcher(), nil}
+}
+
+func (matcher *DeploymentMatcher) WithPodMatching(config PodMatcherConfig) *DeploymentMatcher {
+	config(matcher.pod)
+
+	return matcher
+}
+
+func (matcher *DeploymentMatcher) Match(actual interface{}) (bool, error) {
+	deployment, ok := actual.(*appV1.Deployment)
+	if !ok {
+		return false, fmt.Errorf("Expected a deployment. Got\n%s", format.Object(actual, 1))
+	}
+
+	matcher.executed = matcher.pod
+	if pass, err := matcher.pod.Match(deployment.Spec.Template); !pass || err != nil {
+		return pass, err
+	}
+
+	return true, nil
+}
+
+func (matcher *DeploymentMatcher) FailureMessage(actual interface{}) string {
+	return matcher.executed.FailureMessage(actual)
+}
+
+func (matcher *DeploymentMatcher) NegatedFailureMessage(actual interface{}) string {
+	return matcher.executed.NegatedFailureMessage(actual)
+}

--- a/k8s/test/deployment_test.go
+++ b/k8s/test/deployment_test.go
@@ -14,9 +14,17 @@ var _ = Describe("Deployment", func() {
 		valuesPath = pathToTemplate(filepath.Join("values", "values.yml"))
 	})
 
-	It("Constructs the YAML from a set of files", func() {
+	It("Renders a deployment for the UAA", func() {
 		ctx := NewRenderingContext(deploymentPath, valuesPath)
 
-		Expect(ctx).To(ProduceYAML(RepresentingContainer("uaa")))
+		Expect(ctx).To(
+			ProduceYAML(
+				RepresentingDeployment().WithPodMatching(func(pod *PodMatcher) {
+					pod.WithContainerMatching(func(container *ContainerMatcher) {
+						container.WithName("uaa")
+					})
+				}),
+			),
+		)
 	})
 })

--- a/k8s/test/pod_matcher_test.go
+++ b/k8s/test/pod_matcher_test.go
@@ -1,0 +1,55 @@
+package k8s_test
+
+import (
+	"fmt"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/types"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+type ContainerMatcherConfig func(*ContainerMatcher)
+
+type PodMatcher struct {
+	containers []types.GomegaMatcher
+
+	executed types.GomegaMatcher
+}
+
+func NewPodMatcher() *PodMatcher {
+	return &PodMatcher{[]types.GomegaMatcher{}, nil}
+}
+
+func (matcher *PodMatcher) WithContainerMatching(config ContainerMatcherConfig) *PodMatcher {
+	container := NewContainerMatcher()
+	config(container)
+	matcher.containers = append(matcher.containers, container)
+
+	return matcher
+}
+
+func (matcher *PodMatcher) Match(actual interface{}) (bool, error) {
+	pod, ok := actual.(coreV1.PodTemplateSpec)
+	if !ok {
+		return false, fmt.Errorf("Expected pod. Got\n%s", format.Object(actual, 1))
+	}
+
+	for _, container := range matcher.containers {
+		contains := gomega.ContainElement(container)
+
+		matcher.executed = container
+		if pass, err := contains.Match(pod.Spec.Containers); !pass || err != nil {
+			return pass, err
+		}
+	}
+
+	return true, nil
+}
+
+func (matcher *PodMatcher) FailureMessage(actual interface{}) string {
+	return matcher.executed.FailureMessage(actual)
+}
+
+func (matcher *PodMatcher) NegatedFailureMessage(actual interface{}) string {
+	return matcher.executed.NegatedFailureMessage(actual)
+}


### PR DESCRIPTION
Prior to this PR, the matchers used a simplified interface to make assertions, but this proved difficult to extend.

This PR brings the k8s matchers closer to the underlying structure of the data resulting from parsing the resulting YAML. This should ease both the extension of the matchers and their expressiveness.