### PR TITLE
Minimal Fix auth code cleanup function

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -216,7 +216,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
         Instant now = Instant.now();
         if (enoughTimeHasPassedSinceLastExpirationClean(last, now)) {
             //avoid concurrent deletes from the same UAA - performance improvement
-            if (lastClean.compareAndSet(last, last.plus(getExpirationTime()))) {
+            if (lastClean.compareAndSet(last, now)) {
                 try {
                     JdbcTemplate template = new JdbcTemplate(dataSource);
                     int expired = template.update(SQL_EXPIRE_STATEMENT, now.toEpochMilli());


### PR DESCRIPTION
Problem. Cleanup should not be called with each Token creation, but periodically to not stress DB too much