### PR TITLE
Performance optimation: Prevent expensive duplicate key exception and use upsert instead

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/JdbcRevocableTokenProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/JdbcRevocableTokenProvisioning.java
@@ -63,7 +63,7 @@ public class JdbcRevocableTokenProvisioning implements RevocableTokenProvisionin
         return null;
     }
 
-    private boolean exits(String id, boolean checkExpired, String zoneId) {
+    private boolean exists(String id, boolean checkExpired, String zoneId) {
         if (checkExpired) {
             checkExpired();
         }
@@ -98,7 +98,7 @@ public class JdbcRevocableTokenProvisioning implements RevocableTokenProvisionin
     }
 
     public void createIfNotExists(RevocableToken t, String zoneId) {
-        if (exits(t.getTokenId(), true, zoneId)) {
+        if (exists(t.getTokenId(), true, zoneId)) {
             return;
         }
         template.update(INSERT_QUERY,
@@ -148,7 +148,7 @@ public class JdbcRevocableTokenProvisioning implements RevocableTokenProvisionin
     }
 
     public void upsert(String id, RevocableToken t, String zoneId) {
-        if (exits(t.getTokenId(), true, zoneId)) {
+        if (exists(t.getTokenId(), true, zoneId)) {
             template.update(UPDATE_QUERY, // NOSONAR
                     t.getClientId(),
                     t.getUserId(),

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/JdbcRevocableTokenProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/JdbcRevocableTokenProvisioning.java
@@ -29,6 +29,7 @@ public class JdbcRevocableTokenProvisioning implements RevocableTokenProvisionin
     private static final String SELECT = "SELECT ";
     private static final String FROM = " FROM ";
     private final static String GET_QUERY = "SELECT " + FIELDS + " FROM " + TABLE + " WHERE token_id=? AND identity_zone_id=?";
+    private final static String GET_COUNT_QUERY = "SELECT COUNT(*) FROM " + TABLE + " WHERE token_id=? AND identity_zone_id=?";
     private final static String GET_BY_USER_QUERY = "SELECT " + FIELDS + " FROM " + TABLE + " WHERE user_id=? AND identity_zone_id=?";
     private final static String GET_BY_CLIENT_QUERY = "SELECT " + FIELDS + " FROM " + TABLE + " WHERE client_id=? AND identity_zone_id=?";
     private final static String UPDATE_QUERY = "UPDATE " + TABLE + " SET " + UPDATE_FIELDS + " WHERE token_id=? and identity_zone_id=?";
@@ -67,12 +68,8 @@ public class JdbcRevocableTokenProvisioning implements RevocableTokenProvisionin
         if (checkExpired) {
             checkExpired();
         }
-        List<String> idResults = template.queryForList(SELECT + " token_id " + FROM + TABLE + " WHERE token_id=? AND identity_zone_id=?",
-                String.class, id, zoneId);
-        if (idResults != null && idResults.size() == 1) {
-            return true;
-        }
-        return false;
+        Integer idResults = template.queryForObject(GET_COUNT_QUERY, Integer.class, id, zoneId);
+        return idResults != null && idResults == 1;
     }
 
     public RevocableToken retrieve(String id, boolean checkExpired, String zoneId) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/RevocableTokenProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/RevocableTokenProvisioning.java
@@ -26,6 +26,7 @@ public interface RevocableTokenProvisioning extends ResourceManager<RevocableTok
 
     List<RevocableToken> getClientTokens(String clientId, String zoneId);
 
+    void upsert(String id, RevocableToken t, String zoneId);
 
-
+    void createIfNotExists(RevocableToken t, String zoneId);
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
@@ -11,7 +11,6 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -145,7 +144,7 @@ public class JdbcScimGroupMembershipManager implements ScimGroupMembershipManage
         // first validate the supplied groupId, memberId
         validateRequest(groupId, member, zoneId);
         final String type = (member.getType() == null ? ScimGroupMember.Type.USER : member.getType()).toString();
-        if (exits(groupId, member.getMemberId(), zoneId)) {
+        if (exists(groupId, member.getMemberId(), zoneId)) {
             throw new MemberAlreadyExistsException(member.getMemberId() + " is already part of the group: " + groupId);
         }
         logger.debug("Associating group:" + groupId + " with member:" + member);
@@ -270,7 +269,7 @@ public class JdbcScimGroupMembershipManager implements ScimGroupMembershipManage
         return sgm;
     }
 
-    private boolean exits(String groupId, String memberId, String zoneId) {
+    private boolean exists(String groupId, String memberId, String zoneId) {
         List<String> idResults = jdbcTemplate.queryForList(GET_SINGLE_MEMBER_SQL, String.class, memberId, groupId, zoneId);
         if (idResults != null && idResults.size() == 1) {
             return true;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
@@ -45,7 +45,7 @@ public class JdbcScimGroupMembershipManager implements ScimGroupMembershipManage
 
     private static final String GET_MEMBER_SQL = String.format("select %s from %s where member_id=? and group_id=? and identity_zone_id=?", MEMBERSHIP_FIELDS, MEMBERSHIP_TABLE);
 
-    private static final String GET_SINGLE_MEMBER_SQL = String.format("select member_id from %s where member_id=? and group_id=? and identity_zone_id=?", MEMBERSHIP_TABLE);
+    private static final String GET_MEMBER_COUNT_SQL = String.format("select count(*) from %s where member_id=? and group_id=? and identity_zone_id=?", MEMBERSHIP_TABLE);
 
     private static final String DELETE_MEMBER_WITH_ORIGIN_SQL = String.format("delete from %s where member_id=? and origin = ? and identity_zone_id=?", MEMBERSHIP_TABLE);
 
@@ -270,11 +270,8 @@ public class JdbcScimGroupMembershipManager implements ScimGroupMembershipManage
     }
 
     private boolean exists(String groupId, String memberId, String zoneId) {
-        List<String> idResults = jdbcTemplate.queryForList(GET_SINGLE_MEMBER_SQL, String.class, memberId, groupId, zoneId);
-        if (idResults != null && idResults.size() == 1) {
-            return true;
-        }
-        return false;
+        Integer idResults = jdbcTemplate.queryForObject(GET_MEMBER_COUNT_SQL, Integer.class, memberId, groupId, zoneId);
+        return idResults != null && idResults == 1;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsService.java
@@ -76,6 +76,9 @@ public class MultitenantJdbcClientDetailsService extends MultitenantClientServic
     private static final String DEFAULT_SELECT_STATEMENT =
             BASE_FIND_STATEMENT + " where client_id = ? and identity_zone_id = ?";
 
+    private static final String SINGLE_SELECT_STATEMENT =
+            "select client_id from oauth_client_details where client_id = ? and identity_zone_id = ?";
+
     private static final String DEFAULT_INSERT_STATEMENT =
             "insert into oauth_client_details (" + CLIENT_FIELDS
                     + ", client_id, identity_zone_id, created_by) values (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
@@ -129,11 +132,18 @@ public class MultitenantJdbcClientDetailsService extends MultitenantClientServic
 
     @Override
     public void addClientDetails(ClientDetails clientDetails, String zoneId) throws ClientAlreadyExistsException {
-        try {
-            jdbcTemplate.update(DEFAULT_INSERT_STATEMENT, getInsertClientDetailsFields(clientDetails, zoneId));
-        } catch (DuplicateKeyException e) {
-            throw new ClientAlreadyExistsException("Client already exists: " + clientDetails.getClientId(), e);
+        if (exits(clientDetails.getClientId(), zoneId)) {
+            throw new ClientAlreadyExistsException("Client already exists: " + clientDetails.getClientId());
         }
+        jdbcTemplate.update(DEFAULT_INSERT_STATEMENT, getInsertClientDetailsFields(clientDetails, zoneId));
+    }
+
+    private boolean exits(String clientId, String zoneId) {
+        List<String> idResults = jdbcTemplate.queryForList(SINGLE_SELECT_STATEMENT, String.class, clientId, zoneId);
+        if (idResults != null && idResults.size() == 1) {
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsService.java
@@ -11,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -132,13 +131,13 @@ public class MultitenantJdbcClientDetailsService extends MultitenantClientServic
 
     @Override
     public void addClientDetails(ClientDetails clientDetails, String zoneId) throws ClientAlreadyExistsException {
-        if (exits(clientDetails.getClientId(), zoneId)) {
+        if (exists(clientDetails.getClientId(), zoneId)) {
             throw new ClientAlreadyExistsException("Client already exists: " + clientDetails.getClientId());
         }
         jdbcTemplate.update(DEFAULT_INSERT_STATEMENT, getInsertClientDetailsFields(clientDetails, zoneId));
     }
 
-    private boolean exits(String clientId, String zoneId) {
+    private boolean exists(String clientId, String zoneId) {
         List<String> idResults = jdbcTemplate.queryForList(SINGLE_SELECT_STATEMENT, String.class, clientId, zoneId);
         if (idResults != null && idResults.size() == 1) {
             return true;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
@@ -48,6 +48,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.stubbing.Answer;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.core.GrantedAuthority;
@@ -82,6 +83,7 @@ import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -256,6 +258,16 @@ public class CheckTokenEndpointTests {
                 String id = (String) invocation.getArguments()[0];
                 return tokenMap.get(id);
             });
+            doAnswer((Answer<Void>) invocation -> {
+                RevocableToken arg = (RevocableToken)invocation.getArguments()[1];
+                tokenMap.put(arg.getTokenId(), arg);
+                return null;
+            }).when(tokenProvisioning).upsert(anyString(), any(), anyString());
+            doAnswer((Answer<Void>) invocation -> {
+                RevocableToken arg = (RevocableToken)invocation.getArguments()[0];
+                tokenMap.put(arg.getTokenId(), arg);
+                return null;
+            }).when(tokenProvisioning).createIfNotExists(any(), anyString());
 
 
             requestParameters.put(TokenConstants.REQUEST_TOKEN_FORMAT, OPAQUE.getStringValue());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
@@ -151,7 +151,8 @@ public class DeprecatedUaaTokenServicesTests {
           true);
 
         ArgumentCaptor<RevocableToken> rt = ArgumentCaptor.forClass(RevocableToken.class);
-        verify(tokenProvisioning, times(2)).create(rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).upsert(anyString(), rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).createIfNotExists(rt.capture(), anyString());
         assertNotNull(rt.getAllValues());
         assertThat(rt.getAllValues().size(), equalTo(2));
         assertNotNull(rt.getAllValues().get(0));
@@ -176,7 +177,8 @@ public class DeprecatedUaaTokenServicesTests {
           true);
         ArgumentCaptor<RevocableToken> rt = ArgumentCaptor.forClass(RevocableToken.class);
         verify(tokenProvisioning, times(1)).deleteRefreshTokensForClientAndUserId("clientId", "userId", IdentityZoneHolder.get().getId());
-        verify(tokenProvisioning, times(2)).create(rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).upsert(anyString(), rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).createIfNotExists(rt.capture(), anyString());
         RevocableToken refreshToken = rt.getAllValues().get(1);
         assertEquals(RevocableToken.TokenType.REFRESH_TOKEN, refreshToken.getResponseType());
     }
@@ -194,7 +196,8 @@ public class DeprecatedUaaTokenServicesTests {
         ArgumentCaptor<RevocableToken> rt = ArgumentCaptor.forClass(RevocableToken.class);
         String currentZoneId = IdentityZoneHolder.get().getId();
         verify(tokenProvisioning, times(0)).deleteRefreshTokensForClientAndUserId(anyString(), anyString(), eq(currentZoneId));
-        verify(tokenProvisioning, times(2)).create(rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).upsert(anyString(), rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).createIfNotExists(rt.capture(), anyString());
         RevocableToken refreshToken = rt.getAllValues().get(1);
         assertEquals(RevocableToken.TokenType.REFRESH_TOKEN, refreshToken.getResponseType());
     }
@@ -312,7 +315,7 @@ public class DeprecatedUaaTokenServicesTests {
           false);
 
         ArgumentCaptor<RevocableToken> rt = ArgumentCaptor.forClass(RevocableToken.class);
-        verify(tokenProvisioning, times(1)).create(rt.capture(), anyString());
+        verify(tokenProvisioning, times(1)).createIfNotExists(rt.capture(), anyString());
         assertNotNull(rt.getAllValues());
         assertEquals(1, rt.getAllValues().size());
         assertEquals(RevocableToken.TokenType.REFRESH_TOKEN, rt.getAllValues().get(0).getResponseType());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenTestSupport.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenTestSupport.java
@@ -79,6 +79,7 @@ import static org.cloudfoundry.identity.uaa.user.UaaAuthority.USER_AUTHORITIES;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -238,6 +239,16 @@ public class TokenTestSupport {
         clientDetailsService.setClientDetailsStore(IdentityZoneHolder.get().getId(), clientDetailsMap);
 
         tokenProvisioning = mock(RevocableTokenProvisioning.class);
+        doAnswer((Answer<Void>) invocation -> {
+            RevocableToken arg = (RevocableToken)invocation.getArguments()[1];
+            tokens.put(arg.getTokenId(), arg);
+            return null;
+        }).when(tokenProvisioning).upsert(anyString(), any(), anyString());
+        doAnswer((Answer<Void>) invocation -> {
+            RevocableToken arg = (RevocableToken)invocation.getArguments()[0];
+            tokens.put(arg.getTokenId(), arg);
+            return null;
+        }).when(tokenProvisioning).createIfNotExists(any(), anyString());
         when(tokenProvisioning.create(any(), anyString())).thenAnswer((Answer<RevocableToken>) invocation -> {
             RevocableToken arg = (RevocableToken)invocation.getArguments()[0];
             tokens.put(arg.getTokenId(), arg);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManagerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManagerTests.java
@@ -9,6 +9,7 @@ import org.cloudfoundry.identity.uaa.resources.jdbc.LimitSqlAdapter;
 import org.cloudfoundry.identity.uaa.scim.ScimGroup;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupMember;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidScimResourceException;
+import org.cloudfoundry.identity.uaa.scim.exception.MemberAlreadyExistsException;
 import org.cloudfoundry.identity.uaa.scim.exception.MemberNotFoundException;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceNotFoundException;
 import org.cloudfoundry.identity.uaa.scim.test.TestUtils;
@@ -20,6 +21,7 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
 import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,6 +46,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -587,6 +590,17 @@ class JdbcScimGroupMembershipManagerTests {
         List<String> groupIds = groups.stream().map(ScimGroup::getId).collect(Collectors.toList());
         assertThat(groupIds, hasItem("g1"));
         assertThat(groupIds, hasItem("g2"));
+    }
+
+    @Test
+    public void canAddMultipleMembers() {
+        jdbcScimGroupMembershipManager.addMember("g1", new ScimGroupMember("m1", ScimGroupMember.Type.USER), uaaIdentityZone.getId());
+        try {
+            jdbcScimGroupMembershipManager.addMember("g1", new ScimGroupMember("m1", ScimGroupMember.Type.USER), uaaIdentityZone.getId());
+            Assertions.fail();
+        } catch (MemberAlreadyExistsException e) {
+            assertNotNull(e);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/event/IdentityZoneModifiedEventTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/event/IdentityZoneModifiedEventTest.java
@@ -49,15 +49,15 @@ public class IdentityZoneModifiedEventTest {
 
     @Test
     public void identityZoneCreated() {
-        evaluteZoneAuditData(IdentityZoneModifiedEvent.identityZoneCreated(zone));
+        evaluateZoneAuditData(IdentityZoneModifiedEvent.identityZoneCreated(zone));
     }
 
     @Test
     public void identityZoneModified() {
-        evaluteZoneAuditData(IdentityZoneModifiedEvent.identityZoneModified(zone));
+        evaluateZoneAuditData(IdentityZoneModifiedEvent.identityZoneModified(zone));
     }
 
-    public void evaluteZoneAuditData(IdentityZoneModifiedEvent event) {
+    public void evaluateZoneAuditData(IdentityZoneModifiedEvent event) {
         String s = event.getAuditEvent().getData();
         assertEquals(String.format(IdentityZoneModifiedEvent.dataFormat,
                                    zone.getId(),


### PR DESCRIPTION
Prevent duplicate key exception handling for insertion/update of recocable_tokens, group_membership, and oauth_client_details since these operations are expensive in regards of computation time. Instead, check if the respective entry already exists and use upsert mechanism if applicable.

This does not change the semantics existing functionalities.