### PR TITLE
Set memory and cpu requests and limit values for all containers

### DIFF
--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -114,8 +114,11 @@ spec:
         image: #@ data.values.image
         resources:
           requests:
-            memory: #@ data.values.resources.requests.memory
-            cpu: #@ data.values.resources.requests.cpu
+            memory: #@ data.values.resources.uaa.requests.memory
+            cpu: #@ data.values.resources.uaa.requests.cpu
+          limits:
+            memory: #@ data.values.resources.uaa.limits.memory
+            cpu: #@ data.values.resources.uaa.limits.cpu
         ports:
         - name: http-uaa
           containerPort: 8080
@@ -174,6 +177,13 @@ spec:
         - name: "metrics-uaa"
           containerPort: 9102
           protocol: "TCP"
+        resources:
+          requests:
+            memory: #@ data.values.resources.statsd_exporter.requests.memory
+            cpu: #@ data.values.resources.statsd_exporter.requests.cpu
+          limits:
+            memory: #@ data.values.resources.statsd_exporter.limits.memory
+            cpu: #@ data.values.resources.statsd_exporter.limits.cpu
       volumes:
       - name: uaa-config
         configMap:

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -10,9 +10,20 @@ labels:
   managedBy: kubectl
 
 resources:
-  requests:
-    memory: 512Mi
-    cpu: 500m
+  uaa:
+    requests:
+      memory: 512Mi
+      cpu: 50m
+    limits:
+      memory: 2000Mi
+      cpu: 500m
+  statsd_exporter:
+    requests:
+      memory: 10Mi
+      cpu: 10m
+    limits:
+      memory: 100Mi
+      cpu: 100m
 
 tomcat:
   accessLoggingEnabled: "y"


### PR DESCRIPTION
Relint is currently working on a scaling and Quality of Service (QoS) set of stories.

We are targeting 1.0 to be configured out-of-the-box as a "developer" edition aimed at those users who want to kick the tyres. As part of this, we would like to set limits on mem/cpu.

Since a "developer" edition may not be preferred by everyone, we want each component to be configurable to scale both horizontally (replicas) and vertically (mem/cpu). This will also allow users to deliver a Guaranteed QoS when required (although we are recommending that all of our pods and containers use the Burstable QoS) As part of this we would like to ask you to do several things:

1. consider which of your pods/containers you would like to expose for scaling properties for.
1. expose said configuration properties.
1. sets mem and cpu values for all containers in order to provide as much meta-data to k8s as possible so that its scheduler can do as good a job as possible. This PR is an initial attempt at setting these values, although we know you are much more likely to have insight into your components mem/cpu requirements than our guess.

If you have any questions or concerns, please let us know! Thanks!

[#174462927](https://www.pivotaltracker.com/story/show/174462927)

Co-authored-by: Carson Long <lcarson@vmware.com>

