### PR TITLE
Refactor timeout check

### DIFF
--- a/statsd-lib/src/test/java/org/cloudfoundry/identity/statsd/integration/UaaMetricsEmitterIT.java
+++ b/statsd-lib/src/test/java/org/cloudfoundry/identity/statsd/integration/UaaMetricsEmitterIT.java
@@ -18,6 +18,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.cloudfoundry.identity.statsd.integration.IntegrationTestUtils.*;
@@ -25,7 +26,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.*;
 
 class UaaMetricsEmitterIT {
-    private static final int WAIT_FOR_MESSAGE = 5500;
+    private static final long WAIT_FOR_MESSAGE = TimeUnit.MILLISECONDS.toNanos(5500);
     private static DatagramSocket serverSocket;
     private static byte[] receiveData;
     private static DatagramPacket receivePacket;
@@ -114,7 +115,7 @@ class UaaMetricsEmitterIT {
     }
 
     private static Map<String, String> getMessages(List<String> fragments) throws IOException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         Map<String, String> results = new HashMap<>();
         do {
             receiveData = new byte[65535];
@@ -130,7 +131,7 @@ class UaaMetricsEmitterIT {
             } catch (SocketTimeoutException e) {
                 //expected so that we keep looping
             }
-        } while (results.size() < fragments.size() && (System.currentTimeMillis() < (startTime + UaaMetricsEmitterIT.WAIT_FOR_MESSAGE)));
+        } while (results.size() < fragments.size() && (System.nanoTime() < (startTime + UaaMetricsEmitterIT.WAIT_FOR_MESSAGE)));
         return results;
     }
 


### PR DESCRIPTION
Use nano time for IT
Why: see infinite loops in tests and these might be resulted because of the VM and behaviour of this timeout check if vm goes into a suspend mode (only for a short time) and awakes then the time comparison can be a problem and this could explain the infinite loop. Saw similar things in https://github.com/cloudfoundry/uaa/pull/2105