### PR TITLE
fix: resolve cve with latest snakeyaml 2.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,8 @@
 // Versions we're overriding from the Spring Boot Bom
 ext["flyway.version"] = "7.15.0" // flyway 8+ drops support for mysql 5.7
 ext["mariadb.version"] = "2.7.7" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
-ext["snakeyaml.version"] = "1.33" // Needed to resolve CVEs in internal spring-boot 2.7.12 inclusion of snakeyaml
+ext["snakeyaml.version"] = "2.0" // Needed to resolve CVEs in internal spring-boot 2.7.12 inclusion of snakeyaml
+ext["jackson-bom.version"] = "2.14.2" // Bumping to latest version because of compatiblity to snakeyaml 2.0
 
 def versions = [:]
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/CustomPropertyConstructor.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/CustomPropertyConstructor.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.impl.config;
 
+import org.cloudfoundry.identity.uaa.util.UaaYamlUtils;
 import org.springframework.util.Assert;
 import org.yaml.snakeyaml.TypeDescription;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -35,7 +36,7 @@ public class CustomPropertyConstructor extends Constructor {
     private final Map<Class<?>, AliasSupportingTypeDescription> typeDescriptions = new HashMap<>();
 
     public CustomPropertyConstructor(Class<?> theRoot) {
-        super(theRoot);
+        super(theRoot, UaaYamlUtils.getDefaultLoaderOptions());
         TypeDescription typeDescription = createTypeDescription(theRoot);
         addTypeDescription(typeDescription);
         yamlClassConstructors.put(NodeId.mapping, new CustomPropertyConstructMapping());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaYamlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaYamlUtils.java
@@ -1,0 +1,35 @@
+package org.cloudfoundry.identity.uaa.util;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+public final class UaaYamlUtils {
+
+    private UaaYamlUtils() { }
+
+    public static Yaml createYaml() {
+        return new Yaml(new SafeConstructor(getDefaultLoaderOptions()));
+    }
+
+    public static String dump(Object object) {
+        return createYaml().dump(object);
+    }
+
+    public static LoaderOptions getDefaultLoaderOptions() {
+        LoaderOptions loaderOptions = new LoaderOptions();
+        loaderOptions.setAllowDuplicateKeys(false);
+        return loaderOptions;
+    }
+
+    public static DumperOptions getDefaultDumperOptions() {
+        DumperOptions dump = new DumperOptions();
+        dump.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        dump.setPrettyFlow(true);
+        dump.setIndent(2);
+        dump.setCanonical(false);
+        dump.setExplicitStart(true);
+        return dump;
+    }
+}


### PR DESCRIPTION
update snakeyaml to 2.0 with no currently known vulnerabilities.

Backporting from uaa 76 needed helpers to migrate snakeyaml to the latest release.