### PR TITLE
Fix: Fixing performance while calling containsAll over list

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UserInfo.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UserInfo.java
@@ -67,12 +67,10 @@ public class UserInfo {
     }
 
     protected boolean compareRoles(List<String> l1, List<String> l2) {
-        if (l1==null && l2==null) {
-            return true;
-        } else if (l1==null || l2==null) {
-            return false;
+        if (l1 == null || l2 == null) {
+            return l1 == l2;
         }
-        return new HashSet<>(l1).containsAll(l2) && new HashSet<>(l2).containsAll(l1);
+        return new HashSet<>(l1).equals(new HashSet<>(l2));
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UserInfo.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UserInfo.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import java.util.HashSet;
 import java.util.List;
 
 public class UserInfo {
@@ -71,7 +72,7 @@ public class UserInfo {
         } else if (l1==null || l2==null) {
             return false;
         }
-        return l1.containsAll(l2) && l2.containsAll(l1);
+        return new HashSet<>(l1).containsAll(l2) && new HashSet<>(l2).containsAll(l1);
     }
 
     @Override

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/user/UserInfoTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/user/UserInfoTest.java
@@ -1,0 +1,77 @@
+package org.cloudfoundry.identity.uaa.user;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class UserInfoTest {
+
+    @Nested
+    class Equals {
+
+        @Test
+        void expectTrueWhenBothUserInfoObjectsAreSame() {
+            UserInfo userInfo = new UserInfo();
+            assertTrue(userInfo.equals(userInfo));
+        }
+
+        @Test
+        void expectFalseWhenUserInfoIsComparedWithOtherObject() {
+            UserInfo userInfo = new UserInfo();
+            assertFalse(userInfo.equals(new Object()));
+        }
+
+        @Test
+        void expectTrueWhenBothUserInfoWithoutAnyRole() {
+            UserInfo u1 = new UserInfo();
+            UserInfo u2 = new UserInfo();
+            assertTrue(u1.equals(u2));
+        }
+
+        @Test
+        void expectFalseWhenOnlyOneUserInfoHasRole() {
+            UserInfo u1 = userInfoWithRoles(List.of("group1"));
+            UserInfo u2 = new UserInfo();
+            assertFalse(u1.equals(u2));
+        }
+
+        @Test
+        void expectTrueWhenBothUserInfoHaveSameRole() {
+            UserInfo u1 = userInfoWithRoles(List.of("group1"));
+            UserInfo u2 = userInfoWithRoles(List.of("group1"));
+            assertTrue(u1.equals(u2));
+        }
+
+        @Test
+        void expectFalseWhenBothUserInfoHaveDifferentRoles() {
+            UserInfo u1 = userInfoWithRoles(List.of("group1"));
+            UserInfo u2 = userInfoWithRoles(List.of("group2"));
+            assertFalse(u1.equals(u2));
+        }
+
+        @Test
+        void expectFalseWhenBothUserInfoHaveMultipleRolesAndFewAreCommon() {
+            UserInfo u1 = userInfoWithRoles(List.of("group1", "group2", "group3"));
+            UserInfo u2 = userInfoWithRoles(List.of("group2", "group3", "group4"));
+            assertFalse(u1.equals(u2));
+        }
+
+        @Test
+        void expectTrueWhenBothUserInfoHaveMultipleRolesAndAllAreCommon() {
+            UserInfo u1 = userInfoWithRoles(List.of("group1", "group2", "group3"));
+            UserInfo u2 = userInfoWithRoles(List.of("group1", "group2", "group3"));
+            assertTrue(u1.equals(u2));
+        }
+
+    }
+
+    private UserInfo userInfoWithRoles(List<String> roles) {
+        UserInfo userInfo = new UserInfo();
+        userInfo.setRoles(roles);
+        return userInfo;
+    }
+}


### PR DESCRIPTION
Improving performance in case of 
```java
list.containsAll(anotherList)
```

by using `HashSet` wrapper around one of the lists
```java
new HashSet<>(list).containsAll(anotherList)
```

This improves time complexity.