### PR TITLE
wip: Updating usage of postgres SQL for v15 to avoid system tables in…

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/db/PostgresDbMigrationIntegrationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/db/PostgresDbMigrationIntegrationTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 public class PostgresDbMigrationIntegrationTest extends DbMigrationIntegrationTestParent {
 
     private String checkPrimaryKeyExists = "SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_CATALOG = ? AND TABLE_NAME = LOWER(?) AND CONSTRAINT_NAME LIKE LOWER(?)";
-    private String getAllTableNames = "SELECT distinct TABLE_NAME from information_schema.KEY_COLUMN_USAGE where TABLE_CATALOG = ? and TABLE_NAME != 'schema_version'";
+    private String getAllTableNames = "SELECT distinct TABLE_NAME from information_schema.KEY_COLUMN_USAGE where TABLE_CATALOG = ? and (TABLE_NAME != 'schema_version' OR TABLE_SCHEMA != 'pg_catalog')";
     private String insertNewOauthCodeRecord = "insert into oauth_code(code) values('code');";
     private String fetchColumnTypeFromTable = "SELECT udt_name FROM information_schema.columns WHERE table_name = ? and TABLE_SCHEMA = ? and column_name = ?";
     private String fetchIsNullableFromTable = "SELECT is_nullable FROM information_schema.columns WHERE table_name = ? and TABLE_SCHEMA = ? and column_name = ?";

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/db/PostgresDbMigrationIntegrationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/db/PostgresDbMigrationIntegrationTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.fail;
 public class PostgresDbMigrationIntegrationTest extends DbMigrationIntegrationTestParent {
 
     private String checkPrimaryKeyExists = "SELECT COUNT(*) FROM information_schema.KEY_COLUMN_USAGE WHERE TABLE_CATALOG = ? AND TABLE_NAME = LOWER(?) AND CONSTRAINT_NAME LIKE LOWER(?)";
-    private String getAllTableNames = "SELECT distinct TABLE_NAME from information_schema.KEY_COLUMN_USAGE where TABLE_CATALOG = ? and (TABLE_NAME != 'schema_version' OR TABLE_SCHEMA != 'pg_catalog')";
+    private String getAllTableNames = "SELECT distinct TABLE_NAME from information_schema.KEY_COLUMN_USAGE where TABLE_CATALOG = ? and TABLE_NAME != 'schema_version' AND TABLE_SCHEMA != 'pg_catalog'";
     private String insertNewOauthCodeRecord = "insert into oauth_code(code) values('code');";
     private String fetchColumnTypeFromTable = "SELECT udt_name FROM information_schema.columns WHERE table_name = ? and TABLE_SCHEMA = ? and column_name = ?";
     private String fetchIsNullableFromTable = "SELECT is_nullable FROM information_schema.columns WHERE table_name = ? and TABLE_SCHEMA = ? and column_name = ?";


### PR DESCRIPTION
… the table_schema='pg_catalog' to avoid system fields not having a _pk suffix in the name as a proxy for a primary key.

Postgres 15 returns _index suffixed names in internal system constraints/indexes.

[#184197793]