### PR TITLE
CVE-2022-34169: omit xalan

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     }
     implementation(libraries.springSecuritySaml) {
         exclude(module: "bcprov-ext-jdk15on")
+        exclude(module: "xalan")
     }
     implementation(libraries.xmlSecurity)
     implementation(libraries.springSessionJdbc)


### PR DESCRIPTION
see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-34169
e.g.
Note: Java runtimes (such as OpenJDK) include repackaged copies of Xalan.



