### PR TITLE
Add "FOR UPDATE SKIP LOCKED" DeleteExpiredQuery

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/PostgresLimitSqlAdapter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/PostgresLimitSqlAdapter.java
@@ -31,6 +31,6 @@ public class PostgresLimitSqlAdapter implements LimitSqlAdapter {
             " < ? " +
             " ORDER BY " +
             expiresColumn +
-            " LIMIT "+maxRows+"))";
+            " LIMIT "+maxRows+" FOR UPDATE SKIP LOCKED))";
     }
 }


### PR DESCRIPTION
Postgresql 9.5 onwards supports this feature.
It prevents deadlocks in such scenarios were a delete is done with an inner select, see
https://stackoverflow.com/questions/68626800/deadlock-when-using-delete-on-postgresql

Assume that rely on the version 9.5 and higher is ok, since EOL
https://endoflife.software/applications/databases/postgresql
shows that you should have a newer DB