### PR TITLE
exclude prometheus endpoint from Istio proxy

### DIFF
--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -24,6 +24,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9102'
         prometheus.io/path: '/metrics'
+        traffic.sidecar.istio.io/excludeInboundPorts: '9102'
       labels:
         app: uaa-deployment
     spec: #! pod spec


### PR DESCRIPTION
The prometheus /metrics endpoints needs to be excluded from being handled by the Istio proxy in cf-for-k8s, otherwise the port will not be accessible from a Prometheus deployment that resides outside the Istio service mesh.

Signed-off-by: Fabio Berchtold <fabio.berchtold@swisscom.com>