### PR TITLE
Revert "build(deps): bump rack from 2.0.9.1 to 2.1.4.2 in /uaa/slate"

### DIFF
--- a/uaa/slate/Gemfile
+++ b/uaa/slate/Gemfile
@@ -10,5 +10,5 @@ gem 'rouge', '~> 2.0.5'
 gem 'redcarpet', '~> 3.5.1'
 gem 'nokogiri', '~> 1.13.10'
 gem 'ffi', '~> 1.9.24'
-gem 'rack', '~> 2.1.4.2'
+gem 'rack', '~> 2.0.9.1'
 gem 'therubyracer', :platform => :ruby

--- a/uaa/slate/Gemfile.lock
+++ b/uaa/slate/Gemfile.lock
@@ -94,7 +94,7 @@ GEM
     parallel (1.10.0)
     public_suffix (4.0.6)
     racc (1.6.1)
-    rack (2.1.4.2)
+    rack (2.0.9.1)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
       ffi (>= 0.5.0)
@@ -127,7 +127,7 @@ DEPENDENCIES
   middleman-sprockets (~> 4.1.1)
   middleman-syntax (~> 3.0.0)
   nokogiri (~> 1.13.10)
-  rack (~> 2.1.4.2)
+  rack (~> 2.0.9.1)
   redcarpet (~> 3.5.1)
   rouge (~> 2.0.5)
   therubyracer


### PR DESCRIPTION
Reverts cloudfoundry/uaa#2169