### PR TITLE
[sonar] Short-circuit logic should be used in boolean contexts

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/extension/NestedLdapAuthoritiesPopulator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/extension/NestedLdapAuthoritiesPopulator.java
@@ -145,7 +145,7 @@ public class NestedLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopula
                     role = role.toUpperCase();
                 }
                 role = getRolePrefix() + role;
-                circular = circular || (!authorities.add(new LdapAuthority(role, dn, record)));
+                circular = (!authorities.add(new LdapAuthority(role, dn, record))) || circular;
             }
             String roleName = roles.size()>0 ? roles.iterator().next() : dn;
             if (!circular) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/extension/NestedLdapAuthoritiesPopulator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/extension/NestedLdapAuthoritiesPopulator.java
@@ -145,7 +145,7 @@ public class NestedLdapAuthoritiesPopulator extends DefaultLdapAuthoritiesPopula
                     role = role.toUpperCase();
                 }
                 role = getRolePrefix() + role;
-                circular = circular | (!authorities.add(new LdapAuthority(role,dn,record)));
+                circular = circular || (!authorities.add(new LdapAuthority(role, dn, record)));
             }
             String roleName = roles.size()>0 ? roles.iterator().next() : dn;
             if (!circular) {


### PR DESCRIPTION
Rule: java:S2178, e.g. https://rules.sonarsource.com/java/RSPEC-2178 

https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER&id=cloudfoundry-identity-parent&open=AYBVU2mG8w5rn7tLse0R&tab=why