### PR TITLE
make DB test script compatible with postgres 13 docker image

### DIFF
--- a/scripts/start_db_helper.sh
+++ b/scripts/start_db_helper.sh
@@ -17,7 +17,7 @@ function bootDB {
 
   if [[ "${db}" = "postgresql" ]]; then
     bootLogLocation="/var/log/postgres-boot.log"
-    launchDB="(POSTGRES_HOST_AUTH_METHOD=trust /docker-entrypoint.sh postgres -c 'max_connections=250' &> ${bootLogLocation}) &"
+    launchDB="(POSTGRES_HOST_AUTH_METHOD=trust docker-entrypoint.sh postgres -c 'max_connections=250' &> ${bootLogLocation}) &"
     testConnection="(! ps aux | grep docker-entrypoint | grep -v 'grep') && psql -h localhost -U postgres -c '\conninfo' &>/dev/null"
     initDB="psql -c 'drop database if exists uaa;' -U postgres; psql -c 'create database uaa;' -U postgres; psql -c 'drop user if exists root;' --dbname=uaa -U postgres; psql -c \"create user root with superuser password 'changeme';\" --dbname=uaa -U postgres; psql -c 'show max_connections;' --dbname=uaa -U postgres;"
 


### PR DESCRIPTION
- in the new postgres 13 docker image, it no longer adds the image
layer to run `/bin/sh -c ln -s usr/local/bin/docker-entrypoint.sh / #
backwards compat` like postgres 10 or 9 images do; hence we will see
this error:
```
/tmp/build/b4e0c68a/uaa/scripts/start_db_helper.sh: line 66: /docker-entrypoint.sh: No such file or directory
```
- edit the script to simply call `docker-entrypoint.sh` since
`usr/local/bin/docker-entrypoint.sh` exists across all postgres
docker images.

[#181066137]

Co-authored-by: Hongchol Sinn <hsinn@vmware.com>