### PR TITLE
Fix gradle deprecation warnings, hard-mode

### DIFF
--- a/metrics-data/build.gradle
+++ b/metrics-data/build.gradle
@@ -1,8 +1,8 @@
 description = "CloudFoundry Identity Metrics Data Jar"
 
 dependencies {
-  compile(libraries.jacksonDatabind)
-  compile(libraries.jacksonAnnotations)
+  implementation(libraries.jacksonDatabind)
+  implementation(libraries.jacksonAnnotations)
 }
 
 processResources {

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,25 +1,25 @@
 description = "CloudFoundry Identity Model JAR"
 
 dependencies {
-    compile(project(":cloudfoundry-identity-metrics-data"))
+    implementation(project(":cloudfoundry-identity-metrics-data"))
 
-    compile(libraries.jacksonDatabind)
-    compile(libraries.jacksonAnnotations)
+    implementation(libraries.jacksonDatabind)
+    implementation(libraries.jacksonAnnotations)
 
-    compile(libraries.javaxValidationApi)
+    implementation(libraries.javaxValidationApi)
 
-    compile(libraries.commonsIo)
+    implementation(libraries.commonsIo)
 
-    compile(libraries.springWeb)
-    compile(libraries.springWebMvc)
-    compile(libraries.springSecurityConfig)
+    implementation(libraries.springWeb)
+    implementation(libraries.springWebMvc)
+    implementation(libraries.springSecurityConfig)
 
-    compile(libraries.springSecurityOauth) {
+    implementation(libraries.springSecurityOauth) {
         exclude(module: "jackson-mapper-asl")
         exclude(module: "spring-security-web")
     }
 
-    compile(libraries.slf4jApi)
+    implementation(libraries.slf4jApi)
 
     testImplementation(libraries.junit)
 

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -3,6 +3,9 @@ description = "CloudFoundry Identity Model JAR"
 dependencies {
     compile(project(":cloudfoundry-identity-metrics-data"))
 
+    compile(libraries.jacksonDatabind)
+    compile(libraries.jacksonAnnotations)
+
     compile(libraries.javaxValidationApi)
 
     compile(libraries.commonsIo)

--- a/samples/api/build.gradle
+++ b/samples/api/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     Project identityParent = parent.parent
     Project identityServer = identityParent.subprojects.find { it.name.equals("cloudfoundry-identity-server") }
 
-    compile(identityServer)
+    implementation(identityServer)
     implementation(libraries.springSecurityOauth) {
         exclude(module: "commons-codec")
         exclude(module: "jackson-mapper-asl")
@@ -21,11 +21,11 @@ dependencies {
     }
 
     providedCompile(libraries.tomcatEmbed)
-    compile(libraries.springSecurityTaglibs) {
+    implementation(libraries.springSecurityTaglibs) {
         exclude(module: "spring-jdbc")
         exclude(module: "spring-tx")
     }
-    compile(libraries.springSecurityConfig)
+    implementation(libraries.springSecurityConfig)
 
     testImplementation(identityServer.configurations.testImplementation.dependencies)
     testImplementation(identityServer.sourceSets.test.output)

--- a/samples/api/build.gradle
+++ b/samples/api/build.gradle
@@ -14,6 +14,11 @@ dependencies {
     Project identityServer = identityParent.subprojects.find { it.name.equals("cloudfoundry-identity-server") }
 
     compile(identityServer)
+    implementation(libraries.springSecurityOauth) {
+        exclude(module: "commons-codec")
+        exclude(module: "jackson-mapper-asl")
+        exclude(module: "spring-security-web")
+    }
 
     providedCompile(libraries.tomcatEmbed)
     compile(libraries.springSecurityTaglibs) {

--- a/samples/app/build.gradle
+++ b/samples/app/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     Project identityParent = parent.parent
     Project identityServer = identityParent.subprojects.find { it.name.equals("cloudfoundry-identity-server") }
 
-    compile(identityServer)
+    implementation(identityServer)
     implementation(libraries.springSecurityOauth) {
         exclude(module: "commons-codec")
         exclude(module: "jackson-mapper-asl")

--- a/samples/app/build.gradle
+++ b/samples/app/build.gradle
@@ -14,6 +14,11 @@ dependencies {
     Project identityServer = identityParent.subprojects.find { it.name.equals("cloudfoundry-identity-server") }
 
     compile(identityServer)
+    implementation(libraries.springSecurityOauth) {
+        exclude(module: "commons-codec")
+        exclude(module: "jackson-mapper-asl")
+        exclude(module: "spring-security-web")
+    }
 
     providedCompile(libraries.tomcatEmbed)
     runtimeOnly(libraries.javaxServlet)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,73 +4,73 @@ apply plugin: 'com.github.johnrengelman.shadow'
 description = "CloudFoundry Identity Server JAR"
 
 dependencies {
-    compile(project(":cloudfoundry-identity-metrics-data"))
-    compile(project(":cloudfoundry-identity-model"))
+    implementation(project(":cloudfoundry-identity-metrics-data"))
+    implementation(project(":cloudfoundry-identity-model"))
 
-    compile(libraries.tomcatJdbc)
+    implementation(libraries.tomcatJdbc)
     provided(libraries.tomcatEmbed)
-    compile(libraries.javaxMail)
+    implementation(libraries.javaxMail)
 
-    compile(libraries.jacksonDatabind)
-    compile(libraries.jsonPath)
-    compile(libraries.zxing)
-    compile(libraries.springBeans)
-    compile(libraries.springContext)
-    compile(libraries.springContextSupport)
-    compile(libraries.springTx)
-    compile(libraries.springJdbc)
-    compile(libraries.springWeb)
-    compile(libraries.springSecurityCore)
-    compile(libraries.springSecurityJwt)
-    compile(libraries.springSecurityWeb)
-    compile(libraries.springSecuritySaml)
-    compile(libraries.springSessionJdbc)
+    implementation(libraries.jacksonDatabind)
+    implementation(libraries.jsonPath)
+    implementation(libraries.zxing)
+    implementation(libraries.springBeans)
+    implementation(libraries.springContext)
+    implementation(libraries.springContextSupport)
+    implementation(libraries.springTx)
+    implementation(libraries.springJdbc)
+    implementation(libraries.springWeb)
+    implementation(libraries.springSecurityCore)
+    implementation(libraries.springSecurityJwt)
+    implementation(libraries.springSecurityWeb)
+    implementation(libraries.springSecuritySaml)
+    implementation(libraries.springSessionJdbc)
 
-    compile(libraries.springSecurityOauth) {
+    implementation(libraries.springSecurityOauth) {
         exclude(module: "commons-codec")
         exclude(module: "jackson-mapper-asl")
         exclude(module: "spring-security-web")
     }
 
-    compile(libraries.bouncyCastleProv)
-    compile(libraries.bouncyCastlePkix)
+    implementation(libraries.bouncyCastleProv)
+    implementation(libraries.bouncyCastlePkix)
 
-    compile(libraries.guava)
+    implementation(libraries.guava)
 
-    compile(libraries.aspectJRt)
-    compile(libraries.aspectJWeaver)
+    implementation(libraries.aspectJRt)
+    implementation(libraries.aspectJWeaver)
 
-    compile(libraries.thymeleafSpring5)
-    compile(libraries.thymeleafDialect)
-    compile(libraries.thymeleafExtrasSpringSecurity5)
+    implementation(libraries.thymeleafSpring5)
+    implementation(libraries.thymeleafDialect)
+    implementation(libraries.thymeleafExtrasSpringSecurity5)
 
-    compile(libraries.unboundIdScimSdk) {
+    implementation(libraries.unboundIdScimSdk) {
         exclude(module: "servlet-api")
         exclude(module: "commons-logging")
         exclude(module: "httpclient")
         exclude(module: "wink-client-apache-httpclient")
     }
 
-    compile(libraries.hibernateValidator)
-    compile(libraries.flywayCore)
-    compile(libraries.mariaJdbcDriver)
-    compile(libraries.hsqldb)
+    implementation(libraries.hibernateValidator)
+    implementation(libraries.flywayCore)
+    implementation(libraries.mariaJdbcDriver)
+    implementation(libraries.hsqldb)
 
-    compile(libraries.snakeyaml)
+    implementation(libraries.snakeyaml)
 
-    compile(libraries.springSecurityLdap)
-    compile(libraries.springLdapCore)
-    compile(libraries.springLdapCoreTiger)
-    compile(libraries.apacheLdapApi) {
+    implementation(libraries.springSecurityLdap)
+    implementation(libraries.springLdapCore)
+    implementation(libraries.springLdapCoreTiger)
+    implementation(libraries.apacheLdapApi) {
         exclude(module: "slf4j-api")
     }
 
-    compile(libraries.passay)
+    implementation(libraries.passay)
 
-    compile(libraries.googleAuth)
+    implementation(libraries.googleAuth)
 
-    compile(libraries.slf4jImpl)
-    compile(libraries.log4jCore)
+    implementation(libraries.slf4jImpl)
+    implementation(libraries.log4jCore)
 
     implementation(libraries.javaxXmlBindApi)
     implementation(libraries.javaxXmlBindCore)

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -4,12 +4,14 @@ apply plugin: 'com.github.johnrengelman.shadow'
 description = "CloudFoundry Identity Server JAR"
 
 dependencies {
+    compile(project(":cloudfoundry-identity-metrics-data"))
     compile(project(":cloudfoundry-identity-model"))
 
     compile(libraries.tomcatJdbc)
     provided(libraries.tomcatEmbed)
     compile(libraries.javaxMail)
 
+    compile(libraries.jacksonDatabind)
     compile(libraries.jsonPath)
     compile(libraries.zxing)
     compile(libraries.springBeans)

--- a/statsd-lib/build.gradle
+++ b/statsd-lib/build.gradle
@@ -5,16 +5,16 @@ repositories {
 }
 
 dependencies {
-    compile(project(":cloudfoundry-identity-metrics-data"))
-    compile(libraries.springBootStarter)
-    compile(libraries.springBootStarterWeb)
-    compile(libraries.springBootStarterLog4j2)
-    compile(libraries.statsdClient)
+    implementation(project(":cloudfoundry-identity-metrics-data"))
+    implementation(libraries.springBootStarter)
+    implementation(libraries.springBootStarterWeb)
+    implementation(libraries.springBootStarterLog4j2)
+    implementation(libraries.statsdClient)
     testImplementation(libraries.mockito)
     testImplementation(libraries.springBootStarterTest)
 
-    compile(libraries.jacksonDataformatYaml)
-    compile(libraries.jacksonDatabind)
+    implementation(libraries.jacksonDataformatYaml)
+    implementation(libraries.jacksonDatabind)
 }
 
 test {

--- a/statsd/build.gradle
+++ b/statsd/build.gradle
@@ -12,6 +12,7 @@ repositories {
 
 dependencies {
     implementation(project(":cloudfoundry-identity-statsd-lib"))
+    implementation(libraries.springBootStarterWeb)
     providedCompile(libraries.tomcatEmbed)
     providedRuntime(libraries.springBootStarterTomcat)
 }

--- a/statsd/build.gradle
+++ b/statsd/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile(project(":cloudfoundry-identity-statsd-lib"))
+    implementation(project(":cloudfoundry-identity-statsd-lib"))
     providedCompile(libraries.tomcatEmbed)
     providedRuntime(libraries.springBootStarterTomcat)
 }

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -35,6 +35,11 @@ dependencies {
     implementation(project(":cloudfoundry-identity-statsd-lib"))
     implementation(libraries.springBootStarter)
     implementation(libraries.springBootStarterWeb)
+    implementation(libraries.springSecurityOauth) {
+        exclude(module: "commons-codec")
+        exclude(module: "jackson-mapper-asl")
+        exclude(module: "spring-security-web")
+    }
     runtimeOnly(libraries.springSecurityConfig)
     runtimeOnly(libraries.springRetry)
     runtimeOnly(libraries.aspectJWeaver)
@@ -46,24 +51,43 @@ dependencies {
 
     providedCompile(libraries.tomcatEmbed)
 
-    testImplementation(identityServer.configurations.testImplementation.dependencies)
     testImplementation(identityServer.sourceSets.test.output)
 
+    testImplementation(project(":cloudfoundry-identity-model"))
     testImplementation(libraries.apacheDsProtocolLdap) {
         exclude(module: "bcprov-jdk15")
         exclude(module: "slf4j-api")
         exclude(module: "slf4j-log4j12")
     }
+    testImplementation(libraries.apacheLdapApi) {
+        exclude(module: "slf4j-api")
+    }
+    testImplementation(libraries.flywayCore)
+    testImplementation(libraries.googleAuth)
+    testImplementation(libraries.hibernateValidator)
     testImplementation(libraries.junit)
     testImplementation(libraries.selenium)
     testImplementation(libraries.dumbster)
     testImplementation(libraries.zxing)
     testImplementation(libraries.jsonAssert)
+    testImplementation(libraries.jsonPathAssert)
+    testImplementation(libraries.unboundIdScimSdk) {
+        exclude(module: "servlet-api")
+        exclude(module: "commons-logging")
+        exclude(module: "httpclient")
+        exclude(module: "wink-client-apache-httpclient")
+    }
+    testImplementation(libraries.springContextSupport)
+    testImplementation(libraries.springSessionJdbc)
     testImplementation(libraries.springTest)
+    testImplementation(libraries.springSecurityJwt)
+    testImplementation(libraries.springSecurityLdap)
+    testImplementation(libraries.springSecuritySaml)
     testImplementation(libraries.springSecurityTest)
     testImplementation(libraries.mockito)
     testImplementation(libraries.tomcatJdbc)
     testImplementation(libraries.springRestdocs)
+    testImplementation(libraries.javaxMail)
     testImplementation(libraries.greenmail)
 }
 

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation(identityServer.sourceSets.test.output)
 
     testImplementation(project(":cloudfoundry-identity-model"))
+    testImplementation(project(":cloudfoundry-identity-metrics-data"))
     testImplementation(libraries.apacheDsProtocolLdap) {
         exclude(module: "bcprov-jdk15")
         exclude(module: "slf4j-api")
@@ -77,6 +78,7 @@ dependencies {
         exclude(module: "httpclient")
         exclude(module: "wink-client-apache-httpclient")
     }
+    testImplementation(libraries.springBootStarterLog4j2)
     testImplementation(libraries.springContextSupport)
     testImplementation(libraries.springSessionJdbc)
     testImplementation(libraries.springTest)


### PR DESCRIPTION
This PR will replace the `compile` and related configurations in gradle build scripts.
* [Dependencies should no longer be declared using the compile and runtime configurations](https://docs.gradle.org/6.3/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations)

This is a more complex since the shift from `compile` => `implementation` hides module dependencies from consuming modules. This means that consuming code which previously had transitive access to the dependencies of modules it consumes no longer has that access. The consuming modules will now need to explicitly include dependencies which had previously been transitively available.

* [The Java Library plugin configurations](https://docs.gradle.org/6.3/userguide/java_library_plugin.html#sec:java_library_configurations_graph)