### PR TITLE
omit json-smart library

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,7 +11,9 @@ dependencies {
     implementation(libraries.javaxMail)
 
     implementation(libraries.jacksonDatabind)
-    implementation(libraries.jsonPath)
+    implementation(libraries.jsonPath) {
+        exclude(module: "json-smart")
+    }
     implementation(libraries.zxing)
     implementation(libraries.springBeans)
     implementation(libraries.springContext)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/JacksonObjectMapperConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/JacksonObjectMapperConfig.java
@@ -6,7 +6,6 @@ import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
 import com.jayway.jsonpath.spi.json.JsonProvider;
 import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.jayway.jsonpath.spi.mapper.MappingProvider;
-import org.springframework.context.annotation.Bean;
 
 import java.util.EnumSet;
 import java.util.Set;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/JacksonObjectMapperConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/JacksonObjectMapperConfig.java
@@ -1,0 +1,44 @@
+package org.cloudfoundry.identity.uaa.impl.config;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.json.JsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.jayway.jsonpath.spi.mapper.MappingProvider;
+import org.springframework.context.annotation.Bean;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+
+public class JacksonObjectMapperConfig {
+
+  private JacksonObjectMapperConfig() {
+  }
+
+  /*
+   * configures Jayway JsonPath parser to work with Jackson
+   */
+  public static void configureJsonPathForJackson() {
+      Configuration.setDefaults(new Configuration.Defaults() {
+      private final JsonProvider jsonProvider = new JacksonJsonProvider();
+      private final MappingProvider mappingProvider = new JacksonMappingProvider();
+
+      @Override
+      public JsonProvider jsonProvider() {
+        return jsonProvider;
+      }
+
+      @Override
+      public MappingProvider mappingProvider() {
+        return mappingProvider;
+      }
+
+      @Override
+      public Set<Option> options() {
+        return EnumSet.noneOf(Option.class);
+      }
+    });
+  }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/YamlServletProfileInitializer.java
@@ -86,6 +86,8 @@ public class YamlServletProfileInitializer implements ApplicationContextInitiali
             servletContext.addListener(publisher);
         }
 
+        JacksonObjectMapperConfig.configureJsonPathForJackson();
+
         WebApplicationContextUtils.initServletPropertySources(applicationContext.getEnvironment().getPropertySources(),
                 servletContext, applicationContext.getServletConfig());
 


### PR DESCRIPTION
fix CVE-2021-27568

Use SPI from https://github.com/json-path/JsonPath and set existing jackson library instead of minidev library
The used json-smart library brings uaa the CVE https://nvd.nist.gov/vuln/detail/CVE-2021-27568 but since json-path support other JSON parsers the solution should be to use exsiting library instead - without CVE