### PR TITLE
fix: incorrect elapsed time determination

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -214,7 +214,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
         Instant last = lastClean.get();
         //check if we should expire again
         Instant now = Instant.now();
-        if (Duration.between(last, now).getSeconds() > getExpirationTime().getSeconds()) {
+        if (enoughTimeHasPassedSinceLastExpirationClean(last, now)) {
             //avoid concurrent deletes from the same UAA - performance improvement
             if (lastClean.compareAndSet(last, last.plus(getExpirationTime()))) {
                 try {
@@ -228,6 +228,10 @@ public class UaaTokenStore implements AuthorizationCodeServices {
                 }
             }
         }
+    }
+
+    private boolean enoughTimeHasPassedSinceLastExpirationClean(Instant last, Instant now) {
+        return Duration.between(last, now).getSeconds() > getExpirationTime().getSeconds();
     }
 
     public Duration getExpirationTime() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -231,7 +231,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
     }
 
     private boolean enoughTimeHasPassedSinceLastExpirationClean(Instant last, Instant now) {
-        return Duration.between(last, now).getSeconds() > getExpirationTime().getSeconds();
+        return Duration.between(last, now).toMillis() > getExpirationTime().toMillis();
     }
 
     public Duration getExpirationTime() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -214,7 +214,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
         Instant last = lastClean.get();
         //check if we should expire again
         Instant now = Instant.now();
-        if (Duration.between(last, now).getNano() > getExpirationTime().getNano()) {
+        if (Duration.between(last, now).getSeconds() > getExpirationTime().getSeconds()) {
             //avoid concurrent deletes from the same UAA - performance improvement
             if (lastClean.compareAndSet(last, last.plus(getExpirationTime()))) {
                 try {


### PR DESCRIPTION
* A recent previous refactor commit was using the `getNano()` method, thinking that it would return the total number of nanoseconds in the duration, which is does not. It returns the number of nanoseconds within one second, which is not at all what we wanted.

* We decided to go ahead and just use the `getSeconds` method, which this time actually returns the total number of seconds in the duration object. We understand that previously the precision of this was to the millisecond level. We believe that it's OK if we change to the second level. The cleanup will still happen every n minutes, just not at the precise millisecond.