### PR TITLE
Add property option for mail.smtp.ssl.protocols

### DIFF
--- a/k8s/matchers/uaa_config_structs.go
+++ b/k8s/matchers/uaa_config_structs.go
@@ -61,10 +61,11 @@ type Database struct {
 }
 
 type Smtp struct {
-	Host        string `yaml:"host"`
-	Port        string `yaml:"port"`
-	Starttls    string `yaml:"starttls"`
-	FromAddress string `yaml:"from_address"`
+	Host         string `yaml:"host"`
+	Port         string `yaml:"port"`
+	Starttls     string `yaml:"starttls"`
+	FromAddress  string `yaml:"from_address"`
+        Sslprotocols string `yaml:"sslprotocols"`
 }
 
 type OauthClient struct {

--- a/k8s/matchers/uaa_config_structs.go
+++ b/k8s/matchers/uaa_config_structs.go
@@ -65,7 +65,7 @@ type Smtp struct {
 	Port         string `yaml:"port"`
 	Starttls     string `yaml:"starttls"`
 	FromAddress  string `yaml:"from_address"`
-        Sslprotocols string `yaml:"sslprotocols"`
+	Sslprotocols string `yaml:"sslprotocols"`
 }
 
 type OauthClient struct {

--- a/k8s/templates/uaa.lib.yml
+++ b/k8s/templates/uaa.lib.yml
@@ -23,6 +23,7 @@ smtp:
   port: #@ data.values.smtp.port
   starttls: #@ data.values.smtp.starttls
   from_address: #@ data.values.smtp.from_address
+  sslprotocols: #@ data.values.smtp.sslprotocols
 
 oauth:
   client:

--- a/k8s/templates/values/_values.yml
+++ b/k8s/templates/values/_values.yml
@@ -64,6 +64,7 @@ smtp:
   password: ~
   starttls: ~
   from_address: ~
+  sslprotocols: ~
 
 admin:
   client_secret: ~

--- a/k8s/test/config_map_test.go
+++ b/k8s/test/config_map_test.go
@@ -130,7 +130,7 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 					"smtp.port":         "smtp port",
 					"smtp.starttls":     "smtp starttls",
 					"smtp.from_address": "smtp from_address",
-                                        "smtp.sslprotocols": "smtp sslprotocols",
+					"smtp.sslprotocols": "smtp sslprotocols",
 					"issuer.uri":        "http://some.example.com/with/path",
 				})
 
@@ -149,7 +149,7 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 									"Host":         Equal("smtp host"),
 									"Port":         Equal("smtp port"),
 									"Starttls":     Equal("smtp starttls"),
-                                                                        "Sslprotocols": Equal("smtp sslprotocols"),
+									"Sslprotocols": Equal("smtp sslprotocols"),
 									"FromAddress":  Equal("smtp from_address"),
 								}),
 							})

--- a/k8s/test/config_map_test.go
+++ b/k8s/test/config_map_test.go
@@ -130,6 +130,7 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 					"smtp.port":         "smtp port",
 					"smtp.starttls":     "smtp starttls",
 					"smtp.from_address": "smtp from_address",
+                                        "smtp.sslprotocols": "smtp sslprotocols",
 					"issuer.uri":        "http://some.example.com/with/path",
 				})
 
@@ -145,10 +146,11 @@ logger.cfIdentity.appenderRef.uaaDefaultAppender.ref = UaaDefaultAppender`
 									"Url":      Equal("any other database connection string"),
 								}),
 								"Smtp": MatchFields(IgnoreExtras, Fields{
-									"Host":        Equal("smtp host"),
-									"Port":        Equal("smtp port"),
-									"Starttls":    Equal("smtp starttls"),
-									"FromAddress": Equal("smtp from_address"),
+									"Host":         Equal("smtp host"),
+									"Port":         Equal("smtp port"),
+									"Starttls":     Equal("smtp starttls"),
+                                                                        "Sslprotocols": Equal("smtp sslprotocols"),
+									"FromAddress":  Equal("smtp from_address"),
 								}),
 							})
 						}),

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -452,6 +452,7 @@
             <props>
                 <prop key="mail.smtp.auth">${smtp.auth:false}</prop>
                 <prop key="mail.smtp.starttls.enable">${smtp.starttls:false}</prop>
+                <prop key="mail.smtp.ssl.protocols">${smtp.sslprotocols:TLSv1.2}</prop>
             </props>
         </property>
     </bean>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -452,7 +452,6 @@
             <props>
                 <prop key="mail.smtp.auth">${smtp.auth:false}</prop>
                 <prop key="mail.smtp.starttls.enable">${smtp.starttls:false}</prop>
-                <prop key="mail.smtp.ssl.protocols">${smtp.protocols:TLSv1.2 TLSv1.4}</prop>
             </props>
         </property>
     </bean>


### PR DESCRIPTION
allow setting via YAML
Default TLSv1.2 (best pratice for year 2021)

Former test
Reverts cloudfoundry/uaa#1604

UAA Bosh Release
https://github.com/cloudfoundry/uaa-release/pull/305

