### PR TITLE
[#172158373] Make Account Chooser page aware of the origin

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -385,7 +385,7 @@ public class LoginInfoEndpoint {
 
         if (discoveryEnabled) {
             if (model.containsAttribute("login_hint")) {
-                return goToPasswordPage(null, model);
+                return goToPasswordPage(request.getParameter("email"), model);
             }
             boolean accountChooserNeeded = accountChooserEnabled
                     && !(otherAccountSignIn || savedAccountsEmpty)

--- a/server/src/main/resources/templates/web/idp_discovery/account_chooser.html
+++ b/server/src/main/resources/templates/web/idp_discovery/account_chooser.html
@@ -20,13 +20,14 @@
       <li class="list-group-item" th:each="account, iter : ${savedAccounts}" th:inline="text">
         <form th:id="${account.userId}" action="/login/idp_discovery" th:action="@{/login/idp_discovery}" method="post" role="form">
           <input type="hidden" class="form-control" name="email" th:value="${account.origin == 'uaa' || account.origin == 'ldap' ? account.username : account.email}" />
+          <input type="hidden" class="form-control" name="login_hint" th:value="${'%7B%22origin%22:%22'+account.origin+'%22%7D'}" />
         </form>
         <a href="#" th:data-userId="${account.userId}" th:onclick="'javascript:document.getElementById(this.getAttribute(\'data-userId\')).submit();'">
           <span class="account-avatar txt-c ptl txt-m" th:style="'background-color: rgb(' + ${account.red} + ',' + ${account.green} + ',' + ${account.blue} +')'">
             <div class="h2 abbr txt-c pan man em-high">[[${account.username[0]}]]</div>
           </span>
           <span class="email-address txt-m mll pvxl">
-          [[${account.username}]]
+          [[${account.username}]] (origin: [[${account.origin}]])
           </span>
         </a>
         <span class="remove-account">

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
@@ -13,6 +13,8 @@
 package org.cloudfoundry.identity.uaa.integration.feature;
 
 import com.dumbster.smtp.SimpleSmtpServer;
+
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.security.web.CookieBasedCsrfTokenRepository;
 import org.cloudfoundry.identity.uaa.zone.BrandingInformation;
@@ -404,10 +406,12 @@ public class LoginIT {
         webDriver.get(zoneUrl + "/logout.do");
 
         webDriver.get(zoneUrl);
-        assertEquals(userEmail, webDriver.findElement(By.className("email-address")).getText());
+        assertThat(webDriver.findElement(By.className("email-address")).getText(), startsWith(userEmail));
+        assertThat(webDriver.findElement(By.className("email-address")).getText(), containsString(OriginKeys.UAA));
         webDriver.findElement(By.className("email-address")).click();
 
         assertEquals(userEmail, webDriver.findElement(By.id("username")).getAttribute("value"));
+        assertThat(webDriver.getCurrentUrl(), containsString("login_hint"));
         webDriver.findElement(By.id("password")).sendKeys(USER_PASSWORD);
         webDriver.findElement(By.xpath("//input[@value='Sign in']")).click();
         assertEquals("Where to?", webDriver.findElement(By.cssSelector(".island h1")).getText());


### PR DESCRIPTION
Display the origin for each account on the account chooser page
Pass the origin of the user as login_hint when choosing an account
Adopt tests accordingly