### PR TITLE
prepare fix of gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,8 @@ buildscript {
 
     repositories {
         mavenCentral()
-        jcenter()
         maven {
-            url("https://repo.spring.io/plugins-release")
+            url("https://plugins.gradle.org/m2/")
         }
     }
 
@@ -30,8 +29,8 @@ def applicationPort = project.hasProperty('port') ? project.getProperty('port').
 apply(plugin: "com.bmuschko.cargo")
 
 allprojects {
-    apply(plugin: "propdeps")
-    apply(plugin: "propdeps-maven")
+    apply(plugin: "cn.bestwu.propdeps")
+    apply(plugin: "cn.bestwu.propdeps-maven")
     apply(plugin: "io.spring.dependency-management")
 
     dependencyManagement {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -120,6 +120,6 @@ libraries.orgJson = "org.json:json:20211205"
 // gradle plugins
 libraries.asciidoctorGradlePlugin = "org.asciidoctor:asciidoctor-gradle-plugin:1.6.1"
 libraries.cargoGradlePlugin = "com.bmuschko:gradle-cargo-plugin:2.8.0"
-libraries.prodepsGradlePlugin = "io.spring.gradle:propdeps-plugin:0.0.10.RELEASE"
+libraries.prodepsGradlePlugin = "gradle.plugin.cn.bestwu.gradle:propdeps-plugin:0.0.10"
 libraries.springBootGradlePlugin = "org.springframework.boot:spring-boot-gradle-plugin:${versions.springBootVersion}"
 libraries.springDependencyMangementGradlePlugin = "io.spring.gradle:dependency-management-plugin"


### PR DESCRIPTION
https://blog.gradle.org/jcenter-shutdown

So uaa needs to change its dependencies and with this

Dont know if we should keep propdepsor simple remove it because we dont need maven pom generation, however found
https://plugins.gradle.org/plugin/cn.bestwu.propdeps via search
https://plugins.gradle.org/search?term=propdeps
