### PR TITLE
feature: Set LDAP connection timeout to 30 minutes

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LdapIntegrationConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LdapIntegrationConfig.java
@@ -2,13 +2,11 @@ package org.cloudfoundry.identity.uaa.impl.config;
 
 import org.cloudfoundry.identity.uaa.provider.ldap.ExtendedLdapUserMapper;
 import org.cloudfoundry.identity.uaa.provider.ldap.ProcessLdapProperties;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,6 +15,9 @@ import static java.util.Optional.ofNullable;
 
 @Configuration
 public class LdapIntegrationConfig {
+  public static final String CONNECT_TIMEOUT_MILLIS_KEY =
+          "com.sun.jndi.ldap.connect.timeout";
+  public static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofMinutes(30);
 
   @Bean
   public ProcessLdapProperties ldapPropertyProcessor(Environment environment) {
@@ -30,6 +31,8 @@ public class LdapIntegrationConfig {
   public Map ldapProperties(Environment environment) {
     Map initialLdapProperties = new HashMap();
     initialLdapProperties.put("com.sun.jndi.ldap.connect.pool", false);
+    initialLdapProperties.put(CONNECT_TIMEOUT_MILLIS_KEY,
+            String.valueOf(DEFAULT_CONNECT_TIMEOUT.toMillis()));
     initialLdapProperties.put("java.naming.referral", ofNullable(environment.getProperty("ldap.base.referral")).orElse("follow"));
     return ldapPropertyProcessor(environment).process(initialLdapProperties);
   }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/BaseLdapSocketFactory.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/BaseLdapSocketFactory.java
@@ -29,6 +29,11 @@ public abstract class BaseLdapSocketFactory extends SSLSocketFactory {
     }
 
     @Override
+    public Socket createSocket() throws IOException {
+        return delegate.createSocket();
+    }
+
+    @Override
     public Socket createSocket(Socket socket, String s, int i, boolean b) throws IOException {
         return delegate.createSocket(socket, s, i, b);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/LdapIntegrationConfigTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/impl/config/LdapIntegrationConfigTest.java
@@ -1,0 +1,27 @@
+package org.cloudfoundry.identity.uaa.impl.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.env.Environment;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LdapIntegrationConfigTest {
+    LdapIntegrationConfig ldapIntegrationConfig;
+
+    @BeforeEach
+    void beforeEach() {
+        ldapIntegrationConfig = new LdapIntegrationConfig();
+    }
+
+    @Test
+    void testSetLdapTimeoutPropertyTo30Minutes() {
+        Environment env = Mockito.mock(Environment.class);
+        Map properties = ldapIntegrationConfig.ldapProperties(env);
+        assertEquals(String.valueOf(30 * 60 * 1000),
+                properties.get("com.sun.jndi.ldap.connect.timeout"));
+    }
+}


### PR DESCRIPTION
- So as to prevent UAA server from holding onto LDAP sockets indefinitely
- Implement `createSocket()` method in `BaseLdapSocketFactory` class, which is used in test code, because the default base class method just throws UnsupportedOperationException causing unit test failures when the timeout is specified

[#182374849]

Co-authored-by: Peter Chen <peterch@vmware.com>
Co-authored-by: Bruce Ricard <bricard@vmware.com>
Co-authored-by: Danny Faught <dfaught@vmware.com>