### PR TITLE
Add additional logging if we pass the tests after passing retry of th…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,12 @@ subprojects {
         jvmArgs += ["-Xmx1024m", "-XX:+StartAttachListener", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/var/log/uaa-tests.hprof"]
 
         retry {
-            failOnPassedAfterRetry = Boolean.parseBoolean(System.getProperty("failOnPassedAfterRetry", "false"));
+            def retryFailOnPassedAfterRetry = Boolean.parseBoolean(
+                    System.getProperty("failOnPassedAfterRetry", "false"));
+            if (!retryFailOnPassedAfterRetry)
+                logger.warn("retry: Failed tests are to be retried and considered as passed if the retry passes.")
+
+            failOnPassedAfterRetry = retryFailOnPassedAfterRetry
             maxFailures = Integer.parseInt(System.getProperty("maxFailures", "3"))
             maxRetries = Integer.parseInt(System.getProperty("maxRetries", "1"))
         }


### PR DESCRIPTION
…e failed tests

- Because we did not realize that retry plugin was used and wondered why the test suite passed when there was a failed test in the log

[#184739970]