### PR TITLE
support logout for OpenId proxy mode

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration.java
@@ -29,6 +29,9 @@ public class OpenIdConfiguration {
     @JsonProperty("jwks_uri")
     private String jwksUri;
 
+    @JsonProperty("end_session_endpoint")
+    private String logoutEndpoint;
+
     @JsonProperty("scopes_supported")
     private String[] scopes = new String[]{"openid", "profile", "email", "phone", "roles", "user_attributes"};
 
@@ -69,5 +72,6 @@ public class OpenIdConfiguration {
         this.tokenUrl = contextPath + "/oauth/token";
         this.userInfoUrl = contextPath + "/userinfo";
         this.jwksUri = contextPath + "/token_keys";
+        this.logoutEndpoint = contextPath + "/logout.do";
     }
 }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractExternalOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractExternalOAuthIdentityProviderDefinition.java
@@ -29,6 +29,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
     private URL tokenKeyUrl;
     private String tokenKey;
     private URL userInfoUrl;
+    private URL logoutUrl;
     private String linkText;
     private boolean showLinkText = true;
     private boolean clientAuthInBody = false;
@@ -82,6 +83,15 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
 
     public T setUserInfoUrl(URL userInfoUrl) {
         this.userInfoUrl = userInfoUrl;
+        return (T) this;
+    }
+
+    public URL getLogoutUrl() {
+        return logoutUrl;
+    }
+
+    public T setLogoutUrl(URL logoutUrl) {
+        this.logoutUrl = logoutUrl;
         return (T) this;
     }
 

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/account/OpenIdConfigurationTests.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/account/OpenIdConfigurationTests.java
@@ -32,6 +32,7 @@ class OpenIdConfigurationTests extends JsonTranslation<OpenIdConfiguration> {
         assertArrayEquals(new String[]{"RS256", "HS256"}, defaultConfig.getTokenEndpointAuthSigningValues());
         assertEquals("/uaa/userinfo", defaultConfig.getUserInfoUrl());
         assertEquals("/uaa/token_keys", defaultConfig.getJwksUri());
+        assertEquals("/uaa/logout.do", defaultConfig.getLogoutEndpoint());
         assertArrayEquals(new String[]{"openid", "profile", "email", "phone", "roles", "user_attributes"}, defaultConfig.getScopes());
         assertArrayEquals(new String[]{"code", "code id_token", "id_token", "token id_token"}, defaultConfig.getResponseTypes());
         assertArrayEquals(new String[]{"public"}, defaultConfig.getSubjectTypesSupported());

--- a/model/src/test/resources/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration-nulls.json
+++ b/model/src/test/resources/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration-nulls.json
@@ -6,6 +6,7 @@
   "token_endpoint_auth_signing_alg_values_supported": null,
   "userinfo_endpoint": null,
   "jwks_uri": null,
+  "end_session_endpoint": null,
   "scopes_supported": null,
   "response_types_supported": null,
   "subject_types_supported": null,

--- a/model/src/test/resources/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration.json
+++ b/model/src/test/resources/org/cloudfoundry/identity/uaa/account/OpenIdConfiguration.json
@@ -12,6 +12,7 @@
   ],
   "userinfo_endpoint": "<context path>/userinfo",
   "jwks_uri": "<context path>/token_keys",
+  "end_session_endpoint": "<context path>/logout.do",
   "scopes_supported": [
     "openid",
     "profile",

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/WhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/WhitelistLogoutHandler.java
@@ -64,7 +64,11 @@ public final class WhitelistLogoutHandler extends SimpleUrlLogoutSuccessHandler 
 
     @Override
     protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
-        String targetUrl = super.determineTargetUrl(request, response);
+        String targetUrl = request.getParameter("post_logout_redirect_uri");
+
+        if (targetUrl == null) {
+            targetUrl = super.determineTargetUrl(request, response);
+        }
 
         if(isInternalRedirect(targetUrl, request)) {
             return targetUrl;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
@@ -15,6 +15,7 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
 
+import org.cloudfoundry.identity.uaa.provider.oauth.ExernalOAuthLogoutHandler;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
@@ -29,14 +30,20 @@ import java.io.IOException;
 public class ZoneAwareWhitelistLogoutHandler implements LogoutSuccessHandler {
 
     private final MultitenantClientServices clientDetailsService;
+    private final ExernalOAuthLogoutHandler exernalOAuthLogoutHandler;
 
-    public ZoneAwareWhitelistLogoutHandler(MultitenantClientServices clientDetailsService) {
+    public ZoneAwareWhitelistLogoutHandler(MultitenantClientServices clientDetailsService, ExernalOAuthLogoutHandler exernalOAuthLogoutHandler) {
         this.clientDetailsService = clientDetailsService;
+        this.exernalOAuthLogoutHandler = exernalOAuthLogoutHandler;
     }
 
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        getZoneHandler().onLogoutSuccess(request, response, authentication);
+        if (exernalOAuthLogoutHandler.isExternalOAuthentication(authentication)) {
+            exernalOAuthLogoutHandler.onLogoutSuccess(request, response, authentication);
+        } else {
+            getZoneHandler().onLogoutSuccess(request, response, authentication);
+        }
     }
 
     protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
@@ -36,11 +36,7 @@ public class ZoneAwareWhitelistLogoutHandler implements LogoutSuccessHandler {
 
     public ZoneAwareWhitelistLogoutHandler(MultitenantClientServices clientDetailsService, ExernalOAuthLogoutHandler exernalOAuthLogoutHandler) {
         this.clientDetailsService = clientDetailsService;
-        if (exernalOAuthLogoutHandler != null) {
-            this.exernalOAuthLogoutHandler = exernalOAuthLogoutHandler;
-        } else {
-            this.exernalOAuthLogoutHandler = null;
-        }
+        this.exernalOAuthLogoutHandler = exernalOAuthLogoutHandler;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandler.java
@@ -33,6 +33,7 @@ public class ExernalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     this.oidcMetadataFetcher = oidcMetadataFetcher;
   }
 
+
   @Override
   protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
     AbstractExternalOAuthIdentityProviderDefinition oauthConfig = getOAuthProviderForAuthentication(authentication);
@@ -44,6 +45,10 @@ public class ExernalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
       return defaultUrl;
     }
 
+    return constructOAuthProviderLogoutUrl(request, logoutUrl, oauthConfig);
+  }
+
+  public String constructOAuthProviderLogoutUrl(HttpServletRequest request, String logoutUrl, AbstractExternalOAuthIdentityProviderDefinition oauthConfig) {
     StringBuffer oauthLogoutUriBuilder = request.getRequestURL();
     if (StringUtils.hasText(request.getQueryString())) {
       oauthLogoutUriBuilder.append("?");
@@ -58,16 +63,7 @@ public class ExernalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     return sb.toString();
   }
 
-  public boolean isExternalOAuthentication(Authentication authentication) {
-    if (authentication != null && authentication.getPrincipal() instanceof UaaPrincipal) {
-      UaaPrincipal principal = (UaaPrincipal) authentication.getPrincipal();
-      String origin = principal.getOrigin();
-      return !defaultOrigin.contains(origin);
-    }
-    return false;
-  }
-
-  private String getLogoutUrl(AbstractExternalOAuthIdentityProviderDefinition oAuthIdentityProviderDefinition) {
+  public String getLogoutUrl(AbstractExternalOAuthIdentityProviderDefinition oAuthIdentityProviderDefinition) {
     if (oAuthIdentityProviderDefinition != null && oAuthIdentityProviderDefinition.getLogoutUrl() != null) {
       return oAuthIdentityProviderDefinition.getLogoutUrl().toString();
     } else {
@@ -84,8 +80,8 @@ public class ExernalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     return null;
   }
 
-  private AbstractExternalOAuthIdentityProviderDefinition getOAuthProviderForAuthentication(Authentication authentication) {
-    if (isExternalOAuthentication(authentication)) {
+  public AbstractExternalOAuthIdentityProviderDefinition getOAuthProviderForAuthentication(Authentication authentication) {
+    if (isExternalAuthentication(authentication)) {
       UaaPrincipal principal = (UaaPrincipal) authentication.getPrincipal();
       String origin = principal.getOrigin();
       if (!defaultOrigin.contains(origin)) {
@@ -97,6 +93,15 @@ public class ExernalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
       }
     }
     return null;
+  }
+
+  private boolean isExternalAuthentication(Authentication authentication) {
+    if (authentication != null && authentication.getPrincipal() instanceof UaaPrincipal) {
+      UaaPrincipal principal = (UaaPrincipal) authentication.getPrincipal();
+      String origin = principal.getOrigin();
+      return !defaultOrigin.contains(origin);
+    }
+    return false;
   }
 
   private String getZoneDefaultUrl() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandler.java
@@ -1,0 +1,109 @@
+package org.cloudfoundry.identity.uaa.provider.oauth;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+
+public class ExernalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExernalOAuthLogoutHandler.class);
+
+  private final IdentityProviderProvisioning providerProvisioning;
+  private final OidcMetadataFetcher oidcMetadataFetcher;
+  private final Set<String> defaultOrigin = Set.of(OriginKeys.UAA, OriginKeys.LDAP);
+
+  public ExernalOAuthLogoutHandler(final IdentityProviderProvisioning providerProvisioning, final OidcMetadataFetcher oidcMetadataFetcher) {
+    this.providerProvisioning = providerProvisioning;
+    this.oidcMetadataFetcher = oidcMetadataFetcher;
+  }
+
+  @Override
+  protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+    AbstractExternalOAuthIdentityProviderDefinition oauthConfig = getOAuthProviderForAuthentication(authentication);
+    String logoutUrl = getLogoutUrl(oauthConfig);
+
+    if (logoutUrl == null) {
+      String defaultUrl = getZoneDefaultUrl();
+      LOGGER.warn(String.format("OAuth logout null, use default: %s", defaultUrl));
+      return defaultUrl;
+    }
+
+    StringBuffer oauthLogoutUriBuilder = request.getRequestURL();
+    if (StringUtils.hasText(request.getQueryString())) {
+      oauthLogoutUriBuilder.append("?");
+      oauthLogoutUriBuilder.append(request.getQueryString());
+    }
+    String oauthLogoutUri = URLEncoder.encode(oauthLogoutUriBuilder.toString(), StandardCharsets.UTF_8);
+    StringBuilder sb = new StringBuilder(logoutUrl);
+    sb.append("?post_logout_redirect_uri=");
+    sb.append(oauthLogoutUri);
+    sb.append("&client_id=");
+    sb.append(oauthConfig.getRelyingPartyId());
+    return sb.toString();
+  }
+
+  public boolean isExternalOAuthentication(Authentication authentication) {
+    if (authentication != null && authentication.getPrincipal() instanceof UaaPrincipal) {
+      UaaPrincipal principal = (UaaPrincipal) authentication.getPrincipal();
+      String origin = principal.getOrigin();
+      return !defaultOrigin.contains(origin);
+    }
+    return false;
+  }
+
+  private String getLogoutUrl(AbstractExternalOAuthIdentityProviderDefinition oAuthIdentityProviderDefinition) {
+    if (oAuthIdentityProviderDefinition != null && oAuthIdentityProviderDefinition.getLogoutUrl() != null) {
+      return oAuthIdentityProviderDefinition.getLogoutUrl().toString();
+    } else {
+      if (oAuthIdentityProviderDefinition instanceof OIDCIdentityProviderDefinition) {
+        OIDCIdentityProviderDefinition oidcIdentityProviderDefinition = (OIDCIdentityProviderDefinition) oAuthIdentityProviderDefinition;
+        try {
+          oidcMetadataFetcher.fetchMetadataAndUpdateDefinition(oidcIdentityProviderDefinition);
+          return oidcIdentityProviderDefinition.getLogoutUrl() != null ? oidcIdentityProviderDefinition.getLogoutUrl().toString() : null;
+        } catch (OidcMetadataFetchingException e) {
+          LOGGER.warn(e.getLocalizedMessage(), e);
+        }
+      }
+    }
+    return null;
+  }
+
+  private AbstractExternalOAuthIdentityProviderDefinition getOAuthProviderForAuthentication(Authentication authentication) {
+    if (isExternalOAuthentication(authentication)) {
+      UaaPrincipal principal = (UaaPrincipal) authentication.getPrincipal();
+      String origin = principal.getOrigin();
+      if (!defaultOrigin.contains(origin)) {
+        IdentityProvider identityProvider = providerProvisioning.retrieveByOrigin(origin, principal.getZoneId());
+        if (identityProvider != null && identityProvider.getConfig() instanceof AbstractExternalOAuthIdentityProviderDefinition && (
+            OriginKeys.OIDC10.equals(identityProvider.getType()) || OriginKeys.OAUTH20.equals(identityProvider.getType()))) {
+          return (AbstractExternalOAuthIdentityProviderDefinition) identityProvider.getConfig();
+        }
+      }
+    }
+    return null;
+  }
+
+  private String getZoneDefaultUrl() {
+    IdentityZoneConfiguration config = IdentityZoneHolder.get().getConfig();
+    if (config == null) {
+      config = new IdentityZoneConfiguration();
+    }
+    return config.getLinks().getLogout().getRedirectUrl();
+  }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -314,6 +314,10 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                 .collect(Collectors.toSet())
             );
         }
+        if (authentication.getAuthenticationMethods()==null) {
+            authentication.setAuthenticationMethods(new HashSet<>());
+        }
+        authentication.getAuthenticationMethods().add("oauth");
         super.populateAuthenticationAttributes(authentication, request, authenticationData);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadata.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadata.java
@@ -19,6 +19,9 @@ public class OidcMetadata {
     @JsonProperty("jwks_uri")
     private URL jsonWebKeysUri;
 
+    @JsonProperty("end_session_endpoint")
+    private URL logoutEndpoint;
+
     private String issuer;
 
     public URL getAuthorizationEndpoint() {
@@ -60,4 +63,8 @@ public class OidcMetadata {
     public void setIssuer(String issuer) {
         this.issuer = issuer;
     }
+
+    public URL getLogoutEndpoint() { return this.logoutEndpoint;   }
+
+    public void setLogoutEndpoint(URL logoutEndpoint) { this.logoutEndpoint = logoutEndpoint; }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadata.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadata.java
@@ -67,5 +67,4 @@ public class OidcMetadata {
     public URL getLogoutEndpoint() { return this.logoutEndpoint;   }
 
     public void setLogoutEndpoint(URL logoutEndpoint) { this.logoutEndpoint = logoutEndpoint; }
-
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadata.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadata.java
@@ -67,4 +67,5 @@ public class OidcMetadata {
     public URL getLogoutEndpoint() { return this.logoutEndpoint;   }
 
     public void setLogoutEndpoint(URL logoutEndpoint) { this.logoutEndpoint = logoutEndpoint; }
+
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
@@ -97,6 +97,7 @@ public class OidcMetadataFetcher {
         definition.setTokenKeyUrl(ofNullable(definition.getTokenKeyUrl()).orElse(oidcMetadata.getJsonWebKeysUri()));
         definition.setUserInfoUrl(ofNullable(definition.getUserInfoUrl()).orElse(oidcMetadata.getUserinfoEndpoint()));
         definition.setIssuer(ofNullable(definition.getIssuer()).orElse(oidcMetadata.getIssuer()));
+        definition.setLogoutUrl(ofNullable(definition.getLogoutUrl()).orElse(oidcMetadata.getLogoutEndpoint()));
     }
 
     private boolean shouldFetchMetadata(OIDCIdentityProviderDefinition definition) {

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -332,8 +332,15 @@
         <constructor-arg name="redirectNotLoggedIn" value="/login?error=invalid_login_request"/>
     </bean>
 
+    <bean id="externalOAuthLogoutHandler"
+          class="org.cloudfoundry.identity.uaa.provider.oauth.ExernalOAuthLogoutHandler">
+        <constructor-arg name="providerProvisioning" ref="externalOAuthProviderConfigurator"/>
+        <constructor-arg name="oidcMetadataFetcher" ref="oidcMetadataFetcher"/>
+    </bean>
+
     <bean id="logoutHandler" class="org.cloudfoundry.identity.uaa.authentication.ZoneAwareWhitelistLogoutHandler">
         <constructor-arg ref="jdbcClientDetailsService"/>
+        <constructor-arg ref="externalOAuthLogoutHandler"/>
     </bean>
 
     <!--<mvc:resources location="/" mapping="/**" />-->

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
@@ -14,6 +14,7 @@
 
 package org.cloudfoundry.identity.uaa.authentication;
 
+import org.cloudfoundry.identity.uaa.provider.oauth.ExernalOAuthLogoutHandler;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -40,6 +41,7 @@ public class ZoneAwareWhitelistLogoutHandlerTests {
     private MockHttpServletResponse response = new MockHttpServletResponse();
     private BaseClientDetails client = new BaseClientDetails(CLIENT_ID, "", "", "", "", "http://*.testing.com,http://testing.com");
     private MultitenantClientServices clientDetailsService =  mock(MultitenantClientServices.class);
+    private ExernalOAuthLogoutHandler oAuthLogoutHandler = mock(ExernalOAuthLogoutHandler.class);
     private ZoneAwareWhitelistLogoutHandler handler;
     IdentityZoneConfiguration configuration = new IdentityZoneConfiguration();
     IdentityZoneConfiguration original;
@@ -53,7 +55,7 @@ public class ZoneAwareWhitelistLogoutHandlerTests {
             .setDisableRedirectParameter(true)
             .setRedirectParameterName("redirect");
         when(clientDetailsService.loadClientByClientId(CLIENT_ID, "uaa")).thenReturn(client);
-        handler = new ZoneAwareWhitelistLogoutHandler(clientDetailsService);
+        handler = new ZoneAwareWhitelistLogoutHandler(clientDetailsService, oAuthLogoutHandler);
         IdentityZoneHolder.get().setConfig(configuration);
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandlerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandlerTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doThrow;
@@ -62,6 +63,7 @@ class ExernalOAuthLogoutHandlerTest {
     identityProvider.setConfig(oAuthIdentityProviderDefinition);
     when(providerProvisioning.retrieveByOrigin("test", "uaa")).thenReturn(identityProvider);
     when(uaaAuthentication.getPrincipal()).thenReturn(uaaPrincipal);
+    when(uaaAuthentication.getAuthenticationMethods()).thenReturn(Set.of("ext", "oauth"));
     when(uaaPrincipal.getOrigin()).thenReturn("test");
     when(uaaPrincipal.getZoneId()).thenReturn("uaa");
     oAuthLogoutHandler = new ExernalOAuthLogoutHandler(providerProvisioning, oidcMetadataFetcher);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandlerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExernalOAuthLogoutHandlerTest.java
@@ -1,0 +1,130 @@
+package org.cloudfoundry.identity.uaa.provider.oauth;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ExernalOAuthLogoutHandlerTest {
+
+  private MockHttpServletRequest request = new MockHttpServletRequest();
+  private MockHttpServletResponse response = new MockHttpServletResponse();
+  private IdentityProvider identityProvider;
+  private OIDCIdentityProviderDefinition oAuthIdentityProviderDefinition;
+  private IdentityProviderProvisioning providerProvisioning = mock(IdentityProviderProvisioning.class);
+  private OidcMetadataFetcher oidcMetadataFetcher = mock(OidcMetadataFetcher.class);
+  private UaaAuthentication uaaAuthentication = mock(UaaAuthentication.class);
+  private UaaPrincipal uaaPrincipal = mock(UaaPrincipal.class);
+
+  private ExernalOAuthLogoutHandler oAuthLogoutHandler = mock(ExernalOAuthLogoutHandler.class);
+  IdentityZoneConfiguration configuration = new IdentityZoneConfiguration();
+  IdentityZoneConfiguration original;
+  private final String uaa_endsession_url = "http://localhost:8080/uaa/logout.do";
+
+
+  @BeforeEach
+  public void setUp() throws MalformedURLException {
+    original = IdentityZone.getUaa().getConfig();
+    configuration.getLinks().getLogout()
+        .setRedirectUrl("/login")
+        .setDisableRedirectParameter(true)
+        .setRedirectParameterName("redirect");
+    identityProvider = new IdentityProvider();
+    identityProvider.setType(OriginKeys.OIDC10);
+    identityProvider.setOriginKey("test");
+    identityProvider.setId("id");
+    identityProvider.setName("name");
+    identityProvider.setActive(true);
+    oAuthIdentityProviderDefinition = new OIDCIdentityProviderDefinition();
+    oAuthIdentityProviderDefinition.setLogoutUrl(new URL(uaa_endsession_url));
+    oAuthIdentityProviderDefinition.setRelyingPartyId("id");
+    identityProvider.setConfig(oAuthIdentityProviderDefinition);
+    when(providerProvisioning.retrieveByOrigin("test", "uaa")).thenReturn(identityProvider);
+    when(uaaAuthentication.getPrincipal()).thenReturn(uaaPrincipal);
+    when(uaaPrincipal.getOrigin()).thenReturn("test");
+    when(uaaPrincipal.getZoneId()).thenReturn("uaa");
+    oAuthLogoutHandler = new ExernalOAuthLogoutHandler(providerProvisioning, oidcMetadataFetcher);
+    IdentityZoneHolder.get().setConfig(configuration);
+    SecurityContextHolder.getContext().setAuthentication(uaaAuthentication);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    IdentityZoneHolder.clear();
+    IdentityZone.getUaa().setConfig(original);
+    SecurityContextHolder.clearContext();
+    request.setQueryString(null);
+  }
+
+  @Test
+  void determineTargetUrl() {
+    request.setQueryString("parameter=value");
+    assertEquals("http://localhost:8080/uaa/logout.do?post_logout_redirect_uri=http%3A%2F%2Flocalhost%3Fparameter%3Dvalue&client_id=id",
+        oAuthLogoutHandler.determineTargetUrl(request, response, uaaAuthentication));
+  }
+
+  @Test
+  void determineDefaultTargetUrl() {
+    oAuthIdentityProviderDefinition.setLogoutUrl(null);
+    IdentityZoneHolder.get().setConfig(null);
+    assertEquals("/login",
+        oAuthLogoutHandler.determineTargetUrl(request, response, uaaAuthentication));
+  }
+
+  @Test
+  void constructOAuthProviderLogoutUrl() {
+    oAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, "", oAuthIdentityProviderDefinition);
+  }
+
+  @Test
+  void getLogoutUrl() throws OidcMetadataFetchingException {
+    assertEquals(uaa_endsession_url, oAuthLogoutHandler.getLogoutUrl(oAuthIdentityProviderDefinition));
+    verify(oidcMetadataFetcher, times(0)).fetchMetadataAndUpdateDefinition(oAuthIdentityProviderDefinition);
+  }
+
+  @Test
+  void getNewFetchedLogoutUrl() throws OidcMetadataFetchingException {
+    oAuthIdentityProviderDefinition.setLogoutUrl(null);
+    assertEquals(null, oAuthLogoutHandler.getLogoutUrl(oAuthIdentityProviderDefinition));
+    verify(oidcMetadataFetcher, times(1)).fetchMetadataAndUpdateDefinition(oAuthIdentityProviderDefinition);
+  }
+
+  @Test
+  void getNewInvalidFetchedLogoutUrl() throws OidcMetadataFetchingException {
+    oAuthIdentityProviderDefinition.setLogoutUrl(null);
+    doThrow(new OidcMetadataFetchingException("")).when(oidcMetadataFetcher).fetchMetadataAndUpdateDefinition(oAuthIdentityProviderDefinition);
+    assertEquals(null, oAuthLogoutHandler.getLogoutUrl(oAuthIdentityProviderDefinition));
+    verify(oidcMetadataFetcher, times(1)).fetchMetadataAndUpdateDefinition(oAuthIdentityProviderDefinition);
+  }
+
+  @Test
+  void getOAuthProviderForAuthentication() {
+    assertEquals(oAuthIdentityProviderDefinition, oAuthLogoutHandler.getOAuthProviderForAuthentication(uaaAuthentication));
+  }
+
+  @Test
+  void getNullOAuthProviderForAuthentication() {
+    assertEquals(null, oAuthLogoutHandler.getOAuthProviderForAuthentication(null));
+  }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -1076,7 +1076,7 @@ class ExternalOAuthAuthenticationManagerIT {
         claims.put("amr", Arrays.asList("mfa", "rba"));
         mockToken();
         UaaAuthentication authentication = (UaaAuthentication) externalOAuthAuthenticationManager.authenticate(xCodeToken);
-        assertThat(authentication.getAuthenticationMethods(), containsInAnyOrder("mfa", "rba", "ext"));
+        assertThat(authentication.getAuthenticationMethods(), containsInAnyOrder("mfa", "rba", "ext", "oauth"));
     }
 
     @Test


### PR DESCRIPTION
Feature description: https://openid.net/specs/openid-connect-session-1_0.html 

Support end_session_endpoint in own OIDC well-known configuration
Use end_session_endpoint from OIDC well-known configuration in Proxy Mode

Why: Support same logout (single logout) possibility SAML2 has. Needed for switching from SAML to OpenID connect scenarios. Almost all known Idp provide end_session_endpoint endpoint flow already.

Missing: id_token_hint in flow but use current parameter e.g. redirect_uri from zone and/or client and client_id
