### PR TITLE
Add configuration options for HttpClient

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
@@ -11,10 +11,10 @@ public class RestTemplateConfig {
     @Value("${rest.template.timeout:10000}")
     public int timeout;
 
-    @Value("${rest.template.maxTotal:0}")
+    @Value("${rest.template.maxTotal:20}")
     public int maxTotal;
 
-    @Value("${rest.template.maxPerRoute:0}")
+    @Value("${rest.template.maxPerRoute:2}")
     public int maxPerRoute;
 
     @Value("${rest.template.maxKeepAlive:0}")

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
@@ -11,13 +11,22 @@ public class RestTemplateConfig {
     @Value("${rest.template.timeout:10000}")
     public int timeout;
 
+    @Value("${rest.template.maxTotal:0}")
+    public int maxTotal;
+
+    @Value("${rest.template.maxPerRoute:0}")
+    public int maxPerRoute;
+
+    @Value("${rest.template.maxKeepAlive:0}")
+    public int maxKeepAlive;
+
     @Bean
     public RestTemplate nonTrustingRestTemplate() {
-        return new RestTemplate(UaaHttpRequestUtils.createRequestFactory(false, timeout));
+        return new RestTemplate(UaaHttpRequestUtils.createRequestFactory(false, timeout, maxTotal, maxPerRoute, maxKeepAlive));
     }
 
     @Bean
     public RestTemplate trustingRestTemplate() {
-        return new RestTemplate(UaaHttpRequestUtils.createRequestFactory(true, timeout));
+        return new RestTemplate(UaaHttpRequestUtils.createRequestFactory(true, timeout, maxTotal, maxPerRoute, maxKeepAlive));
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -51,7 +51,7 @@ public abstract class UaaHttpRequestUtils {
     private static Logger logger = LoggerFactory.getLogger(UaaHttpRequestUtils.class);
 
     public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int timeout) {
-        return createRequestFactory(getClientBuilder(skipSslValidation), timeout);
+        return createRequestFactory(getClientBuilder(skipSslValidation, 20, 2, 0), timeout);
     }
 
     public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int timeout, int poolSize, int defaultMaxPerRoute, int maxKeepAlive) {
@@ -67,10 +67,6 @@ public abstract class UaaHttpRequestUtils {
         return httpComponentsClientHttpRequestFactory;
     }
 
-    protected static HttpClientBuilder getClientBuilder(boolean skipSslValidation) {
-        return getClientBuilder(skipSslValidation, 0,0, 0);
-    }
-
     protected static HttpClientBuilder getClientBuilder(boolean skipSslValidation, int poolSize, int defaultMaxPerRoute, int maxKeepAlive) {
         HttpClientBuilder builder = HttpClients.custom()
             .useSystemProperties()
@@ -79,15 +75,10 @@ public abstract class UaaHttpRequestUtils {
             builder.setSslcontext(getNonValidatingSslContext());
             builder.setSSLHostnameVerifier(new NoopHostnameVerifier());
         }
-        if (poolSize > 0) {
-            PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
-            cm.setMaxTotal(poolSize);
-
-            if (defaultMaxPerRoute > 0) {
-                cm.setDefaultMaxPerRoute(defaultMaxPerRoute);
-            }
-            builder.setConnectionManager(cm);
-        }
+        PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+        cm.setMaxTotal(poolSize);
+        cm.setDefaultMaxPerRoute(defaultMaxPerRoute);
+        builder.setConnectionManager(cm);
 
         if (maxKeepAlive <= 0) {
             builder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -12,6 +12,14 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.util;
 
+import org.apache.http.HeaderElement;
+import org.apache.http.HeaderElementIterator;
+import org.apache.http.HttpResponse;
+import org.apache.http.conn.ConnectionKeepAliveStrategy;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHeaderElementIterator;
+import org.apache.http.protocol.HTTP;
+import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -33,6 +41,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
@@ -45,6 +54,10 @@ public abstract class UaaHttpRequestUtils {
         return createRequestFactory(getClientBuilder(skipSslValidation), timeout);
     }
 
+    public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int timeout, int poolSize, int defaultMaxPerRoute, int maxKeepAlive) {
+        return createRequestFactory(getClientBuilder(skipSslValidation, poolSize, defaultMaxPerRoute, maxKeepAlive), timeout);
+    }
+
     protected static ClientHttpRequestFactory createRequestFactory(HttpClientBuilder builder, int timeoutInMs) {
         HttpComponentsClientHttpRequestFactory httpComponentsClientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory(builder.build());
 
@@ -55,6 +68,10 @@ public abstract class UaaHttpRequestUtils {
     }
 
     protected static HttpClientBuilder getClientBuilder(boolean skipSslValidation) {
+        return getClientBuilder(skipSslValidation, 0,0, 0);
+    }
+
+    protected static HttpClientBuilder getClientBuilder(boolean skipSslValidation, int poolSize, int defaultMaxPerRoute, int maxKeepAlive) {
         HttpClientBuilder builder = HttpClients.custom()
             .useSystemProperties()
             .setRedirectStrategy(new DefaultRedirectStrategy());
@@ -62,7 +79,22 @@ public abstract class UaaHttpRequestUtils {
             builder.setSslcontext(getNonValidatingSslContext());
             builder.setSSLHostnameVerifier(new NoopHostnameVerifier());
         }
-        builder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
+        if (poolSize > 0) {
+            PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
+            cm.setMaxTotal(poolSize);
+
+            if (defaultMaxPerRoute > 0) {
+                cm.setDefaultMaxPerRoute(defaultMaxPerRoute);
+            }
+            builder.setConnectionManager(cm);
+        }
+
+        if (maxKeepAlive <= 0) {
+            builder.setConnectionReuseStrategy(NoConnectionReuseStrategy.INSTANCE);
+        } else {
+            builder.setKeepAliveStrategy(new UaaConnectionKeepAliveStrategy(maxKeepAlive));
+        }
+
         return builder;
     }
 
@@ -99,5 +131,36 @@ public abstract class UaaHttpRequestUtils {
 
         }
         return false;
+    }
+
+    private static class UaaConnectionKeepAliveStrategy implements ConnectionKeepAliveStrategy {
+
+        private static final String TIMEOUT = "timeout";
+
+        private final long connectionKeepAliveMax;
+
+        public UaaConnectionKeepAliveStrategy(long connectionKeepAliveMax) {
+            this.connectionKeepAliveMax = connectionKeepAliveMax;
+        }
+
+        @Override public long getKeepAliveDuration(HttpResponse httpResponse, HttpContext httpContext) {
+            HeaderElementIterator elementIterator = new BasicHeaderElementIterator(httpResponse.headerIterator(HTTP.CONN_KEEP_ALIVE));
+            long result = connectionKeepAliveMax;
+
+            while (elementIterator.hasNext()) {
+                HeaderElement element = elementIterator.nextElement();
+                String elementName = element.getName();
+                String elementValue = element.getValue();
+                if (elementValue != null && elementName != null && elementName.equalsIgnoreCase(TIMEOUT)) {
+                    try {
+                        result = Math.min(TimeUnit.SECONDS.toMillis(Long.parseLong(elementValue)), connectionKeepAliveMax);
+                    } catch (NumberFormatException e) {
+                        //Ignore Exception and keep current elementValue of result
+                    }
+                    break;
+                }
+            }
+            return result;
+        }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
@@ -130,7 +130,7 @@ public class UaaHttpRequestUtilsTest {
     }
 
     public void testHttpProxy(String url, int expectedPort, String expectedHost, boolean wantHandlerInvoked) {
-        HttpClientBuilder builder = UaaHttpRequestUtils.getClientBuilder(true);
+        HttpClientBuilder builder = UaaHttpRequestUtils.getClientBuilder(true, 20, 2, 5);
         HttpRoutePlanner planner = (HttpRoutePlanner) ReflectionTestUtils.getField(builder.build(), "routePlanner");
         SystemProxyRoutePlanner routePlanner = new SystemProxyRoutePlanner(planner);
         builder.setRoutePlanner(routePlanner);

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -560,6 +560,14 @@ uaa:
 #  user:
 #  password:
 
+# Configure Rest Templates
+#rest:
+#  template:
+#    timeout: 10000
+#    maxTotal: 20
+#    maxPerRoute: 2
+#    maxKeepAlive: 0
+
 ldap:
   profile:
     file: ldap/ldap-search-and-bind.xml


### PR DESCRIPTION
PR for #1430 

Added the two configuration parameters to the RestTemplateConfig, as discussed there.

In addition I also added a configuration to enable connection reuse (currently also not possible to configure). As alternative a ConnectionKeepAliveStrategy is added (based on our own experience with connection reuse). This can be configured independently from the other configurations.

I also added an example configuration (commented out) to the uaa.yml so it is clear how these values should be configured there. 

Note that I implemented all new properties in a way that not configuring these values (or setting the values to 0) will fall back to the default configuration of the HttpClient - so existing configurations will not be affected by this PR (neither positive nor negative). 