### PR TITLE
Optimize IdP requests to database on login

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -303,8 +303,16 @@ public class LoginInfoEndpoint {
                 } catch (EmptyResultDataAccessException ignored) {
                 }
             }
-            oauthIdentityProviders = Collections.emptyMap();
-            samlIdentityProviders = Collections.emptyMap();
+            if (!loginHintProviders.isEmpty()) {
+                oauthIdentityProviders = Collections.emptyMap();
+                samlIdentityProviders = Collections.emptyMap();
+            } else {
+                samlIdentityProviders = getSamlIdentityProviderDefinitions(allowedIdentityProviderKeys);
+                oauthIdentityProviders = getOauthIdentityProviderDefinitions(allowedIdentityProviderKeys);
+                allIdentityProviders = new HashMap<>();
+                allIdentityProviders.putAll(samlIdentityProviders);
+                allIdentityProviders.putAll(oauthIdentityProviders);
+            }
         } else if (accountChooserNeeded || (discoveryEnabled && !discoveryPerformed)) {
             //Account Chooser and discovery do not need any IdP information
             oauthIdentityProviders = Collections.emptyMap();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -74,6 +74,7 @@ import java.security.Principal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
@@ -273,15 +274,31 @@ public class LoginInfoEndpoint {
             clientName = (String) clientInfo.get(ClientConstants.CLIENT_NAME);
         }
 
-        Map<String, SamlIdentityProviderDefinition> samlIdentityProviders =
-                getSamlIdentityProviderDefinitions(allowedIdentityProviderKeys);
-        Map<String, AbstractExternalOAuthIdentityProviderDefinition> oauthIdentityProviders =
-                getOauthIdentityProviderDefinitions(allowedIdentityProviderKeys);
-        Map<String, AbstractIdentityProviderDefinition> allIdentityProviders =
-                new HashMap<>() {{
-                    putAll(samlIdentityProviders);
-                    putAll(oauthIdentityProviders);
-                }};
+        Map<String, SamlIdentityProviderDefinition> samlIdentityProviders;
+        Map<String, AbstractExternalOAuthIdentityProviderDefinition> oauthIdentityProviders;
+        Map<String, AbstractIdentityProviderDefinition> allIdentityProviders = Collections.emptyMap();
+        Map<String, AbstractIdentityProviderDefinition> loginHintProviders = Collections.emptyMap();
+
+        String loginHintParam = extractLoginHintParam(session, request);
+        UaaLoginHint uaaLoginHint = UaaLoginHint.parseRequestParameter(loginHintParam);
+        if (uaaLoginHint != null && (allowedIdentityProviderKeys == null || allowedIdentityProviderKeys.contains(uaaLoginHint.getOrigin()))) {
+            if (!(OriginKeys.UAA.equals(uaaLoginHint.getOrigin()) || OriginKeys.LDAP.equals(uaaLoginHint.getOrigin()))) {
+                try {
+                    IdentityProvider loginHintProvider = externalOAuthProviderConfigurator
+                            .retrieveByOrigin(uaaLoginHint.getOrigin(), IdentityZoneHolder.get().getId());
+                    loginHintProviders = Collections.singletonList(loginHintProvider).stream().collect(
+                            new MapCollector<IdentityProvider, String, AbstractIdentityProviderDefinition>(
+                                    IdentityProvider::getOriginKey, IdentityProvider::getConfig));
+                } catch (EmptyResultDataAccessException ignored) {
+                }
+            }
+            oauthIdentityProviders = Collections.emptyMap();
+            samlIdentityProviders = Collections.emptyMap();
+        } else {
+            samlIdentityProviders = getSamlIdentityProviderDefinitions(allowedIdentityProviderKeys);
+            oauthIdentityProviders = getOauthIdentityProviderDefinitions(allowedIdentityProviderKeys);
+            allIdentityProviders = new HashMap<>() {{putAll(samlIdentityProviders);putAll(oauthIdentityProviders);}};
+        }
 
         boolean fieldUsernameShow = true;
         boolean returnLoginPrompts = true;
@@ -311,8 +328,8 @@ public class LoginInfoEndpoint {
         }
 
         Map.Entry<String, AbstractIdentityProviderDefinition> idpForRedirect;
-        idpForRedirect = evaluateLoginHint(model, session, samlIdentityProviders,
-                oauthIdentityProviders, allIdentityProviders, allowedIdentityProviderKeys, request);
+        idpForRedirect = evaluateLoginHint(model, samlIdentityProviders,
+                oauthIdentityProviders, allIdentityProviders, allowedIdentityProviderKeys, loginHintParam, uaaLoginHint, loginHintProviders);
 
         boolean discoveryEnabled = IdentityZoneHolder.get().getConfig().isIdpDiscoveryEnabled();
         boolean discoveryPerformed = Boolean.parseBoolean(request.getParameter("discoveryPerformed"));
@@ -480,27 +497,29 @@ public class LoginInfoEndpoint {
         return idpForRedirect;
     }
 
-    private Map.Entry<String, AbstractIdentityProviderDefinition> evaluateLoginHint(
-            Model model,
-            HttpSession session,
-            Map<String, SamlIdentityProviderDefinition> samlIdentityProviders,
-            Map<String, AbstractExternalOAuthIdentityProviderDefinition> oauthIdentityProviders,
-            Map<String, AbstractIdentityProviderDefinition> allIdentityProviders,
-            List<String> allowedIdentityProviderKeys,
-            HttpServletRequest request
-    ) {
-
-        Map.Entry<String, AbstractIdentityProviderDefinition> idpForRedirect = null;
+    private String extractLoginHintParam(HttpSession session, HttpServletRequest request) {
         String loginHintParam =
                 ofNullable(session)
                         .flatMap(s -> ofNullable(SessionUtils.getSavedRequestSession(s)))
                         .flatMap(sr -> ofNullable(sr.getParameterValues("login_hint")))
                         .flatMap(lhValues -> Arrays.stream(lhValues).findFirst())
                         .orElse(request.getParameter("login_hint"));
+        return loginHintParam;
+    }
 
+    private Map.Entry<String, AbstractIdentityProviderDefinition> evaluateLoginHint(
+            Model model,
+            Map<String, SamlIdentityProviderDefinition> samlIdentityProviders,
+            Map<String, AbstractExternalOAuthIdentityProviderDefinition> oauthIdentityProviders,
+            Map<String, AbstractIdentityProviderDefinition> allIdentityProviders,
+            List<String> allowedIdentityProviderKeys,
+            String loginHintParam,
+            UaaLoginHint uaaLoginHint,
+            Map<String, AbstractIdentityProviderDefinition> loginHintProviders
+    ) {
+        Map.Entry<String, AbstractIdentityProviderDefinition> idpForRedirect = null;
         if (loginHintParam != null) {
             // parse login_hint in JSON format
-            UaaLoginHint uaaLoginHint = UaaLoginHint.parseRequestParameter(loginHintParam);
             if (uaaLoginHint != null) {
                 logger.debug("Received login hint: " + loginHintParam);
                 logger.debug("Received login hint with origin: " + uaaLoginHint.getOrigin());
@@ -519,12 +538,13 @@ public class LoginInfoEndpoint {
                             allIdentityProviders.entrySet().stream().filter(
                                     idp -> idp.getKey().equals(uaaLoginHint.getOrigin())
                             ).collect(Collectors.toList());
-                    if (hintIdentityProviders.size() > 1) {
+                    if (loginHintProviders.size() > 1) {
                         throw new IllegalStateException(
                                 "There is a misconfiguration with the identity provider(s). Please contact your system administrator."
                         );
-                    } else if (hintIdentityProviders.size() == 1) {
-                        idpForRedirect = hintIdentityProviders.get(0);
+                    }
+                    if (loginHintProviders.size() == 1) {
+                        idpForRedirect = new ArrayList<>(loginHintProviders.entrySet()).get(0);
                         logger.debug("Setting redirect from origin login_hint to: " + idpForRedirect);
                     } else {
                         logger.debug("Client does not allow provider for login_hint with origin key: "

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -818,13 +818,6 @@ class LoginInfoEndpointTests {
         MultitenantClientServices clientDetailsService = mock(MultitenantClientServices.class);
         when(clientDetailsService.loadClientByClientId("client-id", "other-zone")).thenReturn(clientDetails);
 
-        // mock SamlIdentityProviderConfigurator
-        List<SamlIdentityProviderDefinition> clientIDPs = new LinkedList<>();
-        clientIDPs.add(createIdentityProviderDefinition("my-client-awesome-idp1", "other-zone"));
-        clientIDPs.add(createIdentityProviderDefinition("uaa", "other-zone"));
-        when(mockSamlIdentityProviderConfigurator.getIdentityProviderDefinitions(eq(allowedProviders), eq(zone))).thenReturn(clientIDPs);
-
-
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get(), clientDetailsService);
         endpoint.loginForHtml(extendedModelMap, null, request, singletonList(MediaType.TEXT_HTML));
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/performance/LoginPagePerformanceMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/performance/LoginPagePerformanceMockMvcTest.java
@@ -1,0 +1,166 @@
+package org.cloudfoundry.identity.uaa.performance;
+
+import static org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils.CookieCsrfPostProcessor.cookieCsrf;
+import static org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils.createOtherIdentityZoneAndReturnResult;
+import static org.junit.Assert.assertFalse;
+import static org.springframework.http.MediaType.TEXT_HTML;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Collections;
+
+import org.cloudfoundry.identity.uaa.DefaultTestContext;
+import org.cloudfoundry.identity.uaa.codestore.JdbcExpiringCodeStore;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.impl.config.IdentityZoneConfigurationBootstrap;
+import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
+import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.oauth.OidcMetadataFetcher;
+import org.cloudfoundry.identity.uaa.util.SetServerNameRequestPostProcessor;
+import org.cloudfoundry.identity.uaa.web.LimitedModeUaaFilter;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.common.util.RandomValueStringGenerator;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.util.StopWatch;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.WebApplicationContext;
+
+@DefaultTestContext
+@DirtiesContext
+public class LoginPagePerformanceMockMvcTest {
+
+    private WebApplicationContext webApplicationContext;
+
+    private RandomValueStringGenerator generator;
+
+    private MockMvc mockMvc;
+
+
+
+    private File originalLimitedModeStatusFile;
+
+    @MockBean
+    OidcMetadataFetcher oidcMetadataFetcher;
+
+    @BeforeEach
+    void setUpContext(
+            @Autowired WebApplicationContext webApplicationContext,
+            @Autowired MockMvc mockMvc,
+            @Autowired LimitedModeUaaFilter limitedModeUaaFilter
+    )  {
+        generator = new RandomValueStringGenerator();
+        this.webApplicationContext = webApplicationContext;
+        this.mockMvc = mockMvc;
+        SecurityContextHolder.clearContext();
+
+        originalLimitedModeStatusFile = MockMvcUtils.getLimitedModeStatusFile(webApplicationContext);
+        MockMvcUtils.resetLimitedModeStatusFile(webApplicationContext, null);
+        assertFalse(limitedModeUaaFilter.isEnabled());
+    }
+
+    @AfterEach
+    void resetGenerator(
+            @Autowired JdbcExpiringCodeStore jdbcExpiringCodeStore
+    ) {
+        jdbcExpiringCodeStore.setGenerator(new RandomValueStringGenerator(24));
+    }
+
+    @AfterEach
+    void tearDown(@Autowired IdentityZoneConfigurationBootstrap identityZoneConfigurationBootstrap) throws Exception {
+        MockMvcUtils.setSelfServiceLinksEnabled(webApplicationContext, IdentityZone.getUaaZoneId(), true);
+        identityZoneConfigurationBootstrap.afterPropertiesSet();
+        SecurityContextHolder.clearContext();
+        IdentityZoneHolder.clear();
+        MockMvcUtils.resetLimitedModeStatusFile(webApplicationContext, originalLimitedModeStatusFile);
+    }
+
+    @Test
+    void idpDiscoveryRedirectsToOIDCProvider(
+            @Autowired JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning
+    ) throws Exception {
+        String subdomain = "oidc-discovery-" + generator.generate().toLowerCase();
+        IdentityZone zone = MultitenancyFixture.identityZone(subdomain, subdomain);
+        zone.getConfig().setIdpDiscoveryEnabled(true);
+        BaseClientDetails client = new BaseClientDetails("admin", null, null, "client_credentials",
+                "clients.admin,scim.read,scim.write,idps.write,uaa.admin", "http://redirect.url");
+        client.setClientSecret("admin-secret");
+        createOtherIdentityZoneAndReturnResult(mockMvc, webApplicationContext, client, zone, false, IdentityZoneHolder.getCurrentZoneId());
+
+
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", null);
+        String originKey = createOIDCProvider(jdbcIdentityProviderProvisioning, generator, zone, "id_token code", "test.org");
+
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        for (int i = 0; i <1000; i++) {
+            MvcResult mvcResult = mockMvc.perform(get("/login")
+                    .with(cookieCsrf())
+                    .header("Accept", TEXT_HTML)
+                    .with(new SetServerNameRequestPostProcessor(zone.getSubdomain() + ".localhost")))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            MockHttpServletResponse response = mvcResult.getResponse();
+        }
+
+        stopWatch.stop();
+        long totalTimeMillis = stopWatch.getTotalTimeMillis();
+
+        System.out.println(totalTimeMillis + "ms");
+    }
+
+
+    private static String createOIDCProvider(JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning, RandomValueStringGenerator generator, IdentityZone zone, String responseType, String domain) throws Exception {
+        String originKey = generator.generate();
+        AbstractExternalOAuthIdentityProviderDefinition definition = new OIDCIdentityProviderDefinition();
+        definition.setAuthUrl(new URL("http://myauthurl.com"));
+        definition.setTokenKey("key");
+        definition.setTokenUrl(new URL("http://mytokenurl.com"));
+        definition.setRelyingPartyId("id");
+        definition.setRelyingPartySecret("secret");
+        definition.setLinkText("my oidc provider");
+        if (StringUtils.hasText(responseType)) {
+            definition.setResponseType(responseType);
+        }
+        if (StringUtils.hasText(domain)) {
+            definition.setEmailDomain(Collections.singletonList(domain));
+        }
+
+        IdentityProvider identityProvider = MultitenancyFixture.identityProvider(originKey, zone.getId());
+        identityProvider.setType(OriginKeys.OIDC10);
+        identityProvider.setConfig(definition);
+        createIdentityProvider(jdbcIdentityProviderProvisioning, zone, identityProvider);
+        return originKey;
+    }
+
+    private static IdentityProvider createIdentityProvider(JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning, IdentityZone identityZone, IdentityProvider activeIdentityProvider) {
+        activeIdentityProvider.setIdentityZoneId(identityZone.getId());
+        return jdbcIdentityProviderProvisioning.create(activeIdentityProvider, identityZone.getId());
+    }
+}


### PR DESCRIPTION
This PR addresses Issue #1439

It includes two optimizations w.r.t. retrieving the identity providers from the database:

1) Whenever a login_hint is provided, we do not need to retrieve a full list of all identity providers, but it is sufficient to try to retrieve the identity provider with the given origin. If that does not work an error is returned anyways. So we can optimize the login method in a way, that we only retrieve a single idp, when we have a login_hint. Note that this includes the case, where we click on an account in the account_chooser page.

2) On the pages for the account_chooser and the page for entering the email for idp discovery, the list of all identity providers is retrieved but completely unused. By first determining the parameters and configuration valid for the current request, we can decide if we need to retrieve the identity providers or not. 

As the login method is called several times for each login flow, you will save the unnecessary requests also possibly multiple times per login.  

The optimized scenarios already were covered by Unit tests. The mocks for those were changed, to represent the optimized database requests. But the asserts stay the same, as the visible behavior does not change. 

The visible behavior does not change with this PR - that is also why the Integration Tests do not change. We only optimize the requests to the database (=performance improvement).

If you want to, we can also have a session where we discuss these changes.