### PR TITLE
K8s templates now allow configuring `issuer.uri`

### DIFF
--- a/k8s/templates/uaa.lib.yml
+++ b/k8s/templates/uaa.lib.yml
@@ -4,9 +4,7 @@
 #@ def config():
 ---
 issuer:
-  uri: http://localhost:8080/uaa
-
-
+  uri: #@ data.values.issuer.uri
 
 #! The secret that an external login server will use to authenticate to the uaa using the id `login`
 LOGIN_SECRET: loginsecret

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -25,6 +25,9 @@ resources:
       memory: 100Mi
       cpu: 100m
 
+issuer:
+  uri: http://localhost:8080/uaa
+
 tomcat:
   accessLoggingEnabled: "y"
 

--- a/k8s/test/config_map_test.go
+++ b/k8s/test/config_map_test.go
@@ -121,7 +121,7 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 				)
 			})
 		})
-		Context("with overriden values", func() {
+		Context("with overridden values", func() {
 			It("produces yaml", func() {
 				ctx := NewRenderingContext(templates...).WithData(map[string]string{
 					"database.scheme":   "postgres",
@@ -130,6 +130,7 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 					"smtp.port":         "smtp port",
 					"smtp.starttls":     "smtp starttls",
 					"smtp.from_address": "smtp from_address",
+					"issuer.uri":        "http://some.example.com/with/path",
 				})
 
 				Expect(ctx).To(
@@ -137,7 +138,7 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 						RepresentingConfigMap().WithDataFieldMatching(UaaYmlConfigKey, func(uaaYml *DataFieldMatcher) {
 							uaaYml.WithFields(Fields{
 								"LoginSecret": Equal("loginsecret"),
-								"Issuer":      Equal(Issuer{Uri: "http://localhost:8080/uaa"}),
+								"Issuer":      Equal(Issuer{Uri: "http://some.example.com/with/path"}),
 								"Database": MatchFields(IgnoreExtras, Fields{
 									"Username": BeEmpty(),
 									"Password": BeEmpty(),


### PR DESCRIPTION
So that we can configure the `issuer` returned from `/.well-known/openid-configuration` and the `iss` claim in tokens.