### PR TITLE
remove String Passwords variables from 3 classes:

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/AutologinRequestConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/AutologinRequestConverter.java
@@ -12,6 +12,12 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.authentication.manager;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.cloudfoundry.identity.uaa.login.AutologinRequest;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
@@ -27,15 +33,12 @@ import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.util.MultiValueMap;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
 public class AutologinRequestConverter extends AbstractHttpMessageConverter<AutologinRequest> {
+    private static final String USERNAME = "username";
+    private static final String PASSWORD = "password";
 
-    private FormHttpMessageConverter formConverter = new FormHttpMessageConverter();
-    private StringHttpMessageConverter stringConverter = new StringHttpMessageConverter();
+    private final FormHttpMessageConverter formConverter = new FormHttpMessageConverter();
+    private final StringHttpMessageConverter stringConverter = new StringHttpMessageConverter();
 
     public AutologinRequestConverter() {
         setSupportedMediaTypes(Arrays.asList(
@@ -64,32 +67,34 @@ public class AutologinRequestConverter extends AbstractHttpMessageConverter<Auto
     protected AutologinRequest readInternal(Class<? extends AutologinRequest> clazz, HttpInputMessage inputMessage)
                     throws IOException, HttpMessageNotReadableException {
 
-        String username, password;
+        AutologinRequest result = new AutologinRequest();
+
+        UnaryOperator<String> getValue;
         if (isJsonContent(inputMessage.getHeaders().get(HttpHeaders.CONTENT_TYPE))) {
             Map<String, String> map = JsonUtils.readValue(stringConverter.read(String.class, inputMessage),
                                                           new TypeReference<Map<String, String>>() {});
-            username = map.get("username");
-            password = map.get("password");
+            if (map == null) {
+                return result;
+            }
+            getValue = map::get;
         } else {
             MultiValueMap<String, String> map = formConverter.read(null, inputMessage);
-            username = map.getFirst("username");
-            password = map.getFirst("password");
+            getValue = map::getFirst;
         }
-        AutologinRequest result = new AutologinRequest();
-        result.setUsername(username);
-        result.setPassword(password);
+        result.setUsername(getValue.apply(USERNAME));
+        result.setPassword(getValue.apply(PASSWORD));
         return result;
     }
 
     @Override
     protected void writeInternal(AutologinRequest t, HttpOutputMessage outputMessage) throws IOException,
                     HttpMessageNotWritableException {
-        MultiValueMap<String, String> map = new LinkedMaskingMultiValueMap<String, String>("password");
+        MultiValueMap<String, String> map = new LinkedMaskingMultiValueMap<String, String>(PASSWORD);
         if (t.getUsername() != null) {
-            map.set("username", t.getUsername());
+            map.set(USERNAME, t.getUsername());
         }
         if (t.getPassword() != null) {
-            map.set("password", t.getPassword());
+            map.set(PASSWORD, t.getPassword());
         }
         formConverter.write(map, MediaType.APPLICATION_FORM_URLENCODED, outputMessage);
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
@@ -223,8 +223,9 @@ public class ExternalLoginAuthenticationManager<ExternalAuthenticationDetails> i
             userDetails = (UserDetails) request.getPrincipal();
         } else if (request instanceof UsernamePasswordAuthenticationToken) {
             String username = request.getPrincipal().toString();
-            String password = request.getCredentials() != null ? request.getCredentials().toString() : "";
-            userDetails = new User(username, password, true, true, true, true, UaaAuthority.USER_AUTHORITIES);
+            Object credentials = request.getCredentials();
+            userDetails = new User(username, (credentials != null) ? credentials.toString() : "",
+                                   true, true, true, true, UaaAuthority.USER_AUTHORITIES);
         } else if (request.getPrincipal() == null) {
             logger.debug(this.getClass().getName() + "[" + name + "] cannot process null principal");
             return null;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/KeystoneAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/KeystoneAuthenticationManager.java
@@ -65,31 +65,26 @@ public class KeystoneAuthenticationManager extends RestAuthenticationManager {
     public interface KeystoneAuthenticationRequest {
     }
 
+    // Manual creation, but must support JSON serialization - does NOT support direct binding from JSON (no default constructors)
     public static class KeystoneV2AuthenticationRequest implements KeystoneAuthenticationRequest{
-        private KeystoneAuthentication auth;
+        private final KeystoneAuthentication auth;
 
         public KeystoneV2AuthenticationRequest(String tenant, String username, String password) {
             auth = new KeystoneAuthentication(tenant, username, password);
         }
 
-        public KeystoneV2AuthenticationRequest(KeystoneAuthentication auth) {
-            this.auth = auth;
-        }
+//        public KeystoneV2AuthenticationRequest(KeystoneAuthentication auth) {
+//            this.auth = auth;
+//        }
 
         @JsonProperty("auth")
         public KeystoneAuthentication getAuth() {
             return auth;
         }
 
-        @JsonProperty("auth")
-        public void setAuth(KeystoneAuthentication auth) {
-            this.auth = auth;
-        }
-
-
         public static class KeystoneAuthentication {
-            private String tenant;
-            private KeystoneCredentials credentials;
+            private final String tenant;
+            private final KeystoneCredentials credentials;
 
             public KeystoneAuthentication(String tenant, String username, String password) {
                 this.tenant = tenant;
@@ -101,53 +96,44 @@ public class KeystoneAuthenticationManager extends RestAuthenticationManager {
                 return tenant;
             }
 
-            @JsonProperty("tenantName")
-            public void setTenant(String tenant) {
-                this.tenant = tenant;
-            }
-
             @JsonProperty("passwordCredentials")
             public KeystoneCredentials getCredentials() {
                 return credentials;
             }
-
-            public void setCredentials(KeystoneCredentials credentials) {
-                this.credentials = credentials;
-            }
         }
 
-        public static class KeystoneCredentials {
-            private String username;
-            private String password;
+        public static class KeystoneCredentials extends NonStringPassword {
+            private final String username;
 
             public KeystoneCredentials(String username, String password) {
-                super();
+                super(password);
                 this.username = username;
-                this.password = password;
             }
 
+            @JsonProperty("username")
             public String getUsername() {
                 return username;
             }
-
-            public void setUsername(String username) {
-                this.username = username;
-            }
-
-            public String getPassword() {
-                return password;
-            }
-
-            public void setPassword(String password) {
-                this.password = password;
-            }
-
         }
 
     }
 
+    public static class NonStringPassword {
+        private final char[] password;
+
+        protected NonStringPassword(String password) {
+            this.password = (password == null) ? null : password.toCharArray();
+        }
+
+        @JsonProperty("password")
+        public String getPassword() {
+            return (password == null) ? null : new String(password);
+        }
+    }
+
+    // Manual creation, but must support JSON serialization - does NOT support direct binding from JSON (no default constructors)
     public static class KeystoneV3AuthenticationRequest implements KeystoneAuthenticationRequest{
-        private KeystoneIdentity identity;
+        private final KeystoneIdentity identity;
 
         public KeystoneV3AuthenticationRequest(String domain, String username, String password) {
             identity = new KeystoneIdentity(new KeystoneAuthentication(domain, username, password));
@@ -163,23 +149,18 @@ public class KeystoneAuthenticationManager extends RestAuthenticationManager {
                 this.auth = auth;
             }
 
-            private KeystoneAuthentication auth;
+            private final KeystoneAuthentication auth;
+
             @JsonProperty("identity")
             public KeystoneAuthentication getAuth() {
                 return auth;
             }
-
-            @JsonProperty("identity")
-            public void setAuth(KeystoneAuthentication auth) {
-                this.auth = auth;
-            }
-
         }
 
         public static class KeystoneAuthentication {
-            private String[] methods = new String[] {"password"};
-            private String domain;
-            private KeystoneCredentials credentials;
+            private final String[] methods = new String[] {"password"};
+            private final String domain; // No getter and no toString?
+            private final KeystoneCredentials credentials;
 
             public KeystoneAuthentication(String domain, String username, String password) {
                 this.domain = domain;
@@ -191,25 +172,15 @@ public class KeystoneAuthenticationManager extends RestAuthenticationManager {
                 return methods;
             }
 
-            @JsonProperty("methods")
-            public void setMethods(String[] methods) {
-                this.methods = methods;
-            }
-
             @JsonProperty("password")
             public KeystoneCredentials getCredentials() {
                 return credentials;
             }
-
-            @JsonProperty("password")
-            public void setCredentials(KeystoneCredentials credentials) {
-                this.credentials = credentials;
-            }
         }
 
         public static class KeystoneCredentials {
+            private final KeystoneUser user;
 
-            private KeystoneUser user;
             public KeystoneCredentials(String username, String password) {
                 user = new KeystoneUser(username, password);
             }
@@ -217,41 +188,24 @@ public class KeystoneAuthenticationManager extends RestAuthenticationManager {
             public KeystoneUser getUser() {
                 return user;
             }
-
-            public void setUser(KeystoneUser user) {
-                this.user = user;
-            }
         }
 
-        public static class KeystoneUser {
-            private String name;
-            private String password;
+        public static class KeystoneUser extends NonStringPassword {
+            private final String name;
 
             public KeystoneUser(String name, String password) {
+                super(password);
                 this.name = name;
-                this.password = password;
             }
 
             public KeystoneDomain getDomain() {
                 return new KeystoneDomain();
             }
 
+            @JsonProperty("username")
             public String getName() {
                 return name;
             }
-
-            public void setName(String name) {
-                this.name = name;
-            }
-
-            public String getPassword() {
-                return password;
-            }
-
-            public void setPassword(String password) {
-                this.password = password;
-            }
-
         }
 
         public static class KeystoneDomain {


### PR DESCRIPTION
Issue #1838

All Tests pass!

Used different techniques:
AutologinRequestConverter: switched local variables to method references / lambdas.
ExternalLoginAuthenticationManager: changed "String password" to "Object credentials" then inlined the conversion to string to pass on.
KeystoneAuthenticationManager: changed "String password" to "char[] password" in super class: converted to/from String for getter

Dropped unneeded Setters (making variables final)