### PR TITLE
refactor: implement recommendation from thymeleaf

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/ThymeleafConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/ThymeleafConfig.java
@@ -28,6 +28,7 @@ import org.thymeleaf.extras.springsecurity5.dialect.SpringSecurityDialect;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 import org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver;
 import org.thymeleaf.spring5.view.ThymeleafViewResolver;
+import org.thymeleaf.templatemode.TemplateMode;
 import org.thymeleaf.templateresolver.ITemplateResolver;
 
 import java.nio.charset.StandardCharsets;
@@ -104,7 +105,7 @@ public class ThymeleafConfig  {
     private SpringResourceTemplateResolver baseHtmlTemplateResolver(ApplicationContext context) {
         SpringResourceTemplateResolver templateResolver = new SpringResourceTemplateResolver();
         templateResolver.setSuffix(".html");
-        templateResolver.setTemplateMode("HTML5");
+        templateResolver.setTemplateMode(TemplateMode.HTML);
         templateResolver.setApplicationContext(context);
         return templateResolver;
     }

--- a/server/src/main/resources/templates/web/access_confirmation.html
+++ b/server/src/main/resources/templates/web/access_confirmation.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/html"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
 </head>

--- a/server/src/main/resources/templates/web/access_confirmation_error.html
+++ b/server/src/main/resources/templates/web/access_confirmation_error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <div class="island" layout:fragment="page-content">
     <div class="island-content">
         <div th:if="${error_message_code}" class="alert alert-error">

--- a/server/src/main/resources/templates/web/accounts/email_sent.html
+++ b/server/src/main/resources/templates/web/accounts/email_sent.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <link rel="stylesheet" href="/resources/font-awesome/css/font-awesome.min.css" th:href="@{/resources/font-awesome/css/font-awesome.min.css}" />
 </head>

--- a/server/src/main/resources/templates/web/accounts/link_prompt.html
+++ b/server/src/main/resources/templates/web/accounts/link_prompt.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <div class="island-landscape" layout:fragment="page-content">
     <div class="island-title">
         <h1>Create your <th:block th:text="${!companyName.equals('Cloud Foundry') and isUaa ? companyName + ' account': 'account'}">account</th:block></h1>

--- a/server/src/main/resources/templates/web/accounts/new_activation_email.html
+++ b/server/src/main/resources/templates/web/accounts/new_activation_email.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <div th:switch="${error_message_code}" class="island-landscape" layout:fragment="page-content">
     <div class="island-title">
         <h1>Create your <th:block th:text="${!companyName.equals('Cloud Foundry') and isUaa ? (companyName + ' account') : 'account'}">account</th:block></h1>

--- a/server/src/main/resources/templates/web/approvals.html
+++ b/server/src/main/resources/templates/web/approvals.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/html"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
     <script type="text/javascript">

--- a/server/src/main/resources/templates/web/change_email.html
+++ b/server/src/main/resources/templates/web/change_email.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
 </head>

--- a/server/src/main/resources/templates/web/change_password.html
+++ b/server/src/main/resources/templates/web/change_password.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
 </head>

--- a/server/src/main/resources/templates/web/email_sent.html
+++ b/server/src/main/resources/templates/web/email_sent.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <head>
     <link rel="stylesheet" href="/resources/font-awesome/css/font-awesome.min.css" th:href="@{/resources/font-awesome/css/font-awesome.min.css}" />
 </head>

--- a/server/src/main/resources/templates/web/error.html
+++ b/server/src/main/resources/templates/web/error.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <head>
 </head>
 <div class="island" layout:fragment="page-content">

--- a/server/src/main/resources/templates/web/external_auth_error.html
+++ b/server/src/main/resources/templates/web/external_auth_error.html
@@ -13,7 +13,7 @@
   ~ *******************************************************************************
   -->
 
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <head>
 </head>
 <body>

--- a/server/src/main/resources/templates/web/force_password_change.html
+++ b/server/src/main/resources/templates/web/force_password_change.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <div class="island" layout:fragment="page-content">
     <h1>Force Change Password</h1>
     <div class="island-content">

--- a/server/src/main/resources/templates/web/forgot_password.html
+++ b/server/src/main/resources/templates/web/forgot_password.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <div class="island" layout:fragment="page-content">
     <h1>Reset Password</h1>
     <div class="island-content">

--- a/server/src/main/resources/templates/web/home.html
+++ b/server/src/main/resources/templates/web/home.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
     <style th:each="tile,status : ${tiles}" th:utext="'.tile-' + ${status.count} + ' .tile-icon {background-image: url(&#34;' + @{${tile.appIcon}} + '&#34;)}'"></style>

--- a/server/src/main/resources/templates/web/idp_discovery/account_chooser.html
+++ b/server/src/main/resources/templates/web/idp_discovery/account_chooser.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/pui-account-discovery-main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/pui-account-discovery-main}">
 <div layout:fragment="page-content">
   <h4 class="txt-c pbxxl ptxl" th:text="${T(org.springframework.util.StringUtils).hasText(clientName) ? 'Sign in to continue to ' + clientName : 'Sign in to continue'}">
     Choose an account

--- a/server/src/main/resources/templates/web/idp_discovery/email.html
+++ b/server/src/main/resources/templates/web/idp_discovery/email.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/pui-account-discovery-main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/pui-account-discovery-main}">
 <div layout:fragment="page-content">
 <h4 class="txt-c pbxxl ptxl" th:text="${T(org.springframework.util.StringUtils).hasText(clientName) ? 'Sign in to continue to ' + clientName : 'Sign in to continue'}">
     Sign in to continue

--- a/server/src/main/resources/templates/web/idp_discovery/password.html
+++ b/server/src/main/resources/templates/web/idp_discovery/password.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/pui-account-discovery-main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/pui-account-discovery-main}">
 <div layout:fragment="page-content">
     <form action="/login.do" th:action="@{/login.do}" method="post" role="form" _lpchecked="1">
         <div class="form-group">

--- a/server/src/main/resources/templates/web/invalid_request.html
+++ b/server/src/main/resources/templates/web/invalid_request.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <div class="island" layout:fragment="page-content">
     <div class="island-content">
         <div class="alert alert-error">

--- a/server/src/main/resources/templates/web/invitations/accept_invite.html
+++ b/server/src/main/resources/templates/web/invitations/accept_invite.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main" >
-<div class="island-landscape" layout:fragment="page-content">
+      layout:decorate="~{layouts/main}">
+<div class="island-landscape" layout:fragment="page-content" th:with="isLdap=${provider=='ldap'}">
     <div class="island-title">
-        <h1><th:block th:unless="${provider=='ldap'}">Create</th:block><th:block th:if="${provider=='ldap'}">Link</th:block> your <th:block th:text="${!companyName.equals('Cloud Foundry') and isUaa ? (companyName + ' account') : 'account'}">account</th:block></h1>
+        <h1><th:block th:unless="${isLdap}">Create</th:block><th:block th:if="${isLdap}">Link</th:block> your <th:block th:text="${!companyName.equals('Cloud Foundry') and isUaa ? (companyName + ' account') : 'account'}">account</th:block></h1>
     </div>
     <div class="island-content">
         <div th:text="|Email: ${email}|" th:unless="${error_message_code == 'code_expired'}" class="email-display">Email: user@example.com</div>
@@ -31,7 +31,7 @@
                 <input type="submit" th:value="${!companyName.equals('Cloud Foundry') and isUaa ? 'Create ' + companyName + ' account' : 'Create account'}" class="island-button"/>
             </form>
           </th:block>
-            <th:block th:if="${provider=='ldap'}">
+            <th:block th:if="${isLdap}">
                 <p>Sign in with enterprise credentials: </p>
                 <form th:action="@{/invitations/accept_enterprise.do}" method="post" novalidate="novalidate">
                     <input name="enterprise_email" type="hidden" th:value="${email}"/>

--- a/server/src/main/resources/templates/web/login.html
+++ b/server/src/main/resources/templates/web/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <head>
     <meta http-equiv="refresh" th:content="${@loginCookieCsrfRepository.getCookieMaxAge()}" />
 </head>

--- a/server/src/main/resources/templates/web/login_implicit.html
+++ b/server/src/main/resources/templates/web/login_implicit.html
@@ -15,7 +15,7 @@
   ~ *****************************************************************************
   -->
 
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/main">
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 
 <div class="island" layout:fragment="page-content">
     <h1 th:text="${T(org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder).uaa ? 'One more step!':'One more step to access '+zone_name+'!'}">Your authentication is being processed!</h1>

--- a/server/src/main/resources/templates/web/mfa/enter_code.html
+++ b/server/src/main/resources/templates/web/mfa/enter_code.html
@@ -15,7 +15,7 @@
 
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/pui-mfa-main">
+      layout:decorate="~{layouts/pui-mfa-main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
 </head>

--- a/server/src/main/resources/templates/web/mfa/manual_registration.html
+++ b/server/src/main/resources/templates/web/mfa/manual_registration.html
@@ -15,7 +15,7 @@
 
 <html xmlns:th="http://www.thymeleaf.org"
             xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-            layout:decorator="layouts/pui-mfa-main">
+            layout:decorate="~{layouts/pui-mfa-main}">
 <body>
 <div class="island" layout:fragment="page-content">
     <h2 id="mfa-identity-zone" th:text="${identity_zone}" class="txt-c mfa-header"></h2>

--- a/server/src/main/resources/templates/web/mfa/qr_code.html
+++ b/server/src/main/resources/templates/web/mfa/qr_code.html
@@ -15,7 +15,7 @@
 
 <html xmlns:th="http://www.thymeleaf.org"
             xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-            layout:decorator="layouts/pui-mfa-main">
+            layout:decorate="~{layouts/pui-mfa-main}">
 <body>
 <div class="island" layout:fragment="page-content">
     <h2 id="mfa-identity-zone" th:text="${identity_zone}" class="txt-c mfa-header"></h2>

--- a/server/src/main/resources/templates/web/passcode.html
+++ b/server/src/main/resources/templates/web/passcode.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
 </head>

--- a/server/src/main/resources/templates/web/reset_password.html
+++ b/server/src/main/resources/templates/web/reset_password.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <div class="island" layout:fragment="page-content">
     <h1>Reset Password</h1>
     <div class="island-content">

--- a/server/src/main/resources/templates/web/switch_idp.html
+++ b/server/src/main/resources/templates/web/switch_idp.html
@@ -2,7 +2,7 @@
 <html xmlns="http://www.w3.org/1999/html"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorator="layouts/main">
+      layout:decorate="~{layouts/main}">
 <head>
     <th:block layout:include="nav :: head"></th:block>
 </head>


### PR DESCRIPTION
by chance I found warnings in log. in total 3 warnings found

[THYMELEAF][Test worker] Template Mode 'HTML5' is deprecated. Using Template Mode 'HTML' instead.
[THYMELEAF][Test worker] Template Mode 'HTML5' is deprecated. Using Template Mode 'HTML' instead.
Initializing Spring TestDispatcherServlet ''
Initializing Servlet ''
Completed initialization in 3 ms
The layout:decorator/data-layout-decorator processor has been deprecated and will be removed in the next major version of the layout dialect.  Please use layout:decorate/data-layout-decorate instead to future-proof your code.  See https://github.com/ultraq/thymeleaf-layout-dialect/issues/95 for more information.
Fragment expression "layouts/main" is being wrapped as a Thymeleaf 3 fragment expression (~{...}) for backwards compatibility purposes.  This wrapping will be dropped in the next major version of the expression processor, so please rewrite as a Thymeleaf 3 fragment expression to future-proof your code.  See https://github.com/thymeleaf/thymeleaf/issues/451 for more information.

Implemented following recommendations

1. https://github.com/ultraq/thymeleaf-layout-dialect/issues/95 , changed layout:decorator to layout:decorate
2. use template mode HTML instead of HTML5
3. switched back to call >>th:with="isLdap.." << which was removed with spring update in a former PR