### PR TITLE
UAA's admin client secret is now a K8s secret object

### DIFF
--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -7,8 +7,8 @@ GOFILES=`find . -type f -name '*.go'`
 .PHONY: test
 .PHONY: render
 .PHONY: apply
-.PHONY: minikube
 .PHONY: kubectl-clean
+.PHONY: kubectl-clean-all
 .PHONY: docker-run
 .PHONY: docker-debug
 .PHONY: brew-cli
@@ -33,11 +33,11 @@ render:
 apply:
 	@ytt -f templates | kubectl apply -f -
 
-minikube:
-	@ytt -f templates -f addons | kubectl apply -f -
-
 kubectl-clean:
 	kubectl delete deployments,services,secrets,replicasets,services,pods,configmaps,serviceaccounts --all
+
+kubectl-clean-all:
+	kubectl delete all,ingress --all
 
 docker-run:
 	docker pull cfidentity/uaa:latest \

--- a/k8s/Makefile
+++ b/k8s/Makefile
@@ -9,8 +9,6 @@ GOFILES=`find . -type f -name '*.go'`
 .PHONY: apply
 .PHONY: kubectl-clean
 .PHONY: kubectl-clean-all
-.PHONY: docker-run
-.PHONY: docker-debug
 .PHONY: brew-cli
 
 help:
@@ -38,27 +36,6 @@ kubectl-clean:
 
 kubectl-clean-all:
 	kubectl delete all,ingress --all
-
-docker-run:
-	docker pull cfidentity/uaa:latest \
-	&& docker run \
-		--detach \
-		--publish 8080:8080 \
-		--mount type=bind,source=${PWD}/../scripts/cargo/uaa.yml,target=/uaa.yml \
-		--env CLOUDFOUNDRY_CONFIG_PATH= \
-		--env spring_profiles=default,hsqldb \
-		cfidentity/uaa:latest
-
-docker-debug:
-	docker run \
-		--detach \
-		--publish 8080:8080 \
-		--publish 5005:5005 \
-		--mount type=bind,source=${PWD}/../scripts/cargo/uaa.yml,target=/uaa.yml \
-		--env CLOUDFOUNDRY_CONFIG_PATH= \
-		--env spring_profiles=default,hsqldb \
-		--env JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Djava.security.egd=file:/dev/./urandom" \
-		cfidentity/uaa:latest
 
 brew-cli:
 	brew install cloudfoundry/tap/uaa-cli

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,31 @@
+## Testing image `cfidentity/uaa` 
+
+To test image `cfidentity/uaa`, you can make use of these sample docker commands:
+
+### Docker Run
+
+```shell script
+docker pull cfidentity/uaa:latest \
+	&& docker run \
+		--detach \
+		--publish 8080:8080 \
+		--mount type=bind,source=${PWD}/../scripts/cargo/uaa.yml,target=/uaa.yml \
+		--env CLOUDFOUNDRY_CONFIG_PATH= \
+		--env spring_profiles=default,hsqldb \
+		cfidentity/uaa:latest
+```
+
+### Docker Debug
+
+```shell script
+docker pull cfidentity/uaa:latest \
+   	&& docker run \
+		--detach \
+		--publish 8080:8080 \
+		--publish 5005:5005 \
+		--mount type=bind,source=${PWD}/../scripts/cargo/uaa.yml,target=/uaa.yml \
+		--env CLOUDFOUNDRY_CONFIG_PATH= \
+		--env spring_profiles=default,hsqldb \
+		--env JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Djava.security.egd=file:/dev/./urandom" \
+		cfidentity/uaa:latest
+```

--- a/k8s/matchers/container_matcher.go
+++ b/k8s/matchers/container_matcher.go
@@ -87,7 +87,7 @@ func (matcher *ContainerMatcher) Match(actual interface{}) (bool, error) {
 	identifyVolumeMountByName := func(element interface{}) string {
 		return element.(coreV1.VolumeMount).Name
 	}
-	matcher.fields["VolumeMounts"] = MatchElements(identifyVolumeMountByName, 0, matcher.volumeMounts)
+	matcher.fields["VolumeMounts"] = MatchElements(identifyVolumeMountByName, IgnoreExtras, matcher.volumeMounts)
 
 	matcher.executed = MatchFields(IgnoreExtras, matcher.fields)
 	return matcher.executed.Match(container)

--- a/k8s/matchers/pod_matcher.go
+++ b/k8s/matchers/pod_matcher.go
@@ -85,7 +85,7 @@ func (matcher *PodMatcher) Match(actual interface{}) (bool, error) {
 	identifyVolumeByName := func(element interface{}) string {
 		return element.(coreV1.Volume).Name
 	}
-	matcher.executed = gstruct.MatchElements(identifyVolumeByName, 0, matcher.volumes)
+	matcher.executed = gstruct.MatchElements(identifyVolumeByName, gstruct.IgnoreExtras, matcher.volumes)
 	if pass, err := matcher.executed.Match(pod.Spec.Volumes); !pass || err != nil {
 		return pass, err
 	}

--- a/k8s/matchers/throw_error_matcher.go
+++ b/k8s/matchers/throw_error_matcher.go
@@ -1,0 +1,40 @@
+package matchers
+
+import (
+	"fmt"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+type ThrowErrorMatcher struct {
+	text string
+}
+
+func ThrowError(text string) *ThrowErrorMatcher {
+	return &ThrowErrorMatcher{text: text}
+}
+
+func (matcher *ThrowErrorMatcher) Match(actual interface{}) (bool, error) {
+	rendering, ok := actual.(RenderingContext)
+	if !ok {
+		return false, fmt.Errorf("ThrowErrorMatcher must be passed a RenderingContext. Got\n%s", format.Object(actual, 1))
+	}
+
+	session, _ := renderWithData(rendering.templates, rendering.data)
+	if session == nil {
+		return false, fmt.Errorf("ThrowErrorMatcher received a nil render session")
+	}
+
+	gomega.Eventually(session.Err).Should(gbytes.Say(matcher.text))
+	return gomega.Eventually(session).Should(gexec.Exit(1)), nil
+}
+
+func (matcher *ThrowErrorMatcher) FailureMessage(actual interface{}) string {
+	return "ThrowErrorMatcher FailureMessage not implemented"
+}
+
+func (matcher *ThrowErrorMatcher) NegatedFailureMessage(actual interface{}) string {
+	return "ThrowErrorMatcher NegatedFailureMessage not implemented"
+}

--- a/k8s/matchers/uaa_config_structs.go
+++ b/k8s/matchers/uaa_config_structs.go
@@ -8,6 +8,7 @@ type UaaConfig struct {
 	Jwt         Jwt        `yaml:"jwt"`
 	Database    Database   `yaml:"database"`
 	Smtp        Smtp       `yaml:"smtp"`
+	Oauth       Oauth      `yaml:"oauth"`
 }
 
 type Issuer struct {
@@ -64,4 +65,22 @@ type Smtp struct {
 	Port        string `yaml:"port"`
 	Starttls    string `yaml:"starttls"`
 	FromAddress string `yaml:"from_address"`
+}
+
+type OauthClient struct {
+	Override bool `yaml:"override"`
+}
+
+type SingleOauthClient struct {
+	AuthorizedGrantTypes string `yaml:"authorized-grant-types"`
+	Authorities          string `yaml:"authorities"`
+}
+
+type OauthClients struct {
+	Admin SingleOauthClient `yaml:"admin"`
+}
+
+type Oauth struct {
+	Client  OauthClient  `yaml:"client"`
+	Clients OauthClients `yaml:"clients"`
 }

--- a/k8s/run-minikube.sh
+++ b/k8s/run-minikube.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+UAA_INGRESS_IP=""
+UAA_ADMIN_CLIENT_SECRET=""
+UAA_CONFIG_DIR="${HOME}/.uaa"
+UAA_ADMIN_CLIENT_SECRET_LOCATION="${UAA_CONFIG_DIR}/admin_client_secret.json"
+
+get_admin_client_secret() {
+  mkdir -p "${UAA_CONFIG_DIR}"
+
+  local admin_client_secret
+  admin_client_secret=$(jq ".admin.client_secret" "${UAA_ADMIN_CLIENT_SECRET_LOCATION}" -e -r 2> /dev/null)
+
+  if [ $? -ne 0 ]; then
+    admin_client_secret="$(openssl rand -hex 12)"
+    create_admin_client_secret "${admin_client_secret}"
+  fi
+
+  UAA_ADMIN_CLIENT_SECRET="${admin_client_secret}"
+}
+
+create_admin_client_secret() {
+  local admin_client_secret
+  admin_client_secret="${1}"
+
+  cat << EOF > "${UAA_ADMIN_CLIENT_SECRET_LOCATION}"
+{
+  "admin": {
+    "client_secret": "${admin_client_secret}"
+  }
+}
+EOF
+
+}
+
+ytt_and_minikube() {
+  local ytt_kubectl_cmd="ytt -f templates -f addons -v admin.client_secret=${UAA_ADMIN_CLIENT_SECRET} ${@} | kubectl apply -f -"
+
+  echo "Running '${ytt_kubectl_cmd}'"
+  eval "${ytt_kubectl_cmd}"
+}
+
+wait_for_ingress() {
+  echo "Waiting for ingress availability"
+
+  local get_ip_cmd="kubectl get ingress -o json | jq '.items[0].status.loadBalancer.ingress[0].ip' -e -r"
+  local ip
+  ip=$(eval "${get_ip_cmd}")
+
+  while [ $? -ne 0 ]; do
+    echo "Checking for ingress ip... ${ip}"
+    sleep 4
+    ip=$(eval "${get_ip_cmd}")
+  done
+
+  echo "Checking for ingress ip... ${ip}"
+  UAA_INGRESS_IP="${ip}"
+}
+
+wait_for_availability() {
+  echo "Waiting for UAA availability"
+
+  local status_cmd="kubectl get deployments/uaa -o json | jq '.status.readyReplicas' -e"
+  local count_ready=
+  count_ready=$(eval "${status_cmd}")
+
+  while [ $? -ne 0 ]; do
+    echo "Waiting for UAA availability..."
+    sleep 2
+    count_ready=$(eval "${status_cmd}")
+  done
+
+  while [ 1 -gt ${count_ready} ]; do
+    echo "Waiting for UAA availability..."
+    sleep 2
+    count_ready=$(eval "${status_cmd}")
+  done
+}
+
+target_uaa() {
+  echo "Attempting to target the UAA"
+
+  local target_cmd="uaa target 'http://${UAA_INGRESS_IP}' --skip-ssl-validation"
+  eval "${target_cmd}"
+
+  while [ $? -ne 0 ]; do
+    echo "Attempting to target the UAA..."
+    sleep 2
+    eval "${target_cmd}"
+  done
+}
+
+get_client_credentials_token() {
+  local get_token_cmd
+  get_token_cmd="uaa get-client-credentials-token admin -s '${UAA_ADMIN_CLIENT_SECRET}' > /dev/null 2> /dev/null"
+
+  eval "${get_token_cmd}"
+
+  if [ $? -ne 0 ]; then
+    echo "Unable to retrieve admin client token. Performing a rollout restart."
+    kubectl rollout restart deployments/uaa
+  fi
+
+  eval "${get_token_cmd}"
+  while [ $? -ne 0 ]; do
+    echo "Attempting to get a client_token for the UAA..."
+    sleep 4
+    eval "${get_token_cmd}"
+  done
+}
+
+main() {
+  get_admin_client_secret
+  ytt_and_minikube "${@}"
+  wait_for_ingress
+  wait_for_availability
+  target_uaa "${UAA_INGRESS_IP}"
+  get_client_credentials_token
+}
+
+main $@

--- a/k8s/templates/deployment.star
+++ b/k8s/templates/deployment.star
@@ -1,11 +1,3 @@
-def spring_profiles(database_scheme):
-  if database_scheme in ["postgresql","mysql"]:
-    return database_scheme
-  else:
-    return "hsqldb"
-  end
-end
-
 config_dir = "/etc/config"
 
 java_opts_list = [

--- a/k8s/templates/deployment.star
+++ b/k8s/templates/deployment.star
@@ -2,7 +2,7 @@ def spring_profiles(database_scheme):
   if database_scheme in ["postgresql","mysql"]:
     return database_scheme
   else:
-    return "default,hsqldb"
+    return "hsqldb"
   end
 end
 

--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -51,6 +51,10 @@ spec:
           mountPath: #@ "{}/database_credentials.yml".format(secrets_dir)
           subPath: database_credentials.yml
           readOnly: true
+        - name: admin-client-credentials-file
+          mountPath: #@ "{}/admin_client_credentials.yml".format(secrets_dir)
+          subPath: admin_client_credentials.yml
+          readOnly: true
         livenessProbe:
           httpGet:
             path: /healthz
@@ -74,3 +78,6 @@ spec:
         secret:
           optional: true
           secretName: uaa-database-credentials
+      - name: admin-client-credentials-file
+        secret:
+          secretName: uaa-admin-client-credentials

--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -1,5 +1,5 @@
 #@ load("@ytt:data", "data")
-#@ load("deployment.star", "java_opts", "spring_profiles", "config_dir")
+#@ load("deployment.star", "java_opts", "config_dir")
 
 #@ secrets_dir = "/etc/secrets"
 ---
@@ -35,7 +35,7 @@ spec:
         - name: JAVA_OPTS
           value: #@ java_opts()
         - name: spring_profiles
-          value: #@ spring_profiles(data.values.database.scheme)
+          value: #@ data.values.database.scheme or "hsqldb"
         - name: CLOUDFOUNDRY_CONFIG_PATH
           value: #@ config_dir
         - name: SECRETS_DIR

--- a/k8s/templates/secrets/admin_client_credentials.yml
+++ b/k8s/templates/secrets/admin_client_credentials.yml
@@ -1,11 +1,12 @@
 #@ load("@ytt:data", "data")
 #@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:assert", "assert")
 
 #@ def admin_client_credentials():
 oauth:
   clients:
     admin:
-      secret: #@ data.values.admin.client_secret
+      secret: #@ data.values.admin.client_secret or assert.fail("admin.client_secret is required")
 #@ end
 
 ---

--- a/k8s/templates/secrets/admin_client_credentials.yml
+++ b/k8s/templates/secrets/admin_client_credentials.yml
@@ -1,0 +1,18 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:yaml", "yaml")
+
+#@ def admin_client_credentials():
+oauth:
+  clients:
+    admin:
+      secret: #@ data.values.admin.client_secret
+#@ end
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: uaa-admin-client-credentials
+type: Opaque
+stringData:
+  admin_client_credentials.yml: #@ yaml.encode(admin_client_credentials())

--- a/k8s/templates/uaa.lib.yml
+++ b/k8s/templates/uaa.lib.yml
@@ -8,8 +8,8 @@ issuer:
 encryption:
   active_key_label: CHANGE-THIS-KEY
   encryption_keys:
-  - label: CHANGE-THIS-KEY
-    passphrase: CHANGEME
+    - label: CHANGE-THIS-KEY
+      passphrase: CHANGEME
 
 login:
   serviceProviderKey: |
@@ -72,4 +72,13 @@ smtp:
   port: #@ data.values.smtp.port
   starttls: #@ data.values.smtp.starttls
   from_address: #@ data.values.smtp.from_address
+
+oauth:
+  client:
+    override: true
+  clients:
+    admin:
+      authorized-grant-types: client_credentials
+      authorities: "clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write"
+
 #@ end

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -38,3 +38,6 @@ smtp:
   password: ~
   starttls: ~
   from_address: ~
+
+admin:
+  client_secret: ~

--- a/k8s/test/config_map_test.go
+++ b/k8s/test/config_map_test.go
@@ -82,6 +82,17 @@ var _ = Describe("Uaa ConfigMap", func() {
 									"Starttls":    BeEmpty(),
 									"FromAddress": BeEmpty(),
 								}),
+								"Oauth": MatchFields(0, Fields{
+									"Client": MatchFields(0, Fields{
+										"Override": Equal(true),
+									}),
+									"Clients": MatchFields(0, Fields{
+										"Admin": MatchFields(0, Fields{
+											"AuthorizedGrantTypes": Equal("client_credentials"),
+											"Authorities":          Equal("clients.read,clients.write,clients.secret,uaa.admin,scim.read,scim.write,password.write"),
+										}),
+									}),
+								}),
 							})
 						}),
 					))

--- a/k8s/test/deployment_test.go
+++ b/k8s/test/deployment_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Deployment", func() {
 					pod.WithContainerMatching(func(container *ContainerMatcher) {
 						container.WithName("uaa")
 						container.WithImageContaining("cfidentity/uaa@sha256:")
-						container.WithEnvVar("spring_profiles", "default,hsqldb")
+						container.WithEnvVar("spring_profiles", "hsqldb")
 						container.WithEnvVar("CLOUDFOUNDRY_CONFIG_PATH", "/etc/config")
 						container.WithEnvVar("BPL_TOMCAT_ACCESS_LOGGING", "y")
 						container.WithEnvVar("JAVA_OPTS", "-Djava.security.egd=file:/dev/./urandom -Dlogging.config=/etc/config/log4j2.properties -Dlog4j.configurationFile=/etc/config/log4j2.properties")

--- a/k8s/test/deployment_test.go
+++ b/k8s/test/deployment_test.go
@@ -81,10 +81,6 @@ var _ = Describe("Deployment", func() {
 						container.WithName("uaa")
 						container.WithImage("image from testing")
 					})
-					pod.WithVolume("uaa-config", Not(BeNil()))
-					pod.WithVolume("database-credentials-file", Not(BeNil()))
-					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
-					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)
@@ -104,10 +100,6 @@ var _ = Describe("Deployment", func() {
 						container.WithName("uaa")
 						container.WithResourceRequests("888Mi", "999m")
 					})
-					pod.WithVolume("uaa-config", Not(BeNil()))
-					pod.WithVolume("database-credentials-file", Not(BeNil()))
-					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
-					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)
@@ -136,10 +128,6 @@ var _ = Describe("Deployment", func() {
 							container.WithName("uaa")
 							container.WithEnvVar("spring_profiles", databaseScheme)
 						})
-						pod.WithVolume("uaa-config", Not(BeNil()))
-						pod.WithVolume("database-credentials-file", Not(BeNil()))
-						pod.WithVolume("smtp-credentials-file", Not(BeNil()))
-						pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 					}),
 				),
 			)
@@ -166,10 +154,6 @@ var _ = Describe("Deployment", func() {
 				WithNamespace("default").
 				WithPodMatching(func(pod *PodMatcher) {
 					pod.WithLabels(labels)
-					pod.WithVolume("uaa-config", Not(BeNil()))
-					pod.WithVolume("database-credentials-file", Not(BeNil()))
-					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
-					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)

--- a/k8s/test/deployment_test.go
+++ b/k8s/test/deployment_test.go
@@ -80,10 +80,6 @@ var _ = Describe("Deployment", func() {
 					pod.WithContainerMatching(func(container *ContainerMatcher) {
 						container.WithName("uaa")
 						container.WithImage("image from testing")
-						container.WithVolumeMount("uaa-config", Not(BeNil()))
-						container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
-						container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
-						container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 					})
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
@@ -107,10 +103,6 @@ var _ = Describe("Deployment", func() {
 					pod.WithContainerMatching(func(container *ContainerMatcher) {
 						container.WithName("uaa")
 						container.WithResourceRequests("888Mi", "999m")
-						container.WithVolumeMount("uaa-config", Not(BeNil()))
-						container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
-						container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
-						container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 					})
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
@@ -143,10 +135,6 @@ var _ = Describe("Deployment", func() {
 						pod.WithContainerMatching(func(container *ContainerMatcher) {
 							container.WithName("uaa")
 							container.WithEnvVar("spring_profiles", databaseScheme)
-							container.WithVolumeMount("uaa-config", Not(BeNil()))
-							container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
-							container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
-							container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 						})
 						pod.WithVolume("uaa-config", Not(BeNil()))
 						pod.WithVolume("database-credentials-file", Not(BeNil()))

--- a/k8s/test/deployment_test.go
+++ b/k8s/test/deployment_test.go
@@ -23,6 +23,13 @@ var _ = Describe("Deployment", func() {
 		"ReadOnly":  Equal(true),
 	})
 
+	adminCredentialsVolumeMountMatcher := gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Name":      Equal("admin-client-credentials-file"),
+		"MountPath": Equal("/etc/secrets/admin_client_credentials.yml"),
+		"SubPath":   Equal("admin_client_credentials.yml"),
+		"ReadOnly":  Equal(true),
+	})
+
 	BeforeEach(func() {
 		templates = []string{
 			pathToFile("deployment.yml"),
@@ -51,11 +58,13 @@ var _ = Describe("Deployment", func() {
 						container.WithVolumeMount("uaa-config", Not(BeNil()))
 						container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
 						container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
+						container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 						container.WithResourceRequests("512Mi", "500m")
 					})
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
 					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
+					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)
@@ -74,10 +83,12 @@ var _ = Describe("Deployment", func() {
 						container.WithVolumeMount("uaa-config", Not(BeNil()))
 						container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
 						container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
+						container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 					})
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
 					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
+					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)
@@ -99,10 +110,12 @@ var _ = Describe("Deployment", func() {
 						container.WithVolumeMount("uaa-config", Not(BeNil()))
 						container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
 						container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
+						container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 					})
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
 					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
+					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)
@@ -133,10 +146,12 @@ var _ = Describe("Deployment", func() {
 							container.WithVolumeMount("uaa-config", Not(BeNil()))
 							container.WithVolumeMount("database-credentials-file", databaseVolumeMountMatcher)
 							container.WithVolumeMount("smtp-credentials-file", smtpVolumeMountMatcher)
+							container.WithVolumeMount("admin-client-credentials-file", adminCredentialsVolumeMountMatcher)
 						})
 						pod.WithVolume("uaa-config", Not(BeNil()))
 						pod.WithVolume("database-credentials-file", Not(BeNil()))
 						pod.WithVolume("smtp-credentials-file", Not(BeNil()))
+						pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 					}),
 				),
 			)
@@ -166,6 +181,7 @@ var _ = Describe("Deployment", func() {
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
 					pod.WithVolume("smtp-credentials-file", Not(BeNil()))
+					pod.WithVolume("admin-client-credentials-file", Not(BeNil()))
 				}),
 			),
 		)

--- a/k8s/test/secrets_test.go
+++ b/k8s/test/secrets_test.go
@@ -133,4 +133,17 @@ var _ = Describe("Secrets", func() {
 		)
 	})
 
+	It("Admin client credentials are required", func() {
+		templates = []string{
+			pathToFile(filepath.Join("values", "_values.yml")),
+			pathToFile(filepath.Join("secrets", "admin_client_credentials.yml")),
+		}
+
+		renderingContext := NewRenderingContext(templates...)
+
+		Expect(renderingContext).To(
+			ThrowError("admin.client_secret is required"),
+		)
+	})
+
 })

--- a/k8s/test/secrets_test.go
+++ b/k8s/test/secrets_test.go
@@ -109,4 +109,28 @@ var _ = Describe("Secrets", func() {
 		Expect(renderingContext).To(ProduceEmptyYAML())
 	})
 
+	It("Renders with admin client credentials", func() {
+		templates = []string{
+			pathToFile(filepath.Join("values", "_values.yml")),
+			pathToFile(filepath.Join("secrets", "admin_client_credentials.yml")),
+		}
+
+		renderingContext := NewRenderingContext(templates...).WithData(
+			map[string]string{
+				"admin.client_secret": "my admin client secret",
+			})
+
+		adminClientCredentials := `oauth:
+  clients:
+    admin:
+      secret: my admin client secret
+`
+
+		Expect(renderingContext).To(
+			ProduceYAML(RepresentingASecret().
+				WithName("uaa-admin-client-credentials").
+				WithStringData("admin_client_credentials.yml", adminClientCredentials)),
+		)
+	})
+
 })


### PR DESCRIPTION
Implements the story (https://www.pivotaltracker.com/story/show/171398937).

### Admin client secret

The UAA admin client secret can now be provided to `ytt` render commands via `-v admin.client_secret=<some value>`. This will create an admin client with authority of at least `uaa.admin` and grant type `client_credentials`. This admin client will be the only client configured in the UAA. 

### Other clients and the default profile

No other clients or users will be configured in the UAA (the `default` Spring profile is not applied).

### Local developer experience

Adds `./k8s/run-minikube.sh` as the default developer experience for deploying the UAA to minikube locally for development purposes.
