### PR TITLE
Dependency fixes

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ ext {
 ext["mariadb.version"] = "2.7.7" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
 ext["flyway.version"] = "7.15.0" // the next major (v8)'s community edition drops support with MySQL 5.7, which UAA still needs to support. Can bump to v8 once we solve this issue.
 ext["snakeyaml.version"] = "1.33" // manual update, see because of missing in spring boot https://github.com/spring-projects/spring-boot/issues/32221
+ext["hsqldb.version"] = "2.7.1" // HSQL-DB used for tests but not supported for productive usage
 
 // Versions shared between multiple dependencies
 versions.aspectJVersion = "1.9.4"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -33,7 +33,6 @@ libraries.apacheDsProtocolLdap = "org.apache.directory.server:apacheds-protocol-
 libraries.apacheLdapApi = "org.apache.directory.api:api-ldap-model:2.1.2"
 libraries.aspectJRt = "org.aspectj:aspectjrt"
 libraries.aspectJWeaver = "org.aspectj:aspectjweaver"
-libraries.beanutils = "commons-beanutils:commons-beanutils:1.9.4"
 libraries.bouncyCastlePkix = "org.bouncycastle:bcpkix-jdk18on:${versions.bouncyCastleVersion}"
 libraries.bouncyCastleProv = "org.bouncycastle:bcprov-jdk18on:${versions.bouncyCastleVersion}"
 libraries.commonsIo = "commons-io:commons-io:2.11.0"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -124,6 +124,7 @@ configurations.all {
     exclude(group: "org.apache-extras.beanshell", module: "bsh")
     exclude(group: "org.bouncycastle", module: "bcpkix-jdk15on")
     exclude(group: "org.bouncycastle", module: "bcprov-jdk15on")
+    exclude(group: "com.fasterxml.woodstox", module: "woodstox-core")
 }
 
 jar {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -85,7 +85,7 @@ dependencies {
     }
 
     implementation(libraries.passay)
-    implementation(libraries.beanutils)
+
     implementation(libraries.velocity)
     implementation(libraries.xerces)
 
@@ -125,6 +125,8 @@ configurations.all {
     exclude(group: "org.bouncycastle", module: "bcpkix-jdk15on")
     exclude(group: "org.bouncycastle", module: "bcprov-jdk15on")
     exclude(group: "com.fasterxml.woodstox", module: "woodstox-core")
+    exclude(group: "commons-beanutils", module: "commons-beanutils")
+    exclude(group: "commons-collections", module: "commons-collections")
 }
 
 jar {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/ScimExternalGroupsTypeResolvingFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/ScimExternalGroupsTypeResolvingFactoryBean.java
@@ -14,7 +14,7 @@
  */
 package org.cloudfoundry.identity.uaa.impl.config;
 
-import org.apache.commons.collections.ListUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 
 import java.util.*;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwk/RsaJsonWebKeyTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwk/RsaJsonWebKeyTests.java
@@ -18,7 +18,7 @@ package org.cloudfoundry.identity.uaa.oauth.jwk;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jose.util.BigIntegerUtils;
-import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections4.map.HashedMap;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoBuilder;


### PR DESCRIPTION
- exclude woodstox-core to ignore CVE, thus we don't need it
- update hsqldb, even if we don't support the productive usage on it