### PR TITLE
Allow caller with uaa.admin scope to change a user's password

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
@@ -181,12 +181,12 @@
 
     <http name="scimUserPassword" pattern="/User*/*/password" create-session="stateless"
           authentication-manager-ref="emptyAuthenticationManager"
-          entry-point-ref="oauthAuthenticationEntryPoint" access-decision-manager-ref="accessDecisionManager"
-          use-expressions="false"
+          entry-point-ref="oauthAuthenticationEntryPoint"
           xmlns="http://www.springframework.org/schema/security">
-        <intercept-url pattern="/**" access="IS_AUTHENTICATED_FULLY,scope=password.write"/>
-        <custom-filter ref="passwordResourceAuthenticationFilter" position="PRE_AUTH_FILTER"/>
+        <intercept-url pattern="/**" access="isFullyAuthenticated() and #oauth2.hasAnyScope('password.write')"/>
+        <custom-filter ref="resourceAgnosticAuthenticationFilter" position="PRE_AUTH_FILTER"/>
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
+        <expression-handler ref="oauthWebExpressionHandler"/>
         <csrf disabled="true"/>
     </http>
 
@@ -242,9 +242,6 @@
         <access-denied-handler ref="oauthAccessDeniedHandler"/>
         <csrf disabled="true"/>
     </http>
-
-    <oauth:resource-server id="passwordResourceAuthenticationFilter" token-services-ref="tokenServices"
-                           resource-id="password" entry-point-ref="oauthAuthenticationEntryPoint"/>
 
     <oauth:resource-server id="scimResourceAuthenticationFilter" token-services-ref="tokenServices"
                            resource-id="scim" entry-point-ref="oauthAuthenticationEntryPoint"/>


### PR DESCRIPTION
The documentation for the change user password call says, for Authorization:

Access token with password.write or uaa.admin required

However the current configuration only allows the call if the caller has the
password.write scope.

This fix changes the configuration to match the documentation. It replaces:

IS_AUTHENTICATED_FULLY,scope=password.write

with the expression:

isFullyAuthenticated() and #oauth2.hasAnyScope('password.write')

The UAA custom version of hasAnyScope has an internal check for the uaa.admin
scope. It also removes the passwordResourceAuthenticationFilter, which also
insisted on a scope with the password prefix.