### PR TITLE
Fix pemEncodePublicKey

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwk/JsonWebKey.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwk/JsonWebKey.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.nimbusds.jose.HeaderParameterNames;
 import com.nimbusds.jose.jwk.JWKParameterNames;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.BaseNCodec;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -46,6 +47,8 @@ import static org.springframework.util.StringUtils.hasText;
 @JsonDeserialize(using = JsonWebKeyDeserializer.class)
 @JsonSerialize(using = JsonWebKeySerializer.class)
 public class JsonWebKey {
+
+    private static final java.util.Base64.Encoder base64encoder = java.util.Base64.getMimeEncoder(BaseNCodec.PEM_CHUNK_SIZE, "\n".getBytes());
 
     // value is not defined in RFC 7517
     public static final String PUBLIC_KEY_VALUE = "value";
@@ -155,7 +158,8 @@ public class JsonWebKey {
         String begin = "-----BEGIN PUBLIC KEY-----\n";
         String end = "\n-----END PUBLIC KEY-----";
         byte[] data = publicKey.getEncoded();
-        String base64encoded = new String(new Base64(false).encode(data));
+        String base64encoded = new String(base64encoder.encode(data));
+
         return begin + base64encoded + end;
     }
 


### PR DESCRIPTION
There were 2 version, one in KeyInfo, one in JsonWebKey The version from JsonWebKey was with \r\n instead of only \n

Deleted the version from KeyInfo with PR #2118, fix this now. Ensure that value entry in token_key is as before