### PR TITLE
Extend SCIM limit for ITs

### DIFF
--- a/scripts/cargo/uaa.yml
+++ b/scripts/cargo/uaa.yml
@@ -82,7 +82,7 @@ ratelimit:
       pathSelectors:
         - "equals:/info"
     - name: SCIM
-      withCallerCredentialsID: 200r/s
+      withCallerCredentialsID: 500r/s
       pathSelectors:
         - "startsWith:/Users"
         - "startsWith:/Groups"


### PR DESCRIPTION
github action tests run that fast, that we have to increase this limit, otherwise we see from time to time 429