### PR TITLE
Allow configuration of UAA port from commandline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import java.nio.file.Files
 import java.nio.file.Paths
 
+def applicationPort = project.hasProperty('port') ? project.getProperty('port').toInteger() : 8080
+
 buildscript {
     apply from: "dependencies.gradle"
 
@@ -148,7 +150,7 @@ subprojects {
 
 cargo {
     containerId = "tomcat9x"
-    port = 8080
+    port = applicationPort
 
     deployable {
         file = file("statsd/build/libs/cloudfoundry-identity-statsd-" + version + ".war")
@@ -171,7 +173,9 @@ cargo {
     }
 
     local {
+        configHomeDir = file(Paths.get(System.getProperty("java.io.tmpdir") + "/uaa-${applicationPort}"))
         startStopTimeout = 540000
+        rmiPort = applicationPort + 1
         List activeProfiles = System.getProperty("spring.profiles.active", "").split(",")
         jvmArgs = "-DLOGIN_CONFIG_URL=classpath:required_configuration.yml"
         if (activeProfiles.contains("debug")) {
@@ -189,6 +193,10 @@ cargo {
             property "metrics.perRequestMetrics", System.getProperty("metrics.perRequestMetrics", "true")
             property "smtp.host", "localhost"
             property "smtp.port", 2525
+        }
+
+        containerProperties {
+            property 'cargo.tomcat.ajp.port', applicationPort + 2
         }
 
         installer {
@@ -224,9 +232,9 @@ task manifests(dependsOn: assemble, type: Copy) {
 }
 
 task cleanCargoConfDir {
-    delete file(System.getProperty("java.io.tmpdir") + "/cargo/conf")
+    delete file(System.getProperty("java.io.tmpdir") + "/cargo/uaa-${applicationPort}")
     try {
-        Files.createDirectory(Paths.get(System.getProperty("java.io.tmpdir") + "/cargo"))
+        Files.createDirectory(Paths.get(System.getProperty("java.io.tmpdir") + "/uaa-${applicationPort}"))
     } catch (all) {
     }
 }


### PR DESCRIPTION
Prior to this commit, `build.gradle` ran the UAA on port 8080 no ifs ands or buts.  Now, that can be overridden by specifying `-Pport=<port>`.