### PR TITLE
fix: Bug with Origin chooser and allowed providers

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -380,7 +380,7 @@ public class LoginInfoEndpoint {
         }
 
         boolean linkCreateAccountShow = fieldUsernameShow;
-        if (fieldUsernameShow && (allowedIdentityProviderKeys != null) && (!discoveryEnabled || discoveryPerformed)) {
+        if (fieldUsernameShow && (allowedIdentityProviderKeys != null) && ((!discoveryEnabled && !accountChooserEnabled) || discoveryPerformed)) {
             if (!allowedIdentityProviderKeys.contains(OriginKeys.UAA)) {
                 linkCreateAccountShow = false;
                 model.addAttribute("login_hint", new UaaLoginHint(OriginKeys.LDAP).toString());


### PR DESCRIPTION
When we tested the origin chooser feature we recently contributed (configuration accountChooser: enabled, idpDiscovery: disabled) we found a bug in the new behavior:

When a client uses the allowedProviders configuration to restrict the possible identity providers and restricts the idps to either UAA or LDAP (but not both of them) - and some external providers, the user was redirected to the UAA login page instead of the origin chooser. 

We found this was due to a missing adoption in one of the many ifs in the LoginInfoEndpoint method that handles this request.

The tests did cover allowed providers, but unfortunately the combination of only UAA and some external Idps was not covered by the tests (it was always UAA+LDAP+External). So I added this combination and also other possible configurations of the allowed identity providers to check that with all of those configurations the origin chooser is returned and not some other page. But no other combination showed any problems. 