### PR TITLE
Fix Tests for configurable HttpClient

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCacheTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCacheTests.java
@@ -144,6 +144,9 @@ class ExpiringUrlCacheTests {
         void throwUnavailableIdpWhenServerMetadataDoesNotReply() {
             RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
             restTemplateConfig.timeout = 120;
+            restTemplateConfig.maxTotal = 20;
+            restTemplateConfig.maxPerRoute = 2;
+            restTemplateConfig.maxKeepAlive = 0;
             RestTemplate restTemplate = restTemplateConfig.trustingRestTemplate();
 
             assertTimeout(Duration.ofSeconds(60), () -> assertThrows(ResourceAccessException.class,

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -176,6 +176,10 @@ class ExternalOAuthAuthenticationManagerIT {
     @BeforeEach
     void setUp() throws Exception {
         RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
+        restTemplateConfig.timeout = 120;
+        restTemplateConfig.maxTotal = 20;
+        restTemplateConfig.maxPerRoute = 2;
+        restTemplateConfig.maxKeepAlive = 0;
         RestTemplate nonTrustingRestTemplate = restTemplateConfig.nonTrustingRestTemplate();
         RestTemplate trustingRestTemplate = restTemplateConfig.trustingRestTemplate();
         SecurityContextHolder.clearContext();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfiguratorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfiguratorTest.java
@@ -73,6 +73,9 @@ public class SamlServiceProviderConfiguratorTest {
         when(mockTimeService.getCurrentTimeMillis()).thenAnswer(e -> System.currentTimeMillis());
         RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
         restTemplateConfig.timeout = 120;
+        restTemplateConfig.maxTotal = 20;
+        restTemplateConfig.maxPerRoute = 2;
+        restTemplateConfig.maxKeepAlive = 0;
         FixedHttpMetaDataProvider fixedHttpMetaDataProvider = new FixedHttpMetaDataProvider(
                 restTemplateConfig.trustingRestTemplate(),
                 restTemplateConfig.nonTrustingRestTemplate(),

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
@@ -102,7 +102,7 @@ public class UaaHttpRequestUtilsTest {
         String host = "localhost";
         System.setProperty(HTTP_HOST_PROPERTY, host);
         System.setProperty(HTTP_PORT_PROPERTY, String.valueOf(httpServer.getAddress().getPort()));
-        testHttpProxy("http://google.com:80/", httpServer.getAddress().getPort(), host, true);
+        testHttpProxy("http://google.com:80/", httpServer.getAddress().getPort(), host, false);
     }
 
     @Test
@@ -118,7 +118,7 @@ public class UaaHttpRequestUtilsTest {
         String ip = "127.0.0.1";
         System.setProperty(HTTP_HOST_PROPERTY, ip);
         System.setProperty(HTTP_PORT_PROPERTY, String.valueOf(httpServer.getAddress().getPort()));
-        testHttpProxy("http://google.com:80/", httpServer.getAddress().getPort(), ip, true);
+        testHttpProxy("http://google.com:80/", httpServer.getAddress().getPort(), ip, false);
     }
 
     @Test


### PR DESCRIPTION
Today  I found that with my latest merged PR #1434 there were some tests that failed in the current develop branch. With this PR all those failures should be fixed. I only checked the initial changes locally, where all the test were green, but after the requested changes, some of the tests fail.

Most of the tests were simply failing due to missing configuration when using the RestTemplates - these could easily be fixed.

Only real issue was, that the skipSslValidation as implemented before the change does not work in combination with using a custom Connection Manager. I changed the implementation so that the skipSslValidation is configured correctly with the custom Connection Manager (basically doing what the builder did before for its own connection manager). 