### PR TITLE
Implement support for Github OAuth 2.0 provider in UAA

### DIFF
--- a/docs/github-oauth2-provider.md
+++ b/docs/github-oauth2-provider.md
@@ -24,7 +24,7 @@ Github can be setup as an Oauth2 provider for UAA.
                 providerDescription: Github OAuth provider, using the 'Authorization Code Grant' flow
                 authUrl: https://github.com/login/oauth/authorize
                 tokenUrl: https://github.com/login/oauth/access_token
-                checkTokenUrl: https://api.github.com/user
+                userInfoUrl: https://api.github.com/user
                 scopes:
                   - read:user
                   - user:email

--- a/docs/github-oauth2-provider.md
+++ b/docs/github-oauth2-provider.md
@@ -1,6 +1,6 @@
 # Registering Github as external OAuth provider in UAA
- 
-Github can be setup as an Oauth2 provider for UAA. 
+
+Github can be setup as an Oauth2 provider for UAA.
 
 1. Create an OAuth “application” client in Github.
    For example at: `https://github.com/organizations/{YOUR-ORG}/settings/applications/new`.
@@ -13,7 +13,7 @@ Github can be setup as an Oauth2 provider for UAA.
 
 2. Make sure you have `Client ID` and `Client secret`.
 
-3. The following configuration needs to be added in login.yml. 
+3. The following configuration needs to be added in login.yml.
    Please refer to 'https://accounts.google.com/.well-known/openid-configuration' for authUrl and tokenUrl
 
         login:

--- a/docs/github-oauth2-provider.md
+++ b/docs/github-oauth2-provider.md
@@ -1,0 +1,46 @@
+# Registering Github as external OAuth provider in UAA
+ 
+Github can be setup as an Oauth2 provider for UAA. 
+
+1. Create an OAuth “application” client in Github.
+   For example at: `https://github.com/organizations/{YOUR-ORG}/settings/applications/new`.
+
+   Add following URI in the “_Authorization callback URL_” text field:
+   `http://{UAA_HOST}/login/callback/{origin}`. Additional Github
+   documentation for achieving this can be found here:
+   [Creating an OAuth App](https://docs.github.com/en/free-pro-team@latest/developers/apps/creating-an-oauth-app)
+   [Authorizing OAuth Apps](https://docs.github.com/en/free-pro-team@latest/developers/apps/authorizing-oauth-apps)
+
+2. Make sure you have `Client ID` and `Client secret`.
+
+3. The following configuration needs to be added in login.yml. 
+   Please refer to 'https://accounts.google.com/.well-known/openid-configuration' for authUrl and tokenUrl
+
+        login:
+          oauth:
+            providers:
+              github:
+                type: oauth2.0
+                providerDescription: Github OAuth provider, using the 'Authorization Code Grant' flow
+                authUrl: https://github.com/login/oauth/authorize
+                tokenUrl: https://github.com/login/oauth/access_token
+                checkTokenUrl: https://api.github.com/user
+                scopes:
+                  - read:user
+                  - user:email
+                linkText: Login with Github
+                showLinkText: true
+                addShadowUserOnLogin: true # users won't need to be pre-populated into the UAA database prior to authenticating with Github
+                relyingPartyId: REPLACE_WITH_CLIENT_ID
+                relyingPartySecret: REPLACE_WITH_CLIENT_SECRET
+                skipSslValidation: false
+                clientAuthInBody: true
+                attributeMappings:
+                  given_name: login
+                  family_name: name # Github doesn't split 'given_name' and 'family_name'
+                  user_name: email
+
+4. Ensure that the scope `email` is included in the`scopes` property. Without
+   this, UAA will not be able to identify the authenticated user.
+
+5. Restart UAA. You will see `Login with github` link on your login page.

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractExternalOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractExternalOAuthIdentityProviderDefinition.java
@@ -28,6 +28,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
     private URL tokenUrl;
     private URL tokenKeyUrl;
     private String tokenKey;
+    private URL userInfoUrl;
     private String linkText;
     private boolean showLinkText = true;
     private boolean clientAuthInBody = false;
@@ -72,6 +73,15 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
 
     public T setTokenKey(String tokenKey) {
         this.tokenKey = tokenKey;
+        return (T) this;
+    }
+
+    public URL getUserInfoUrl() {
+        return userInfoUrl;
+    }
+
+    public T setUserInfoUrl(URL userInfoUrl) {
+        this.userInfoUrl = userInfoUrl;
         return (T) this;
     }
 
@@ -187,6 +197,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
         if (!Objects.equals(tokenUrl, that.tokenUrl)) return false;
         if (!Objects.equals(tokenKeyUrl, that.tokenKeyUrl)) return false;
         if (!Objects.equals(tokenKey, that.tokenKey)) return false;
+        if (!Objects.equals(userInfoUrl, that.userInfoUrl)) return false;
         if (!Objects.equals(linkText, that.linkText)) return false;
         if (!Objects.equals(relyingPartyId, that.relyingPartyId))
             return false;
@@ -206,6 +217,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
         result = 31 * result + (tokenUrl != null ? tokenUrl.hashCode() : 0);
         result = 31 * result + (tokenKeyUrl != null ? tokenKeyUrl.hashCode() : 0);
         result = 31 * result + (tokenKey != null ? tokenKey.hashCode() : 0);
+        result = 31 * result + (userInfoUrl != null ? userInfoUrl.hashCode() : 0);
         result = 31 * result + (linkText != null ? linkText.hashCode() : 0);
         result = 31 * result + (showLinkText ? 1 : 0);
         result = 31 * result + (skipSslValidation ? 1 : 0);

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/OIDCIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/OIDCIdentityProviderDefinition.java
@@ -24,21 +24,11 @@ import java.util.Objects;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OIDCIdentityProviderDefinition extends AbstractExternalOAuthIdentityProviderDefinition<OIDCIdentityProviderDefinition>
 implements Cloneable {
-    private URL userInfoUrl;
     private URL discoveryUrl;
     private boolean passwordGrantEnabled = false;
     private boolean setForwardHeader = false;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<Prompt> prompts = null;
-
-    public URL getUserInfoUrl() {
-        return userInfoUrl;
-    }
-
-    public OIDCIdentityProviderDefinition setUserInfoUrl(URL userInfoUrl) {
-        this.userInfoUrl = userInfoUrl;
-        return this;
-    }
 
     public URL getDiscoveryUrl() {
         return discoveryUrl;
@@ -85,7 +75,6 @@ implements Cloneable {
 
         OIDCIdentityProviderDefinition that = (OIDCIdentityProviderDefinition) o;
 
-        if (!Objects.equals(userInfoUrl, that.userInfoUrl)) return false;
         if (this.passwordGrantEnabled != that.passwordGrantEnabled) return false;
         if (this.setForwardHeader != that.setForwardHeader) return false;
         return Objects.equals(discoveryUrl, that.discoveryUrl);
@@ -95,7 +84,6 @@ implements Cloneable {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + (userInfoUrl != null ? userInfoUrl.hashCode() : 0);
         result = 31 * result + (discoveryUrl != null ? discoveryUrl.hashCode() : 0);
         result = 31 * result + (passwordGrantEnabled ? 1 : 0);
         result = 31 * result + (setForwardHeader ? 1 : 0);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -530,7 +530,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             }
         } else if ("code".equals(config.getResponseType())
                 && RawExternalOAuthIdentityProviderDefinition.class.isAssignableFrom(config.getClass())
-                && ((RawExternalOAuthIdentityProviderDefinition) config).getCheckTokenUrl() != null) {
+                && ((RawExternalOAuthIdentityProviderDefinition) config).getUserInfoUrl() != null) {
             RawExternalOAuthIdentityProviderDefinition narrowedConfig = (RawExternalOAuthIdentityProviderDefinition) config;
 
             HttpHeaders headers = new HttpHeaders();
@@ -540,9 +540,9 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             URI requestUri;
             HttpEntity<Object> requestEntity = new HttpEntity<>(headers);
             try {
-                requestUri = narrowedConfig.getCheckTokenUrl().toURI();
+                requestUri = narrowedConfig.getUserInfoUrl().toURI();
             } catch (URISyntaxException exc) {
-                logger.error("Invalid URI configured: <" + narrowedConfig.getCheckTokenUrl() + ">", exc);
+                logger.error("Invalid user info URI configured: <" + narrowedConfig.getUserInfoUrl() + ">", exc);
                 return null;
             }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -37,6 +37,7 @@ import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserPrototype;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.util.LinkedMaskingMultiValueMap;
+import org.cloudfoundry.identity.uaa.util.SessionUtils;
 import org.cloudfoundry.identity.uaa.util.TokenValidation;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.slf4j.Logger;
@@ -63,6 +64,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.support.RequestContextUtils;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -472,6 +474,8 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         if (RawExternalOAuthIdentityProviderDefinition.class.isAssignableFrom(config.getClass())) {
             if ("signed_request".equals(config.getResponseType()))
                 return "signed_request";
+            else if ("code".equals(config.getResponseType()))
+                return "code";
             else
                 return "token";
         } else if (OIDCIdentityProviderDefinition.class.isAssignableFrom(config.getClass())) {
@@ -523,6 +527,35 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                 logger.error("Exception", e);
                 return null;
             }
+        } else if ("code".equals(config.getResponseType())
+                && RawExternalOAuthIdentityProviderDefinition.class.isAssignableFrom(config.getClass())
+                && ((RawExternalOAuthIdentityProviderDefinition) config).getCheckTokenUrl() != null) {
+            RawExternalOAuthIdentityProviderDefinition narrowedConfig = (RawExternalOAuthIdentityProviderDefinition) config;
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.add("Authorization", "token " + idToken);
+            headers.add("Accept", "application/json");
+
+            URI requestUri;
+            HttpEntity requestEntity = new HttpEntity<>(headers);
+            try {
+                requestUri = narrowedConfig.getCheckTokenUrl().toURI();
+            } catch (URISyntaxException exc) {
+                logger.error("Invalid URI configured:" + narrowedConfig.getCheckTokenUrl(), exc);
+                return null;
+            }
+
+            logger.debug(String.format("Performing token check with url:%s", requestUri));
+            ResponseEntity<Map<String, Object>> responseEntity =
+                getRestTemplate(config)
+                    .exchange(requestUri,
+                              HttpMethod.GET,
+                              requestEntity,
+                              new ParameterizedTypeReference<Map<String, Object>>() {
+                              }
+                    );
+            logger.debug(String.format("Request completed with status:%s", responseEntity.getStatusCode()));
+            return responseEntity.getBody();
         } else {
             TokenValidation validation = validateToken(idToken, config);
             logger.debug("Decoding id_token");
@@ -596,9 +629,12 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
         MultiValueMap<String, String> body = new LinkedMaskingMultiValueMap<>("code", "client_secret");
         body.add("grant_type", GRANT_TYPE_AUTHORIZATION_CODE);
-        body.add("response_type", getResponseType(config));
+        body.add("response_type", getResponseType(config)); // not required by the Oauth 2.0 standard in this 'Access Token Request'
         body.add("code", codeToken.getCode());
         body.add("redirect_uri", codeToken.getRedirectUrl());
+        // NOTE: the "state" body parameter is optional. We also are in
+        // trouble here about how to obtain the correct 'httpSession' to use.
+//         body.add("state", SessionUtils.getStateParam(RequestContextHolder...httpSession, SessionUtils.stateParameterAttributeKeyForIdp(codeToken.getOrigin())));
 
         logger.debug("Adding new client_id and client_secret for token exchange");
         body.add("client_id", config.getRelyingPartyId());
@@ -634,12 +670,20 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                           }
                 );
         logger.debug(String.format("Request completed with status:%s", responseEntity.getStatusCode()));
-        return responseEntity.getBody().get(getResponseType(config));
+        return responseEntity.getBody().get(getTokenFieldName(config));
     }
 
     private String getClientAuthHeader(AbstractExternalOAuthIdentityProviderDefinition config) {
         String clientAuth = new String(Base64.encodeBase64((config.getRelyingPartyId() + ":" + config.getRelyingPartySecret()).getBytes()));
         return "Basic " + clientAuth;
+    }
+
+    private String getTokenFieldName(AbstractExternalOAuthIdentityProviderDefinition config) {
+        String responseType = getResponseType(config);
+        if (responseType == "code" || responseType == "token") {
+            return "access_token"; // Oauth 2.0
+        }
+        return responseType;
     }
 
     public void setTokenEndpointBuilder(TokenEndpointBuilder tokenEndpointBuilder) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -98,6 +98,7 @@ import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDef
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.USER_NAME_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.util.TokenValidation.buildIdTokenValidator;
 import static org.cloudfoundry.identity.uaa.util.UaaHttpRequestUtils.isAcceptedInvitationAuthentication;
+import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.util.StringUtils.hasText;
 import static org.springframework.util.StringUtils.isEmpty;
 
@@ -537,20 +538,18 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             headers.add("Accept", "application/json");
 
             URI requestUri;
-            HttpEntity requestEntity = new HttpEntity<>(headers);
+            HttpEntity<Object> requestEntity = new HttpEntity<>(headers);
             try {
                 requestUri = narrowedConfig.getCheckTokenUrl().toURI();
             } catch (URISyntaxException exc) {
-                logger.error("Invalid URI configured:" + narrowedConfig.getCheckTokenUrl(), exc);
+                logger.error("Invalid URI configured: <" + narrowedConfig.getCheckTokenUrl() + ">", exc);
                 return null;
             }
 
             logger.debug(String.format("Performing token check with url:%s", requestUri));
             ResponseEntity<Map<String, Object>> responseEntity =
                 getRestTemplate(config)
-                    .exchange(requestUri,
-                              HttpMethod.GET,
-                              requestEntity,
+                    .exchange(requestUri, GET, requestEntity,
                               new ParameterizedTypeReference<Map<String, Object>>() {
                               }
                     );

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
@@ -68,7 +68,7 @@ public class ExternalOAuthAuthenticationManagerGithubTest {
         providerConfig.setResponseType("code");
         providerConfig.setAuthUrl(new URL(AUTH_URL));
         providerConfig.setTokenUrl(new URL(TOKEN_URL));
-        providerConfig.setCheckTokenUrl(new URL(USER_INFO_URL));
+        providerConfig.setUserInfoUrl(new URL(USER_INFO_URL));
         providerConfig.setScopes(newArrayList(new String[] { "openid", "email" }));
         providerConfig.setAddShadowUserOnLogin(true); // the default anyway
         providerConfig.setRelyingPartyId("github_app_client_id");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
@@ -1,0 +1,149 @@
+package org.cloudfoundry.identity.uaa.provider.oauth;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.cloudfoundry.identity.uaa.util.UaaMapUtils.entry;
+import static org.cloudfoundry.identity.uaa.util.UaaMapUtils.map;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
+import org.cloudfoundry.identity.uaa.oauth.TokenEndpointBuilder;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.RawExternalOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager.AuthenticationData;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+public class ExternalOAuthAuthenticationManagerGithubTest {
+    
+    private static final String AUTH_URL = "https://github.example.com/login/oauth/authorize";
+    private static final String TOKEN_URL = "https://github.example.com/login/oauth/access_token";
+    private static final String USER_INFO_URL = "https://api.github.example.com/user";
+
+    private MockRestServiceServer mockGithubServer;
+
+    private ExternalOAuthAuthenticationManager authManager;
+    private String origin;
+    private String zoneId;
+
+    private RawExternalOAuthIdentityProviderDefinition providerConfig;
+    private String uaaIssuerBaseUrl;
+    private TokenEndpointBuilder tokenEndpointBuilder;
+
+    @Before
+    public void setup() throws Exception {
+        origin = "github";
+        zoneId = "zoneId";
+        IdentityZone identityZone = new IdentityZone();
+        identityZone.setId(zoneId);
+        IdentityZoneHolder.set(identityZone);
+
+        IdentityProviderProvisioning identityProviderProvisioning = mock(IdentityProviderProvisioning.class);
+        IdentityProvider<RawExternalOAuthIdentityProviderDefinition> provider = new IdentityProvider<>();
+        providerConfig = new RawExternalOAuthIdentityProviderDefinition();
+        providerConfig.setResponseType("code");
+        providerConfig.setAuthUrl(new URL(AUTH_URL));
+        providerConfig.setTokenUrl(new URL(TOKEN_URL));
+        providerConfig.setCheckTokenUrl(new URL(USER_INFO_URL));
+        providerConfig.setScopes(newArrayList(new String[] { "openid", "email" }));
+        providerConfig.setAddShadowUserOnLogin(true); // the default anyway
+        providerConfig.setRelyingPartyId("github_app_client_id");
+        providerConfig.setRelyingPartySecret("github_app_client_secret");
+        providerConfig.setSkipSslValidation(false); // the default
+        providerConfig.setClientAuthInBody(true);
+        Map<String, Object> attributeMappings = map(
+                entry("given_name", "login"),
+                entry("family_name", "name"),
+                entry("user_name", "email")
+        );
+        providerConfig.setAttributeMappings(attributeMappings);
+        provider.setConfig(providerConfig);
+        when(identityProviderProvisioning.retrieveByOrigin(origin, zoneId)).thenReturn(provider);
+        uaaIssuerBaseUrl = "http://uaa.example.com";
+        tokenEndpointBuilder = new TokenEndpointBuilder(uaaIssuerBaseUrl);
+        
+        RestTemplate trustingRestTemplate = null;
+        RestTemplate nonTrustingRestTemplate = new RestTemplate();
+        mockGithubServer = MockRestServiceServer.createServer(nonTrustingRestTemplate);
+        
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, trustingRestTemplate, nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(uaaIssuerBaseUrl));
+    }
+
+    @After
+    public void cleanup() {
+        IdentityZoneHolder.clear();
+    }
+
+
+    @Test
+    public void getExternalAuthenticationDetails_doesNotThrowWhenIdTokenIsValid() {
+        // Given
+        String idToken = "xyz";
+        String accessToken = "e72e16c7e42f292c6912e7710c838347ae178b4a";
+        String tokenResponse = "{\"access_token\":\"" + accessToken + "\", \"scope\":\"repo,gist\", \"token_type\":\"bearer\"}";
+        mockGithubServer.expect(method(POST))
+            .andExpect(requestTo(TOKEN_URL))
+            .andExpect(header(ACCEPT, APPLICATION_JSON_VALUE))
+//            .andExpect(content().json("{\n"
+//                    + "\"client_id\": \"github_app_client_id\",\n"
+//                    + "\"client_secret\": \"github_app_client_secret\",\n"
+//                    + "\"code\": \"" + idToken + "\"\n"
+//                    + "}"))
+            .andRespond(withSuccess(tokenResponse, APPLICATION_JSON));
+
+        String userInfoResponse = "{\n"
+                + "  \"login\": \"octocat\",\n"
+                + "  \"id\": 1,\n"
+                + "  \"type\": \"User\",\n"
+                + "  \"site_admin\": false,\n"
+                + "  \"name\": \"monalisa octocat\",\n"
+                + "  \"company\": \"GitHub\",\n"
+                + "  \"email\": \"octocat@github.example.com\"\n"
+                + "}";
+        mockGithubServer.expect(method(GET))
+            .andExpect(requestTo(USER_INFO_URL))
+            .andExpect(header(ACCEPT, APPLICATION_JSON_VALUE))
+            .andExpect(header(AUTHORIZATION, "token " + accessToken))
+            .andRespond(withSuccess(userInfoResponse, APPLICATION_JSON));
+        
+        ExternalOAuthCodeToken oauth2Authentication = new ExternalOAuthCodeToken(null, origin, "http://uaa.example.com/login/callback/github", idToken, "accesstoken", "signedrequest");
+
+        // When
+        AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oauth2Authentication);
+
+        // Then
+        mockGithubServer.verify();
+        assertThat(authenticationData.getUsername(), is(equalTo("octocat@github.example.com")));
+
+        Map<String, Object> claims = authenticationData.getClaims();
+        assertThat(claims.get("login"), is(equalTo("octocat")));
+        assertThat(claims.get("name"), is(equalTo("monalisa octocat")));
+        assertThat(claims.get("email"), is(equalTo("octocat@github.example.com")));
+        
+    }
+    
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -284,10 +284,13 @@ class ExternalOAuthAuthenticationManagerIT {
     void get_response_type_for_oauth2() {
         RawExternalOAuthIdentityProviderDefinition signed = new RawExternalOAuthIdentityProviderDefinition();
         signed.setResponseType("signed_request");
+        RawExternalOAuthIdentityProviderDefinition code = new RawExternalOAuthIdentityProviderDefinition();
         RawExternalOAuthIdentityProviderDefinition token = new RawExternalOAuthIdentityProviderDefinition();
+        token.setResponseType("token");
         OIDCIdentityProviderDefinition oidcIdentityProviderDefinition = new OIDCIdentityProviderDefinition();
 
         assertEquals("signed_request", externalOAuthAuthenticationManager.getResponseType(signed));
+        assertEquals("code", externalOAuthAuthenticationManager.getResponseType(code));
         assertEquals("token", externalOAuthAuthenticationManager.getResponseType(token));
         assertEquals("id_token", externalOAuthAuthenticationManager.getResponseType(oidcIdentityProviderDefinition));
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -467,6 +467,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
                 fieldWithPath("config.tokenUrl").required().type(STRING).description("The OAuth 2.0 token endpoint URL"),
                 fieldWithPath("config.tokenKeyUrl").optional(null).type(STRING).description("The URL of the token key endpoint which renders a verification key for validating token signatures"),
                 fieldWithPath("config.tokenKey").optional(null).type(STRING).description("A verification key for validating token signatures, set to null if a `tokenKeyUrl` is provided."),
+                fieldWithPath("config.userInfoUrl").optional(null).type(STRING).description("A URL for fetching user info attributes when queried with the obtained token authorization."),
                 fieldWithPath("config.showLinkText").optional(true).type(BOOLEAN).description("A flag controlling whether a link to this provider's login will be shown on the UAA login page"),
                 fieldWithPath("config.linkText").optional(null).type(STRING).description("Text to use for the login link to the provider"),
                 fieldWithPath("config.relyingPartyId").required().type(STRING).description("The client ID which is registered with the external OAuth provider for use by the UAA"),


### PR DESCRIPTION
Hi Cloud Foundry fellows,

I've implemented support for Github OAuth 2 as Identity Provider (IdP). This fixes the issue described in #798 .

All 4600+ tests are passing. (I didn't fork from the latests `develop` HEAD because tests are currently not passing there.)
I've added some unit tests to cover the main Github use-case OAuth 2.0 “Autorization Code Grant” flow.
There is also some documentation showing how to use it.
I've deployed this version of UAA in a Cloud Foundry, making a fork of the `uaa-release`. Testing the result my own Gstack's sandbox CF environment, the real-life Github authentication works fine.

As a design choice that could be discussed, I've re-used the `checkTokenUrl` property (that is not used anywhere), in order to implement the “user-info” endpoint.
In #798, the `userInfoUrl` config is suggested and definitely looks more appropriate. I'll submit some improvement soon to address this. (**edit:** this is pushed now, see below)

Best,
Benjamin
