### PR TITLE
Update UAA server debug mode run options

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,21 @@ To load JDWP agent for UAA jvm debugging, start the server as follows:
 ```sh
 ./gradlew run -Dxdebug=true
 ```
+or
+```sh
+./gradlew -Dspring.profiles.active=default,hsqldb,debug run
+```
 You can then attach your debugger to port 5005 of the jvm process.
+
+To suspend the server start-up until the debugger is attached (useful for
+debugging start-up code), start the server as follows:
+```sh
+./gradlew run -Dxdebugs=true
+```
+or
+```sh
+./gradlew -Dspring.profiles.active=default,hsqldb,debugs run
+```
 
 ## Running tests
 

--- a/build.gradle
+++ b/build.gradle
@@ -187,13 +187,12 @@ cargo {
         jvmArgs = String.format("%s -DCLOUDFOUNDRY_CONFIG_PATH='%s'", jvmArgs, file("scripts/cargo").getAbsolutePath())
         jvmArgs = String.format("%s -Dlogging.config='%s'", jvmArgs, file("scripts/cargo/log4j2.properties").getAbsolutePath())
         jvmArgs = String.format("%s -Dstatsd.enabled=true", jvmArgs)
-        if (System.getProperty("spring.profiles.active", "").split(',').contains("debug")) {
-            jvmArgs = String.format("%s -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005", jvmArgs)
+        String activeSpringProfiles = System.getProperty("spring.profiles.active", "").split(',');
+        if (activeSpringProfiles.contains("debugs") || Boolean.valueOf(System.getProperty("xdebugs"))) {
+            jvmArgs = String.format("%s -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005", jvmArgs)
         }
-        else if (Boolean.valueOf(System.getProperty("xdebug"))) {
-            jvmArgs = String.format("%s -Xdebug " +
-                    "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 " +
-                    "-Xnoagent -Djava.compiler=NONE", jvmArgs)
+        else if (activeSpringProfiles.contains("debug") || Boolean.valueOf(System.getProperty("xdebug"))) {
+            jvmArgs = String.format("%s -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005", jvmArgs)
         }
 
         outputFile = file("uaa/build/reports/tests/uaa-server.log")


### PR DESCRIPTION
- Use `-agentlib` option instead of `-Xrunjdwp`
- Add gradle run option to suspend the server till the debugger is attached
- Update the related section in README