### PR TITLE
Fix missing Login checks in case UAA acts as SAML Idp

### DIFF
--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -257,6 +257,8 @@
           xmlns="http://www.springframework.org/schema/security">
         <intercept-url pattern="/**" access="isFullyAuthenticated()"/>
         <custom-filter before="BASIC_AUTH_FILTER" ref="idpMetadataGeneratorFilter"/>
+        <custom-filter ref="passwordChangeUiRequiredFilter" after="BASIC_AUTH_FILTER"/>
+        <custom-filter ref="mfaUiRequiredFilter" after="FORM_LOGIN_FILTER"/>
         <custom-filter after="FILTER_SECURITY_INTERCEPTOR" ref="samlIdpLoginFilter"/>
         <csrf disabled="true"/>
     </http>


### PR DESCRIPTION
Without the checks the SAML response is generated, but it must not generate a SAML authentication if e.g. password change is required