### PR TITLE
Make the openid parameter clearer

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserInfoEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserInfoEndpointDocs.java
@@ -59,7 +59,7 @@ class UserInfoEndpointDocs extends EndpointDocs {
 
         Snippet requestHeaders = requestHeaders(
                 headerWithName("Authorization")
-                        .description("Access token with openid required. If the `" + USER_ATTRIBUTES + "` scope is in the token, " +
+                        .description("Access token with `openid` required. If the `" + USER_ATTRIBUTES + "` scope is in the token, " +
                                 "the response object will contain custom attributes, if mapped to the external identity provider." +
                                 "If  the `roles` scope is present, the response object will contain group memberships  from the external identity provider."
 


### PR DESCRIPTION
Myself and @samze were setting up an app to go through the access token grant flow. We skimmed the docs and misread that we should add the user_attributes scope and missed the openid scope. We think this was because it is formatted more prominently so think we should do the same for the openid scope.