### PR TITLE
Fix UAA startup if postgresql is used for session store

### DIFF
--- a/scripts/cargo/uaa.yml
+++ b/scripts/cargo/uaa.yml
@@ -1,5 +1,8 @@
 servlet:
   session-store: database
+  session-cookie:
+    encode-base64: true
+
 
 encryption:
   active_key_label: CHANGE-THIS-KEY

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaSessionConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaSessionConfig.java
@@ -29,13 +29,15 @@ public class UaaSessionConfig {
 
     @Bean
     public CookieSerializer uaaCookieSerializer(
-            final @Value("${servlet.session-cookie.max-age:-1}") int cookieMaxAge
+        final @Value("${servlet.session-cookie.max-age:-1}") int cookieMaxAge,
+        final @Value("${servlet.session-cookie.encode-base64:true}") boolean useBase64Encoding
     ) {
         DefaultCookieSerializer cookieSerializer = new DefaultCookieSerializer();
         cookieSerializer.setSameSite("None");
         cookieSerializer.setUseSecureCookie(true);
         cookieSerializer.setCookieMaxAge(cookieMaxAge);
         cookieSerializer.setCookieName("JSESSIONID");
+        cookieSerializer.setUseBase64Encoding(useBase64Encoding);
 
         return cookieSerializer;
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/UaaSessionConfigTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/UaaSessionConfigTest.java
@@ -8,9 +8,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.core.env.Environment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.session.web.http.CookieSerializer;
+
+import javax.servlet.http.Cookie;
+import java.util.List;
+import java.util.UUID;
 
 import static org.cloudfoundry.identity.uaa.util.AssertThrowsWithMessage.assertThrowsWithMessageThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -58,5 +66,34 @@ class UaaSessionConfigTest {
                 IllegalArgumentException.class,
                 () -> new UaaJdbcSessionConfig.DatabaseConfigured().matches(mockConditionContext, null),
                 equalTo("foobar is not a valid argument for servlet.session-store. Please choose memory or database."));
+    }
+
+    @Test
+    void whenCookieSeralizeDefault() {
+        when(mockEnvironment.getProperty("servlet.session-store", "memory")).thenReturn("database");
+        assertTrue(new UaaJdbcSessionConfig.DatabaseConfigured().matches(mockConditionContext, null));
+        assertEquals(0, runCookieTest(true).size());
+    }
+
+    @Test
+    void whenCookieSeralizeNoDefault() {
+        when(mockEnvironment.getProperty("servlet.session-store", "memory")).thenReturn("database");
+        assertTrue(new UaaJdbcSessionConfig.DatabaseConfigured().matches(mockConditionContext, null));
+        assertEquals(1, runCookieTest(false).size());
+    }
+
+    private static List<String> runCookieTest(boolean defaults) {
+        String sessionId = UUID.randomUUID().toString();
+        String sessionName = "JSESSIONID";
+        MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest("GET", "/uaa/login");
+        MockHttpServletResponse mockHttpServletResponse = new MockHttpServletResponse();
+        UaaSessionConfig config = new UaaJdbcSessionConfig();
+        CookieSerializer cookieSerializer = config.uaaCookieSerializer(defaults ? -1 : 1, defaults ? true : false);
+        mockHttpServletRequest.setCookies(new Cookie(sessionName, sessionId));
+        List<String> cookies = cookieSerializer.readCookieValues(mockHttpServletRequest);
+        for (String value : cookies) {
+            cookieSerializer.writeCookieValue(new CookieSerializer.CookieValue(mockHttpServletRequest, mockHttpServletResponse, value));
+        }
+        return cookies;
     }
 }


### PR DESCRIPTION
found by accident on postgresql startup
Same as https://github.com/cloudfoundry/uaa/issues/1769 but then we cannot use database session store for postgresql. Without base64, it works, see
https://github.com/spring-projects/spring-session/issues/1201 Because null value would be written into postgresql with error, see https://stackoverflow.com/questions/53160867/postgres-error-invalid-byte-sequence-for-encoding-utf8-0xca-0x2d