### PR TITLE
Fix SAML login flow by configuring JSESSIONID cookie

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaSessionConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaSessionConfig.java
@@ -32,7 +32,8 @@ public class UaaSessionConfig {
             final @Value("${servlet.session-cookie.max-age:-1}") int cookieMaxAge
     ) {
         DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
-        cookieSerializer.setSameSite(null);
+        cookieSerializer.setSameSite("None");
+        cookieSerializer.setUseSecureCookie(true);
         cookieSerializer.setCookieMaxAge(cookieMaxAge);
         cookieSerializer.setCookieName("JSESSIONID");
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
@@ -138,8 +138,8 @@ public class LoginIT {
             if (cookie.contains("JSESSIONID")) {
                 jsessionIdValidated = true;
                 assertTrue(cookie.contains("HttpOnly"));
-                assertFalse(cookie.contains("Secure"));
-
+                assertTrue(cookie.contains("SameSite=None"));
+                assertTrue(cookie.contains("Secure"));
             }
         }
         assertTrue("Did not find JSESSIONID", jsessionIdValidated);


### PR DESCRIPTION
- Explicitly set JSESSIONID cookie to `SameSite=None`, on which the expected SAML login relies:
After an end-user logs in via SAML, they are redirected back to UAA. At this point, UAA validates
that the SAML assertion originated from the original UAA login by examining the JSESSIONID cookie.
Currently, only `SameSite=None` would guarantee that the cookie would get sent to back UAA after
redirection from SAML login (see: https://web.dev/samesite-cookies-explained/).
- Previously, the SameSite is set to null (https://github.com/cloudfoundry/uaa/commit/8528a19f268fad41d8dd96e9).
We believe that this prior commit intends to set it to `None`, but mistakenly set it to null,
which worked at the time because browsers likely defaulted to `None` in the null case. However,
browsers have changed their default to `Lax`, causing our SAML login to fail. So the current
commit simply restores the prior intended cookie setting.
- Now browsers also require cookies to have the `Secure` attribute when `SameSite=None`
(see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
- Workaround a test that uses an implementation of httpclient that would not send
the `JSESSIONID` cookie that has `Secure` attribute, by manually attaching the `JSESSIONID`
cookie to the request. Though this is "hacky", I deem this acceptable because there are enough
other tests that cover the login behavior; they use webdriver, which would make an exception
for HTTP on localhost (which is the standard [browser behavior](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies))

[Fixes Issue #1620]
[#178935973]