### PR TITLE
Complying with RFC https://tools.ietf.org/html/rfc7662 for introspect…

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/IntrospectionClaims.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/IntrospectionClaims.java
@@ -16,16 +16,31 @@ package org.cloudfoundry.identity.uaa.oauth.token;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
+
 public class IntrospectionClaims extends Claims {
 
-    @JsonProperty("active")
-    private boolean active;
+	@JsonProperty("active")
+	private boolean active;
+	@JsonProperty("scope")
+	private String scopes;
 
-    public void setActive(boolean active) {
-        this.active = active;
-    }
+	public boolean isActive() {
+		return active;
+	}
 
-    public boolean isActive() {
-        return active;
-    }
+	public void setActive(boolean active) {
+		this.active = active;
+	}
+
+	public String getScopes() {
+		return this.scopes;
+	}
+
+	@JsonProperty("scope")
+	public void setScopes(List<String> scopes) {
+		if (scopes == null)
+			this.scopes = null;
+		this.scopes = String.join(" ", scopes);
+	}
 }


### PR DESCRIPTION
### Fix for Issue - Introspect endpoint don't follow rfc7662
 https://github.com/cloudfoundry/uaa/issues/1229

### Description

According to RFC, the SCOPE of `introspect token` should be a JSON String containing a space-
separated list of scopes associated with the token. And this is how all the frameworks like Spring Security etc. and most of the major programming languages has built by following RFC.

[RFC for Reference](https://tools.ietf.org/html/rfc7662#section-3.3)

`"scope" : "scim.userids openid cloud_controller.read password.write cloud_controller.write`

### What did you see instead?

I get the scope as an array like below: 
`"scope" : [ "scim.userids", "openid", "cloud_controller.read", "password.write", "cloud_controller.write" ]`

## How did I fixed this?

I created a property in subclass and serializing the SCOPE property in claims as a JSON String