### PR TITLE
more memory for gradle tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,9 +85,9 @@ subprojects {
     targetCompatibility = 1.11
 
     test {
-        maxParallelForks = 6
+        maxParallelForks = Runtime.runtime.availableProcessors() 
         useJUnitPlatform()
-        jvmArgs += ["-Xmx1024m", "-XX:+StartAttachListener", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/var/log/uaa-tests.hprof"]
+        jvmArgs += ["-Xmx2048m", "-XX:+UseContainerSupport", "-XX:+StartAttachListener", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/var/log/uaa-tests.hprof"]
 
         testLogging {
             events("skipped", "failed", "passed")


### PR DESCRIPTION
in pipeline I noticed often a failure because of memory
found here recommendations:
https://stackoverflow.com/questions/38967991/why-are-my-gradle-builds-dying-with-exit-code-137