### PR TITLE
Github action: Unit and Integration Tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: JUnit tests on database
+name: Integration tests on database
 on:
   pull_request:
     branches: [ develop ]
@@ -23,16 +23,16 @@ jobs:
         run: echo "DB=$(echo ${{ matrix.database }} | sed 's/[-0-9]//g')" >> $GITHUB_ENV
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: JUnit tests on container
+      - name: Integration tests on container
         id: testrun
-        run: /root/uaa/scripts/unit-tests.sh $DB,default
+        run: /root/uaa/scripts/integration-tests.sh $DB,default
         continue-on-error: true
       - name: Test result upload
         uses: actions/upload-artifact@v3
         if: steps.testrun.outcome == 'failure'
         with:
           name: Server test
-          path: /root/uaa/*/build/reports/tests/test/
+          path: /root/uaa/*/build/reports/tests/integrationTest/
       - name: Check error Result
         run: exit 1
         if: steps.testrun.outcome == 'failure'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        database: [ 'postgresql-11', 'postgresql-15', 'mysql-5', 'mysql-8' ]
+        database: [ 'postgresql-11', 'postgresql-15', 'mysql', 'mysql-8' ]
     container:
       image: cfidentity/uaa-${{ matrix.database }}
       volumes:
@@ -20,7 +20,7 @@ jobs:
       options: --privileged --tty --interactive --shm-size=1G
     steps:
       - name: Set env
-        run: echo "DB=$(echo ${{ matrix.database }} | sed 's/[-0-9]//g'" >> $GITHUB_ENV
+        run: echo "DB=$(echo ${{ matrix.database }} | sed 's/[-0-9]//g')" >> $GITHUB_ENV
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: JUnit tests on container

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         database: [ 'postgresql-11', 'postgresql-15', 'mysql-5', 'mysql-8' ]
     container:
-      image: cfidentity/${{ matrix.database }}
+      image: cfidentity/uaa-${{ matrix.database }}
       volumes:
         - ${{ github.workspace }}:/root/uaa
       options: --privileged --tty --interactive --shm-size=1G

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-        matrix:
-          database: [ 'postgresql-11', 'postgresql-15', 'mysql-5', 'mysql-8' ]
+      matrix:
+        database: [ 'postgresql-11', 'postgresql-15', 'mysql-5', 'mysql-8' ]
     container:
       image: cfidentity/${{ matrix.database }}
       volumes:

--- a/.github/workflows/unit-tests.yml 
+++ b/.github/workflows/unit-tests.yml 
@@ -1,0 +1,38 @@
+name: JUnit tests on database
+on:
+  pull_request:
+    branches: [ develop ]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  container-test-job:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+        matrix:
+          database: [ 'postgresql-11', 'postgresql-15', 'mysql-5', 'mysql-8' ]
+    container:
+      image: cfidentity/${{ matrix.database }}
+      volumes:
+        - ${{ github.workspace }}:/root/uaa
+      options: --privileged --tty --interactive --shm-size=1G
+    steps:
+      - name: Set env
+        run: echo "DB=$(echo ${{ matrix.database }} | sed 's/[-0-9]//g'" >> $GITHUB_ENV
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: JUnit tests on container
+        id: testrun
+        run: env DB=$DB /root/uaa/scripts/unit-tests.sh $DB,default
+        continue-on-error: true
+      - name: Test result upload
+        uses: actions/upload-artifact@v3
+        if: steps.testrun.outcome == 'failure'
+        with:
+          name: Server test
+          path: /root/uaa/*/build/reports/tests/test/
+      - name: Check error Result
+        run: exit 1
+        if: steps.testrun.outcome == 'failure'

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -21,10 +21,10 @@ case "${DB}" in
         PROFILE_NAME=mysql
         ;;
 
-    postgresql)
+    postgresql|postgresql-15||postgresql-11)
         DB_IMAGE_NAME=$1
-        DB=$1
-        PROFILE_NAME=$1
+        DB=postgresql
+        PROFILE_NAME=postgresql
         ;;
 
     mysql|mysql-8)


### PR DESCRIPTION
Created 2 GH Actions to run all Unit and Integration tests in Docker - as CI in hush house does it
There is currently an issue with latest postgres version, therefore one failing.

If there are new DBs, define them in the matrix. I defined only 2 per postgres and mysql. hdbsql is not needed because we have another GH job which does unit tests

If you open Checks in a PR , e.g. https://github.com/cloudfoundry/uaa/pull/2161/checks you see all workers.
In case of a failure, I upload the test output to this PR, so that you can get more infos . 
I do not upload these test results in success case because I dont see a need to upload some MBs 