### PR TITLE
fix: Handle verify user requests with HEAD method

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/AccountsController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/AccountsController.java
@@ -101,6 +101,12 @@ public class AccountsController {
         return "accounts/email_sent";
     }
 
+    @RequestMapping(value = "/verify_user", method = RequestMethod.HEAD)
+    public String verifyUser() {
+        // Some mail providers initially send a HEAD request to check the validity of the link before redirecting users.
+        return "redirect:/login";
+    }
+
     @RequestMapping(value = "/verify_user", method = GET)
     public String verifyUser(Model model,
                              @RequestParam("code") String code,


### PR DESCRIPTION
- Basically same issue as described here: https://github.com/cloudfoundry/uaa/issues/2381
- Similar fix as https://github.com/cloudfoundry/uaa/pull/2389 (difference here: we do not have a Thymeleaf template for _verify_user_ therefore we redirect to login)