### PR TITLE
Allow to use Account Chooser without Idp Discovery

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -70,6 +70,7 @@ import javax.servlet.http.HttpSession;
 import java.awt.*;
 import java.io.IOException;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.security.Principal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
@@ -278,12 +279,17 @@ public class LoginInfoEndpoint {
         boolean discoveryEnabled = IdentityZoneHolder.get().getConfig().isIdpDiscoveryEnabled();
         boolean discoveryPerformed = Boolean.parseBoolean(request.getParameter("discoveryPerformed"));
         String defaultIdentityProviderName = IdentityZoneHolder.get().getConfig().getDefaultIdentityProvider();
+        if (defaultIdentityProviderName != null) {
+            model.addAttribute("defaultIdpName", defaultIdentityProviderName);
+        }
         boolean accountChooserEnabled = IdentityZoneHolder.get().getConfig().isAccountChooserEnabled();
         boolean otherAccountSignIn = Boolean.parseBoolean(request.getParameter("otherAccountSignIn"));
         boolean savedAccountsEmpty = getSavedAccounts(request.getCookies(), SavedAccountOption.class).isEmpty();
         boolean accountChooserNeeded = accountChooserEnabled
                 && !(otherAccountSignIn || savedAccountsEmpty)
                 && !discoveryPerformed;
+        boolean newLoginPageEnabled = accountChooserEnabled || discoveryEnabled;
+
 
         String loginHintParam = extractLoginHintParam(session, request);
         UaaLoginHint uaaLoginHint = UaaLoginHint.parseRequestParameter(loginHintParam);
@@ -354,7 +360,7 @@ public class LoginInfoEndpoint {
                 oauthIdentityProviders, allIdentityProviders, allowedIdentityProviderKeys, loginHintParam, uaaLoginHint, loginHintProviders);
 
         idpForRedirect = evaluateIdpDiscovery(model, samlIdentityProviders, oauthIdentityProviders,
-                allIdentityProviders, allowedIdentityProviderKeys, idpForRedirect, discoveryEnabled, discoveryPerformed, defaultIdentityProviderName);
+                allIdentityProviders, allowedIdentityProviderKeys, idpForRedirect, discoveryPerformed, newLoginPageEnabled, defaultIdentityProviderName);
         if (idpForRedirect == null && !jsonResponse && !fieldUsernameShow && allIdentityProviders.size() == 1) {
             idpForRedirect = allIdentityProviders.entrySet().stream().findAny().get();
         }
@@ -399,7 +405,7 @@ public class LoginInfoEndpoint {
                 excludedPrompts, returnLoginPrompts);
 
         if (principal == null) {
-            return getUnauthenticatedRedirect(model, request, discoveryEnabled, discoveryPerformed, accountChooserNeeded);
+            return getUnauthenticatedRedirect(model, request, discoveryEnabled, discoveryPerformed, accountChooserNeeded ,accountChooserEnabled);
         }
         return "home";
     }
@@ -409,13 +415,13 @@ public class LoginInfoEndpoint {
             HttpServletRequest request,
             boolean discoveryEnabled,
             boolean discoveryPerformed,
-            boolean accountChooserNeeded
+            boolean accountChooserNeeded,
+            boolean accountChooserEnabled
     ) {
         String formRedirectUri = request.getParameter(UaaSavedRequestAwareAuthenticationSuccessHandler.FORM_REDIRECT_PARAMETER);
         if (hasText(formRedirectUri)) {
             model.addAttribute(UaaSavedRequestAwareAuthenticationSuccessHandler.FORM_REDIRECT_PARAMETER, formRedirectUri);
         }
-
         if (discoveryEnabled) {
             if (accountChooserNeeded) {
                 return "idp_discovery/account_chooser";
@@ -424,6 +430,21 @@ public class LoginInfoEndpoint {
                 return "idp_discovery/email";
             }
             return goToPasswordPage(request.getParameter("email"), model);
+        }
+        if (accountChooserNeeded) {
+            return "idp_discovery/account_chooser";
+        }
+        if (accountChooserEnabled) {
+            if (model.containsAttribute("login_hint")) {
+                return goToPasswordPage(request.getParameter("email"), model);
+            }
+            if (model.containsAttribute("error")) {
+                return "idp_discovery/account_chooser";
+            }
+            if (discoveryPerformed) {
+                return goToPasswordPage(request.getParameter("email"), model);
+            }
+            return "idp_discovery/origin";
         }
         return "login";
     }
@@ -485,11 +506,11 @@ public class LoginInfoEndpoint {
             Map<String, AbstractIdentityProviderDefinition> allIdentityProviders,
             List<String> allowedIdentityProviderKeys,
             Map.Entry<String, AbstractIdentityProviderDefinition> idpForRedirect,
-            boolean discoveryEnabled,
             boolean discoveryPerformed,
+            boolean newLoginPageEnabled,
             String defaultIdentityProviderName
     ) {
-        if (idpForRedirect == null && (discoveryPerformed || !discoveryEnabled) && defaultIdentityProviderName != null && !model.containsAttribute("login_hint")) { //Default set, no login_hint given, discovery disabled or performed
+        if (idpForRedirect == null && (discoveryPerformed || !newLoginPageEnabled) && defaultIdentityProviderName != null && !model.containsAttribute("login_hint") && !model.containsAttribute("error")) { //Default set, no login_hint given, no error, discovery performed
             if (!OriginKeys.UAA.equals(defaultIdentityProviderName) && !OriginKeys.LDAP.equals(defaultIdentityProviderName)) {
                 if (allIdentityProviders.containsKey(defaultIdentityProviderName)) {
                     idpForRedirect =
@@ -758,6 +779,16 @@ public class LoginInfoEndpoint {
         }
         return null;
     }
+
+    @RequestMapping(value = "/origin-chooser", method = RequestMethod.POST)
+    public String loginUsingOrigin(@RequestParam(required = false, name = "login_hint") String loginHint, Model model, HttpSession session, HttpServletRequest request) {
+        if (!StringUtils.hasText(loginHint)) {
+            return "redirect:/login?discoveryPerformed=true";
+        }
+        UaaLoginHint uaaLoginHint = new UaaLoginHint(loginHint);
+        return "redirect:/login?discoveryPerformed=true&login_hint=" + URLEncoder.encode(uaaLoginHint.toString(), UTF_8);
+    }
+
 
     @RequestMapping(value = "/login/idp_discovery", method = RequestMethod.POST)
     public String discoverIdentityProvider(@RequestParam String email, @RequestParam(required = false) String skipDiscovery, @RequestParam(required = false, name = "login_hint") String loginHint,  @RequestParam(required = false, name = "username") String username,Model model, HttpSession session, HttpServletRequest request) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -322,6 +322,11 @@ public class LoginInfoEndpoint {
                 allIdentityProviders.putAll(samlIdentityProviders);
                 allIdentityProviders.putAll(oauthIdentityProviders);
             }
+        } else if (!jsonResponse && (accountChooserNeeded || (accountChooserEnabled && !discoveryEnabled && !discoveryPerformed))) {
+            // when `/login` is requested to return html response (as opposed to json response)
+            //Account and origin chooser do not need idp information
+            oauthIdentityProviders = Collections.emptyMap();
+            samlIdentityProviders = Collections.emptyMap();
         } else {
             samlIdentityProviders = getSamlIdentityProviderDefinitions(allowedIdentityProviderKeys);
             oauthIdentityProviders = getOauthIdentityProviderDefinitions(allowedIdentityProviderKeys);
@@ -422,17 +427,14 @@ public class LoginInfoEndpoint {
         if (hasText(formRedirectUri)) {
             model.addAttribute(UaaSavedRequestAwareAuthenticationSuccessHandler.FORM_REDIRECT_PARAMETER, formRedirectUri);
         }
+        if (accountChooserNeeded) {
+            return "idp_discovery/account_chooser";
+        }
         if (discoveryEnabled) {
-            if (accountChooserNeeded) {
-                return "idp_discovery/account_chooser";
-            }
             if (!discoveryPerformed) {
                 return "idp_discovery/email";
             }
             return goToPasswordPage(request.getParameter("email"), model);
-        }
-        if (accountChooserNeeded) {
-            return "idp_discovery/account_chooser";
         }
         if (accountChooserEnabled) {
             if (model.containsAttribute("login_hint")) {

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -270,6 +270,7 @@
         <intercept-url pattern="/login/mfa/**" access="isFullyAuthenticated()"/>
         <intercept-url pattern="/create_account*" access="isAnonymous()"/>
         <intercept-url pattern="/login/idp_discovery/**" access="isAnonymous()"/>
+        <intercept-url pattern="/origin-chooser" access="isAnonymous()"/>
         <intercept-url pattern="/login**" access="isAnonymous() or isFullyAuthenticated()"/>
         <intercept-url pattern="/**" access="isFullyAuthenticated()"/>
         <security:custom-filter before="FIRST" ref="metadataGeneratorFilter"/>

--- a/server/src/main/resources/templates/web/idp_discovery/origin.html
+++ b/server/src/main/resources/templates/web/idp_discovery/origin.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorator="layouts/pui-account-discovery-main">
+<div layout:fragment="page-content">
+    <h4 class="txt-c pbxxl ptxl">
+        Choose your identity provider
+    </h4>
+    <div class="form-group">
+        <form action="/origin-chooser" th:action="@{/origin-chooser}" method="post" role="form">
+            <input th:name="login_hint"
+                   th:type="hidden"
+                   class="form-control" style="margin-top:20px"/>
+            <input type="submit" th:if="${defaultIdpName}" value="Sign in with default identity provider" class="btn btn-highlight btn-block btn-lg" style="margin-top:20px"/>
+        </form>
+        <hr th:if="${defaultIdpName}" class="divider-alternate-1"/>
+        <form action="/origin-chooser" th:action="@{/origin-chooser}" method="post" role="form">
+            <input th:name="login_hint"
+                   th:type="text"
+                   class="form-control" placeholder="Enter the origin key of your identity provider" style="margin-top:20px"/>
+            <input type="submit" value="Sign in with alternative identity provider" class="btn btn-highlight btn-block btn-lg" style="margin-top:20px"/>
+        </form>
+    </div>
+    <th:block th:if="${linkCreateAccountShow}">
+        <hr class="divider-alternate-1"/>
+        <div class="addl-actions txt-c mtl">
+            <div class="action">
+                <a th:unless="${#strings.isEmpty(links['createAccountLink'])}" href="/create_account" th:href="@{${links['createAccountLink']}}">Create account</a>
+            </div>
+        </div>
+    </th:block>
+</div>
+</html>

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -100,6 +100,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -1220,6 +1221,8 @@ class LoginInfoEndpointTests {
         String redirect = endpoint.loginForHtml(extendedModelMap, null, mockHttpServletRequest, Collections.singletonList(MediaType.TEXT_HTML));
 
         assertEquals("idp_discovery/account_chooser", redirect);
+        verify(mockIdentityProviderProvisioning, times(0)).retrieveAll(eq(true), anyString());
+        verify(mockSamlIdentityProviderConfigurator, times(0)).getIdentityProviderDefinitions(any(), any());
     }
 
     @Test
@@ -1619,6 +1622,8 @@ class LoginInfoEndpointTests {
         String redirect = endpoint.loginForHtml(extendedModelMap, null, mockHttpServletRequest, singletonList(MediaType.TEXT_HTML));
 
         assertEquals("idp_discovery/origin", redirect);
+        verify(mockIdentityProviderProvisioning, times(0)).retrieveAll(eq(true), anyString());
+        verify(mockSamlIdentityProviderConfigurator, times(0)).getIdentityProviderDefinitions(any(), any());
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointDocs.java
@@ -90,7 +90,7 @@ class IdentityZoneEndpointDocs extends EndpointDocs {
     private static final String PROMPTS_TYPE_DESC = "What kind of field this is (e.g. text or password)";
     private static final String PROMPTS_TEXT_DESC = "Actual text displayed on prompt for field";
     private static final String IDP_DISCOVERY_ENABLED_FLAG = "IDP Discovery should be set to true if you have configured more than one identity provider for UAA. The discovery relies on email domain being set for each additional provider";
-    private static final String ACCOUNT_CHOOSER_ENABLED_FLAG = "This flag is required to enable account choosing functionality for IDP discovery page.";
+    private static final String ACCOUNT_CHOOSER_ENABLED_FLAG = "This flag enables the account choosing functionality. If idpDiscoveryEnabled is set to true in the config the IDP is chosen by discovery. Otherwise, the user can enter the IDP by providing the origin.";
     private static final String BRANDING_COMPANY_NAME_DESC = "This name is used on the UAA Pages and in account management related communication in UAA";
     private static final String BRANDING_PRODUCT_LOGO_DESC = "This is a base64Url encoded PNG image which will be used as the logo on all UAA pages like Login, Sign Up etc.";
     private static final String BRANDING_SQUARE_LOGO_DESC = "This is a base64 encoded PNG image which will be used as the favicon for the UAA pages";


### PR DESCRIPTION
Hi,

This PR is a proposal for #1345 

As described there it allows to use the account chooser page without the idp discovery - which is not possible until now.
The PR introduces the page to choose the origin as it is proposed by the linked issue - the only difference being that instead of the field for the origin value being pre-filled with the value of the default identity provider (if it is configured) - the default identity provider now has a separate button, that can be used to sign in with the default idp without any further input. 

All of the currently supported configurations of account chooser and idp discovery remain as they are - only the currently unsupported combination of using only the account chooser, will now work with the described behavior.

We are happy to get your feedback on this new functionality. 
