### PR TITLE
Fix: add scope parameter if defined in password grant

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.authentication.manager;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.cloudfoundry.identity.uaa.authentication.ProviderConfigurationException;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
 import org.cloudfoundry.identity.uaa.authentication.UaaLoginHint;
@@ -168,6 +169,9 @@ public class PasswordGrantAuthenticationManager implements AuthenticationManager
         params.add("response_type","id_token");
         params.add("username", userName);
         params.add("password", passProvider.get());
+        if (ObjectUtils.isNotEmpty(config.getScopes())) {
+            params.add("scope", String.join(" ", config.getScopes()));
+        }
 
         List<Prompt> prompts = config.getPrompts();
         List<String> promptsToInclude = new ArrayList<>();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManagerTest.java
@@ -374,6 +374,7 @@ class PasswordGrantAuthenticationManagerTest {
         /* mock idp config using jwt client authentication */
         when(idpConfig.getRelyingPartySecret()).thenReturn(null);
         when(idpConfig.getJwtClientAuthentication()).thenReturn(true);
+        when(idpConfig.getScopes()).thenReturn(Arrays.asList("openid", "email"));
         /* hint mock to use idp for password grant */
         Authentication auth = getAuthenticationWithUaaHint();
         /* HTTP mock */
@@ -390,6 +391,8 @@ class PasswordGrantAuthenticationManagerTest {
         assertTrue(httpEntityBody.containsKey("client_assertion"));
         assertTrue(httpEntityBody.containsKey("client_assertion_type"));
         assertEquals(Collections.singletonList(JwtClientAuthentication.GRANT_TYPE), httpEntityBody.get("client_assertion_type"));
+        assertTrue(httpEntityBody.containsKey("scope"));
+        assertEquals(Collections.singletonList("openid email"), httpEntityBody.get("scope"));
         /* verify client assertion according OIDC private_key_jwt */
         JWTClaimsSet jwtClaimsSet = JWTParser.parse((String) httpEntityBody.get("client_assertion").get(0)).getJWTClaimsSet();
         assertEquals(Collections.singletonList("http://localhost:8080/uaa/oauth/token"), jwtClaimsSet.getAudience());


### PR DESCRIPTION
found by accident during manual test with Okta
Okta defined as OIDC proxy , set as default Idp and then do password grant to UAA

scope is optional in many IDPs but Okta requires it, https://www.rfc-editor.org/rfc/rfc6749