### PR TITLE
Added note to a test that passes on retry

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcTests.java
@@ -337,6 +337,7 @@ class PasscodeMockMvcTests {
         assertThat(content, Matchers.containsString("Passcode information is missing."));
     }
 
+    // NOTE: This test is flaky but passes on retry
     @Test
     void testPasscodeReturnSpecialCharaters() throws Exception {
         UaaAuthenticationDetails details = new UaaAuthenticationDetails(new MockHttpServletRequest());


### PR DESCRIPTION
- Added a comment to the `testPasscodeReturnSpecialCharaters` test to
  mention it fails at first then passes on retry.

[#184739970]

Co-authored-by: Jhonathan Aristizabal <jhonathana@vmware.com>
Co-authored-by: Hongchol Sinn <hsinn@vmware.com>
