### PR TITLE
Additional test cases to verify that ldap bindSecret is not included …

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpointsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpointsTest.java
@@ -474,4 +474,22 @@ class IdentityProviderEndpointsTest {
         assertNull(((AbstractExternalOAuthIdentityProviderDefinition)deleteResponse
                 .getBody().getConfig()).getRelyingPartySecret());
     }
+
+    @Test
+    void testDeleteIdentityProviderResponseNotContainingBindPassword() {
+        String zoneId = IdentityZone.getUaaZoneId();
+        IdentityProvider identityProvider = getLdapDefinition();
+        when(mockIdentityProviderProvisioning.retrieve(
+                identityProvider.getId(), zoneId)).thenReturn(identityProvider);
+        identityProviderEndpoints.setApplicationEventPublisher(
+                mock(ApplicationEventPublisher.class));
+
+        // Verify that the response's config does not contain bindPassword
+        ResponseEntity<IdentityProvider> deleteResponse =
+                identityProviderEndpoints.deleteIdentityProvider(
+                        identityProvider.getId(), false);
+        assertEquals(HttpStatus.OK, deleteResponse.getStatusCode());
+        assertNull(((LdapIdentityProviderDefinition)deleteResponse
+                .getBody().getConfig()).getBindPassword());
+    }
 }


### PR DESCRIPTION
…in the response for the CVE issue where the delete-identity-provider response contained sensitive data #178139149