### PR TITLE
Build fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,15 @@ buildscript {
         mavenCentral()
         gradlePluginPortal()
         maven {
-            url "https://repo.spring.io/plugins-release"
+            url("https://plugins.gradle.org/m2/")
+        }
+        maven {
+            url("https://repo.spring.io/plugins-release")
         }
     }
 
     dependencies {
         classpath(libraries.gradleCargoPlugin)
-        classpath(libraries.asciidoctorGradlePlugin)
         classpath(libraries.springDependencyMgmtPlugin)
         classpath(libraries.springBootGradlePlugin)
     }

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -1,7 +1,6 @@
 Project identityServer = parent.subprojects.find { it.name.equals("cloudfoundry-identity-server") }
 
 apply(plugin: "war")
-apply(plugin: "org.asciidoctor.convert")
 
 processResources {
     //maven replaces project.artifactId in the log4j.properties file


### PR DESCRIPTION
Gradle should use its plugins from gradle
ascii-doctor is no long maintained

@Tallicia only a small fix, but maybe you take all build files from develop and also upgrade gradle.... The code can stay as it is

e.g. https://github.com/cloudfoundry/uaa/pull/2197/files