### PR TITLE
Update externalId on login

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
@@ -296,7 +296,7 @@ public class ExternalLoginAuthenticationManager<ExternalAuthenticationDetails> i
 
     protected boolean haveUserAttributesChanged(UaaUser existingUser, UaaUser user) {
         if (!StringUtils.equals(existingUser.getGivenName(), user.getGivenName()) || !StringUtils.equals(existingUser.getFamilyName(), user.getFamilyName()) ||
-            !StringUtils.equals(existingUser.getPhoneNumber(), user.getPhoneNumber()) || !StringUtils.equals(existingUser.getEmail(), user.getEmail())) {
+            !StringUtils.equals(existingUser.getPhoneNumber(), user.getPhoneNumber()) || !StringUtils.equals(existingUser.getEmail(), user.getEmail()) || !StringUtils.equals(existingUser.getExternalId(), user.getExternalId())) {
             return true;
         }
         return false;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LdapLoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/LdapLoginAuthenticationManager.java
@@ -124,6 +124,7 @@ public class LdapLoginAuthenticationManager extends ExternalLoginAuthenticationM
                                                          userFromRequest.getGivenName(),
                                                          userFromRequest.getFamilyName(),
                                                          userFromRequest.getPhoneNumber(),
+                                                         userFromRequest.getExternalId(),
                                                          userFromDb.isVerified() || userFromRequest.isVerified())
                     .modifyUsername(userFromRequest.getUsername());
                 userModified = true;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -410,6 +410,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                                                          userFromRequest.getGivenName(),
                                                          userFromRequest.getFamilyName(),
                                                          userFromRequest.getPhoneNumber(),
+                                                         userFromRequest.getExternalId(),
                                                          userFromDb.isVerified() || userFromRequest.isVerified())
                     .modifyUsername(userFromRequest.getUsername());
                 userModified = true;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
@@ -381,6 +381,7 @@ public class LoginSamlAuthenticationProvider extends SAMLAuthenticationProvider 
                     userWithSamlAttributes.getGivenName(),
                     userWithSamlAttributes.getFamilyName(),
                     userWithSamlAttributes.getPhoneNumber(),
+                    userWithSamlAttributes.getExternalId(),
                     user.isVerified() || userWithSamlAttributes.isVerified());
         }
         publish(
@@ -422,6 +423,7 @@ public class LoginSamlAuthenticationProvider extends SAMLAuthenticationProvider 
                 !StringUtils.equals(existingUser.getGivenName(), user.getGivenName()) ||
                 !StringUtils.equals(existingUser.getFamilyName(), user.getFamilyName()) ||
                 !StringUtils.equals(existingUser.getPhoneNumber(), user.getPhoneNumber()) ||
-                !StringUtils.equals(existingUser.getEmail(), user.getEmail());
+                !StringUtils.equals(existingUser.getEmail(), user.getEmail())||
+                !StringUtils.equals(existingUser.getExternalId(), user.getExternalId());
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUser.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUser.java
@@ -357,6 +357,7 @@ public class UaaUser {
                                     String givenName,
                                     String familyName,
                                     String phoneNumber,
+                                    String externalId,
                                     boolean verified) {
         return new UaaUser(new UaaUserPrototype()
                 .withEmail(email)

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManagerTest.java
@@ -419,7 +419,7 @@ public class ExternalLoginAuthenticationManagerTest  {
 
         // Invited users are created with their email as their username.
         UaaUser invitedUser = addUserToDb(email, userId, origin, email);
-        when(invitedUser.modifyAttributes(anyString(), anyString(), anyString(), anyString(), anyBoolean())).thenReturn(invitedUser);
+        when(invitedUser.modifyAttributes(anyString(), anyString(), anyString(), anyString(), anyString(), anyBoolean())).thenReturn(invitedUser);
         UaaUser updatedUser = new UaaUser(new UaaUserPrototype().withUsername(username).withId(userId).withOrigin(origin).withEmail(email));
         when(invitedUser.modifyUsername(username)).thenReturn(updatedUser);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManagerTest.java
@@ -349,6 +349,7 @@ public class ExternalLoginAuthenticationManagerTest  {
         manager.setOrigin(origin);
         when(user.getEmail()).thenReturn(email);
         when(user.getOrigin()).thenReturn(origin);
+        when(user.getExternalId()).thenReturn(dn);
         when(uaaUserDatabase.retrieveUserByName(eq(userName),eq(origin)))
             .thenReturn(null)
             .thenReturn(user);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -13,6 +13,7 @@
 package org.cloudfoundry.identity.uaa.integration.feature;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+
 import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -51,6 +52,7 @@ import org.springframework.security.oauth2.common.util.RandomValueStringGenerato
 import org.springframework.security.oauth2.provider.client.BaseClientDetails;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
@@ -76,6 +78,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -258,10 +261,35 @@ public class OIDCLoginIT {
         Long afterTest = System.currentTimeMillis();
         String zoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
         String origUserId = IntegrationTestUtils.getUserId(adminToken, baseUrl, "uaa", testAccounts.getUserName());
+        ScimUser user = IntegrationTestUtils
+                .getUserByZone(zoneAdminToken, baseUrl, subdomain, testAccounts.getUserName());
+        IntegrationTestUtils.validateUserLastLogon(user, beforeTest, afterTest);
+        assertEquals(origUserId, user.getExternalId());
+        assertEquals(user.getGivenName(), user.getUserName());
+    }
+
+    @Test
+    public void loginWithOIDCProviderUpdatesExternalId() {
+        Long beforeTest = System.currentTimeMillis();
+
+        String zoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
+        String zoneClientToken = IntegrationTestUtils.getClientCredentialsToken(zoneUrl, zoneClient.getClientId(), zoneClient.getClientSecret());
+        ScimUser minimalShadowUser = new ScimUser();
+        minimalShadowUser.setUserName(testAccounts.getUserName());
+        minimalShadowUser.addEmail(testAccounts.getUserName());
+        minimalShadowUser.setOrigin(identityProvider.getOriginKey());
+        IntegrationTestUtils.createUser(zoneClientToken, zoneUrl, minimalShadowUser, null);
+        ScimUser userCreated = IntegrationTestUtils.getUserByZone(zoneAdminToken, baseUrl, subdomain, testAccounts.getUserName());
+        assertFalse(StringUtils.hasText(userCreated.getExternalId()));
+
+        validateSuccessfulOIDCLogin(zoneUrl, testAccounts.getUserName(), testAccounts.getPassword());
+        Long afterTest = System.currentTimeMillis();
+        String origUserId = IntegrationTestUtils.getUserId(adminToken, baseUrl, "uaa", testAccounts.getUserName());
         ScimUser user = IntegrationTestUtils.getUserByZone(zoneAdminToken, baseUrl, subdomain, testAccounts.getUserName());
         IntegrationTestUtils.validateUserLastLogon(user, beforeTest, afterTest);
         assertEquals(origUserId, user.getExternalId());
         assertEquals(user.getGivenName(), user.getUserName());
+        assertTrue(StringUtils.hasText(user.getExternalId()));
     }
 
     @Test


### PR DESCRIPTION
With this PR the field externalId of the user is added to the attributes that are updated on user login.

Background:
When creating a shadow user manually the externalId field is typically not set. When a such a user now does a login, the field will not be updated and the field will stay empty. However if the shadow user is created during the first login of a user, the field will always be set. So the two types of users look different, which should not be the case.
With the proposed change the field will be updated when a user does a login and afterwards the field will always be set - regardless of how the shadow user was initially created.

This also updates the externalId if the value changes, e.g. if the IdP is changing the format (say from using an id to using the email)