### PR TITLE
exclude mina-core

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -74,6 +74,7 @@ dependencies {
     implementation(libraries.springLdapCoreTiger)
     implementation(libraries.apacheLdapApi) {
         exclude(module: "slf4j-api")
+        exclude(module: "mina-core")
     }
 
     implementation(libraries.passay)


### PR DESCRIPTION
because: CVE-2021-41973
https://mina.apache.org/mina-project/