### PR TITLE
fix id_token mapping

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -399,7 +399,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
         if (claimObject instanceof Collection) {
             Set<String> entry = ((Collection<?>) claimObject).stream().map(String.class::cast).collect(Collectors.toSet());
-            if (entry.size() == 1) {
+            if (entry.size() == 1 && entry.stream().findFirst().isPresent()) {
                 return entry.stream().findFirst().get();
             } else if (entry.size() == 0) {
                 return null;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -399,9 +399,9 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
         if (claimObject instanceof Collection) {
             Set<String> entry = ((Collection<?>) claimObject).stream().map(String.class::cast).collect(Collectors.toSet());
-            if (entry.size() == 1 && entry.stream().findFirst().isPresent()) {
-                return entry.stream().findFirst().get();
-            } else if (entry.size() == 0) {
+            if (entry.size() == 1 ) {
+                return entry.stream().collect(Collectors.toList()).get(0);
+            } else if (entry.isEmpty()) {
                 return null;
             } else {
                 logger.warn("Claim mapping for {} attribute is ambiguous. ({}) ", claimName, entry.size());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -404,11 +404,11 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             } else if (entry.size() == 0) {
                 return null;
             } else {
-                logger.warn("Claim mapping for {} is ambigous. ({}) ", claimName, entry.size());
-                throw new BadCredentialsException("Claim mapping for " + internalName + " is ambigous");
+                logger.warn("Claim mapping for {} attribute is ambiguous. ({}) ", claimName, entry.size());
+                throw new BadCredentialsException("Claim mapping for " + internalName + " attribute is ambiguous");
             }
         }
-        logger.warn("Claim {} cannot be mapped because of invalid type {} ", claimName, claimObject.getClass().getSimpleName());
+        logger.warn("Claim attribute {} cannot be mapped because of invalid type {} ", claimName, claimObject.getClass().getSimpleName());
         throw new BadCredentialsException("External token attribute " + claimName + " cannot be mapped to user attribute " + internalName);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -85,6 +85,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
 import static java.util.Optional.ofNullable;
 import static org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey.KeyType.MAC;
 import static org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey.KeyType.RSA;
@@ -351,10 +352,10 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             Map<String, Object> claims = authenticationData.getClaims();
 
             String username = authenticationData.getUsername();
-            String givenName = (String) claims.get(givenNameClaim == null ? "given_name" : givenNameClaim);
-            String familyName = (String) claims.get(familyNameClaim == null ? "family_name" : familyNameClaim);
-            String phoneNumber = (String) claims.get(phoneClaim == null ? "phone_number" : phoneClaim);
-            String email = (String) claims.get(emailClaim == null ? "email" : emailClaim);
+            String givenName =  getMappedClaim(givenNameClaim, "given_name", claims);
+            String familyName = getMappedClaim(familyNameClaim, "family_name", claims);
+            String phoneNumber = getMappedClaim(phoneClaim, "phone_number", claims);
+            String email = getMappedClaim(emailClaim, "email",claims);
             Object verifiedObj = claims.get(emailVerifiedClaim == null ? "email_verified" : emailVerifiedClaim);
             boolean verified =  verifiedObj instanceof Boolean ? (Boolean)verifiedObj: false;
 
@@ -384,6 +385,31 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
         logger.debug("Authenticate data is missing, unable to return user");
         return null;
+    }
+
+    private String getMappedClaim(String externalName, String internalName, Map<String, Object> claims) {
+        String claimName = isNull(externalName) ? internalName : externalName;
+        Object claimObject = claims.get(claimName);
+
+        if (isNull(claimObject)) {
+            return null;
+        }
+        if (claimObject instanceof String) {
+            return (String) claimObject;
+        }
+        if (claimObject instanceof Collection) {
+            Set<String> entry = ((Collection<?>) claimObject).stream().map(String.class::cast).collect(Collectors.toSet());
+            if (entry.size() == 1) {
+                return entry.stream().findFirst().get();
+            } else if (entry.size() == 0) {
+                return null;
+            } else {
+                logger.warn("Claim mapping for {} is ambigous. ({}) ", claimName, entry.size());
+                throw new BadCredentialsException("Claim mapping for " + internalName + " is ambigous");
+            }
+        }
+        logger.warn("Claim {} cannot be mapped because of invalid type {} ", claimName, claimObject.getClass().getSimpleName());
+        throw new BadCredentialsException("External token attribute " + claimName + " cannot be mapped to user attribute " + internalName);
     }
 
     private List<? extends GrantedAuthority> extractExternalOAuthUserAuthorities(Map<String, Object> attributeMappings, Map<String, Object> claims) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -338,7 +338,7 @@ public class ExternalOAuthAuthenticationManagerTest {
   }
 
     @Test
-    public void getUser_doesThrowWhenIdTokenMappingIsAmbigous() {
+    public void getUser_doesThrowWhenIdTokenMappingIsAmbiguous() {
         Map<String, Object> header = map(
             entry(ALG, "HS256"),
             entry(KID, "oidc-provider-key")
@@ -360,7 +360,7 @@ public class ExternalOAuthAuthenticationManagerTest {
         String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
 
         expectedException.expect(BadCredentialsException.class);
-        expectedException.expectMessage("Claim mapping for family_name is ambigous");
+        expectedException.expectMessage("Claim mapping for family_name attribute is ambiguous");
         ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, origin, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
         authManager.getUser(oidcAuthentication, authManager.getExternalAuthenticationDetails(oidcAuthentication));
     }


### PR DESCRIPTION
fix issue 1831

Issue is in ExternalOAuthAuthenticationManager class where the external id_token is mapped to UAA user attributes. 
Flow is https://docs.cloudfoundry.org/api/uaa/version/75.20.0/index.html#openid-connect-flow

