### PR TITLE
PKCE support in IDP (OIDC) proxy authorization flow

### DIFF
--- a/docs/okta-public-oidc-provider.md
+++ b/docs/okta-public-oidc-provider.md
@@ -1,0 +1,33 @@
+# Registering Okta as external, public OIDC provider in UAA
+
+Okta can be setup as an [OIDC provider](https://developer.okta.com/docs/guides/add-an-external-idp/openidconnect/configure-idp-in-okta/) for UAA login.
+In order to prevent storing a client secret in UAA configuration and all of it's successor problems like secret rotation and so on, register the
+external OIDC provider with a public client.
+
+1. Create an OIDC application and set it with [PKCE public](https://developer.okta.com/blog/2019/08/22/okta-authjs-pkce#use-pkce-to-make-your-apps-more-secure).
+   Register the "Redirect URIs" in the application section "OpenID Connect Configuration"
+
+   Add following URI in list field:
+   `http://{UAA_HOST}/login/callback/{origin}`. [Additional documentation for achieving this can be found here](https://developer.okta.com/docs/guides/implement-auth-code-pkce/overview/).
+   
+2. Copy client id.
+
+3. Minimal OIDC configuration needs to be added in login.ym.
+   Read configuration refer to 'https://<your-tenant>.okta.com/.well-known/openid-configuration' for discoveryUrl and issuer
+
+        login:
+          oauth:
+            providers:
+              okta.public:
+                type: oidc1.0
+                discoveryUrl: https://trailaccount.okta.com/.well-known/openid-configuration
+                issuer: https://trailaccount.okta.com
+                scopes:
+                  - openid
+                linkText: Login with Okta-Public
+                showLinkText: true
+                relyingPartyId: 0iak4aiaC4HV39L6g123
+
+4. Ensure that the scope `openid` is included in the`scopes` property.
+
+5. Restart UAA. You will see `Login with Okta-Public` link on your login page.

--- a/docs/sap-public-oidc-provider.md
+++ b/docs/sap-public-oidc-provider.md
@@ -1,0 +1,36 @@
+# Registering SAP IAS as external, public OIDC provider in UAA
+
+SAP IAS can be setup as an [OIDC provider](https://help.sap.com/viewer/6d6d63354d1242d185ab4830fc04feb1/Cloud/en-US/a789c9c8c0f5439da8c30b5d9e43bece.htm) for UAA login.
+In order to prevent storing a client secret in UAA configuration and all of it's successor problems like secret rotation and so on, register the
+external OIDC provider with a public client.
+
+1. Create an OIDC application and set it with [type public](https://help.sap.com/viewer/6d6d63354d1242d185ab4830fc04feb1/Cloud/en-US/a721157cd40544eb9bad40085cf8ec15.html).
+   Register the "Redirect URIs" in the application section "OpenID Connect Configuration"
+
+   Add following URI in list field:
+   `http://{UAA_HOST}/login/callback/{origin}`. [Additional documentation for achieving this can be found here](https://help.sap.com/viewer/6d6d63354d1242d185ab4830fc04feb1/Cloud/en-US/1ae324ee3b2d4a728650eb022d5fd910.html).
+   
+2. Copy client id.
+
+3. Minimal OIDC configuration needs to be added in login.ym.
+   Read configuration refer to '[https://<tenant ID>.accounts.ondemand.com/.well-known/openid-configuration](https://help.sap.com/viewer/6d6d63354d1242d185ab4830fc04feb1/Cloud/en-US/c297516bae4547eb82eeed80fea2b937.html)' for discoveryUrl and issuer
+
+        login:
+          oauth:
+            providers:
+              ias.public:
+                type: oidc1.0
+                discoveryUrl: https://trailaccount.accounts.ondemand.com/.well-known/openid-configuration
+                issuer: https://trailaccount.accounts.ondemand.com
+                scopes:
+                  - openid
+                  - email
+                  - profile
+                linkText: Login with IAS-Public
+                showLinkText: true
+                relyingPartyId: 3feb7ecb-d106-4432-b335-aca2689ad123
+
+4. Ensure that the scope `openid`, `email` and `profile` is included in the`scopes` property. Then UAA shadow user (if addShadowUserOnLogin=true) is created
+   with all properties. 
+
+5. Restart UAA. You will see `Login with IAS-Public` link on your login page.

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/pkce/verifiers/S256PkceVerifier.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/pkce/verifiers/S256PkceVerifier.java
@@ -28,18 +28,22 @@ public class S256PkceVerifier implements PkceVerifier {
         if (codeVerifier == null || codeChallenge == null) {
             return false;
         }
+        return codeChallenge.contentEquals(compute(codeVerifier));
+    }
+
+    public String compute(String codeVerifier) {
         try {
             byte[] bytes = codeVerifier.getBytes("US-ASCII");
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(bytes, 0, bytes.length);
             byte[] digest = md.digest();
-            return codeChallenge.contentEquals(Base64.encodeBase64URLSafeString(digest));
+            return Base64.encodeBase64URLSafeString(digest);
         } catch (UnsupportedEncodingException e) {
             logger.debug(e.getMessage(),e);
         } catch (NoSuchAlgorithmException e) {
-        	logger.debug(e.getMessage(),e);
+            logger.debug(e.getMessage(),e);
         }
-        return false;
+        return null;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthIdentityProviderConfigValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthIdentityProviderConfigValidator.java
@@ -46,10 +46,6 @@ public class ExternalOAuthIdentityProviderConfigValidator extends BaseIdentityPr
             errors.add("Relying Party Id must be the client-id for the UAA that is registered with the external IDP");
         }
 
-        /*if (!hasText(def.getRelyingPartySecret()) && !def.getResponseType().contains("token")) {
-            errors.add("Relying Party Secret must be the client-secret for the UAA that is registered with the external IDP");
-        }*/
-
         if (def.isShowLinkText() && !hasText(def.getLinkText())) {
             errors.add("Link Text must be specified because showLinkText is true");
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthIdentityProviderConfigValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthIdentityProviderConfigValidator.java
@@ -46,9 +46,9 @@ public class ExternalOAuthIdentityProviderConfigValidator extends BaseIdentityPr
             errors.add("Relying Party Id must be the client-id for the UAA that is registered with the external IDP");
         }
 
-        if (!hasText(def.getRelyingPartySecret()) && !def.getResponseType().contains("token")) {
+        /*if (!hasText(def.getRelyingPartySecret()) && !def.getResponseType().contains("token")) {
             errors.add("Relying Party Secret must be the client-secret for the UAA that is registered with the external IDP");
-        }
+        }*/
 
         if (def.isShowLinkText() && !hasText(def.getLinkText())) {
             errors.add("Link Text must be specified because showLinkText is true");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfigurator.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.provider.oauth;
 
-import org.cloudfoundry.identity.uaa.oauth.pkce.PkceVerifier;
 import org.cloudfoundry.identity.uaa.oauth.pkce.verifiers.S256PkceVerifier;
 import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
@@ -75,6 +74,8 @@ public class ExternalOAuthProviderConfigurator implements IdentityProviderProvis
                 .queryParam("redirect_uri", callbackUrl)
                 .queryParam("state", state);
 
+        // no client-secret, switch to PKCE and treat client as public, same logic is implemented in spring security
+        // https://docs.spring.io/spring-security/site/docs/5.3.1.RELEASE/reference/html5/#initiating-the-authorization-request
         if (definition.getRelyingPartySecret() == null) {
             var pkceVerifier = new S256PkceVerifier();
             var codeVerifier = generateCodeVerifier();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/SessionUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/SessionUtils.java
@@ -24,6 +24,7 @@ public final class SessionUtils {
     public static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
 
     private static final String EXTERNAL_OAUTH_STATE_ATTRIBUTE_PREFIX = "external-oauth-state-";
+    private static final String EXTERNAL_OAUTH_CODE_VERIFIER_ATTRIBUTE_PREFIX = "external-oauth-verifier-";
 
     private SessionUtils() {}
 
@@ -79,5 +80,9 @@ public final class SessionUtils {
 
     public static String stateParameterAttributeKeyForIdp(String idpOriginKey) {
         return EXTERNAL_OAUTH_STATE_ATTRIBUTE_PREFIX + idpOriginKey;
+    }
+
+    public static String codeVerifierParameterAttributeKeyForIdp(String idpOriginKey) {
+        return EXTERNAL_OAUTH_CODE_VERIFIER_ATTRIBUTE_PREFIX + idpOriginKey;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -425,6 +425,7 @@ class LoginInfoEndpointTests {
         when(idpConfig.getAuthUrl()).thenReturn(new URL("https://example.com/oauth/authorize"));
         when(idpConfig.getResponseType()).thenReturn("code");
         when(idpConfig.getRelyingPartyId()).thenReturn("clientid");
+        when(idpConfig.getRelyingPartySecret()).thenReturn("clientSecret");
         when(idpConfig.getUserPropagationParameter()).thenReturn("username");
         when(idp.getConfig()).thenReturn(idpConfig);
         when(mockIdentityProviderProvisioning.retrieveActive("uaa")).thenReturn(Collections.singletonList(idp));
@@ -904,6 +905,7 @@ class LoginInfoEndpointTests {
 
         definition.setAuthUrl(new URL("http://auth.url"));
         definition.setTokenUrl(new URL("http://token.url"));
+        definition.setRelyingPartySecret("client-secret");
 
         IdentityProvider<AbstractExternalOAuthIdentityProviderDefinition> identityProvider = MultitenancyFixture.identityProvider("oauth-idp-alias", "uaa");
         identityProvider.setConfig(definition);
@@ -1054,6 +1056,7 @@ class LoginInfoEndpointTests {
         AbstractExternalOAuthIdentityProviderDefinition mockOidcConfig = mock(OIDCIdentityProviderDefinition.class);
         when(mockOidcConfig.getAuthUrl()).thenReturn(new URL("http://localhost:8080/uaa"));
         when(mockOidcConfig.getRelyingPartyId()).thenReturn("client-id");
+        when(mockOidcConfig.getRelyingPartySecret()).thenReturn("client-secret");
         when(mockOidcConfig.getResponseType()).thenReturn("token");
         when(mockOidcConfig.getEmailDomain()).thenReturn(singletonList("example.com"));
         when(mockProvider.getConfig()).thenReturn(mockOidcConfig);
@@ -1856,6 +1859,7 @@ class LoginInfoEndpointTests {
         oidcIdentityProvider.setType(OriginKeys.OIDC10);
         OIDCIdentityProviderDefinition definition = new OIDCIdentityProviderDefinition();
         definition.setAuthUrl(new URL("https://" + originKey + ".com"));
+        definition.setRelyingPartySecret("client-secret");
         oidcIdentityProvider.setConfig(definition);
 
         return oidcIdentityProvider;
@@ -1879,6 +1883,7 @@ class LoginInfoEndpointTests {
         AbstractExternalOAuthIdentityProviderDefinition mockOidcConfig = mock(OIDCIdentityProviderDefinition.class);
         when(mockOidcConfig.getAuthUrl()).thenReturn(new URL("http://localhost:8080/uaa"));
         when(mockOidcConfig.getRelyingPartyId()).thenReturn("client-id");
+        when(mockOidcConfig.getRelyingPartySecret()).thenReturn("client-secret");
         when(mockOidcConfig.getResponseType()).thenReturn("token");
         when(mockProvider.getConfig()).thenReturn(mockOidcConfig);
         when(mockOidcConfig.isShowLinkText()).thenReturn(true);
@@ -1893,6 +1898,7 @@ class LoginInfoEndpointTests {
         AbstractExternalOAuthIdentityProviderDefinition mockOidcConfig = mock(OIDCIdentityProviderDefinition.class);
         when(mockOidcConfig.getAuthUrl()).thenReturn(new URL("http://localhost:8080/uaa"));
         when(mockOidcConfig.getRelyingPartyId()).thenReturn("client-id");
+        when(mockOidcConfig.getRelyingPartySecret()).thenReturn("client-secret");
         when(mockOidcConfig.getResponseType()).thenReturn("token");
         when(mockProvider.getConfig()).thenReturn(mockOidcConfig);
         when(mockOidcConfig.isShowLinkText()).thenReturn(true);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthIdentityProviderConfigValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthIdentityProviderConfigValidatorTest.java
@@ -59,7 +59,7 @@ public class ExternalOAuthIdentityProviderConfigValidatorTest {
         validator.validate(definition);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void configWithNullRelyingPartySecret_ThrowsException() {
         definition.setRelyingPartySecret(null);
         validator = new ExternalOAuthIdentityProviderConfigValidator();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -136,7 +136,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
             ATTRIBUTE_MAPPING_CUSTOM_ATTRIBUTES_DEPARTMENT
     };
 
-    private FieldDescriptor relyingPartySecret = fieldWithPath("config.relyingPartySecret").optional().type(STRING).description("The client secret of the relying party at the external OAuth provider. If not set, the external OAuth client is treated as public client, then the flow is protected with [PKCE](https://tools.ietf.org/html/rfc7636).");
+    private FieldDescriptor relyingPartySecret = fieldWithPath("config.relyingPartySecret").optional().type(STRING).description("The client secret of the relying party at the external OAuth provider. If not set, the external OAuth client is treated as public client, then the flow is protected with [PKCE](https://tools.ietf.org/html/rfc7636) using code challenge method `S256`.");
 
     private static InMemoryLdapServer ldapContainer;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -136,7 +136,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
             ATTRIBUTE_MAPPING_CUSTOM_ATTRIBUTES_DEPARTMENT
     };
 
-    private FieldDescriptor relyingPartySecret = fieldWithPath("config.relyingPartySecret").required().type(STRING).description("The client secret of the relying party at the external OAuth provider");
+    private FieldDescriptor relyingPartySecret = fieldWithPath("config.relyingPartySecret").optional().type(STRING).description("The client secret of the relying party at the external OAuth provider. If not set, the external OAuth client is treated as public client, then the flow is protected with [PKCE](https://tools.ietf.org/html/rfc7636).");
 
     private static InMemoryLdapServer ldapContainer;
 


### PR DESCRIPTION
use a simple switch , client_secret

no client-secret, switch to PKCE and treat client as public, same logic is implemented in spring security

https://docs.spring.io/spring-security/site/docs/5.3.1.RELEASE/reference/html5/#initiating-the-authorization-request

>> Public Clients are supported using Proof Key for Code Exchange (PKCE). If the client is running in an untrusted environment (eg. native application or web browser-based application) and therefore incapable of maintaining the confidentiality of it’s credentials, PKCE will automatically be used when the following conditions are true:

>> client-secret is omitted (or empty)

>> client-authentication-method is set to "none" (ClientAuthenticationMethod.NONE)

For UAA empty secret is still a secret, therefore we switch if secret parameter is null / omitted