### PR TITLE
Switch statsd_exporter image to use the one from cloudfoundry dockerhub

### DIFF
--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -30,7 +30,7 @@ tomcat:
 
 #! Statsd Deployment Values
 images:
-  statsd_exporter: oratos/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407
+  statsd_exporter: cloudfoundry/statsd_exporter:v0.15.0@sha256:10a64dc4ad0a3e3fe88372f0481dea5c02595c38d168617836a99a649d3ac407
 
 
 #! UAA Application Values


### PR DESCRIPTION
[#174735977]

We've moved statsd_exporter image to live under the cloudfoundry dockerhub instead.

slack: #logging-and-metrics