### PR TITLE
Reduce noise in logs of excpected error messages

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
@@ -18,11 +18,14 @@ import org.cloudfoundry.identity.uaa.resources.SearchResults;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimException;
 import org.cloudfoundry.identity.uaa.security.beans.SecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.authority.AuthorityUtils;
 
 import java.util.Collection;
@@ -160,15 +163,15 @@ public class UserIdConversionEndpointsTests {
     @Test
     public void testDisabled() {
         endpoints = new UserIdConversionEndpoints(provisioning, mockSecurityContextAccessor, scimUserEndpoints, false);
-        expected.expect(ScimException.class);
-        expected.expectMessage(containsString("Illegal operation."));
-        endpoints.findUsers("id eq \"foo\"", "ascending", 0, 100, false);
+        ResponseEntity<Object> response = endpoints.findUsers("id eq \"foo\"", "ascending", 0, 100, false);
+        Assert.assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        Assert.assertEquals("Illegal Operation: Endpoint not enabled.", response.getBody());
     }
 
     @Test
     public void noActiveIdps_ReturnsEmptyResources() {
         when(provisioning.retrieveActive(anyString())).thenReturn(Collections.emptyList());
-        SearchResults<?> searchResults = endpoints.findUsers("username eq \"foo\"", "ascending", 0, 100, false);
+        SearchResults<?> searchResults = (SearchResults<?>) endpoints.findUsers("username eq \"foo\"", "ascending", 0, 100, false).getBody();
         assertTrue(searchResults.getResources().isEmpty());
     }
 }


### PR DESCRIPTION
This PR addresses this issue: https://github.com/cloudfoundry/uaa/issues/659

By changing the return type of `UserIdConversionEndpoints.findUsers()` to `ResponseEntity` it is possible to return an expected response code of `400` as well as a message without throwing an exception. This also removes the exception from the logs.
Additionally, the log level should be `info`, since this is an expected behaviour.