### PR TITLE
fix: Use short-circuit or operator in UserIdConversionEndpoints.checkFilter

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
@@ -119,8 +119,8 @@ public class UserIdConversionEndpoints implements InitializingBean {
             case AND:
             case OR:
                 // always check both operands, even if left operand returns true
-                final boolean resultRightOperand = checkFilter(filter.getFilterComponents().get(1));
-                return checkFilter(filter.getFilterComponents().get(0)) || resultRightOperand;
+                final boolean resultLeftOperand = checkFilter(filter.getFilterComponents().get(0));
+                return checkFilter(filter.getFilterComponents().get(1)) || resultLeftOperand;
             case EQUALITY:
                 String name = filter.getFilterAttribute().getAttributeName();
                 if ("id".equalsIgnoreCase(name) ||

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
@@ -118,7 +118,9 @@ public class UserIdConversionEndpoints implements InitializingBean {
         switch (filter.getFilterType()) {
             case AND:
             case OR:
-                return checkFilter(filter.getFilterComponents().get(0)) | checkFilter(filter.getFilterComponents().get(1));
+                // always check both operands, even if left operand returns true
+                final boolean resultRightOperand = checkFilter(filter.getFilterComponents().get(1));
+                return checkFilter(filter.getFilterComponents().get(0)) || resultRightOperand;
             case EQUALITY:
                 String name = filter.getFilterAttribute().getAttributeName();
                 if ("id".equalsIgnoreCase(name) ||

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
@@ -101,6 +101,11 @@ public class UserIdConversionEndpointsTests {
     }
 
     @Test
+    public void testGoodFilter2() {
+        endpoints.findUsers("origin eq \"uaa\" and (id eq \"foo\" or username eq \"bar\")", "ascending", 0, 100, false);
+    }
+
+    @Test
     public void testBadFilter1() {
         expected.expect(ScimException.class);
         expected.expectMessage(containsString("Wildcards are not allowed in filter."));
@@ -158,6 +163,15 @@ public class UserIdConversionEndpointsTests {
         expected.expect(ScimException.class);
         expected.expectMessage(containsString("Invalid filter"));
         endpoints.findUsers("origin eq \"uaa\"", "ascending", 0, 100, false);
+    }
+
+    @Test
+    public void testBadFilter10() {
+        expected.expect(ScimException.class);
+        expected.expectMessage(containsString("Wildcards are not allowed in filter."));
+
+        // illegal operator in right operand of root-level "or" -> all branches need to be checked even if left operands are valid
+        endpoints.findUsers("id eq \"foo\" or origin co \"uaa\"", "ascending", 0, 100, false);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
@@ -31,6 +31,7 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import java.util.Collection;
 import java.util.Collections;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -97,12 +98,26 @@ public class UserIdConversionEndpointsTests {
 
     @Test
     public void testGoodFilter1() {
-        endpoints.findUsers("(id eq \"foo\" or username eq \"bar\") and origin eq \"uaa\"", "ascending", 0, 100, false);
+        final ResponseEntity<Object> response = endpoints.findUsers(
+                "(id eq \"foo\" or username eq \"bar\") and origin eq \"uaa\"",
+                "ascending",
+                0,
+                100,
+                false
+        );
+        assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
     public void testGoodFilter2() {
-        endpoints.findUsers("origin eq \"uaa\" and (id eq \"foo\" or username eq \"bar\")", "ascending", 0, 100, false);
+        final ResponseEntity<Object> response = endpoints.findUsers(
+                "origin eq \"uaa\" and (id eq \"foo\" or username eq \"bar\")",
+                "ascending",
+                0,
+                100,
+                false
+        );
+        assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
@@ -172,6 +187,13 @@ public class UserIdConversionEndpointsTests {
 
         // illegal operator in right operand of root-level "or" -> all branches need to be checked even if left operands are valid
         endpoints.findUsers("id eq \"foo\" or origin co \"uaa\"", "ascending", 0, 100, false);
+    }
+
+    @Test
+    public void testBadFilter11() {
+        expected.expect(ScimException.class);
+        expected.expectMessage(containsString("Invalid filter"));
+        endpoints.findUsers("origin eq \"uaa\" or origin eq \"bar\"", "ascending", 0, 100, false);
     }
 
     @Test


### PR DESCRIPTION
see https://sonarcloud.io/project/issues?resolved=false&severities=BLOCKER&id=cloudfoundry-identity-parent&open=AYBVU2vq8w5rn7tLsfE_