### PR TITLE
Add property option for mail.smtp.ssl.protocols

### DIFF
--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -452,7 +452,7 @@
             <props>
                 <prop key="mail.smtp.auth">${smtp.auth:false}</prop>
                 <prop key="mail.smtp.starttls.enable">${smtp.starttls:false}</prop>
-                <prop key="mail.smtp.ssl.protocols">${smtp.protocols:TLSv1.2}</prop>
+                <prop key="mail.smtp.ssl.protocols">${smtp.protocols:TLSv1.2 TLSv1.4}</prop>
             </props>
         </property>
     </bean>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -452,6 +452,7 @@
             <props>
                 <prop key="mail.smtp.auth">${smtp.auth:false}</prop>
                 <prop key="mail.smtp.starttls.enable">${smtp.starttls:false}</prop>
+                <prop key="mail.smtp.ssl.protocols">${smtp.protocols:TLSv1.2}</prop>
             </props>
         </property>
     </bean>


### PR DESCRIPTION
allow setting via YAML 
Default TLSv1.2 (best pratice for year 2021)