### PR TITLE
Fix user details update during password grant flow

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -404,7 +404,6 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
 
         //we must check and see if the email address has changed between authentications
-        if (request.getPrincipal() != null) {
             if (haveUserAttributesChanged(userFromDb, userFromRequest)) {
                 logger.debug("User attributed have changed, updating them.");
                 userFromDb = userFromDb.modifyAttributes(email,
@@ -415,7 +414,6 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                     .modifyUsername(userFromRequest.getUsername());
                 userModified = true;
             }
-        }
 
         ExternalGroupAuthorizationEvent event = new ExternalGroupAuthorizationEvent(userFromDb, userModified, userFromRequest.getAuthorities(), true);
         publish(event);


### PR DESCRIPTION
The password grant flow does not update user information if they have changed on IDP side.
This PR fixes this issue by removing a not needed check from `ExternalOAuthAuthenticationManager`: `request.getPrincipal()` is checked for `null` but is not used afterwards in the method. During a password grant flow, `request.getPrincipal()` is `null` and thus user information are not updated if they have changed.

Scenario to reproduce:
- Register an IDP in the UAA
- Do a password grant flow with a user from this IDP
- Check the user information stored in the UAA database
- Change user information in the IDP (e.g. family name or given name)
- Do a password grant flow again
- The new information are not updated in the UAA database