### PR TITLE
fix http 500 for SAML generic calls

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlDiscovery.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlDiscovery.java
@@ -49,6 +49,12 @@ public class LoginSamlDiscovery extends SAMLDiscovery {
             httpServletResponse.sendRedirect(
                 httpServletResponse.encodeRedirectURL(httpServletRequest.getContextPath() + "/login?error=idp_not_found")
             );
+        } catch (Exception allOtherException) {
+            logger.warn("SAML Discovery exception", allOtherException);
+            HttpServletResponse httpServletResponse = (HttpServletResponse)response;
+            HttpServletRequest httpServletRequest = (HttpServletRequest)request;
+            httpServletRequest.getSession(true).setAttribute("oauth_error", allOtherException.getMessage());
+            httpServletResponse.sendRedirect(httpServletRequest.getContextPath() + "/oauth_error");
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensaml.common.SAMLException;
+import org.opensaml.saml2.metadata.provider.MetadataProviderException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -163,8 +164,16 @@ class HomeControllerViewTests extends TestClassNullifier {
     }
 
     @Test
-    void error500WithSAMLExceptionString() throws Exception {
-        mockMvc.perform(get("/error500").requestAttr("javax.servlet.error.exception", new Exception(new SAMLException("error"))))
+    void error500WithClassException() throws Exception {
+        mockMvc.perform(get("/error500").requestAttr("javax.servlet.error.exception", new Exception("bad")))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(customFooterText)))
+            .andExpect(content().string(containsString(base64ProductLogo)));
+        mockMvc.perform(get("/error500").requestAttr("javax.servlet.error.exception", new Exception(new SAMLException("bad"))))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(containsString(customFooterText)))
+            .andExpect(content().string(containsString(base64ProductLogo)));
+        mockMvc.perform(get("/error500").requestAttr("javax.servlet.error.exception", new Exception(new MetadataProviderException("bad"))))
             .andExpect(status().isBadRequest())
             .andExpect(content().string(containsString(customFooterText)))
             .andExpect(content().string(containsString(base64ProductLogo)));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.opensaml.common.SAMLException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -151,6 +152,22 @@ class HomeControllerViewTests extends TestClassNullifier {
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString(customFooterText)))
                 .andExpect(content().string(containsString(base64ProductLogo)));
+    }
+
+    @Test
+    void errorOauthWithExceptionString() throws Exception {
+        mockMvc.perform(get("/oauth_error").sessionAttr("oauth_error", "auth error"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString(customFooterText)))
+            .andExpect(content().string(containsString(base64ProductLogo)));
+    }
+
+    @Test
+    void error500WithSAMLExceptionString() throws Exception {
+        mockMvc.perform(get("/error500").requestAttr("javax.servlet.error.exception", new Exception(new SAMLException("error"))))
+            .andExpect(status().isBadRequest())
+            .andExpect(content().string(containsString(customFooterText)))
+            .andExpect(content().string(containsString(base64ProductLogo)));
     }
 
     @ParameterizedTest

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlDiscoveryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlDiscoveryTest.java
@@ -1,0 +1,30 @@
+package org.cloudfoundry.identity.uaa.provider.saml;
+
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LoginSamlDiscoveryTest {
+
+  @Test
+  void doFilter() throws ServletException, IOException {
+    LoginSamlDiscovery samlDiscovery = new LoginSamlDiscovery();
+    HttpServletResponse servletResponse = mock(HttpServletResponse.class);
+    HttpServletRequest servletRequest = mock(HttpServletRequest.class);
+    HttpSession session = mock(HttpSession.class);
+    FilterChain chain = mock(FilterChain.class);
+    when(servletRequest.getSession(true)).thenReturn(session);
+    samlDiscovery.doFilter(servletRequest, servletResponse, chain);
+    assertNotNull(servletRequest);
+  }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -71,7 +71,10 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -1423,6 +1426,14 @@ public class SamlLoginIT {
         webDriver.get(baseUrl + "/logout.do");
     }
 
+    @Test
+    public void testSpringSamlEndpointsWithEmptyContext() throws IOException {
+        CallEmpptyPageAndCheckHttpStatusCode("/saml/discovery", 200);
+        CallEmpptyPageAndCheckHttpStatusCode("/saml/SingleLogout", 400);
+        CallEmpptyPageAndCheckHttpStatusCode("/saml/login/alias/foo", 400);
+        CallEmpptyPageAndCheckHttpStatusCode("/saml/web/metadata/login", 404);
+        CallEmpptyPageAndCheckHttpStatusCode("/saml/SSO/foo", 200);
+    }
 
     public SamlIdentityProviderDefinition createTestZone2IDP(String alias) {
         return createSimplePHPSamlIDP(alias, "testzone2");
@@ -1494,5 +1505,12 @@ public class SamlLoginIT {
         webDriver.findElement(By.name("username")).sendKeys(testAccounts.getUserName());
         webDriver.findElement(By.name("password")).sendKeys(testAccounts.getPassword());
         webDriver.findElement(By.xpath("//input[@value='Login']")).click();
+    }
+
+    private void CallEmpptyPageAndCheckHttpStatusCode(String errorPath, int codeExpected) throws IOException {
+        HttpURLConnection cn = (HttpURLConnection)new URL(baseUrl + errorPath).openConnection();
+        cn.setRequestMethod("GET");
+        cn.connect();
+        assertEquals("Check status code from " + errorPath + " is " + codeExpected, cn.getResponseCode(), codeExpected);
     }
 }


### PR DESCRIPTION
spring saml library offers some endpoints, e.g.
https://github.com/spring-projects/spring-security-saml/blob/main/sample/src/main/webapp/WEB-INF/securityContext.xml
if you call some then UAA ends in an exception which causes 500 status codes.

If you run UAA in cloud you should omit http 500 because this will decrease your availability.
Therefore redirect some known issue to 400 with bad request and error from SAML library