### PR TITLE
Ensure SQL parameters do not contain -'s

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -87,8 +87,14 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
     private AttributeNameMapper mapper = new SimpleAttributeNameMapper(Collections.emptyMap());
 
     private boolean dbCaseInsensitive = false;
+    private RandomValueStringGenerator randomStringGenerator;
 
     public SimpleSearchQueryConverter() {
+        randomStringGenerator = new RandomValueStringGenerator();
+    }
+
+    public SimpleSearchQueryConverter(RandomValueStringGenerator randomStringGenerator) {
+        this.randomStringGenerator = randomStringGenerator;
     }
 
     private boolean isDbCaseInsensitive() {
@@ -115,7 +121,7 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
 
     private String generateParameterPrefix(String filter) {
         while (true) {
-            String s = new RandomValueStringGenerator().generate().toLowerCase();
+            String s = randomStringGenerator.generate().toLowerCase();
             if (!filter.contains(s) && !s.contains("-")) {
                 return "__" + s + "_";
             }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -116,7 +116,7 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
     private String generateParameterPrefix(String filter) {
         while (true) {
             String s = new RandomValueStringGenerator().generate().toLowerCase();
-            if (!filter.contains(s)) {
+            if (!filter.contains(s) && !s.contains("-")) {
                 return "__" + s + "_";
             }
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
@@ -5,27 +5,45 @@ import org.cloudfoundry.identity.uaa.resources.jdbc.SearchQueryConverter.Process
 import org.cloudfoundry.identity.uaa.resources.jdbc.SimpleSearchQueryConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
 import org.springframework.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 class ScimSearchQueryConverterTests {
 
     private SimpleSearchQueryConverter filterProcessor;
     private final String zoneId = "fake-zone-id";
     private boolean expectCaseInsensitiveDbBehavior;
+    RandomValueStringGenerator randomStringGenerator = mock(RandomValueStringGenerator.class);
 
     @BeforeEach
     void setUp() {
+        Mockito.when(randomStringGenerator.generate()).thenAnswer(new Answer() {
+            private int count = 0;
+
+            public Object answer(InvocationOnMock invocation) {
+                if (count++ == 1)
+                    return "look-at-all-these-dashes";
+
+                return "nodashesinthisone";
+            }
+        });
+
         expectCaseInsensitiveDbBehavior = false;
         Map<String, String> replaceWith = new HashMap<>();
         replaceWith.put("emails\\.value", "email");
         replaceWith.put("groups\\.display", "authorities");
         replaceWith.put("phoneNumbers\\.value", "phoneNumber");
-        filterProcessor = new SimpleSearchQueryConverter();
+        filterProcessor = new SimpleSearchQueryConverter(randomStringGenerator);
         filterProcessor.setAttributeNameMapper(new SimpleAttributeNameMapper(replaceWith));
     }
 
@@ -136,6 +154,7 @@ class ScimSearchQueryConverterTests {
 
     private void validate(ProcessedFilter filter, String expectedWhereClauseBeforeIdentityZoneCheck, String expectedOrderByClause, int expectedParamCount, Class... types) {
         assertNotNull(filter);
+        assertFalse(filter.getParamPrefix().contains("-"), "Filter's param prefix cannot contain '-': " + filter.getParamPrefix());
 
         // There is always an implied "and also the identity zone must match the zone in which the
         // user performed the query" clause, which also causes an extra param on the filter, so


### PR DESCRIPTION
Add check to ensure SQL parameters generated by RandomValueStringGenerator do not generate with dashes. This was made possible with a change to the codex values of the function at spring-security-oauth2.2.4.1.RELEASE.

Closes: #1379