### PR TITLE
Automount service account tokens

### DIFF
--- a/k8s/templates/service_account.yml
+++ b/k8s/templates/service_account.yml
@@ -4,4 +4,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: uaa
-automountServiceAccountToken: false


### PR DESCRIPTION
In an environment which requires first party jwt tokens, the istio sidecar requires the service account token be mounted to authenticate with the apiserver on behalf of the application.

We are required to use first party tokens because Kind does not support third party tokens, and Kind is a target deployment for cf-for-k8s (and is used in many team's pipelines).

[Related issue](https://github.com/istio/istio/issues/22193)

[Related story](https://www.pivotaltracker.com/story/show/173346213)