### PR TITLE
Add mfa default identity providers into bootstrap

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneValidator;
 import org.cloudfoundry.identity.uaa.zone.InvalidIdentityZoneDetailsException;
 import org.cloudfoundry.identity.uaa.zone.TokenPolicy;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -69,6 +70,9 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
     private IdentityZoneValidator validator = (config, mode) -> config;
     private Map<String, Object> branding;
 
+    @Value("#{'${login.mfa.identityProviders:uaa,ldap}'.split(',')}")
+    private List<String> mfaDefaultIdps;
+
     public void setValidator(IdentityZoneValidator validator) {
         this.validator = validator;
     }
@@ -92,6 +96,7 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         definition.setAccountChooserEnabled(accountChooserEnabled);
         definition.getMfaConfig().setEnabled(mfaEnabled);
         definition.getMfaConfig().setProviderName(mfaProviderName);
+        definition.getMfaConfig().setIdentityProviders(mfaDefaultIdps);
         definition.setDefaultIdentityProvider(defaultIdentityProvider);
 
         samlKeys = ofNullable(samlKeys).orElse(EMPTY_MAP);


### PR DESCRIPTION
Fixes issue #1648

Problem: uaa zone and related configuration options
need to be maintained in yaml file, e.g. uaa.yml

Add in uaa.yml under login section or
**login.mfa.identityProviders: uaa**
See https://github.com/cloudfoundry/uaa-release/blob/develop/spec/compare/all-properties-set-uaa.yml#L603-L611
Example:
```
  mfa:
    enabled: true
    providerName: myExampleProvider
    identityProviders: uaa
    providers:
      myExampleProvider:
        type: google-authenticator
        config:
          providerDescription: test google authenticator
          issuer: google
```

Value is string which is splitted into an array, default uaa,ldap.
```
login:
  mfa:
    identityProviders: uaa,ldap
```