### PR TITLE
Fix for ldap.ssl.skipverification

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/SkipSslLdapSocketFactory.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/SkipSslLdapSocketFactory.java
@@ -19,8 +19,18 @@ import javax.net.ssl.X509TrustManager;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import javax.net.SocketFactory;
 
 public class SkipSslLdapSocketFactory extends BaseLdapSocketFactory {
+
+    private static SocketFactory instance;
+    public static SocketFactory getDefault() {
+        if (instance == null) {
+            instance = new SkipSslLdapSocketFactory();
+        }
+
+        return instance;
+    }
 
     public SkipSslLdapSocketFactory() {
         try {


### PR DESCRIPTION
If you are using directory server with ssl (ldaps), without tls (ldap.ssl.tls: none) and with, for example, self-signed certificate, ldap.ssl.skipverification property is ignored and connection fails with InternalAuthenticationServiceException with root exception SSLHandshakeException: PKIX path building failed ... etc.

When tls is set to none, [SimpleDirContextAuthenticationStrategy](https://github.com/cloudfoundry/uaa/blob/a1fff3d1a2f5969f1c25bfc80e253f3f5a567505/server/src/main/java/org/cloudfoundry/identity/uaa/provider/ldap/ProcessLdapProperties.java#L98) is used, so SocketFactory is not instanced in code (as for tls allowed a couple of lines lower), but relies on JNDI value of `java.naming.ldap.factory.socket`. However, even if the value is correctly set to `SkipSslLdapSocketFactory`, instance of `LdapSocketFactory` is created.

The reason is that `SkipSslLdapSocketFactory` is extended from `BaseLdapSocketFactory`, which creates an instance of `LdapSocketFactory` in `getDefault()` method. And according to the [documentation](https://docs.oracle.com/javase/jndi/tutorial/ldap/security/ssl.html), this method is used to create instace of SocketFactory  defined in `java.naming.ldap.factory.socket`.

The simplest solution is to override `getDefault()` method in `SkipSslLdapSocketFactory` (in same manner as in `BaseLdapSocketFactory` in this pull request).

Maybe this three classes should be refactored in future.
