### PR TITLE
Credentials in UsernamePasswordAuthenticationToken should be String

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ChainedAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ChainedAuthenticationManager.java
@@ -54,7 +54,7 @@ public class ChainedAuthenticationManager implements AuthenticationManager {
             output = (UsernamePasswordAuthenticationToken) authentication;
         } else {
             output = new UsernamePasswordAuthenticationToken(authentication.getPrincipal(),
-                                                             authentication.getCredentials(),
+                                                             (authentication.getCredentials() != null ? authentication.getCredentials().toString() : null),
                                                              authentication.getAuthorities());
             output.setDetails(authentication.getDetails());
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/ChainedAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/ChainedAuthenticationManagerTest.java
@@ -4,7 +4,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -18,6 +20,7 @@ import static org.mockito.Mockito.when;
 
 public class ChainedAuthenticationManagerTest {
 
+    private Authentication success;
     private Authentication failure;
     private AuthenticationManager authenticateTrue;
     private AuthenticationManager authenticateFalse;
@@ -26,9 +29,19 @@ public class ChainedAuthenticationManagerTest {
     private ChainedAuthenticationManager authMgr = new ChainedAuthenticationManager();
     private AuthenticationManager loginAuthenticationManager;
 
+    private class UsernamePasswordAuthenticationManager implements AuthenticationManager {
+        @Override
+        public Authentication authenticate(Authentication authentication)
+                throws AuthenticationException {
+            final UsernamePasswordAuthenticationToken userToken = (UsernamePasswordAuthenticationToken) authentication;
+            String password = (String) authentication.getCredentials();
+            return authentication;
+        }
+    }
+    
     @Before
     public void setUp() {
-        Authentication success = mock(Authentication.class);
+        success = mock(Authentication.class);
         failure = mock(Authentication.class);
 
         authenticateTrue = mock(AuthenticationManager.class);
@@ -111,5 +124,17 @@ public class ChainedAuthenticationManagerTest {
         verify(authenticateThrow, times(1)).authenticate(any(Authentication.class));
         verify(authenticateTrue, times(1)).authenticate(any(Authentication.class));
         verify(loginAuthenticationManager, times(1)).authenticate(any(Authentication.class));
+    }
+    
+    @Test
+    public void testNonStringCredential() {
+        when(success.getCredentials()).thenReturn(new Object());
+        
+        managers[0].setAuthenticationManager(authenticateThrow);
+        managers[1].setAuthenticationManager(new UsernamePasswordAuthenticationManager());
+        Authentication result = authMgr.authenticate(success);
+        assertNotNull(result);
+        assertTrue(result.isAuthenticated());
+        verify(authenticateThrow, times(1)).authenticate(any(Authentication.class));
     }
 }


### PR DESCRIPTION
The current code results in a ClassCastException in AbstractLdapAuthenticationProvider when the current Authentication has a non-String credential, for example when it is a SAMLCredential that has expired. This can happen authenticating with an external SAML IDP that returns an AuthnStatement containing a SessionNotOnOrAfter attribute. Eventually the authentication will expire and you will get a 500 server error and ClassCastException in the logs.
