### PR TITLE
Set memory and cpu requests and limit values for all containers

### DIFF
--- a/k8s/go.sum
+++ b/k8s/go.sum
@@ -326,9 +326,11 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 k8s.io/api v0.19.0 h1:XyrFIJqTYZJ2DU7FBE/bSPz7b1HvbVBuBf07oeo6eTc=
 k8s.io/api v0.19.0/go.mod h1:I1K45XlvTrDjmj5LoM5LuP/KYrhWbjUKT/SoPG0qTjw=
+k8s.io/api v0.19.1 h1:oZf4bYsBdjC49PdTwNfLmrfUFCwKUi94HY/+emXI8Qw=
 k8s.io/api v0.19.1/go.mod h1:+u/k4/K/7vp4vsfdT7dyl8Oxk1F26Md4g5F26Tu85PU=
 k8s.io/apimachinery v0.19.0 h1:gjKnAda/HZp5k4xQYjL0K/Yb66IvNqjthCb03QlKpaQ=
 k8s.io/apimachinery v0.19.0/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
+k8s.io/apimachinery v0.19.1 h1:cwsxZazM/LA9aUsBaL4bRS5ygoM6bYp8dFk22DSYQa4=
 k8s.io/apimachinery v0.19.1/go.mod h1:DnPGDnARWFvYa3pMHgSxtbZb7gpzzAZ1pTfaUNDVlmA=
 k8s.io/client-go v0.19.0 h1:1+0E0zfWFIWeyRhQYWzimJOyAk2UT7TiARaLNwJCf7k=
 k8s.io/client-go v0.19.0/go.mod h1:H9E/VT95blcFQnlyShFgnFT9ZnJOAceiUHM3MlRC+mU=

--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -114,8 +114,11 @@ spec:
         image: #@ data.values.image
         resources:
           requests:
-            memory: #@ data.values.resources.requests.memory
-            cpu: #@ data.values.resources.requests.cpu
+            memory: #@ data.values.resources.uaa.requests.memory
+            cpu: #@ data.values.resources.uaa.requests.cpu
+          limits:
+            memory: #@ data.values.resources.uaa.limits.memory
+            cpu: #@ data.values.resources.uaa.limits.cpu
         ports:
         - name: http-uaa
           containerPort: 8080
@@ -174,6 +177,13 @@ spec:
         - name: "metrics-uaa"
           containerPort: 9102
           protocol: "TCP"
+        resources:
+          requests:
+            memory: #@ data.values.resources.statsd_exporter.requests.memory
+            cpu: #@ data.values.resources.statsd_exporter.requests.cpu
+          limits:
+            memory: #@ data.values.resources.statsd_exporter.limits.memory
+            cpu: #@ data.values.resources.statsd_exporter.limits.cpu
       volumes:
       - name: uaa-config
         configMap:

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -10,9 +10,20 @@ labels:
   managedBy: kubectl
 
 resources:
-  requests:
-    memory: 512Mi
-    cpu: 500m
+  uaa:
+    requests:
+      memory: 512Mi
+      cpu: 50m
+    limits:
+      memory: 2000Mi
+      cpu: 500m
+  statsd_exporter:
+    requests:
+      memory: 10Mi
+      cpu: 10m
+    limits:
+      memory: 100Mi
+      cpu: 100m
 
 tomcat:
   accessLoggingEnabled: "y"

--- a/k8s/test/deployment_test.go
+++ b/k8s/test/deployment_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Deployment", func() {
 						container.WithVolumeMount("truststore-file", truststoreVolumeMountMatcher)
 						container.WithVolumeMount("saml-keys-file", samlKeysVolumeMountMatcher)
 						container.WithVolumeMount("encryption-keys-file", encryptionKeysVolumeMountMatcher)
-						container.WithResourceRequests("512Mi", "500m")
+						container.WithResources("512Mi", "50m", "2000Mi", "500m")
 					})
 					pod.WithVolume("uaa-config", Not(BeNil()))
 					pod.WithVolume("database-credentials-file", Not(BeNil()))
@@ -200,9 +200,11 @@ var _ = Describe("Deployment", func() {
 	It("Renders custom resource requests for the UAA", func() {
 		ctx := NewRenderingContext(templates...).WithData(
 			map[string]string{
-				"resources.requests.memory": "888Mi",
-				"resources.requests.cpu":    "999m",
-				"database.scheme":           "hsqldb",
+				"resources.uaa.requests.memory": "888Mi",
+				"resources.uaa.requests.cpu":    "999m",
+				"resources.uaa.limits.memory":   "1100Mi",
+				"resources.uaa.limits.cpu":      "1200m",
+				"database.scheme":               "hsqldb",
 			})
 
 		Expect(ctx).To(
@@ -210,7 +212,7 @@ var _ = Describe("Deployment", func() {
 				RepresentingDeployment().WithPodMatching(func(pod *PodMatcher) {
 					pod.WithContainerMatching(func(container *ContainerMatcher) {
 						container.WithName("uaa")
-						container.WithResourceRequests("888Mi", "999m")
+						container.WithResources("888Mi", "999m", "1100Mi", "1200m")
 					})
 				}),
 			),


### PR DESCRIPTION
Relint is currently working on a scaling and Quality of Service (QoS) set of stories.

We are targeting 1.0 to be configured out-of-the-box as a "developer" edition aimed at those users who want to kick the tyres. As part of this, we would like to set limits on mem/cpu.

Since a "developer" edition may not be preferred by everyone, we want each component to be configurable to scale both horizontally (replicas) and vertically (mem/cpu). This will also allow users to deliver a Guaranteed QoS when required (although we are recommending that all of our pods and containers use the Burstable QoS) As part of this we would like to ask you to do several things:

consider which of your pods/containers you would like to expose for scaling properties for.
expose said configuration properties.
sets mem and cpu values for all containers in order to provide as much meta-data to k8s as possible so that its scheduler can do as good a job as possible. This PR is an initial attempt at setting these values, although we know you are much more likely to have insight into your components mem/cpu requirements than our guess.
If you have any questions or concerns, please let us know! Thanks!

#174462927