### PR TITLE
Refactor refreshAccessToken()

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        String revocableHashSignature = claims.getRevSig();
         Map<String, String> additionalAuthorizationInfo = claims.getAzAttr();
         Set<String> audience = Set.copyOf(claims.getAud());
         Long authTime = claims.getAuthTime();
@@ -285,7 +284,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 claims.getGrantType(),
                 client);
 
-        throwIfInvalidRevocationHashSignature(revocableHashSignature, user, client);
+        throwIfInvalidRevocationHashSignature(claims.getRevSig(), user, client);
 
         Map<String, Object> additionalRootClaims = new HashMap<>();
         if (uaaTokenEnhancer != null) {
@@ -324,7 +323,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                     refreshTokenValue,
                     additionalAuthorizationInfo,
                     additionalRootClaims,
-                    revocableHashSignature,
+                    claims.getRevSig(),
                     isRevocable,
                     authenticationData
             );

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        Boolean revocableClaim = claims.isRevocable();
         String refreshGrantType = claims.getGrantType();
         String nonce = claims.getNonce();
         String revocableHashSignature = claims.getRevSig();
@@ -261,7 +260,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         }
         boolean isOpaque = OPAQUE.getStringValue().equals(requestedTokenFormat);
 
-        boolean isRevocable = isOpaque || (revocableClaim == null ? false : revocableClaim);
+        // TODO: simplify by removing the null check, after adding condition coverage in the test
+        boolean isRevocable = isOpaque || ((Boolean) claims.isRevocable() == null ? false : claims.isRevocable());
 
         UaaUser user = new UaaUser(userDatabase.retrieveUserPrototypeById(claims.getUserId()));
         BaseClientDetails client = (BaseClientDetails) clientDetailsService.loadClientByClientId(claims.getCid());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        Long authTime = claims.getAuthTime();
 
         // default request scopes to what is in the refresh token
         Set<String> requestedScopes = request.getScope().isEmpty() ? Sets.newHashSet(tokenScopes) : request.getScope();
@@ -297,7 +296,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         }
 
         UserAuthenticationData authenticationData = new UserAuthenticationData(
-                AuthTimeDateConverter.authTimeToDate(authTime),
+                AuthTimeDateConverter.authTimeToDate(claims.getAuthTime()),
                 authenticationMethodsAsSet(refreshTokenClaims),
                 getAcrAsSet(refreshTokenClaims),
                 requestedScopes,
@@ -314,7 +313,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             createCompositeToken(
                     accessTokenId,
                     user,
-                    AuthTimeDateConverter.authTimeToDate(authTime),
+                    AuthTimeDateConverter.authTimeToDate(claims.getAuthTime()),
                     getClientPermissions(client),
                     claims.getCid(),
                     Set.copyOf(claims.getAud()),

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -253,9 +253,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             throw new InvalidGrantException("Wrong client for this refresh token: " + claims.getCid());
         }
         boolean isOpaque = OPAQUE.getStringValue().equals(requestedTokenFormat);
-
-        // TODO: simplify by removing the null check, after adding condition coverage in the test
-        boolean isRevocable = isOpaque || ((Boolean) claims.isRevocable() == null ? false : claims.isRevocable());
+        boolean isRevocable = isRevocable(claims, isOpaque);
 
         UaaUser user = new UaaUser(userDatabase.retrieveUserPrototypeById(claims.getUserId()));
         BaseClientDetails client = (BaseClientDetails) clientDetailsService.loadClientByClientId(claims.getCid());
@@ -330,6 +328,10 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         );
 
         return persistRevocableToken(accessTokenId, compositeToken, expiringRefreshToken, claims.getCid(), user.getId(), isOpaque, isRevocable);
+    }
+
+    static boolean isRevocable(Claims claims, boolean isOpaque) {
+        return isOpaque || claims.isRevocable();
     }
 
     private void throwIfInvalidRevocationHashSignature(String revocableHashSignature, UaaUser user, ClientDetails client) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        Set<String> audience = Set.copyOf(claims.getAud());
         Long authTime = claims.getAuthTime();
 
         // default request scopes to what is in the refresh token
@@ -318,7 +317,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                     AuthTimeDateConverter.authTimeToDate(authTime),
                     getClientPermissions(client),
                     claims.getCid(),
-                    audience,
+                    Set.copyOf(claims.getAud()),
                     refreshTokenValue,
                     claims.getAzAttr(),
                     additionalRootClaims,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        String userId = claims.getUserId();
         String refreshTokenId = claims.getJti();
         Long refreshTokenExpirySeconds = claims.getExp();
         String clientId = claims.getCid();
@@ -267,7 +266,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
         boolean isRevocable = isOpaque || (revocableClaim == null ? false : revocableClaim);
 
-        UaaUser user = new UaaUser(userDatabase.retrieveUserPrototypeById(userId));
+        UaaUser user = new UaaUser(userDatabase.retrieveUserPrototypeById(claims.getUserId()));
         BaseClientDetails client = (BaseClientDetails) clientDetailsService.loadClientByClientId(clientId);
 
         long refreshTokenExpireMillis = refreshTokenExpirySeconds.longValue() * 1000L;
@@ -286,7 +285,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         // ensure all requested scopes are approved: either automatically or
         // explicitly by the user
         approvalService.ensureRequiredApprovals(
-                userId,
+                claims.getUserId(),
                 requestedScopes,
                 refreshGrantType,
                 client);
@@ -310,8 +309,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 authenticationMethodsAsSet(refreshTokenClaims),
                 getAcrAsSet(refreshTokenClaims),
                 requestedScopes,
-                rolesAsSet(userId),
-                getUserAttributes(userId),
+                rolesAsSet(claims.getUserId()),
+                getUserAttributes(claims.getUserId()),
                 nonce,
                 refreshGrantType,
                 generateUniqueTokenId()

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        String nonce = claims.getNonce();
         String revocableHashSignature = claims.getRevSig();
         Map<String, String> additionalAuthorizationInfo = claims.getAzAttr();
         Set<String> audience = Set.copyOf(claims.getAud());
@@ -307,7 +306,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 requestedScopes,
                 rolesAsSet(claims.getUserId()),
                 getUserAttributes(claims.getUserId()),
-                nonce,
+                claims.getNonce(),
                 claims.getGrantType(),
                 generateUniqueTokenId()
         );

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        String refreshTokenId = claims.getJti();
         Long refreshTokenExpirySeconds = claims.getExp();
         String clientId = claims.getCid();
         Boolean revocableClaim = claims.isRevocable();
@@ -335,7 +334,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             );
 
         CompositeExpiringOAuth2RefreshToken expiringRefreshToken = new CompositeExpiringOAuth2RefreshToken(
-                refreshTokenValue, new Date(refreshTokenExpireMillis), refreshTokenId
+                refreshTokenValue, new Date(refreshTokenExpireMillis), claims.getJti()
         );
 
         return persistRevocableToken(accessTokenId, compositeToken, expiringRefreshToken, clientId, user.getId(), isOpaque, isRevocable);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        Long refreshTokenExpirySeconds = claims.getExp();
         String clientId = claims.getCid();
         Boolean revocableClaim = claims.isRevocable();
         String refreshGrantType = claims.getGrantType();
@@ -268,7 +267,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         UaaUser user = new UaaUser(userDatabase.retrieveUserPrototypeById(claims.getUserId()));
         BaseClientDetails client = (BaseClientDetails) clientDetailsService.loadClientByClientId(clientId);
 
-        long refreshTokenExpireMillis = refreshTokenExpirySeconds.longValue() * 1000L;
+        long refreshTokenExpireMillis = claims.getExp().longValue() * 1000L;
         if (new Date(refreshTokenExpireMillis).before(timeService.getCurrentDate())) {
             throw new InvalidTokenException("Invalid refresh token expired at " + new Date(refreshTokenExpireMillis));
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -232,14 +232,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         ArrayList<String> tokenScopes = getScopesFromRefreshToken(refreshTokenClaims);
         refreshTokenCreator.ensureRefreshTokenCreationNotRestricted(tokenScopes);
 
-        Claims claims;
-        try {
-            String s = JsonUtils.writeValueAsString(refreshTokenClaims);
-            claims = JsonUtils.readValue(s, Claims.class);
-        } catch (JsonUtils.JsonUtilException e) {
-            logger.error("Cannot read token claims", e);
-            throw new InvalidTokenException("Cannot read token claims", e);
-        }
+        Claims claims = getClaims(refreshTokenClaims);
 
         // default request scopes to what is in the refresh token
         Set<String> requestedScopes = request.getScope().isEmpty() ? Sets.newHashSet(tokenScopes) : request.getScope();
@@ -316,6 +309,16 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         );
 
         return persistRevocableToken(accessTokenId, compositeToken, expiringRefreshToken, claims.getCid(), user.getId(), isOpaque, isRevocable);
+    }
+
+    Claims getClaims(Map<String, Object> refreshTokenClaims) {
+        try {
+            String s = JsonUtils.writeValueAsString(refreshTokenClaims);
+            return JsonUtils.readValue(s, Claims.class);
+        } catch (JsonUtils.JsonUtilException e) {
+            logger.error("Cannot read token claims", e);
+            throw new InvalidTokenException("Cannot read token claims", e);
+        }
     }
 
     private Map<String, Object> getAdditionalRootClaims(Map<String, Object> refreshTokenClaims) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        Map<String, String> additionalAuthorizationInfo = claims.getAzAttr();
         Set<String> audience = Set.copyOf(claims.getAud());
         Long authTime = claims.getAuthTime();
 
@@ -321,7 +320,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                     claims.getCid(),
                     audience,
                     refreshTokenValue,
-                    additionalAuthorizationInfo,
+                    claims.getAzAttr(),
                     additionalRootClaims,
                     claims.getRevSig(),
                     isRevocable,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -242,7 +242,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             logger.error("Cannot read token claims", e);
             throw new InvalidTokenException("Cannot read token claims", e);
         }
-        String refreshGrantType = claims.getGrantType();
         String nonce = claims.getNonce();
         String revocableHashSignature = claims.getRevSig();
         Map<String, String> additionalAuthorizationInfo = claims.getAzAttr();
@@ -284,7 +283,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         approvalService.ensureRequiredApprovals(
                 claims.getUserId(),
                 requestedScopes,
-                refreshGrantType,
+                claims.getGrantType(),
                 client);
 
         throwIfInvalidRevocationHashSignature(revocableHashSignature, user, client);
@@ -309,7 +308,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 rolesAsSet(claims.getUserId()),
                 getUserAttributes(claims.getUserId()),
                 nonce,
-                refreshGrantType,
+                claims.getGrantType(),
                 generateUniqueTokenId()
         );
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
@@ -1908,6 +1908,36 @@ public class DeprecatedUaaTokenServicesTests {
         tokenServices.refreshAccessToken(getOAuth2AccessToken().getValue(), getRefreshTokenRequest());
     }
 
+    @Test
+    public void isRevocableTrueIfOpaque() {
+        Claims claims = new Claims();
+        claims.setRevocable(false);
+
+        boolean revocable = tokenServices.isRevocable(new Claims(), true);
+
+        assertTrue(revocable);
+    }
+
+    @Test
+    public void isRevocableTrueIfRevocableAndNotOpaque() {
+        Claims claims = new Claims();
+        claims.setRevocable(true);
+
+        boolean revocable = tokenServices.isRevocable(new Claims(), true);
+
+        assertTrue(revocable);
+    }
+
+    @Test
+    public void isRevocableFalseIfRevocableAndNotOpaque() {
+        Claims claims = new Claims();
+        claims.setRevocable(false);
+
+        boolean revocable = tokenServices.isRevocable(new Claims(), false);
+
+        assertFalse(revocable);
+    }
+
     private void readAccessToken(Set<String> excludedClaims) {
         tokenServices.setExcludedClaims(excludedClaims);
         AuthorizationRequest authorizationRequest = new AuthorizationRequest(CLIENT_ID, tokenSupport.requestedAuthScopes);


### PR DESCRIPTION
Refactorings that reduce the `refreshAccessToken()` method from 120 lines to 92 lines, with the goal of making the method easier to change. The method has 100% line coverage from the `DeprecatedUaaTokenServicesTests` unit tests.

There is ample opportunity to refactor this long method further and improve the tests.

Most of the changes were very safe mechanical refactorings done with IntelliJ. Note that some readability was lost when variables were in-lined because the variable names were more expressive than the names of the getters that replaced them. This would be best mitigated by refactoring the method names in the `Claims()` class.