### PR TITLE
set default of http pool to 5 per route and 10 max.

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
@@ -11,10 +11,10 @@ public class RestTemplateConfig {
     @Value("${rest.template.timeout:10000}")
     public int timeout;
 
-    @Value("${rest.template.maxTotal:20}")
+    @Value("${rest.template.maxTotal:10}")
     public int maxTotal;
 
-    @Value("${rest.template.maxPerRoute:2}")
+    @Value("${rest.template.maxPerRoute:5}")
     public int maxPerRoute;
 
     @Value("${rest.template.maxKeepAlive:0}")
@@ -28,5 +28,14 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate trustingRestTemplate() {
         return new RestTemplate(UaaHttpRequestUtils.createRequestFactory(true, timeout, maxTotal, maxPerRoute, maxKeepAlive));
+    }
+
+    public static RestTemplateConfig createDefaults() {
+        RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
+        restTemplateConfig.timeout = 10000;
+        restTemplateConfig.maxTotal = 10;
+        restTemplateConfig.maxPerRoute = 5;
+        restTemplateConfig.maxKeepAlive = 0;
+        return restTemplateConfig;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -20,7 +20,6 @@ import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.ConnectionKeepAliveStrategy;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.message.BasicHeaderElementIterator;
@@ -59,7 +58,7 @@ public abstract class UaaHttpRequestUtils {
     private static Logger logger = LoggerFactory.getLogger(UaaHttpRequestUtils.class);
 
     public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int timeout) {
-        return createRequestFactory(getClientBuilder(skipSslValidation, 20, 2, 0), timeout);
+        return createRequestFactory(getClientBuilder(skipSslValidation, 10, 5, 0), timeout);
     }
 
     public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int timeout, int poolSize, int defaultMaxPerRoute, int maxKeepAlive) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCacheTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCacheTests.java
@@ -142,11 +142,8 @@ class ExpiringUrlCacheTests {
 
         @Test
         void throwUnavailableIdpWhenServerMetadataDoesNotReply() {
-            RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
+            RestTemplateConfig restTemplateConfig = RestTemplateConfig.createDefaults();
             restTemplateConfig.timeout = 120;
-            restTemplateConfig.maxTotal = 20;
-            restTemplateConfig.maxPerRoute = 2;
-            restTemplateConfig.maxKeepAlive = 0;
             RestTemplate restTemplate = restTemplateConfig.trustingRestTemplate();
 
             assertTimeout(Duration.ofSeconds(60), () -> assertThrows(ResourceAccessException.class,

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -175,11 +175,7 @@ class ExternalOAuthAuthenticationManagerIT {
 
     @BeforeEach
     void setUp() throws Exception {
-        RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
-        restTemplateConfig.timeout = 120;
-        restTemplateConfig.maxTotal = 20;
-        restTemplateConfig.maxPerRoute = 2;
-        restTemplateConfig.maxKeepAlive = 0;
+        RestTemplateConfig restTemplateConfig = RestTemplateConfig.createDefaults();
         RestTemplate nonTrustingRestTemplate = restTemplateConfig.nonTrustingRestTemplate();
         RestTemplate trustingRestTemplate = restTemplateConfig.trustingRestTemplate();
         SecurityContextHolder.clearContext();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfiguratorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/idp/SamlServiceProviderConfiguratorTest.java
@@ -71,11 +71,8 @@ public class SamlServiceProviderConfiguratorTest {
         slowHttpServer = new SlowHttpServer();
         TimeService mockTimeService = mock(TimeService.class);
         when(mockTimeService.getCurrentTimeMillis()).thenAnswer(e -> System.currentTimeMillis());
-        RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
+        RestTemplateConfig restTemplateConfig = RestTemplateConfig.createDefaults();
         restTemplateConfig.timeout = 120;
-        restTemplateConfig.maxTotal = 20;
-        restTemplateConfig.maxPerRoute = 2;
-        restTemplateConfig.maxKeepAlive = 0;
         FixedHttpMetaDataProvider fixedHttpMetaDataProvider = new FixedHttpMetaDataProvider(
                 restTemplateConfig.trustingRestTemplate(),
                 restTemplateConfig.nonTrustingRestTemplate(),


### PR DESCRIPTION
with that we can close issue #1403

as described here
https://stackoverflow.com/questions/44188847/springs-resttemplate-default-connection-pool

the builder() method uses

                s = System.getProperty("http.maxConnections", "5"); 
                int max = Integer.parseInt(s); 
                poolingmgr.setDefaultMaxPerRoute(max); 
                poolingmgr.setMaxTotal(2 * max); 

so that we have by default

5 connections per Route and 10 in max.