### PR TITLE
fix https://github.com/cloudfoundry/uaa/issues/1983

### DIFF
--- a/server/src/main/resources/spring/env.xml
+++ b/server/src/main/resources/spring/env.xml
@@ -59,6 +59,7 @@
             <prop key="database.username">sa</prop>
             <prop key="database.password"></prop>
             <prop key="database.maxParameters">-1</prop>
+            <prop key="database.useSkipLocked">false</prop>
         </util:properties>
         <bean id="platform" class="java.lang.String">
             <constructor-arg value="hsqldb"/>
@@ -79,6 +80,7 @@
             <prop key="database.username">root</prop>
             <prop key="database.password">changeme</prop>
             <prop key="database.maxParameters">32767</prop>
+            <prop key="database.useSkipLocked">true</prop>
         </util:properties>
         <bean id="platform" class="java.lang.String">
             <constructor-arg value="postgresql"/>
@@ -99,6 +101,7 @@
             <prop key="database.username">root</prop>
             <prop key="database.password">changeme</prop>
             <prop key="database.maxParameters">-1</prop>
+            <prop key="database.useSkipLocked">false</prop>
         </util:properties>
         <bean id="platform" class="java.lang.String">
             <constructor-arg value="mysql"/>

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabaseTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabaseTests.java
@@ -33,7 +33,9 @@ import java.util.stream.Collectors;
 
 import static org.cloudfoundry.identity.uaa.user.JdbcUaaUserDatabase.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -385,6 +387,18 @@ class JdbcUaaUserDatabaseTests {
         }
 
         jdbcUaaUserDatabase.setMaxSqlParameters(oldValue);
+    }
+
+    @Test
+    void testSkipLockedQuery() {
+        boolean oldValue = jdbcUaaUserDatabase.isUseSkipLocked();
+        jdbcUaaUserDatabase.setUseSkipLocked(true);
+        jdbcUaaUserDatabase.init();
+        assertThat(DEFAULT_UPDATE_USER_LAST_LOGON, containsString("skip locked"));
+        jdbcUaaUserDatabase.setUseSkipLocked(false);
+        jdbcUaaUserDatabase.init();
+        assertThat(DEFAULT_UPDATE_USER_LAST_LOGON, not(containsString("skip locked")));
+        jdbcUaaUserDatabase.setUseSkipLocked(oldValue);
     }
 
     private void validateBob(int numberAuths, UaaUser bob, int prefix) {


### PR DESCRIPTION
alternative fix for issue #1983 

Because of existing paramter maxSqlParameters and https://github.com/cloudfoundry/uaa/pull/1143
The meaning of the parameter was mainly for postgresql but in implementation there was no reference to a DB , same done in this PR

Sonar is green because with the property we can test of switching the behaviour, similar to maxSqlParameter
https://sonarcloud.io/summary/new_code?id=cloudfoundry-identity-parent&pullRequest=1993