### PR TITLE
Simplify HTTP method matching

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
@@ -156,7 +156,7 @@ public class CorsFilter extends OncePerRequestFilter {
                                     FilterChain filterChain,
                                     CorsConfiguration configuration) throws IOException, ServletException {
 
-        boolean isPreflightRequest = OPTIONS.toString().equals(request.getMethod());
+        boolean isPreflightRequest = OPTIONS.matches(request.getMethod());
 
         //Validate if this CORS request is allowed for this method
         String method = request.getMethod();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/UaaRequestMatcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/UaaRequestMatcher.java
@@ -104,7 +104,7 @@ public final class UaaRequestMatcher implements RequestMatcher, BeanNameAware {
             return false;
         }
 
-        if (method != null && !method.toString().equals(request.getMethod().toUpperCase())) {
+        if (method != null && !method.matches(request.getMethod().toUpperCase())) {
             return false;
         }
 


### PR DESCRIPTION
Hello UAA folks,

In this PR, I'm simplifying some code.
The `HttpMethod` enum from Spring Framework has a dedicated method `matches()` that should be favored when checking HTTP method equality.

Best