### PR TITLE
file paths to be quoted in gradle script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -187,8 +187,8 @@ cargo {
         rmiPort = applicationPort + 10
 
         jvmArgs = ""
-        jvmArgs = String.format("%s -DCLOUDFOUNDRY_CONFIG_PATH=%s", jvmArgs, file("scripts/cargo").getAbsolutePath())
-        jvmArgs = String.format("%s -Dlogging.config=%s", jvmArgs, file("scripts/cargo/log4j2.properties").getAbsolutePath())
+        jvmArgs = String.format("%s -DCLOUDFOUNDRY_CONFIG_PATH='%s'", jvmArgs, file("scripts/cargo").getAbsolutePath())
+        jvmArgs = String.format("%s -Dlogging.config='%s'", jvmArgs, file("scripts/cargo/log4j2.properties").getAbsolutePath())
         jvmArgs = String.format("%s -Dstatsd.enabled=true", jvmArgs)
         if (System.getProperty("spring.profiles.active", "").split(',').contains("debug")) {
             jvmArgs = String.format("%s -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005", jvmArgs)


### PR DESCRIPTION
when directory has a '{word1} - {word2}' format as the path
./gradlew run fails as it interprets the '-' as jvmarg for config file

fixes: #1927 