### PR TITLE
Fix a bug with accountChooser and allowedProviders

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -334,7 +334,7 @@ public class LoginInfoEndpoint {
         }
 
         boolean linkCreateAccountShow = fieldUsernameShow;
-        if (fieldUsernameShow && (allowedIdentityProviderKeys != null)) {
+        if (fieldUsernameShow && (allowedIdentityProviderKeys != null) && (!discoveryEnabled || discoveryPerformed)) {
             if (!allowedIdentityProviderKeys.contains(OriginKeys.UAA)) {
                 linkCreateAccountShow = false;
                 model.addAttribute("login_hint", new UaaLoginHint(OriginKeys.LDAP).toString());


### PR DESCRIPTION
Fixes a bug that the accountChooser and idpDiscovery were skipped under certain conditions.

This happened, when:

- you were using idpDiscovery (and the accountChooser) and
- were performing the login during an authorization code flow and 
- the client used in that flow restricted the allowedProviders to "uaa" (XOR "ldap") and some external IdP

When these conditions were met, the LoginInfoEndpoints would set an internal login_hint to restrict the login form to the uaa origin. 
While this works for the "old" login page (idpDiscovery disabled) in the new UI should do the accountChooser and/or idpDiscovery first, before redirecting to the UAA Login form.

The bug is fixed by introducing a check if either the idpDiscovery is disabled OR the discovery was already performed - similar to other steps in the same method.