### PR TITLE
Revert "bump dependency to jakarta.el 3.0.4"

### DIFF
--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -32,7 +32,6 @@ dependencies {
         exclude(module: "jackson-mapper-asl")
         exclude(module: "spring-security-web")
     }
-    implementation("org.glassfish:jakarta.el:3.0.4")
     runtimeOnly(libraries.springSecurityConfig)
     runtimeOnly(libraries.springRetry)
     runtimeOnly(libraries.aspectJWeaver)


### PR DESCRIPTION
Reverts cloudfoundry/uaa#1661

Not needed with spring boot 2.4.11 dependency update