### PR TITLE
k8s templates follow UAA conventions for providing rotatable keys

### DIFF
--- a/k8s/go.sum
+++ b/k8s/go.sum
@@ -170,6 +170,7 @@ k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apimachinery v0.18.3/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/apimachinery v0.18.4 h1:ST2beySjhqwJoIFk6p7Hp5v5O0hYY6Gngq/gUYXTPIA=
 k8s.io/apimachinery v0.18.4/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.18.5 h1:Lh6tgsM9FMkC12K5T5QjRm7rDs6aQN5JHkA0JomULDM=
 k8s.io/apimachinery v0.18.5/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
 k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=
 k8s.io/client-go v11.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=

--- a/k8s/scripts/shell_in.sh
+++ b/k8s/scripts/shell_in.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+POD_NAME=$(kubectl get pods | grep uaa | cut -d' ' -f1)
+kubectl exec --stdin --tty $POD_NAME -- /bin/bash

--- a/k8s/scripts/yeet.sh
+++ b/k8s/scripts/yeet.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+ytt \
+    -f templates \
+    -f addons \
+    --data-value-yaml admin.client_secret=adminsecret \
+    | kubectl apply -f -

--- a/k8s/templates/secrets/jwt_policy_signing_keys.star
+++ b/k8s/templates/secrets/jwt_policy_signing_keys.star
@@ -5,28 +5,13 @@ def signing_keys(jwt_policy):
     assert.fail("jwt.policy.activeKeyId is required")
   end
 
-  found_active_key = False
-
-  if type(jwt_policy.keys) != "list":
-    assert.fail("jwt.policy.keys must be a list")
+  if type(jwt_policy.keys) != "struct":
+    assert.fail("jwt.policy.keys must be an object")
   end
 
-  keys = {}
-  for k in jwt_policy.keys:
-    keys[k.keyId] = {
-      "signingKey": k.signingKey
-    }
-    if k.keyId == jwt_policy.activeKeyId:
-      found_active_key = True
-    end
-  end
-
-  if not found_active_key:
+  if not hasattr(jwt_policy.keys, jwt_policy.activeKeyId):
     assert.fail("jwt.policy.keys must contain keyId matching jwt.policy.activeKeyId")
   end
 
-  return {
-    "activeKeyId": jwt_policy.activeKeyId,
-    "keys": keys,
-  }
+  return jwt_policy
 end

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -32,7 +32,7 @@ database:
 jwt:
   policy:
     activeKeyId: ~
-    keys: []
+    keys: {}
 
 login:
   saml:

--- a/k8s/test/secrets_test.go
+++ b/k8s/test/secrets_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Secrets", func() {
 			)
 		})
 
-		It("activeKeyId must be found in the list of keys", func() {
+		It("activeKeyId must be present in keys", func() {
 			templates = []string{
 				pathToFile(filepath.Join("values", "_values.yml")),
 				pathToFile(filepath.Join("secrets", "jwt_policy_signing_keys.yml")),
@@ -241,7 +241,7 @@ var _ = Describe("Secrets", func() {
 			)
 		})
 
-		It("keys must be a list", func() {
+		It("keys must be an object", func() {
 			templates = []string{
 				pathToFile(filepath.Join("values", "_values.yml")),
 				pathToFile(filepath.Join("secrets", "jwt_policy_signing_keys.yml")),
@@ -254,7 +254,7 @@ var _ = Describe("Secrets", func() {
 			})
 
 			Expect(renderingContext).To(
-				ThrowError("fail: jwt.policy.keys must be a list"),
+				ThrowError("fail: jwt.policy.keys must be an object"),
 			)
 		})
 	})

--- a/k8s/test_fixtures/signing-key-fixture-missing-active-key-id1.yml
+++ b/k8s/test_fixtures/signing-key-fixture-missing-active-key-id1.yml
@@ -2,9 +2,9 @@
 #@ load("@ytt:overlay", "overlay")
 ---
 jwt:
+  #@overlay/replace
   policy:
     activeKeyId: missing_active_key
     keys:
-      #@overlay/match by="keyId",missing_ok=True
-      - keyId: other_key
+      other_key:
         signingKey: signingKey

--- a/k8s/test_fixtures/signing-key-fixture1.yml
+++ b/k8s/test_fixtures/signing-key-fixture1.yml
@@ -2,9 +2,9 @@
 #@ load("@ytt:overlay", "overlay")
 ---
 jwt:
+  #@overlay/replace
   policy:
     activeKeyId: my_active_key_id
     keys:
-      #@overlay/match by="keyId",missing_ok=True
-      - keyId: my_active_key_id
+      my_active_key_id:
         signingKey: aaa

--- a/k8s/test_fixtures/signing-key-fixture2.yml
+++ b/k8s/test_fixtures/signing-key-fixture2.yml
@@ -2,17 +2,16 @@
 #@ load("@ytt:overlay", "overlay")
 ---
 jwt:
+  #@overlay/replace
   policy:
     activeKeyId: other_active_key2
     keys:
-      #@overlay/match by="keyId",missing_ok=True
-      - keyId: other_active_key2
+      other_active_key2:
         signingKey: |
           this
           is
           a
           multiline
           string
-      #@overlay/match by="keyId",missing_ok=True
-      - keyId: unused_key_id
+      unused_key_id:
         signingKey: unused_signing_key


### PR DESCRIPTION
In all other UAA configurations, such as the UAA standalone or the UAA BOSH release, rotatable keys are provided as an object mapped by the key identifier.

In the k8s templates, these rotatable keys are instead provided in a list, where the key identifier is an attribute called `keyId`.

In order to bring the k8s templates into conformity with the other UAA configuration consumers, we are changing the k8s templates to follow the convention.

# Example
## Current k8s templating
```yaml
jwt:
  policy:
    activeKeyId: current-key
    keys:
    - keyId: current-key
       signingKey: super-secure-key
    - keyId: future-key
       signingKey: more-super-secure-key
```
## New k8s templating
```yaml
jwt:
  policy:
    activeKeyId: current-key
    keys:
      current-key:
        signingKey: super-secure-key
      future-key:
        signingKey: more-super-secure-key
```