### PR TITLE
Fix: Username problem with JWT Bearer grant using UAA token

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -174,6 +174,8 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     private IdentityProvider buildInternalUaaIdpConfig(String issuer, String originKey) {
         OIDCIdentityProviderDefinition uaaOidcProviderConfig = new OIDCIdentityProviderDefinition();
         uaaOidcProviderConfig.setIssuer(issuer);
+        Map<String, Object> userNameMapping = Collections.singletonMap(USER_NAME_ATTRIBUTE_NAME, USER_NAME_ATTRIBUTE_NAME);
+        uaaOidcProviderConfig.setAttributeMappings(userNameMapping);
         IdentityProvider<OIDCIdentityProviderDefinition> uaaIdp = new IdentityProvider<>();
         uaaIdp.setOriginKey(originKey);
         uaaIdp.setConfig(uaaOidcProviderConfig);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -80,6 +80,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -442,7 +443,9 @@ class ExternalOAuthAuthenticationManagerIT {
         when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(new ArrayList<>());
 
         String username = RandomStringUtils.random(50);
-        claims.put("sub", username);
+        String userid = UUID.randomUUID().toString();
+        claims.put("sub", userid);
+        claims.put("user_name", username);
         claims.put("iss", "http://localhost/oauth/token");
         claims.put("origin", UAA_ORIGIN);
 
@@ -485,7 +488,9 @@ class ExternalOAuthAuthenticationManagerIT {
         when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));
 
         String username = RandomStringUtils.random(50);
-        claims.put("sub", username);
+        String userid = UUID.randomUUID().toString();
+        claims.put("sub", userid);
+        claims.put("user_name", username);
         claims.put("iss", UAA_ISSUER_URL);
         claims.put("origin", idpProvider.getOriginKey());
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantMockMvcTests.java
@@ -15,10 +15,13 @@
 
 package org.cloudfoundry.identity.uaa.mock.token;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.mock.util.JwtTokenUtils;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
+import org.cloudfoundry.identity.uaa.oauth.token.CompositeToken;
 import org.cloudfoundry.identity.uaa.oauth.token.TokenConstants;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
@@ -42,10 +45,12 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 
 import java.net.URL;
+import java.util.List;
 import java.util.Map;
 
 import static org.cloudfoundry.identity.uaa.oauth.TokenTestSupport.GRANT_TYPE;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_JWT_BEARER;
+import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -82,6 +87,85 @@ public class JwtBearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
                 getUaaIdToken(originZone.getIdentityZone(), originClient, originUser))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.access_token").isNotEmpty());
+    }
+
+    @Test
+    void non_default_zone_jwt_grant_user_update() throws Exception {
+        BaseClientDetails targetZoneClient = new BaseClientDetails(generator.generate(), "", "openid", "password", null);
+        targetZoneClient.setClientSecret(SECRET);
+        String subdomain = generator.generate().toLowerCase();
+        IdentityZone targetZone = MockMvcUtils.createOtherIdentityZoneAndReturnResult(subdomain,
+                mockMvc,
+                webApplicationContext,
+                targetZoneClient,
+                false, IdentityZoneHolder.getCurrentZoneId()).getIdentityZone();
+        ScimUser targetZoneUser = createUser(targetZone);
+
+        String originZoneOriginKey = createProvider(targetZone, getTokenVerificationKey(originZone.getIdentityZone()));
+
+        //Check for internal User
+        String targetZoneIdToken = getUaaIdToken(targetZone, targetZoneClient, targetZoneUser);
+        String accessTokenForTargetZoneUser = performJWTBearerGrantForJWT(targetZone, targetZoneIdToken);
+
+        //Verify JWT Bearer did not change values of internal User
+        ScimUser targetUserAfterGrant = getScimUser(targetZoneUser.getUserName(), OriginKeys.UAA, targetZone.getId());
+        assertEquals(targetZoneUser.getUserName(), targetUserAfterGrant.getUserName());
+        assertEquals(targetZoneUser.getExternalId(), targetUserAfterGrant.getExternalId());
+
+        //Check for user of registered IdP
+        String originZoneIdToken = getUaaIdToken(originZone.getIdentityZone(), originClient, originUser);
+        String accessTokenForOriginZoneUser = performJWTBearerGrantForJWT(targetZone, originZoneIdToken);
+        Map<String, Object> originUserClaims = JwtTokenUtils.getClaimsForToken(accessTokenForOriginZoneUser);
+
+        //Verify values for new shadow user set
+        ScimUser originShadowUser = getScimUser(originUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
+        assertEquals(originShadowUser.getUserName(), originUserClaims.get("user_name"));
+        assertEquals(originShadowUser.getExternalId(), originUser.getId());
+
+        //JWT Bearer with token from target Zone and external User
+        performJWTBearerGrantForJWT(targetZone, accessTokenForOriginZoneUser);
+
+        //Verify username and External ID not changed after this internal grant
+        ScimUser originShadowUserAfterExchange = getScimUser(originUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
+        assertEquals(originShadowUser.getUserName(), originShadowUserAfterExchange.getUserName());
+        assertEquals(originShadowUser.getExternalId(), originShadowUserAfterExchange.getExternalId());
+    }
+
+    @Test
+    void default_zone_jwt_grant_user_update_same_zone_with_registration() throws Exception {
+        BaseClientDetails targetZoneClient = new BaseClientDetails(generator.generate(), "", "openid", "password",
+                null);
+        targetZoneClient.setClientSecret(SECRET);
+        String subdomain = generator.generate().toLowerCase();
+        IdentityZone targetZone = MockMvcUtils.createOtherIdentityZoneAndReturnResult(subdomain,
+                mockMvc,
+                webApplicationContext,
+                targetZoneClient,
+                false, IdentityZoneHolder.getCurrentZoneId()).getIdentityZone();
+        ScimUser targetZoneUser = createUser(targetZone);
+
+        String originZoneOriginKey = createOIDCProvider(targetZone,
+                getTokenVerificationKey(targetZone),
+                "http://" + targetZone.getSubdomain() + ".localhost:8080/uaa/oauth/token",
+                targetZoneClient.getClientId()).getOriginKey();
+
+        String targetZoneIdToken = getUaaIdToken(targetZone, targetZoneClient, targetZoneUser);
+        String accessTokenForTargetZoneUser = performJWTBearerGrantForJWT(targetZone, targetZoneIdToken);
+
+        Map<String, Object> targetUserClaims = JwtTokenUtils.getClaimsForToken(accessTokenForTargetZoneUser);
+
+        //Verify shadow user of same-zone Idp created
+        ScimUser originShadowUser = getScimUser(targetZoneUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
+        assertEquals(originShadowUser.getUserName(), targetUserClaims.get("user_name"));
+        assertEquals(originShadowUser.getExternalId(), targetZoneUser.getId());
+
+        //JWT Bearer with token from target Zone and shadow user of registered IdP (with same issuer)
+        performJWTBearerGrantForJWT(targetZone, accessTokenForTargetZoneUser);
+
+        //Verify username and External ID changed after this internal grant (as they are updated values of registered issuer)
+        ScimUser originShadowUserAfterExchange = getScimUser(targetZoneUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
+        assertEquals(originShadowUserAfterExchange.getUserName(), targetUserClaims.get("user_name"));
+        assertEquals(originShadowUserAfterExchange.getExternalId(), targetUserClaims.get("sub"));
     }
 
     @Test
@@ -164,11 +248,39 @@ public class JwtBearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
             .andDo(print());
     }
 
-    void createProvider(IdentityZone theZone, String verificationKey) throws Exception {
-        createOIDCProvider(theZone,
+    private String performJWTBearerGrantForJWT(IdentityZone theZone, String assertion) throws Exception {
+        ClientDetails client = createJwtBearerClient(theZone);
+
+        MockHttpServletRequestBuilder jwtBearerGrant = post("/oauth/token")
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .param("client_id", client.getClientId())
+                .param("client_secret", client.getClientSecret())
+                .param(GRANT_TYPE, GRANT_TYPE_JWT_BEARER)
+                .param(TokenConstants.REQUEST_TOKEN_FORMAT, TokenConstants.TokenFormat.JWT.getStringValue())
+                .param("response_type", "token id_token")
+                .param("scope", "openid")
+                .param("assertion", assertion);
+        if (hasText(theZone.getSubdomain())) {
+            jwtBearerGrant = jwtBearerGrant.header("Host", theZone.getSubdomain()+".localhost");
+        }
+        String tokenResponse = mockMvc.perform(jwtBearerGrant)
+                .andDo(print())
+                .andExpect(jsonPath("$.access_token").isNotEmpty())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Map<String, Object> tokenMap = JsonUtils.readValue(tokenResponse, Map.class);
+        String accessToken = (String) tokenMap.get("access_token");
+        return accessToken;
+    }
+
+    String createProvider(IdentityZone theZone, String verificationKey) throws Exception {
+        IdentityProvider idp = createOIDCProvider(theZone,
                 verificationKey,
                 "http://" + originZone.getIdentityZone().getSubdomain() + ".localhost:8080/uaa/oauth/token",
                 originClient.getClientId());
+        return idp.getOriginKey();
     }
 
     String getUaaIdToken(IdentityZone zone, ClientDetails client, ScimUser user) throws Exception {
@@ -205,6 +317,14 @@ public class JwtBearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
         } finally {
             IdentityZoneHolder.clear();
         }
+    }
+
+    private ScimUser getScimUser(String username, String origin, String zoneId) {
+        ScimUserProvisioning scimUserProvisioning = webApplicationContext.getBean(ScimUserProvisioning.class);
+
+        List<ScimUser> scimUsers = scimUserProvisioning.retrieveByUsernameAndOriginAndZone(username, origin, zoneId);
+        assertEquals(1, scimUsers.size());
+        return scimUsers.get(0);
     }
 
     ClientDetails createJwtBearerClient(IdentityZone zone) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantMockMvcTests.java
@@ -118,21 +118,21 @@ public class JwtBearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
         Map<String, Object> originUserClaims = JwtTokenUtils.getClaimsForToken(accessTokenForOriginZoneUser);
 
         //Verify values for new shadow user set
-        ScimUser originShadowUser = getScimUser(originUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
-        assertEquals(originShadowUser.getUserName(), originUserClaims.get("user_name"));
-        assertEquals(originShadowUser.getExternalId(), originUser.getId());
+        ScimUser shadowUser = getScimUser(originUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
+        assertEquals(shadowUser.getUserName(), originUserClaims.get("user_name"));
+        assertEquals(shadowUser.getExternalId(), originUser.getId());
 
         //JWT Bearer with token from target Zone and external User
         performJWTBearerGrantForJWT(targetZone, accessTokenForOriginZoneUser);
 
         //Verify username and External ID not changed after this internal grant
-        ScimUser originShadowUserAfterExchange = getScimUser(originUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
-        assertEquals(originShadowUser.getUserName(), originShadowUserAfterExchange.getUserName());
-        assertEquals(originShadowUser.getExternalId(), originShadowUserAfterExchange.getExternalId());
+        ScimUser shadowUserAfterExchange = getScimUser(originUser.getEmails().get(0).getValue(), originZoneOriginKey, targetZone.getId());
+        assertEquals(shadowUser.getUserName(), shadowUserAfterExchange.getUserName());
+        assertEquals(shadowUser.getExternalId(), shadowUserAfterExchange.getExternalId());
     }
 
     @Test
-    void default_zone_jwt_grant_user_update_same_zone_with_registration() throws Exception {
+    void non_default_zone_jwt_grant_user_update_same_zone_with_registration() throws Exception {
         BaseClientDetails targetZoneClient = new BaseClientDetails(generator.generate(), "", "openid", "password",
                 null);
         targetZoneClient.setClientSecret(SECRET);


### PR DESCRIPTION
Adresses #1529 

Fixes the described problem, that the JWT Bearer grant to exchange a token issued by the UAA against another token was not able to identify the user correctly, but was using a wrong username - resulting in a wrong username in the token and also in the updated database entry.

To fix the problem with the wrong username we add a mapping of the user_name claim to the internal representation of the UAA idp. With that the UAA will correctly identify the username in the given token as such. The other claims are already identified by default if contained in the token.

To prevent any updates to the database (e.g. by the changed externalId, which usually is not contained in the token and defaults to "sub") - any update of the entry is blocked, if this we recognize a that it is JWT Bearer with an UAA token (basically repeating the check that is already done earlier - unfortunately there is no possibility to pass this information forward, due to the interfaces implemented here)

The scenario was already covered by tests, but those tests were mocking the "sub" attribute of a UAA token as username, while "sub" is really the userid and only the user_name claim contains the username in UAA tokens. So it the problem was not visible in the tests. I adopted the tests to mock the uaa token correctly and now it is covered by the tests.