### PR TITLE
Replace deprecated Mockito.verifyZeroInteractions on Mockito.verifyNoInteractions

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/BackwardsCompatibleTokenEndpointAuthenticationFilterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/BackwardsCompatibleTokenEndpointAuthenticationFilterTest.java
@@ -49,12 +49,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
 
@@ -126,8 +121,8 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
         filter.doFilter(request, response, chain);
         verify(filter, times(1)).attemptTokenAuthentication(same(request), same(response));
         verify(passwordAuthManager, times(1)).authenticate(any());
-        verifyZeroInteractions(samlAuthFilter);
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(samlAuthFilter);
+        verifyNoInteractions(externalOAuthAuthenticationManager);
     }
 
 
@@ -138,8 +133,8 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
         filter.doFilter(request, response, chain);
         verify(filter, times(1)).attemptTokenAuthentication(same(request), same(response));
         verify(samlAuthFilter, times(1)).attemptAuthentication(same(request), same(response));
-        verifyZeroInteractions(passwordAuthManager);
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(passwordAuthManager);
+        verifyNoInteractions(externalOAuthAuthenticationManager);
     }
 
     @Test
@@ -147,9 +142,9 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
         request.addParameter(GRANT_TYPE, GRANT_TYPE_SAML2_BEARER);
         filter.doFilter(request, response, chain);
         verify(filter, times(1)).attemptTokenAuthentication(same(request), same(response));
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
-        verifyZeroInteractions(passwordAuthManager);
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(passwordAuthManager);
+        verifyNoInteractions(externalOAuthAuthenticationManager);
         ArgumentCaptor<AuthenticationException> exceptionArgumentCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
         verify(entryPoint, times(1)).commence(same(request), same(response), exceptionArgumentCaptor.capture());
         assertNotNull(exceptionArgumentCaptor.getValue());
@@ -167,8 +162,8 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
         verify(filter, times(1)).attemptTokenAuthentication(same(request), same(response));
         ArgumentCaptor<ExternalOAuthCodeToken> authenticateData = ArgumentCaptor.forClass(ExternalOAuthCodeToken.class);
         verify(externalOAuthAuthenticationManager, times(1)).authenticate(authenticateData.capture());
-        verifyZeroInteractions(passwordAuthManager);
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(passwordAuthManager);
+        verifyNoMoreInteractions(externalOAuthAuthenticationManager);
         assertEquals(idToken, authenticateData.getValue().getIdToken());
         assertNull(authenticateData.getValue().getOrigin());
     }
@@ -178,9 +173,9 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
         request.addParameter(GRANT_TYPE, GRANT_TYPE_JWT_BEARER);
         filter.doFilter(request, response, chain);
         verify(filter, times(1)).attemptTokenAuthentication(same(request), same(response));
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
-        verifyZeroInteractions(passwordAuthManager);
-        verifyZeroInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(externalOAuthAuthenticationManager);
+        verifyNoInteractions(passwordAuthManager);
+        verifyNoInteractions(externalOAuthAuthenticationManager);
         ArgumentCaptor<AuthenticationException> exceptionArgumentCaptor = ArgumentCaptor.forClass(AuthenticationException.class);
         verify(entryPoint, times(1)).commence(same(request), same(response), exceptionArgumentCaptor.capture());
         assertNotNull(exceptionArgumentCaptor.getValue());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/BackwardsCompatibleTokenEndpointAuthenticationFilterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/BackwardsCompatibleTokenEndpointAuthenticationFilterTest.java
@@ -49,7 +49,13 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 public class BackwardsCompatibleTokenEndpointAuthenticationFilterTest {
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/CurrentUserCookieRequestFilterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/CurrentUserCookieRequestFilterTest.java
@@ -78,6 +78,6 @@ public class CurrentUserCookieRequestFilterTest {
         assertEquals("application/json", res.getContentType());
         assertThat(JsonUtils.readTree(res.getContentAsString()).get("error").textValue(), equalTo("current_user_cookie_error"));
         assertThat(JsonUtils.readTree(res.getContentAsString()).get("error_description").textValue(), equalTo("There was a problem while creating the Current-User cookie for user id user-guid"));
-        verifyZeroInteractions(filterChain);
+        verifyNoInteractions(filterChain);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeRequiredFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeRequiredFilterTests.java
@@ -36,7 +36,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 public class PasswordChangeRequiredFilterTests {
     private PasswordChangeRequiredFilter filter;
@@ -77,14 +77,14 @@ public class PasswordChangeRequiredFilterTests {
     public void password_change_required() throws Exception {
         SessionUtils.setPasswordChangeRequired(session, true);
         filter.doFilterInternal(request, response, chain);
-        verifyZeroInteractions(chain);
+        verifyNoInteractions(chain);
         verify(entryPoint, times(1)).commence(same(request), same(response), any(InteractionRequiredException.class));
     }
 
     @Test
     public void password_change_not_required() throws Exception {
         filter.doFilterInternal(request, response, chain);
-        verifyZeroInteractions(entryPoint);
+        verifyNoInteractions(entryPoint);
         verify(chain, times(1)).doFilter(same(request), same(response));
     }
 
@@ -92,7 +92,7 @@ public class PasswordChangeRequiredFilterTests {
     public void no_authentication() throws Exception {
         SecurityContextHolder.clearContext();
         filter.doFilterInternal(request, response, chain);
-        verifyZeroInteractions(entryPoint);
+        verifyNoInteractions(entryPoint);
         verify(chain, times(1)).doFilter(same(request), same(response));
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilterTest.java
@@ -33,7 +33,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(PollutionPreventionExtension.class)
@@ -82,8 +82,8 @@ class PasswordChangeUiRequiredFilterTest {
         mockHttpServletRequest.setPathInfo("/login/mfa/register");
         passwordChangeUiRequiredFilter.doFilterInternal(mockHttpServletRequest, mockHttpServletResponse, mockFilterChain);
         verify(mockFilterChain, times(1)).doFilter(same(mockHttpServletRequest), same(mockHttpServletResponse));
-        verifyZeroInteractions(mockHttpServletResponse);
-        verifyZeroInteractions(mockRequestCache);
+        verifyNoInteractions(mockHttpServletResponse);
+        verifyNoInteractions(mockRequestCache);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SessionResetFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SessionResetFilterTests.java
@@ -46,7 +46,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class SessionResetFilterTests {
@@ -143,8 +143,8 @@ public class SessionResetFilterTests {
         SecurityContextHolder.getContext().setAuthentication(authenticationToken);
         filter.doFilterInternal(request, response, chain);
         verify(chain, times(1)).doFilter(request, response);
-        verifyZeroInteractions(request);
-        verifyZeroInteractions(response);
+        verifyNoInteractions(request);
+        verifyNoInteractions(response);
     }
 
     @Test
@@ -163,7 +163,7 @@ public class SessionResetFilterTests {
         filter.doFilterInternal(request, response, chain);
 
         //user is not forwarded, and error response is generated right away
-        Mockito.verifyZeroInteractions(chain);
+        Mockito.verifyNoInteractions(chain);
         //user redirect
         verify(response, times(1)).sendRedirect(any());
         //session was requested
@@ -177,7 +177,7 @@ public class SessionResetFilterTests {
         SecurityContextHolder.getContext().setAuthentication(authentication);
         filter.doFilterInternal(request, response, chain);
         verify(chain, times(1)).doFilter(request, response);
-        verifyZeroInteractions(response);
+        verifyNoInteractions(response);
     }
 
     @Test
@@ -186,8 +186,8 @@ public class SessionResetFilterTests {
         setFieldValue("origin", OriginKeys.LDAP, authentication.getPrincipal());
         filter.doFilterInternal(request, response, chain);
         verify(chain, times(1)).doFilter(request, response);
-        verifyZeroInteractions(request);
-        verifyZeroInteractions(response);
+        verifyNoInteractions(request);
+        verifyNoInteractions(response);
     }
 
     @Test
@@ -197,7 +197,7 @@ public class SessionResetFilterTests {
         filter.doFilterInternal(request, response, chain);
 
         //user is not forwarded, and error response is generated right away
-        Mockito.verifyZeroInteractions(chain);
+        Mockito.verifyNoInteractions(chain);
         //user redirect
         verify(response, times(1)).sendRedirect(any());
         //session was requested

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/listener/AuthenticationSuccessListenerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/listener/AuthenticationSuccessListenerTests.java
@@ -115,7 +115,7 @@ class AuthenticationSuccessListenerTests {
                 OriginKeys.UAA, IdentityZoneHolder.getCurrentZoneId()
         );
         listener.onApplicationEvent(event);
-        verifyZeroInteractions(mockApplicationEventPublisher);
+        verifyNoInteractions(mockApplicationEventPublisher);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/CommonLoginPolicyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/CommonLoginPolicyTest.java
@@ -19,7 +19,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class CommonLoginPolicyTest {
@@ -48,9 +48,9 @@ public class CommonLoginPolicyTest {
         LoginPolicy.Result result = commonLoginPolicy.isAllowed("principal");
         assertTrue(result.isAllowed());
         assertEquals(0, result.getFailureCount());
-        verifyZeroInteractions(lockoutPolicyRetriever);
-        verifyZeroInteractions(timeService);
-        verifyZeroInteractions(auditService);
+        verifyNoInteractions(lockoutPolicyRetriever);
+        verifyNoInteractions(timeService);
+        verifyNoInteractions(auditService);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @WithDatabaseContext
@@ -130,7 +130,7 @@ class ClientAdminBootstrapTests {
 
             clientAdminBootstrap.afterPropertiesSet();
 
-            verifyZeroInteractions(multitenantJdbcClientDetailsService);
+            verifyNoInteractions(multitenantJdbcClientDetailsService);
         }
     }
 
@@ -174,7 +174,7 @@ class ClientAdminBootstrapTests {
         void deleteFromYamlExistingClient() throws Exception {
             createClientInDb(clientIdToDelete, multitenantJdbcClientDetailsService);
             simpleAddClient(clientIdToDelete, clientAdminBootstrap, multitenantJdbcClientDetailsService, clients);
-            verifyZeroInteractions(mockApplicationEventPublisher);
+            verifyNoInteractions(mockApplicationEventPublisher);
 
             clientAdminBootstrap.onApplicationEvent(null);
 
@@ -192,7 +192,7 @@ class ClientAdminBootstrapTests {
             clientAdminBootstrap.onApplicationEvent(new ContextRefreshedEvent(mock(ApplicationContext.class)));
 
             verify(multitenantJdbcClientDetailsService, times(1)).loadClientByClientId(clientIdToDelete, "uaa");
-            verifyZeroInteractions(mockApplicationEventPublisher);
+            verifyNoInteractions(mockApplicationEventPublisher);
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangeEmailControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangeEmailControllerTest.java
@@ -161,7 +161,7 @@ class ChangeEmailControllerTest {
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("profile?error_message_code=email_change.non-uaa-origin"));
 
-        Mockito.verifyZeroInteractions(changeEmailService);
+        Mockito.verifyNoInteractions(changeEmailService);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangePasswordControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangePasswordControllerTest.java
@@ -99,7 +99,7 @@ class ChangePasswordControllerTest {
                 .andExpect(view().name("change_password"))
                 .andExpect(model().attribute("message_code", "form_error"));
 
-        verifyZeroInteractions(changePasswordService);
+        verifyNoInteractions(changePasswordService);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
@@ -180,7 +180,7 @@ class ResetPasswordControllerTest extends TestClassNullifier {
             .andExpect(status().isFound())
             .andExpect(redirectedUrl("email_sent?code=reset_password"));
 
-        Mockito.verifyZeroInteractions(messageService);
+        Mockito.verifyNoInteractions(messageService);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/TotpMfaEndpointTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/TotpMfaEndpointTest.java
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class TotpMfaEndpointTest {
@@ -247,7 +247,7 @@ public class TotpMfaEndpointTest {
         );
 
         assertEquals("mfa/enter_code", returnView.getViewName());
-        verifyZeroInteractions(sessionStatus);
+        verifyNoInteractions(sessionStatus);
         verifyMfaEvent(MfaAuthenticationFailureEvent.class);
     }
 
@@ -274,7 +274,7 @@ public class TotpMfaEndpointTest {
           sessionStatus
         );
 
-        verifyZeroInteractions(sessionStatus);
+        verifyNoInteractions(sessionStatus);
         verifyMfaEvent(MfaAuthenticationFailureEvent.class);
     }
 
@@ -296,7 +296,7 @@ public class TotpMfaEndpointTest {
         );
 
         assertEquals("mfa/enter_code", returnView.getViewName());
-        verifyZeroInteractions(sessionStatus);
+        verifyNoInteractions(sessionStatus);
         verifyMfaEvent(MfaAuthenticationFailureEvent.class);
     }
 
@@ -315,7 +315,7 @@ public class TotpMfaEndpointTest {
             sessionStatus
         );
         assertEquals("mfa/enter_code", returnView.getViewName());
-        verifyZeroInteractions(sessionStatus);
+        verifyNoInteractions(sessionStatus);
         verifyMfaEvent(MfaAuthenticationFailureEvent.class);
     }
 
@@ -334,7 +334,7 @@ public class TotpMfaEndpointTest {
             sessionStatus
         );
         assertEquals("mfa/enter_code", returnView.getViewName());
-        verifyZeroInteractions(sessionStatus);
+        verifyNoInteractions(sessionStatus);
         verifyMfaEvent(MfaAuthenticationFailureEvent.class);
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/mfa/MfaUiRequiredFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/mfa/MfaUiRequiredFilterTests.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(PollutionPreventionExtension.class)
@@ -244,7 +244,7 @@ class MfaUiRequiredFilterTests {
         when(spyFilter.getNextStep(any(HttpServletRequest.class))).thenReturn(NOT_AUTHENTICATED);
         spyFilter.doFilter(request, response, chain);
         verify(chain, times(1)).doFilter(same(request), same(response));
-        verifyZeroInteractions(requestCache);
+        verifyNoInteractions(requestCache);
     }
 
     @Test
@@ -252,7 +252,7 @@ class MfaUiRequiredFilterTests {
         when(spyFilter.getNextStep(any(HttpServletRequest.class))).thenReturn(MFA_IN_PROGRESS);
         spyFilter.doFilter(request, response, chain);
         verify(chain, times(1)).doFilter(same(request), same(response));
-        verifyZeroInteractions(requestCache);
+        verifyNoInteractions(requestCache);
     }
 
     @Test
@@ -260,7 +260,7 @@ class MfaUiRequiredFilterTests {
         when(spyFilter.getNextStep(any(HttpServletRequest.class))).thenReturn(MFA_OK);
         spyFilter.doFilter(request, response, chain);
         verify(chain, times(1)).doFilter(same(request), same(response));
-        verifyZeroInteractions(requestCache);
+        verifyNoInteractions(requestCache);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/mfa/StatelessMfaAuthenticationFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/mfa/StatelessMfaAuthenticationFilterTests.java
@@ -15,8 +15,6 @@
 package org.cloudfoundry.identity.uaa.mfa;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -80,7 +78,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.oauth2.common.util.OAuth2Utils.GRANT_TYPE;
 
@@ -187,9 +185,9 @@ public class StatelessMfaAuthenticationFilterTests {
     public void non_password_grants_ignored() throws Exception {
         request.setParameter(GRANT_TYPE, "other-than-password");
         filter.doFilterInternal(request, response, chain);
-        verifyZeroInteractions(googleAuthenticator);
+        verifyNoInteractions(googleAuthenticator);
         verify(chain).doFilter(same(request), same(response));
-        verifyZeroInteractions(publisher);
+        verifyNoInteractions(publisher);
     }
 
     @Test
@@ -204,8 +202,8 @@ public class StatelessMfaAuthenticationFilterTests {
         try {
             filter.checkMfaCode(request);
         } catch (Exception e) {
-            verifyZeroInteractions(chain);
-            verifyZeroInteractions(googleAuthenticator);
+            verifyNoInteractions(chain);
+            verifyNoInteractions(googleAuthenticator);
             throw e;
         }
     }
@@ -282,7 +280,7 @@ public class StatelessMfaAuthenticationFilterTests {
         try {
             filter.checkMfaCode(request);
         } catch (Exception x) {
-            verifyZeroInteractions(chain);
+            verifyNoInteractions(chain);
             throw x;
         }
     }
@@ -313,10 +311,10 @@ public class StatelessMfaAuthenticationFilterTests {
     public void no_mfa_configured() throws Exception {
         zone.getConfig().getMfaConfig().setEnabled(false);
         filter.doFilterInternal(request, response, chain);
-        verifyZeroInteractions(googleAuthenticator);
-        verifyZeroInteractions(mfaProvider);
+        verifyNoInteractions(googleAuthenticator);
+        verifyNoInteractions(mfaProvider);
         verify(chain).doFilter(same(request), same(response));
-        verifyZeroInteractions(publisher);
+        verifyNoInteractions(publisher);
     }
 
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/ChainedSignatureVerifierTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/ChainedSignatureVerifierTests.java
@@ -193,7 +193,7 @@ public class ChainedSignatureVerifierTests {
         delegates.add(macSigner);
         ReflectionTestUtils.setField(verifier, "delegates", delegates);
         signedValidContent.verifySignature(verifier);
-        Mockito.verifyZeroInteractions(macSigner);
+        Mockito.verifyNoInteractions(macSigner);
     }
 
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcherTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcherTest.java
@@ -131,7 +131,7 @@ class OidcMetadataFetcherTest {
             assertThat(definition.getUserInfoUrl().toString(), is("http://userinfo.not.updated"));
             assertThat(definition.getIssuer(), is("issuer-not-changed"));
 
-            verifyZeroInteractions(urlContentCache);
+            verifyNoInteractions(urlContentCache);
         }
 
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManagerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManagerTests.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @WithDatabaseContext
 class JdbcScimGroupMembershipManagerTests {
@@ -153,7 +153,7 @@ class JdbcScimGroupMembershipManagerTests {
         defaultGroups.forEach(g -> verify(spy, times(1)).createAndIgnoreDuplicate(eq(g), eq(otherIdentityZone.getId())));
         reset(spy);
         defaultGroups.forEach(g -> jdbcScimGroupMembershipManager.createOrGetGroup(g, otherIdentityZone.getId()));
-        verifyZeroInteractions(spy);
+        verifyNoInteractions(spy);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/TokenValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/TokenValidationTest.java
@@ -590,7 +590,7 @@ public class TokenValidationTest {
         buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost"))
                 .checkRevocableTokenStore(revocableTokenProvisioning);
 
-        verifyZeroInteractions(revocableTokenProvisioning);
+        verifyNoInteractions(revocableTokenProvisioning);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoderTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoderTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class BackwardsCompatibleDelegatingPasswordEncoderTest {
@@ -68,7 +68,7 @@ class BackwardsCompatibleDelegatingPasswordEncoderTest {
                     () -> encoder.matches("password", "{otherprefix}encodedPassword"),
                     is("Password encoding {otherprefix} is not supported"));
 
-            verifyZeroInteractions(mockPasswordEncoder);
+            verifyNoInteractions(mockPasswordEncoder);
         }
 
         @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
@@ -166,7 +166,7 @@ class IdentityZoneResolvingFilterTests {
         filter.doFilter(request, response, chain);
         assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
         assertEquals(IdentityZone.getUaa(), IdentityZoneHolder.get());
-        Mockito.verifyZeroInteractions(chain);
+        Mockito.verifyNoInteractions(chain);
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/DynamicZoneAwareAuthenticationManagerTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/DynamicZoneAwareAuthenticationManagerTest.java
@@ -28,7 +28,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(PollutionPreventionExtension.class)
@@ -90,7 +90,7 @@ class DynamicZoneAwareAuthenticationManagerTest {
         DynamicZoneAwareAuthenticationManager manager = getDynamicZoneAwareAuthenticationManager();
         Authentication result = manager.authenticate(null);
         assertNull(result);
-        verifyZeroInteractions(uaaAuthenticationMgr);
+        verifyNoInteractions(uaaAuthenticationMgr);
     }
 
     @Test
@@ -104,7 +104,7 @@ class DynamicZoneAwareAuthenticationManagerTest {
         when(mockManager.getDefinition()).thenReturn(ldapIdentityProviderDefinition);
         Authentication result = manager.authenticate(success);
         assertSame(success, result);
-        verifyZeroInteractions(uaaAuthenticationMgr);
+        verifyNoInteractions(uaaAuthenticationMgr);
     }
 
     @Test
@@ -176,7 +176,7 @@ class DynamicZoneAwareAuthenticationManagerTest {
         when(mockManager.getDefinition()).thenReturn(ldapIdentityProviderDefinition);
         Authentication result = manager.authenticate(success);
         assertSame(success, result);
-        verifyZeroInteractions(uaaAuthenticationMgr);
+        verifyNoInteractions(uaaAuthenticationMgr);
     }
 
     @Test
@@ -194,8 +194,8 @@ class DynamicZoneAwareAuthenticationManagerTest {
         } catch (ProviderNotFoundException x) {
             //expected
         }
-        verifyZeroInteractions(uaaAuthenticationMgr);
-        verifyZeroInteractions(mockManager);
+        verifyNoInteractions(uaaAuthenticationMgr);
+        verifyNoInteractions(mockManager);
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -97,7 +97,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @DefaultTestContext
@@ -662,7 +662,7 @@ class ScimUserEndpointsTests {
     @Test
     void findUsersGroupsNotSyncedIfNotIncluded() {
         scimUserEndpoints.findUsers("emails.value", "id pr", null, "ascending", 1, 100);
-        verifyZeroInteractions(spiedScimGroupMembershipManager);
+        verifyNoInteractions(spiedScimGroupMembershipManager);
     }
 
     @Test
@@ -680,7 +680,7 @@ class ScimUserEndpointsTests {
     @Test
     void findUsersApprovalsNotSyncedIfNotIncluded() {
         scimUserEndpoints.findUsers("emails.value", "id pr", null, "ascending", 1, 100);
-        verifyZeroInteractions(mockApprovalStore);
+        verifyNoInteractions(mockApprovalStore);
     }
 
     @Test


### PR DESCRIPTION
It is my first PR here. Should I create a separate issue for the PR? I wasn't sure. I can do it. It is not a problem. 

The method `Mockito.verifyZeroInteractions` is deprecated since mockito 3.0.1 [mockito javadoc](https://javadoc.io/static/org.mockito/mockito-core/3.12.4/org/mockito/Mockito.html#verifyZeroInteractions-java.lang.Object...-) . It should be replaced on `Mockito.verifyNoInteractions`

Kind regards