### PR TITLE
updates and pipeline fix

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -10,14 +10,14 @@ ext["flyway.version"] = "5.2.4"
 // Versions shared between multiple dependencies
 versions.aspectJVersion = "1.9.4"
 versions.apacheDsVersion = "2.0.0.AM26"
-versions.bouncyCastleVersion = "1.66"
+versions.bouncyCastleVersion = "1.67"
 versions.hamcrestVersion = "2.2"
-versions.springBootVersion = "2.3.5.RELEASE"
+versions.springBootVersion = "2.3.6.RELEASE"
 versions.springSecurityJwtVersion = "1.1.1.RELEASE"
 versions.springSecurityOAuthVersion = "2.4.0.RELEASE"
 versions.springSecuritySamlVersion = "1.0.10.RELEASE"
-versions.springVersion = "5.2.9.RELEASE"
-versions.tomcatVersion = "9.0.38"
+versions.springVersion = "5.2.11.RELEASE"
+versions.tomcatVersion = "9.0.39"
 versions.xmlBind = "2.3.0.1"
 
 // Dependencies (some rely on shared versions, some are shared between projects)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -2818,6 +2818,7 @@ public class LoginMockMvcTests {
 
         if (StringUtils.hasText(discoveryUrl)) {
             definition.setDiscoveryUrl(new URL(discoveryUrl));
+            definition.setSkipSslValidation(true);
         } else {
             definition.setAuthUrl(new URL("http://auth.url"));
             definition.setTokenUrl(new URL("http://token.url"));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -124,6 +124,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -1406,6 +1407,7 @@ public class LoginMockMvcTests {
     void ExternalOAuthRedirectOnlyOneProviderWithDiscoveryUrl(
             @Autowired JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning
     ) throws Exception {
+        assumeTrue(isLimitedMode(limitedModeUaaFilter), "Test only runs in limited mode.");
         final String zoneAdminClientId = "admin";
         BaseClientDetails zoneAdminClient = new BaseClientDetails(zoneAdminClientId, null, "openid", "client_credentials,authorization_code", "clients.admin,scim.read,scim.write", "http://test.redirect.com");
         zoneAdminClient.setClientSecret("admin-secret");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -1407,7 +1407,7 @@ public class LoginMockMvcTests {
     void ExternalOAuthRedirectOnlyOneProviderWithDiscoveryUrl(
             @Autowired JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning
     ) throws Exception {
-        assumeTrue(isLimitedMode(limitedModeUaaFilter), "Test only runs in limited mode.");
+        assumeFalse(isLimitedMode(limitedModeUaaFilter), "Test only runs in non limited mode.");
         final String zoneAdminClientId = "admin";
         BaseClientDetails zoneAdminClient = new BaseClientDetails(zoneAdminClientId, null, "openid", "client_credentials,authorization_code", "clients.admin,scim.read,scim.write", "http://test.redirect.com");
         zoneAdminClient.setClientSecret("admin-secret");


### PR DESCRIPTION
1. Updates, Spring and BC 
2. setSkipSslValidation for the OIDC test in order to prevent any trust issue to OIDC provider
3. skip test in limited mode because in LoginMockMvcTests it runs already