### PR TITLE
minifying application.css

### DIFF
--- a/k8s/templates/values/image.yml
+++ b/k8s/templates/values/image.yml
@@ -1,3 +1,3 @@
 #@data/values
 ---
-image: "cfidentity/uaa@sha256:088587d105552c092f2b3debf407d6b49b84cc0242859fd1dd4e7f400d53c438"
+image: "index.docker.io/cfidentity/uaa@sha256:3c2c5a9b13d8f73053ed56a32930411742af0d780ff373a2c1e7f5ccd7cb89c0"


### PR DESCRIPTION
application.css is 244717 bytes when minified it is 130186 bytes or a reduction 87.97% This file is loaded every time a user tries to authenticate on a landscape, however usually it is not used as after load the user is rediected to SAML/OIDC authentication. This minification will save 88% of the traffic, metered in hundred of GB per month for most productive landscapes