### PR TITLE
Revert "Remove unnecessary version pinnings after bumping `spring-boot` to 2.6.8"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,6 +4,7 @@ ext {
 }
 
 // Versions we're overriding from the Spring Boot Bom
+ext["mariadb.version"] = "2.7.4"
 ext["flyway.version"] = "7.15.0"
 
 // Versions shared between multiple dependencies


### PR DESCRIPTION
This reverts commit 335bf0accc5bcb1fcb82fa738937941d6cb06078.