### PR TITLE
fix: passcode prompt for json 

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -317,6 +317,7 @@ public class LoginInfoEndpoint {
                 allIdentityProviders.putAll(oauthIdentityProviders);
             }
         } else if (!jsonResponse && (accountChooserNeeded || (discoveryEnabled && !discoveryPerformed))) {
+            // when `/login` is requested to return html response (as opposed to json response)
             //Account Chooser and discovery do not need any IdP information
             oauthIdentityProviders = Collections.emptyMap();
             samlIdentityProviders = Collections.emptyMap();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -316,7 +316,7 @@ public class LoginInfoEndpoint {
                 allIdentityProviders.putAll(samlIdentityProviders);
                 allIdentityProviders.putAll(oauthIdentityProviders);
             }
-        } else if (accountChooserNeeded || (discoveryEnabled && !discoveryPerformed)) {
+        } else if (!jsonResponse && (accountChooserNeeded || (discoveryEnabled && !discoveryPerformed))) {
             //Account Chooser and discovery do not need any IdP information
             oauthIdentityProviders = Collections.emptyMap();
             samlIdentityProviders = Collections.emptyMap();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -910,6 +910,44 @@ class LoginInfoEndpointTests {
     }
 
     @Test
+    void passcode_prompt_present_whenThereIsAtleastOneActiveOauthProvider_stillWorksWithAccountChooser() throws Exception {
+        IdentityZoneHolder.get().getConfig().setAccountChooserEnabled(true);
+        LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
+
+        RawExternalOAuthIdentityProviderDefinition definition = new RawExternalOAuthIdentityProviderDefinition()
+                .setAuthUrl(new URL("http://auth.url"))
+                .setTokenUrl(new URL("http://token.url"));
+
+        IdentityProvider<AbstractExternalOAuthIdentityProviderDefinition> identityProvider = MultitenancyFixture.identityProvider("oauth-idp-alias", "uaa");
+        identityProvider.setConfig(definition);
+
+        when(mockIdentityProviderProvisioning.retrieveAll(anyBoolean(), anyString())).thenReturn(singletonList(identityProvider));
+        endpoint.infoForLoginJson(extendedModelMap, null, new MockHttpServletRequest("GET", "http://someurl"));
+
+        Map mapPrompts = (Map) extendedModelMap.get("prompts");
+        assertNotNull(mapPrompts.get("passcode"));
+    }
+
+    @Test
+    void passcode_prompt_present_whenThereIsAtleastOneActiveOauthProvider_stillWorksWithDiscovery() throws Exception {
+        IdentityZoneHolder.get().getConfig().setIdpDiscoveryEnabled(true);
+        LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
+
+        RawExternalOAuthIdentityProviderDefinition definition = new RawExternalOAuthIdentityProviderDefinition()
+                .setAuthUrl(new URL("http://auth.url"))
+                .setTokenUrl(new URL("http://token.url"));
+
+        IdentityProvider<AbstractExternalOAuthIdentityProviderDefinition> identityProvider = MultitenancyFixture.identityProvider("oauth-idp-alias", "uaa");
+        identityProvider.setConfig(definition);
+
+        when(mockIdentityProviderProvisioning.retrieveAll(anyBoolean(), anyString())).thenReturn(singletonList(identityProvider));
+        endpoint.infoForLoginJson(extendedModelMap, null, new MockHttpServletRequest("GET", "http://someurl"));
+
+        Map mapPrompts = (Map) extendedModelMap.get("prompts");
+        assertNotNull(mapPrompts.get("passcode"));
+    }
+
+    @Test
     void we_return_both_oauth_and_oidc_providers() throws Exception {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
 


### PR DESCRIPTION
This PR fixes a bug that we saw in the latest release and that was introduced by #1441 

When you configure the account chooser and/or idp discovery (in our case both of them are configured) and then retrieve the login info as json (as it is done by cf cli), the passcode prompt will be missing from the returned information. This results in an empty prompt shown by the cf cli, which is a bad experience for using the cli.

The cause of this problem is, that the prompt for passcode will be filtered out when no external idp is passed to populate prompts. But with the optimization from #1441 the list is always empty, as it is not needed for the login page. For html the passcode is always filtered from the prompts, so it does not make any difference there, but for the json this now makes a difference.

The proposed approach to fix this is to skip the optimization in case the info is retrieved for json - and keep everything as it is for html. I also added new test cases that now check that the passcode prompt is still included in the response for json even if either discovery or account chooser are activated. 