### PR TITLE
fix: cve resolution for 74-5 and consistency for internal subproject …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,28 +58,10 @@ subprojects {
     }
 
     dependencies {
-        implementation(libraries.snakeyaml)
-        implementation(libraries.velocityEngineCore)
-        implementation(libraries.xmlsec)
+        implementation(libraries.snakeyaml) // CVE resolution
+        implementation(libraries.velocityEngineCore) // CVE resolution
+        implementation(libraries.xmlsec) // CVE resolution
         implementation(libraries.commonsIo) // CVE resolution
-
-        implementation(libraries.guava) // dependency consistency resolution
-        implementation("org.bouncycastle:bcprov-jdk15on:1.70") // dependency consistency resolution
-        implementation("org.bouncycastle:bcprov-ext-jdk15on:1.70") // dependency consistency resolution
-        implementation("org.bouncycastle:bcpkix-jdk15on:1.70") // dependency consistency resolution
-
-        implementation("javax.activation:activation:1.1.1") // dependency consistency resolution
-        implementation("org.ow2.asm:asm:9.5") // dependency consistency resolution
-        implementation("org.ow2.asm:asm-analysis:9.5") // dependency consistency resolution
-        implementation("org.ow2.asm:asm-commons:9.5") // dependency consistency resolution
-        implementation("org.ow2.asm:asm-tree:9.5") // dependency consistency resolution
-        implementation("org.ow2.asm:asm-util:9.5") // dependency consistency resolution
-
-        implementation("org.owasp.esapi:esapi:2.5.2.0") // dependency consistency resolution
-        implementation("xml-apis:xml-apis:1.4.01") // dependency consistency resolution
-        implementation("commons-logging:commons-logging:1.2") // dependency consistency resolution
-        implementation("commons-collections:commons-collections:3.2.2") // dependency consistency resolution
-        implementation("org.checkerframework:checker-qual:3.12.0") // dependency consistency resolution
 
         testImplementation(libraries.springBootStarterTest)
         testImplementation(libraries.hamcrest)

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,11 @@ subprojects {
     }
 
     dependencies {
+        implementation("org.yaml:snakeyaml:1.33") // CVE resolution-internal package for spring-boot:currently 2.7.12
+        implementation("org.apache.velocity:velocity-engine-core:2.3") // CVE resolution
+        implementation("org.apache.santuario:xmlsec:2.3.3") // CVE resolution
+        implementation("commons-io:commons-io:2.12.0") // CVE resolution
+
         testImplementation(libraries.springBootStarterTest)
         testImplementation(libraries.hamcrest)
         testImplementation(libraries.junit5JupiterApi)

--- a/build.gradle
+++ b/build.gradle
@@ -58,10 +58,28 @@ subprojects {
     }
 
     dependencies {
-        implementation("org.yaml:snakeyaml:1.33") // CVE resolution-internal package for spring-boot:currently 2.7.12
-        implementation("org.apache.velocity:velocity-engine-core:2.3") // CVE resolution
-        implementation("org.apache.santuario:xmlsec:2.3.3") // CVE resolution
-        implementation("commons-io:commons-io:2.12.0") // CVE resolution
+        implementation(libraries.snakeyaml)
+        implementation(libraries.velocityEngineCore)
+        implementation(libraries.xmlsec)
+        implementation(libraries.commonsIo) // CVE resolution
+
+        implementation(libraries.guava) // dependency consistency resolution
+        implementation("org.bouncycastle:bcprov-jdk15on:1.70") // dependency consistency resolution
+        implementation("org.bouncycastle:bcprov-ext-jdk15on:1.70") // dependency consistency resolution
+        implementation("org.bouncycastle:bcpkix-jdk15on:1.70") // dependency consistency resolution
+
+        implementation("javax.activation:activation:1.1.1") // dependency consistency resolution
+        implementation("org.ow2.asm:asm:9.5") // dependency consistency resolution
+        implementation("org.ow2.asm:asm-analysis:9.5") // dependency consistency resolution
+        implementation("org.ow2.asm:asm-commons:9.5") // dependency consistency resolution
+        implementation("org.ow2.asm:asm-tree:9.5") // dependency consistency resolution
+        implementation("org.ow2.asm:asm-util:9.5") // dependency consistency resolution
+
+        implementation("org.owasp.esapi:esapi:2.5.2.0") // dependency consistency resolution
+        implementation("xml-apis:xml-apis:1.4.01") // dependency consistency resolution
+        implementation("commons-logging:commons-logging:1.2") // dependency consistency resolution
+        implementation("commons-collections:commons-collections:3.2.2") // dependency consistency resolution
+        implementation("org.checkerframework:checker-qual:3.12.0") // dependency consistency resolution
 
         testImplementation(libraries.springBootStarterTest)
         testImplementation(libraries.hamcrest)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,6 +1,7 @@
 // Versions we're overriding from the Spring Boot Bom
 ext["flyway.version"] = "7.15.0" // flyway 8+ drops support for mysql 5.7
 ext["mariadb.version"] = "2.7.7" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
+ext["snakeyaml.version"] = "1.33"
 
 def versions = [:]
 
@@ -16,6 +17,8 @@ versions.springSecuritySamlVersion = "1.0.10.RELEASE" // this lib has reached EO
 versions.tomcatVersion = "9.0.75"
 versions.statsdClientVersion = "3.1.0" // statsd is not included in spring-boot 2.2 and later, so we need to specify the dependency explicitly
 versions.junitVersion = "4.13.2" // Needed to support junit 4 with spring-boot 2.4
+versions.snakeyamlVersion = "1.33"
+versions.velocityEngineCoreVersion = "2.3"
 
 ext {
     tomcatVersion = "${versions.tomcatVersion}"
@@ -68,7 +71,7 @@ libraries.selenium = "org.seleniumhq.selenium:selenium-java:4.9.1"
 libraries.seleniumHttp = "org.seleniumhq.selenium:selenium-http-jdk-client:4.9.1"
 libraries.slf4jApi = "org.slf4j:slf4j-api"
 libraries.slf4jImpl = "org.apache.logging.log4j:log4j-slf4j-impl"
-libraries.snakeyaml = "org.yaml:snakeyaml"
+libraries.snakeyaml = "org.yaml:snakeyaml:${versions.snakeyamlVersion}"
 libraries.springBeans = "org.springframework:spring-beans"
 libraries.springBootBom = "org.springframework.boot:spring-boot-dependencies:${versions.springBootVersion}"
 libraries.springBootGradlePlugin = "org.springframework.boot:spring-boot-gradle-plugin:${versions.springBootVersion}"
@@ -110,5 +113,7 @@ libraries.tomcatJasperEl = "org.apache.tomcat:tomcat-jasper-el:${versions.tomcat
 libraries.tomcatJdbc = "org.apache.tomcat:tomcat-jdbc:${versions.tomcatVersion}"
 libraries.unboundIdLdapSdk = "com.unboundid:unboundid-ldapsdk"
 libraries.unboundIdScimSdk = "com.unboundid.product.scim:scim-sdk:1.8.26"
+libraries.velocityEngineCore = "org.apache.velocity:velocity-engine-core:${versions.velocityEngineCoreVersion}"
+libraries.xmlsec = "org.apache.santuario:xmlsec:2.3.3"
 libraries.zxing = "com.google.zxing:javase:3.5.1"
 libraries.spingSamlEsapiDependencyVersion = "org.owasp.esapi:esapi:2.5.2.0"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,7 +18,6 @@ versions.springSecuritySamlVersion = "1.0.10.RELEASE" // this lib has reached EO
 versions.tomcatVersion = "9.0.75"
 versions.statsdClientVersion = "3.1.0" // statsd is not included in spring-boot 2.2 and later, so we need to specify the dependency explicitly
 versions.junitVersion = "4.13.2" // Needed to support junit 4 with spring-boot 2.4
-versions.snakeyamlVersion = "1.33" // Needed to resolve CVEs in internal spring-boot 2.7.12 inclusion of snakeyaml
 versions.velocityEngineCoreVersion = "2.3"
 versions.xmlsecVersion ="2.3.3"
 
@@ -73,7 +72,7 @@ libraries.selenium = "org.seleniumhq.selenium:selenium-java:4.9.1"
 libraries.seleniumHttp = "org.seleniumhq.selenium:selenium-http-jdk-client:4.9.1"
 libraries.slf4jApi = "org.slf4j:slf4j-api"
 libraries.slf4jImpl = "org.apache.logging.log4j:log4j-slf4j-impl"
-libraries.snakeyaml = "org.yaml:snakeyaml:${versions.snakeyamlVersion}"
+libraries.snakeyaml = "org.yaml:snakeyaml"
 libraries.springBeans = "org.springframework:spring-beans"
 libraries.springBootBom = "org.springframework.boot:spring-boot-dependencies:${versions.springBootVersion}"
 libraries.springBootGradlePlugin = "org.springframework.boot:spring-boot-gradle-plugin:${versions.springBootVersion}"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Versions we're overriding from the Spring Boot Bom
 ext["flyway.version"] = "7.15.0" // flyway 8+ drops support for mysql 5.7
 ext["mariadb.version"] = "2.7.7" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
-ext["snakeyaml.version"] = "1.33"
+ext["snakeyaml.version"] = "1.33" // Needed to resolve CVEs in internal spring-boot 2.7.12 inclusion of snakeyaml
 
 def versions = [:]
 
@@ -9,6 +9,7 @@ def versions = [:]
 versions.aspectJVersion = "1.9.4"
 versions.apacheDsVersion = "2.0.0.AM26"
 versions.bouncyCastleVersion = "1.70"
+versions.commonsioVersion = "2.12.0"
 versions.hamcrestVersion = "2.2"
 versions.springBootVersion = "2.7.12"
 versions.springSecurityJwtVersion = "1.1.1.RELEASE"
@@ -17,8 +18,9 @@ versions.springSecuritySamlVersion = "1.0.10.RELEASE" // this lib has reached EO
 versions.tomcatVersion = "9.0.75"
 versions.statsdClientVersion = "3.1.0" // statsd is not included in spring-boot 2.2 and later, so we need to specify the dependency explicitly
 versions.junitVersion = "4.13.2" // Needed to support junit 4 with spring-boot 2.4
-versions.snakeyamlVersion = "1.33"
+versions.snakeyamlVersion = "1.33" // Needed to resolve CVEs in internal spring-boot 2.7.12 inclusion of snakeyaml
 versions.velocityEngineCoreVersion = "2.3"
+versions.xmlsecVersion ="2.3.3"
 
 ext {
     tomcatVersion = "${versions.tomcatVersion}"
@@ -33,7 +35,7 @@ libraries.aspectJRt = "org.aspectj:aspectjrt"
 libraries.aspectJWeaver = "org.aspectj:aspectjweaver"
 libraries.bouncyCastlePkix = "org.bouncycastle:bcpkix-jdk15on:${versions.bouncyCastleVersion}"
 libraries.bouncyCastleProv = "org.bouncycastle:bcprov-jdk15on:${versions.bouncyCastleVersion}"
-libraries.commonsIo = "commons-io:commons-io:2.12.0"
+libraries.commonsIo = "commons-io:commons-io:${versions.commonsioVersion}"
 libraries.dumbster = "dumbster:dumbster:1.6"
 libraries.eclipseJgit = "org.eclipse.jgit:org.eclipse.jgit:6.5.0.202303070854-r"
 libraries.flywayCore = "org.flywaydb:flyway-core"
@@ -114,6 +116,6 @@ libraries.tomcatJdbc = "org.apache.tomcat:tomcat-jdbc:${versions.tomcatVersion}"
 libraries.unboundIdLdapSdk = "com.unboundid:unboundid-ldapsdk"
 libraries.unboundIdScimSdk = "com.unboundid.product.scim:scim-sdk:1.8.26"
 libraries.velocityEngineCore = "org.apache.velocity:velocity-engine-core:${versions.velocityEngineCoreVersion}"
-libraries.xmlsec = "org.apache.santuario:xmlsec:2.3.3"
+libraries.xmlsec = "org.apache.santuario:xmlsec:${versions.xmlsecVersion}"
 libraries.zxing = "com.google.zxing:javase:3.5.1"
 libraries.spingSamlEsapiDependencyVersion = "org.owasp.esapi:esapi:2.5.2.0"


### PR DESCRIPTION
…build dependencies. 

Directing subproject gradle builds to use the latest working versions of dependency libraries with identified CVEs.