### PR TITLE
Remove more String Passwords variables reported in the Issue#1838

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/LdapIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/LdapIdentityProviderDefinition.java
@@ -117,7 +117,7 @@ public class LdapIdentityProviderDefinition extends ExternalIdentityProviderDefi
     private String userDNPatternDelimiter;
 
     private String bindUserDn;
-    private String bindPassword;
+    private Object bindPassword;
     private String userSearchBase;
     private String userSearchFilter;
 
@@ -194,7 +194,7 @@ public class LdapIdentityProviderDefinition extends ExternalIdentityProviderDefi
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getBindPassword() {
-        return bindPassword;
+        return (String) bindPassword;
     }
 
     public String getBindUserDn() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/NonStringPassword.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/NonStringPassword.java
@@ -1,0 +1,16 @@
+package org.cloudfoundry.identity.uaa.authentication;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class NonStringPassword {
+    private final char[] password;
+
+    public NonStringPassword(String password) {
+        this.password = (password == null) ? null : password.toCharArray();
+    }
+
+    @JsonProperty("password")
+    public String getPassword() {
+        return (password == null) ? null : new String(password);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
@@ -185,12 +185,11 @@ public class PasscodeAuthenticationFilter extends BackwardsCompatibleTokenEndpoi
                     throw new BadCredentialsException("Credentials must be sent by (one of methods): " + methods);
                 }
 
-                String passcode = expiringCodeAuthentication.getPasscode();
-                if (StringUtils.isEmpty(passcode)) {
+                if (StringUtils.isEmpty(expiringCodeAuthentication.getPasscode())) {
                     throw new InsufficientAuthenticationException("Passcode information is missing.");
                 }
 
-                ExpiringCode eCode = doRetrieveCode(passcode);
+                ExpiringCode eCode = doRetrieveCode(expiringCodeAuthentication.getPasscode());
                 PasscodeInformation pi = null;
                 if (eCode != null && eCode.getData() != null) {
                     try {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilter.java
@@ -185,7 +185,7 @@ public class PasscodeAuthenticationFilter extends BackwardsCompatibleTokenEndpoi
                     throw new BadCredentialsException("Credentials must be sent by (one of methods): " + methods);
                 }
 
-                if (StringUtils.isEmpty(expiringCodeAuthentication.getPasscode())) {
+                if (!StringUtils.hasLength(expiringCodeAuthentication.getPasscode())) {
                     throw new InsufficientAuthenticationException("Passcode information is missing.");
                 }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/KeystoneAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/KeystoneAuthenticationManager.java
@@ -16,6 +16,7 @@
 package org.cloudfoundry.identity.uaa.authentication.manager;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.cloudfoundry.identity.uaa.authentication.NonStringPassword;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -112,19 +113,6 @@ public class KeystoneAuthenticationManager extends RestAuthenticationManager {
             }
         }
 
-    }
-
-    public static class NonStringPassword {
-        private final char[] password;
-
-        protected NonStringPassword(String password) {
-            this.password = (password == null) ? null : password.toCharArray();
-        }
-
-        @JsonProperty("password")
-        public String getPassword() {
-            return (password == null) ? null : new String(password);
-        }
     }
 
     // Manual creation, but must support JSON serialization - does NOT support direct binding from JSON (no default constructors)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
@@ -123,7 +123,7 @@ public class PasswordGrantAuthenticationManager implements AuthenticationManager
         return loginHintToUse;
     }
 
-    private Authentication oidcPasswordGrant(Authentication authentication, OIDCIdentityProviderDefinition config) {
+    Authentication oidcPasswordGrant(Authentication authentication, OIDCIdentityProviderDefinition config) {
         //Token per RestCall
         URL tokenUrl = config.getTokenUrl();
         String clientId = config.getRelyingPartyId();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
@@ -42,6 +42,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.net.URL;
 import java.util.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_PASSWORD;
@@ -131,10 +132,10 @@ public class PasswordGrantAuthenticationManager implements AuthenticationManager
             throw new ProviderConfigurationException("External OpenID Connect provider configuration is missing relyingPartyId or relyingPartySecret.");
         }
         String userName = authentication.getPrincipal() instanceof String ? (String)authentication.getPrincipal() : null;
-        String password = authentication.getCredentials() instanceof String ? (String)authentication.getCredentials() : null;
-        if (userName == null || password == null) {
+        if (userName == null || authentication.getCredentials() == null || !(authentication.getCredentials() instanceof String)) {
             throw new BadCredentialsException("Request is missing username or password.");
         }
+        Supplier<String> passProvider = () -> (String) authentication.getCredentials();
         RestTemplate rt;
         if (config.isSkipSslValidation()) {
             rt = restTemplateConfig.trustingRestTemplate();
@@ -157,7 +158,7 @@ public class PasswordGrantAuthenticationManager implements AuthenticationManager
         params.add("grant_type", GRANT_TYPE_PASSWORD);
         params.add("response_type","id_token");
         params.add("username", userName);
-        params.add("password", password);
+        params.add("password", passProvider.get());
 
         List<Prompt> prompts = config.getPrompts();
         List<String> promptsToInclude = new ArrayList<>();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/RestAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/RestAuthenticationManager.java
@@ -103,18 +103,17 @@ public class RestAuthenticationManager implements AuthenticationManager {
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
         String username = authentication.getName();
-        String password = (String) authentication.getCredentials();
 
         HttpHeaders headers = getHeaders();
 
         @SuppressWarnings("rawtypes")
         ResponseEntity<Map> response = restTemplate.exchange(remoteUrl, HttpMethod.POST,
-                        new HttpEntity<Object>(getParameters(username, password), headers), Map.class);
+                        new HttpEntity<Object>(getParameters(username, (String) authentication.getCredentials()), headers), Map.class);
 
         if (response.getStatusCode() == HttpStatus.OK || response.getStatusCode() == HttpStatus.CREATED) {
             if (evaluateResponse(authentication,response)) {
                 logger.info("Successful authentication request for " + authentication.getName());
-                return new UsernamePasswordAuthenticationToken(username, nullPassword?null:"", UaaAuthority.USER_AUTHORITIES);
+                return new UsernamePasswordAuthenticationToken(username, nullPassword ? null : "", UaaAuthority.USER_AUTHORITIES);
             }
         } else if (response.getStatusCode() == HttpStatus.UNAUTHORIZED) {
             logger.info("Failed authentication request");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderValidationRequest.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderValidationRequest.java
@@ -15,7 +15,7 @@ package org.cloudfoundry.identity.uaa.provider;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.authentication.NonStringPassword;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -45,18 +45,18 @@ public class IdentityProviderValidationRequest {
 
     public static class UsernamePasswordAuthentication implements Authentication {
         private final String username;
-        private final String password;
+        private final NonStringPassword password;
 
         @JsonCreator
         public UsernamePasswordAuthentication(
             @JsonProperty("username") String username,
             @JsonProperty("password") String password) {
-            this.password = password;
+            this.password = new NonStringPassword(password);
             this.username = username;
         }
 
         public String getPassword() {
-            return password;
+            return password.getPassword();
         }
 
         public String getUsername() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/PasswordComparisonAuthenticator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/PasswordComparisonAuthenticator.java
@@ -33,6 +33,7 @@ import javax.naming.NamingException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import java.util.Arrays;
+import java.util.function.Supplier;
 
 /**
  * Unfortunately the Spring PasswordComparisonAuthenticator is final, so we
@@ -56,7 +57,7 @@ public class PasswordComparisonAuthenticator extends AbstractLdapAuthenticator {
     public DirContextOperations authenticate(Authentication authentication) {
         DirContextOperations user = null;
         String username = authentication.getName();
-        String password = (String) authentication.getCredentials();
+        Supplier<String> passProvider = () -> (String) authentication.getCredentials();
 
         SpringSecurityLdapTemplate ldapTemplate = new SpringSecurityLdapTemplate(getContextSource());
 
@@ -84,9 +85,9 @@ public class PasswordComparisonAuthenticator extends AbstractLdapAuthenticator {
         }
 
         if (isLocalCompare()) {
-            localCompareAuthenticate(user, password);
+            localCompareAuthenticate(user, passProvider.get());
         } else {
-            String encodedPassword = passwordEncoder.encode(password);
+            String encodedPassword = passwordEncoder.encode(passProvider.get());
             byte[] passwordBytes = Utf8.encode(encodedPassword);
             searchAuthenticate(user, passwordBytes, ldapTemplate);
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/extension/ExtendedLdapUserImpl.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/extension/ExtendedLdapUserImpl.java
@@ -14,6 +14,7 @@
  */
 package org.cloudfoundry.identity.uaa.provider.ldap.extension;
 
+import org.cloudfoundry.identity.uaa.authentication.NonStringPassword;
 import org.cloudfoundry.identity.uaa.provider.ldap.ExtendedLdapUserDetails;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -32,7 +33,7 @@ public class ExtendedLdapUserImpl implements ExtendedLdapUserDetails {
     private String phoneNumberAttributeName;
     private String emailVerifiedAttributeName;
     private String dn;
-    private String password;
+    private NonStringPassword password = new NonStringPassword(null);
     private String username;
     private Collection<? extends GrantedAuthority> authorities = AuthorityUtils.NO_AUTHORITIES;
     private boolean accountNonExpired = true;
@@ -101,11 +102,11 @@ public class ExtendedLdapUserImpl implements ExtendedLdapUserDetails {
     }
 
     public String getPassword() {
-        return password;
+        return password.getPassword();
     }
 
     public void setPassword(String password) {
-        this.password = password;
+        this.password = new NonStringPassword(password);
     }
 
     public String getUsername() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimUserProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimUserProvisioning.java
@@ -37,7 +37,7 @@ public interface ScimUserProvisioning extends ResourceManager<ScimUser>, Queryab
 
     ScimUser verifyUser(String id, int version, String zoneId) throws ScimResourceNotFoundException, InvalidScimResourceException;
 
-    boolean checkPasswordMatches(String id, String password, String zoneId) throws ScimResourceNotFoundException;
+    boolean checkPasswordMatches(String id, CharSequence password, String zoneId) throws ScimResourceNotFoundException;
 
     boolean checkPasswordChangeIndividuallyRequired(String id, String zoneId) throws ScimResourceNotFoundException;
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimUserProvisioning.java
@@ -316,7 +316,7 @@ public class JdbcScimUserProvisioning extends AbstractQueryable<ScimUser>
     }
 
     // Checks the existing password for a user
-    public boolean checkPasswordMatches(String id, String password, String zoneId) {
+    public boolean checkPasswordMatches(String id, CharSequence password, String zoneId) {
         String currentPassword;
         try {
             currentPassword =

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUser.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUser.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.user;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.cloudfoundry.identity.uaa.authentication.NonStringPassword;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.Assert;
 
@@ -72,7 +73,7 @@ public class UaaUser {
 
     private final String username;
 
-    private final String password;
+    private final NonStringPassword password;
 
     private final String email;
 
@@ -152,7 +153,7 @@ public class UaaUser {
 
         this.id = prototype.getId();
         this.username = prototype.getUsername();
-        this.password = prototype.getPassword();
+        this.password = prototype.getNonStringPassword();
         this.email = prototype.getEmail();
         this.familyName = prototype.getFamilyName();
         this.givenName = prototype.getGivenName();
@@ -181,7 +182,7 @@ public class UaaUser {
     }
 
     public String getPassword() {
-        return password;
+        return password.getPassword();
     }
 
     public String getEmail() {
@@ -216,7 +217,7 @@ public class UaaUser {
         if (!"NaN".equals(this.id)) {
             throw new IllegalStateException("Id already set");
         }
-        return new UaaUser(id, username, password, email, authorities, givenName, familyName, created, modified, origin, externalId, verified, zoneId, salt, passwordLastModified);
+        return new UaaUser(id, username, getPassword(), email, authorities, givenName, familyName, created, modified, origin, externalId, verified, zoneId, salt, passwordLastModified);
     }
 
     public UaaUser authorities(Collection<? extends GrantedAuthority> authorities) {
@@ -228,7 +229,7 @@ public class UaaUser {
         if (!values.contains(UaaAuthority.UAA_USER)) {
             values.add(UaaAuthority.UAA_USER);
         }
-        return new UaaUser(id, username, password, email, values, givenName, familyName, created, modified, origin, externalId, verified, zoneId, salt, passwordLastModified);
+        return new UaaUser(id, username, getPassword(), email, values, givenName, familyName, created, modified, origin, externalId, verified, zoneId, salt, passwordLastModified);
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUserEditor.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUserEditor.java
@@ -30,33 +30,33 @@ public class UaaUserEditor extends PropertyEditorSupport {
     public void setAsText(String text) throws IllegalArgumentException {
         String[] values = text.split("\\|", -1);
         String username = values[0];
-        String password = null, email = username, firstName = null, lastName = null, origin = OriginKeys.UAA;
+        String pwd = null, email = username, firstName = null, lastName = null, origin = OriginKeys.UAA;
         String authorities = null;
 
         if (values.length >= 2) {
             switch (values.length) {
                 case 2:
-                    password = values[1];
+                    pwd = values[1];
                     break;
                 case 3:
-                    password = values[1];
+                    pwd = values[1];
                     authorities = values[2];
                     break;
                 case 5:
-                    password = values[1];
+                    pwd = values[1];
                     email = values[2];
                     firstName = values[3];
                     lastName = values[4];
                     break;
                 case 6:
-                    password = values[1];
+                    pwd = values[1];
                     email = values[2];
                     firstName = values[3];
                     lastName = values[4];
                     authorities = values[5];
                     break;
                 case 7:
-                    password = values[1];
+                    pwd = values[1];
                     email = values[2];
                     firstName = values[3];
                     lastName = values[4];
@@ -68,7 +68,7 @@ public class UaaUserEditor extends PropertyEditorSupport {
             }
         }
 
-        UaaUser user = new UaaUser(username, password, email, firstName, lastName, origin, IdentityZoneHolder.get().getId());
+        UaaUser user = new UaaUser(username, pwd, email, firstName, lastName, origin, IdentityZoneHolder.get().getId());
         if (authorities != null) {
             user = user.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList(authorities));
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUserPrototype.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUserPrototype.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.user;
 
+import org.cloudfoundry.identity.uaa.authentication.NonStringPassword;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.Date;
@@ -23,7 +24,7 @@ public final class UaaUserPrototype {
 
     private String username;
 
-    private String password;
+    private NonStringPassword password = new NonStringPassword(null);
 
     private String email;
 
@@ -106,11 +107,19 @@ public final class UaaUserPrototype {
     }
 
     public String getPassword() {
+        return password.getPassword();
+    }
+
+    NonStringPassword getNonStringPassword() {
         return password;
     }
 
-    public UaaUserPrototype withPassword(String password) {
+    UaaUserPrototype withPassword(NonStringPassword password) {
         this.password = password;
+        return this;
+    }
+    public UaaUserPrototype withPassword(String password) {
+        this.password = new NonStringPassword(password);
         return this;
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasscodeAuthenticationFilterTest.java
@@ -1,0 +1,47 @@
+package org.cloudfoundry.identity.uaa.authentication;
+
+import org.cloudfoundry.identity.uaa.authentication.PasscodeAuthenticationFilter.ExpiringCodeAuthentication;
+import org.cloudfoundry.identity.uaa.authentication.PasscodeAuthenticationFilter.ExpiringCodeAuthenticationManager;
+import org.cloudfoundry.identity.uaa.codestore.ExpiringCodeStore;
+import org.cloudfoundry.identity.uaa.codestore.InMemoryExpiringCodeStore;
+import org.cloudfoundry.identity.uaa.util.MockTimeService;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class PasscodeAuthenticationFilterTest {
+
+    private ExpiringCodeAuthenticationManager manager;
+
+    @Test
+    public void throwsPasscodeInformationIsMissingInsufficientAuthenticationException() {
+        ExpiringCodeAuthentication authentication = new ExpiringCodeAuthentication(null, null);
+        try {
+            manager.authenticate(authentication);
+        } catch (InsufficientAuthenticationException e) {
+            assertEquals("Passcode information is missing.", e.getMessage());
+        }
+    }
+
+    @Test
+    public void throwsInvalidPasscodeInsufficientAuthenticationException() {
+        ExpiringCodeAuthentication authentication = new ExpiringCodeAuthentication(null, "not empty");
+        try {
+            manager.authenticate(authentication);
+        } catch (InsufficientAuthenticationException e) {
+            assertEquals("Invalid passcode", e.getMessage());
+        }
+    }
+
+    @Before
+    public void setup() {
+        Logger logger = LoggerFactory.getLogger(ExpiringCodeAuthenticationManager.class);
+        ExpiringCodeStore expiringCodeStore = new InMemoryExpiringCodeStore(new MockTimeService());
+        manager = new ExpiringCodeAuthenticationManager(null,null, logger, expiringCodeStore, null);
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderValidationRequestTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderValidationRequestTest.java
@@ -1,0 +1,15 @@
+package org.cloudfoundry.identity.uaa.provider;
+
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderValidationRequest.UsernamePasswordAuthentication;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdentityProviderValidationRequestTest {
+
+    @Test
+    void noNPE() {
+        UsernamePasswordAuthentication authentication = new UsernamePasswordAuthentication("user", null);
+        assertNull(authentication.getPassword());
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/ldap/ExtendedLdapUserMapperTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/ldap/ExtendedLdapUserMapperTest.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.identity.uaa.provider.ldap.extension.ExtendedLdapUserImp
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.ldap.core.DirContextAdapter;
 import org.springframework.ldap.core.NameAwareAttributes;
 import org.springframework.security.core.GrantedAuthority;
@@ -90,5 +91,12 @@ public class ExtendedLdapUserMapperTest  {
         UserDetails userDetails = mapper.mapUserFromContext(adapter, "marissa", authorities);
         assertThat(userDetails instanceof ExtendedLdapUserImpl, is(true));
         return (ExtendedLdapUserImpl)userDetails;
+    }
+
+    @Test
+    public void noNPE() {
+        ExtendedLdapUserImpl user = new ExtendedLdapUserImpl(Mockito.mock(ExtendedLdapUserDetails.class));
+        user.setPassword("pass");
+        assertEquals("pass", user.getPassword());
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/ldap/LdapIdentityProviderDefinitionTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/ldap/LdapIdentityProviderDefinitionTest.java
@@ -74,6 +74,14 @@ public class LdapIdentityProviderDefinitionTest {
     }
 
     @Test
+    public void noPasswordCastException() {
+        LdapIdentityProviderDefinition definition = new LdapIdentityProviderDefinition();
+        definition.getBindPassword();
+        definition.setBindPassword("value");
+        definition.getBindPassword();
+    }
+
+    @Test
     public void test_tls_options() {
         ldapIdentityProviderDefinition = new LdapIdentityProviderDefinition();
         ldapIdentityProviderDefinition.setTlsConfiguration(LDAP_TLS_NONE);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/UaaTestAccounts.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/UaaTestAccounts.java
@@ -97,10 +97,9 @@ public class UaaTestAccounts implements TestAccounts {
 
     public UaaUser getUserWithRandomID() {
         String id = UUID.randomUUID().toString();
-        UaaUser user = new UaaUser(id, getUserName(), "<N/A>", getEmail(),
+        UaaUser user = new UaaUser(id, getUserName(), getPassword(), getEmail(),
                         UaaAuthority.USER_AUTHORITIES, "Test", "User", new Date(), new Date(), OriginKeys.UAA, "externalId", true,
             IdentityZoneHolder.get().getId(), id, new Date());
-        ReflectionTestUtils.setField(user, "password", getPassword());
         return user;
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/user/UaaUserEditorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/user/UaaUserEditorTests.java
@@ -78,6 +78,14 @@ public class UaaUserEditorTests {
     }
 
     @Test
+    public void testOrigin() {
+        UaaUserEditor editor = new UaaUserEditor();
+        editor.setAsText("marissa|koala|marissa@test.org|Marissa|Bloggs|uaa.admin|origin");
+        UaaUser user = (UaaUser) editor.getValue();
+        assertEquals("origin", user.getOrigin());
+    }
+
+    @Test
     public void usernameOnly() {
         UaaUserEditor editor = new UaaUserEditor();
         editor.setAsText("marissa");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/user/UaaUserPrototypeTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/user/UaaUserPrototypeTest.java
@@ -1,0 +1,25 @@
+package org.cloudfoundry.identity.uaa.user;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class UaaUserPrototypeTest {
+
+    @Test
+    public void testGetPassword() {
+        UaaUserPrototype prototype = new UaaUserPrototype()
+                .withPassword("pass");
+        assertEquals("pass", prototype.getPassword());
+    }
+
+    @Test
+    public void testGetUserWithId() {
+        UaaUserPrototype prototype = new UaaUserPrototype()
+                .withUsername("name")
+                .withEmail("email")
+                .withPassword("pass");
+        UaaUser userWithId = new UaaUser(prototype).id("new-id");
+        assertEquals("new-id", userWithId.getId());
+    }
+}


### PR DESCRIPTION
All Tests pass!

Changes to password variables:
- string is replaced by non string holder object/class
- string is replaced by supplier that retrieves data immediately before usage
- string variable removed and retrieval call is inlined