### PR TITLE
Increase authorization code size

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -77,7 +77,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
 
     private final DataSource dataSource;
     private final long expirationTime;
-    private final RandomValueStringGenerator generator = new RandomValueStringGenerator(10);
+    private final RandomValueStringGenerator generator = new RandomValueStringGenerator(20);
     private final RowMapper rowMapper = new TokenCodeRowMapper();
 
     private final AtomicLong lastClean = new AtomicLong(0);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStoreTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStoreTests.java
@@ -321,6 +321,15 @@ class UaaTokenStoreTests {
         }
     }
 
+    @Test
+    void beOAuth2StandardCompliant() {
+        // oAuth 2.0 standard suggests 160 bits of randomness
+        // https://datatracker.ietf.org/doc/html/rfc6749#section-10.10
+        String code = store.createAuthorizationCode(clientAuthentication);
+        assertNotNull(code);
+        assertTrue(code.length() >= 20);
+    }
+
     public static class SameConnectionDataSource implements DataSource {
         private final Connection con;
 


### PR DESCRIPTION
Hi,

during internal tests we discovered that authorization codes issued by UAA don't meet the oAuth2.0 standard.
In particular, the [standard](https://datatracker.ietf.org/doc/html/rfc6749#section-10.10) requires 128 bits of randomness and suggests 160 bits of randomness, but UAA currently only uses 80 bits.

Therefore, we suggest to increase the size for the authorization codes from 10 to 20 characters.

Regards,
Jonas