### PR TITLE
Bump mariadb version 2.7.6

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
 }
 
 // Versions we're overriding from the Spring Boot Bom
-ext["mariadb.version"] = "2.7.4"
+ext["mariadb.version"] = "2.7.6"
 ext["flyway.version"] = "7.15.0"
 
 // Versions shared between multiple dependencies


### PR DESCRIPTION
I think you reverted back to 2.7.4 because in spring boot 2.7.x the version is pinned to 3.x
So I am fine with 2.7.x , but I think we should then define  latest version there ?