### PR TITLE
Add liveness, readiness, and startup probes to UAA pod

### DIFF
--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -30,7 +30,8 @@ spec:
         - name: uaa
           image: "cfidentity/uaa@sha256:93b70b26fbb3de88d93728b0daf1ea7b001fde89a24e283c3db36bf4c6af087c"
           ports:
-            - containerPort: 8080
+            - name: http-uaa
+              containerPort: 8080
               protocol: TCP
           env:
             - name: spring_profiles
@@ -40,6 +41,21 @@ spec:
           volumeMounts:
           - name: uaa-config
             mountPath: /etc/config
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http-uaa
+            failureThreshold: 5
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http-uaa
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http-uaa
+            failureThreshold: 20
+            periodSeconds: 15
       volumes:
       - name: uaa-config
         configMap:


### PR DESCRIPTION
This allows the UAA pod to correctly report whether it's running, based on the return value of the healthz endpoint. If it fails, k8s will restart it.

We decided to add a StartupProbe because the UAA can take minutes to start up due to database migrations, but once the start up is complete we would like for k8s to be able to more quickly detect pod failures. Right now we give the pod 5 minutes to start up. There's probably a conversation for us to have about how we do migrations generally, but until then we are a good candidate for a StartupProbe.

We didn't add tests since these values are not currently configurable.

Relevant k8s documentation on probes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

[#170836774]