### PR TITLE
 fix: exclude unsupported response types in exception

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpoint.java
@@ -182,7 +182,7 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint implements Authen
         String grantType = deriveGrantTypeFromResponseType(responseTypes);
 
         if (!supported_response_types.containsAll(responseTypes)) {
-            throw new UnsupportedResponseTypeException("Unsupported response types: " + responseTypes);
+            throw new UnsupportedResponseTypeException("Unsupported response types");
         }
 
         if (authorizationRequest.getClientId() == null) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/UaaRequestMatcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/UaaRequestMatcher.java
@@ -135,7 +135,7 @@ public final class UaaRequestMatcher implements RequestMatcher, BeanNameAware {
 
     private boolean matchesHeader(String requestValue, List<String> expectedValues) {
         for (String headerValue : expectedValues) {
-            if ("bearer ".equalsIgnoreCase(headerValue)) {
+            if ("bearer".equalsIgnoreCase(headerValue.trim())) {
                 //case insensitive for Authorization: Bearer match
                 if (requestValue == null || !requestValue.toLowerCase().startsWith(headerValue)) {
                     return false;


### PR DESCRIPTION
- avoid logging unsanitized input from the request
- this mirrors the change made to AuthorizationEndpoint in spring-security-oauth2 2.5.2.RELEASE, see: https://github.com/spring-attic/spring-security-oauth/commit/2b58aafecac336e82f20ea43da9b208b0a4a40dd

Change-Id: Id93034bc69355fcf988c56827fa65c70338694cf