### PR TITLE
write exception message only 

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCache.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCache.java
@@ -59,7 +59,7 @@ public class ExpiringUrlCache implements UrlContentCache {
             }
             return metadata;
         } catch (RestClientException x) {
-            logger.warn("Unable to fetch metadata for " + uri, x);
+            logger.debug("Unable to fetch metadata for " + uri, x);
             throw x;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCache.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/cache/ExpiringUrlCache.java
@@ -59,7 +59,7 @@ public class ExpiringUrlCache implements UrlContentCache {
             }
             return metadata;
         } catch (RestClientException x) {
-            logger.debug("Unable to fetch metadata for " + uri, x);
+            logger.warn("Unable to fetch metadata for {0}. {1}", uri, x.getMessage());
             throw x;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);


### PR DESCRIPTION
fix for issue #1436

Since the exception is re-thrown, we simply can omit writing it in production.