### PR TITLE
Make automountServiceAccountToken configurable

### DIFF
--- a/k8s/templates/service_account.yml
+++ b/k8s/templates/service_account.yml
@@ -4,4 +4,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: uaa
-automountServiceAccountToken: false
+automountServiceAccountToken: #@ data.values.automountServiceAccountToken

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -43,3 +43,5 @@ admin:
 #! ca_certs should be an array of PEM-encoded certs
 #! These will be added to the UAA's truststore
 ca_certs: []
+
+automountServiceAccountToken: false

--- a/k8s/test/service_account_test.go
+++ b/k8s/test/service_account_test.go
@@ -39,4 +39,17 @@ var _ = Describe("Service Account", func() {
 			),
 		)
 	})
+
+	When("AutomountServiceAccountToken is true", func() {
+		It("Renders a service account with AutomountServiceAccountToken set to true", func() {
+			templates = append(templates, filepath.Join("..", "test_fixtures", "enable-automount-service-account-token.yml"))
+			ctx := NewRenderingContext(templates...)
+
+			Expect(ctx).To(
+				ProduceYAML(
+					RepresentingServiceAccount().
+						WithName("uaa").
+						WithAutomountServiceAccountToken(true)))
+		})
+	})
 })

--- a/k8s/test_fixtures/enable-automount-service-account-token.yml
+++ b/k8s/test_fixtures/enable-automount-service-account-token.yml
@@ -1,0 +1,4 @@
+#@data/values
+---
+
+automountServiceAccountToken: true


### PR DESCRIPTION
Follow up PR to this [older PR](https://github.com/cloudfoundry/uaa/pull/1325).

Now `automountServiceAccountToken` is configurable and defaults to false. We are working on the cf-for-k8s changes + ytt overlay that will set this field to true when using a Kind cluster.

Let us know if you have any questions.

cc my pair: @ndhanushkodi