### PR TITLE
fix: Dependabot can't authenticate to the private package registry ht…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,6 @@ buildscript {
         maven {
             url("https://plugins.gradle.org/m2/")
         }
-        maven {
-            url("https://repo.spring.io/plugins-release")
-        }
     }
 
     dependencies {
@@ -150,9 +147,6 @@ subprojects {
         mavenCentral()
         maven {
             url("https://jitpack.io")
-        }
-        maven {
-            url("https://repo.spring.io/release")
         }
         maven {
             url("https://repo.maven.apache.org/maven2")


### PR DESCRIPTION
…tps://repo.spring.io

- We get errors as follows at https://github.com/cloudfoundry/uaa/network/updates/705768660:
```
Dependabot can't authenticate to a private package registry
The following private package registry was used and caused the update to fail: https://repo.spring.io/release.
```
- Stop using `repo.spring.io` for dependencies. See https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023.

[#185768114]