### PR TITLE
Fix for issue 2368

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -167,19 +167,19 @@ public class ScimUserBootstrap implements
         if (updateGroups) {
             Collection<String> newGroups = convertToGroups(updatedUser.getAuthorities());
             logger.debug("Adding new groups " + newGroups);
-            addGroups(id, newGroups);
+            addGroups(id, newScimUser.getOrigin(), newGroups);
         }
     }
 
     private void createNewUser(UaaUser user) {
         logger.debug("Registering new user account: " + user);
         ScimUser newScimUser = scimUserProvisioning.createUser(convertToScimUser(user), user.getPassword(), IdentityZoneHolder.get().getId());
-        addGroups(newScimUser.getId(), convertToGroups(user.getAuthorities()));
+        addGroups(newScimUser.getId(), newScimUser.getOrigin(), convertToGroups(user.getAuthorities()));
     }
 
-    private void addGroups(String scimUserid, Collection<String> groups) {
+    private void addGroups(String scimUserid, String scimOrigin, Collection<String> groups) {
         for (String group : groups) {
-            addToGroup(scimUserid, group);
+            addToGroup(scimUserid, scimOrigin, group);
         }
     }
 
@@ -248,8 +248,8 @@ public class ScimUserBootstrap implements
         }
     }
 
-    private void addToGroup(String scimUserId, String gName) {
-        addToGroup(scimUserId, gName, OriginKeys.UAA, true);
+    private void addToGroup(String scimUserId, String scimOrigin, String gName) {
+        addToGroup(scimUserId, gName, scimOrigin, true);
     }
 
     private void addToGroup(String scimUserId, String gName, String origin, boolean addGroup) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/jdbc/JdbcScimGroupMembershipManager.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.scim.jdbc;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.scim.*;
 import org.cloudfoundry.identity.uaa.scim.exception.*;
 import org.cloudfoundry.identity.uaa.util.beans.DbUtils;
@@ -413,7 +414,11 @@ public class JdbcScimGroupMembershipManager implements ScimGroupMembershipManage
         if (member.getType() == ScimGroupMember.Type.GROUP) {
             memberZoneId = scimGroupProvisioning.retrieve(member.getMemberId(), IdentityZoneHolder.get().getId()).getZoneId();
         } else {
-            memberZoneId = userProvisioning.retrieve(member.getMemberId(), IdentityZoneHolder.get().getId()).getZoneId();
+            ScimUser scimUser = userProvisioning.retrieve(member.getMemberId(), IdentityZoneHolder.get().getId());
+            if (OriginKeys.UAA.equals(member.getOrigin()) && !scimUser.getOrigin().equals(member.getOrigin())) {
+                member.setOrigin(scimUser.getOrigin());
+            }
+            memberZoneId = scimUser.getZoneId();
         }
         if (!memberZoneId.equals(group.getZoneId())) {
             throw new ScimResourceConstraintFailedException("The zone of the group and the member must be the same.");


### PR DESCRIPTION
If user has custom origin but Group Member add is not providing a origin field uaa is used, which is wrong. If user is deleted the assignment still exists because of wrong origin