### PR TITLE
Refactor fetch of tokenKeyUrl

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/cache/UrlContentCache.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/cache/UrlContentCache.java
@@ -13,6 +13,8 @@
 package org.cloudfoundry.identity.uaa.cache;
 
 
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.client.RestTemplate;
 
 import java.net.URI;
@@ -29,6 +31,16 @@ public interface UrlContentCache {
      * @throws IllegalArgumentException if uri is not valid {@link URI}
      */
     byte[] getUrlContent(String uri, RestTemplate template);
+
+    /**
+     * Retrieves and caches the content for a given URI by invoking
+     * @param uri - must be a valid URI
+     * @param method - HTTP Method
+     * @param requestEntity HTTP Entity
+     * @return byte[] for the content or null if a content retrieval error happened ({@link org.springframework.web.client.RestClientException})
+     * @throws IllegalArgumentException if uri is not valid {@link URI}
+     */
+    byte[] getUrlContent(String uri, final RestTemplate template, final HttpMethod method, HttpEntity<?> requestEntity);
 
     /**
      * Clears the cache unconditionally

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
@@ -1,13 +1,25 @@
 package org.cloudfoundry.identity.uaa.provider.oauth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.cache.UrlContentCache;
+import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey;
+import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKeyHelper;
+import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKeySet;
+import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 
 import static java.util.Optional.ofNullable;
 
@@ -32,6 +44,37 @@ public class OidcMetadataFetcher {
 
             updateIdpDefinition(definition, oidcMetadata);
         }
+    }
+
+    public JsonWebKeySet<JsonWebKey> fetchWebKeySet(AbstractExternalOAuthIdentityProviderDefinition config)
+        throws OidcMetadataFetchingException {
+        URL tokenKeyUrl = config.getTokenKeyUrl();
+        if (tokenKeyUrl == null || !org.springframework.util.StringUtils.hasText(tokenKeyUrl.toString())) {
+            return new JsonWebKeySet<>(Collections.emptyList());
+        }
+        MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add("Authorization", getClientAuthHeader(config));
+        headers.add("Accept", "application/json");
+        HttpEntity tokenKeyRequest = new HttpEntity<>(null, headers);
+        byte[] rawContents;
+        if (config.isSkipSslValidation()) {
+            rawContents = contentCache.getUrlContent(tokenKeyUrl.toString(), trustingRestTemplate, HttpMethod.GET, tokenKeyRequest);
+        } else {
+            rawContents = contentCache.getUrlContent(tokenKeyUrl.toString(), nonTrustingRestTemplate, HttpMethod.GET, tokenKeyRequest);
+        }
+        if (rawContents == null || rawContents.length == 0) {
+            throw new OidcMetadataFetchingException("Unable to fetch verification keys");
+        }
+        try {
+            return JsonWebKeyHelper.deserialize(new String(rawContents, StandardCharsets.UTF_8));
+        } catch (JsonUtils.JsonUtilException e) {
+            throw new OidcMetadataFetchingException(e);
+        }
+    }
+
+    private String getClientAuthHeader(AbstractExternalOAuthIdentityProviderDefinition config) {
+        String clientAuth = new String(Base64.encodeBase64((config.getRelyingPartyId() + ":" + config.getRelyingPartySecret()).getBytes()));
+        return "Basic " + clientAuth;
     }
 
     private OidcMetadata fetchMetadata(URL discoveryUrl, boolean shouldDoSslValidation) throws OidcMetadataFetchingException {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -698,6 +698,32 @@ class ExternalOAuthAuthenticationManagerIT {
     }
 
     @Test
+    void null_key_invalid() throws Exception {
+        String json = new String("");
+        configureTokenKeyResponse("http://localhost/token_key", json);
+        addTheUserOnAuth();
+        try {
+            externalOAuthAuthenticationManager.authenticate(xCodeToken);
+            fail("not expected");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof OidcMetadataFetchingException);
+        }
+    }
+
+    @Test
+    void invalid_key() throws Exception {
+        String json = new String("{x}");
+        configureTokenKeyResponse("http://localhost/token_key", json);
+        addTheUserOnAuth();
+        try {
+            externalOAuthAuthenticationManager.authenticate(xCodeToken);
+            fail("not expected");
+        } catch (Exception e) {
+            assertTrue(e.getCause() instanceof OidcMetadataFetchingException);
+        }
+    }
+
+    @Test
     void multi_key_response() throws Exception {
         configureTokenKeyResponse(
                 "http://localhost/token_key",
@@ -707,6 +733,23 @@ class ExternalOAuthAuthenticationManagerIT {
         addTheUserOnAuth();
         externalOAuthAuthenticationManager.authenticate(xCodeToken);
         verify(urlContentCache, times(1)).getUrlContent(any(), any(), any(), any());
+    }
+
+    @Test
+    void null_key_config_invalid() throws Exception {
+        configureTokenKeyResponse(
+                "http://localhost/token_key",
+                PRIVATE_KEY,
+                "correctKey",
+                true);
+        addTheUserOnAuth();
+        config.setTokenKeyUrl(null);
+        try {
+            externalOAuthAuthenticationManager.authenticate(xCodeToken);
+            fail("not expected");
+        } catch (Exception e) {
+            assertTrue(e instanceof IllegalArgumentException);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -9,6 +9,7 @@ import org.cloudfoundry.identity.uaa.authentication.manager.ExternalGroupAuthori
 import org.cloudfoundry.identity.uaa.authentication.manager.InvitedUserAuthenticatedEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.NewUserAuthenticatedEvent;
 import org.cloudfoundry.identity.uaa.cache.ExpiringUrlCache;
+import org.cloudfoundry.identity.uaa.cache.UrlContentCache;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.impl.config.RestTemplateConfig;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
@@ -132,6 +133,7 @@ class ExternalOAuthAuthenticationManagerIT {
 
     private MockRestServiceServer mockUaaServer;
     private ExternalOAuthAuthenticationManager externalOAuthAuthenticationManager;
+    private UrlContentCache urlContentCache;
     private IdentityProviderProvisioning provisioning;
     private InMemoryUaaUserDatabase userDatabase;
     private ExternalOAuthCodeToken xCodeToken;
@@ -203,8 +205,9 @@ class ExternalOAuthAuthenticationManagerIT {
         publisher = mock(ApplicationEventPublisher.class);
         tokenEndpointBuilder = mock(TokenEndpointBuilder.class);
         when(tokenEndpointBuilder.getTokenEndpoint(IdentityZoneHolder.get())).thenReturn(UAA_ISSUER_URL);
+        urlContentCache = spy(new ExpiringUrlCache(Duration.ofMinutes(2), new TimeServiceImpl(), 10));
         OidcMetadataFetcher oidcMetadataFetcher = new OidcMetadataFetcher(
-                new ExpiringUrlCache(Duration.ofMinutes(2), new TimeServiceImpl(), 10),
+                urlContentCache,
                 trustingRestTemplate,
                 nonTrustingRestTemplate
         );
@@ -214,7 +217,7 @@ class ExternalOAuthAuthenticationManagerIT {
                         oidcMetadataFetcher,
                         mock(UaaRandomStringUtil.class))
         );
-        externalOAuthAuthenticationManager = spy(new ExternalOAuthAuthenticationManager(externalOAuthProviderConfigurator, trustingRestTemplate, nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_URL)));
+        externalOAuthAuthenticationManager = spy(new ExternalOAuthAuthenticationManager(externalOAuthProviderConfigurator, trustingRestTemplate, nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_URL), oidcMetadataFetcher));
         externalOAuthAuthenticationManager.setUserDatabase(userDatabase);
         externalOAuthAuthenticationManager.setExternalMembershipManager(externalMembershipManager);
         externalOAuthAuthenticationManager.setApplicationEventPublisher(publisher);
@@ -703,6 +706,7 @@ class ExternalOAuthAuthenticationManagerIT {
                 true);
         addTheUserOnAuth();
         externalOAuthAuthenticationManager.authenticate(xCodeToken);
+        verify(urlContentCache, times(1)).getUrlContent(any(), any(), any(), any());
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -1,10 +1,12 @@
 package org.cloudfoundry.identity.uaa.provider.oauth;
 
+import org.cloudfoundry.identity.uaa.cache.ExpiringUrlCache;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
 import org.cloudfoundry.identity.uaa.oauth.TokenEndpointBuilder;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.util.TimeServiceImpl;
 import org.cloudfoundry.identity.uaa.util.UaaTokenUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
@@ -18,6 +20,7 @@ import org.springframework.security.jwt.crypto.sign.Signer;
 import org.springframework.security.oauth2.common.exceptions.InvalidTokenException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -109,7 +112,12 @@ public class ExternalOAuthAuthenticationManagerTest {
         when(identityProviderProvisioning.retrieveByOrigin(origin, zoneId)).thenReturn(provider);
         uaaIssuerBaseUrl = "http://uaa.example.com";
         tokenEndpointBuilder = new TokenEndpointBuilder(uaaIssuerBaseUrl);
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(uaaIssuerBaseUrl));
+        OidcMetadataFetcher oidcMetadataFetcher = new OidcMetadataFetcher(
+            new ExpiringUrlCache(Duration.ofMinutes(2), new TimeServiceImpl(), 10),
+            new RestTemplate(),
+            new RestTemplate()
+        );
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(uaaIssuerBaseUrl), oidcMetadataFetcher);
     }
 
     @After

--- a/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/oauth-endpoints.xml
@@ -388,6 +388,7 @@
         <constructor-arg name="nonTrustingRestTemplate" ref="nonTrustingRestTemplate"/>
         <constructor-arg name="tokenEndpointBuilder" ref="tokenEndpointBuilder"/>
         <constructor-arg name="keyInfoService" ref="keyInfoService"/>
+        <constructor-arg name="oidcMetadataFetcher" ref="oidcMetadataFetcher"/>
         <property name="userDatabase" ref="userDatabase"/>
         <property name="externalMembershipManager" ref="externalGroupMembershipManager"/>
     </bean>


### PR DESCRIPTION
Should solve issue #1464
However this is no new featur itself therefore additional new tests

Before:
the token_keys from OIDC servers were fetched if no tokenkey in config and discoveryUrl is set.
Each authentication resulted in a cached call to discoveryUrl but later the webkeys were fetched without any cache.

Now:
Added a new interface to UrlCache because of custom headers but re-use the real call in one method.
Since WebKey belongs to OIDC , added a method fetchWebKeySet in OidcMetadataFetcher.
This call now uses the contentCache - same as from discovery Url.