### PR TITLE
fix: Move refresh rotate check to refresh flow

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/RefreshRotationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/RefreshRotationTest.java
@@ -40,7 +40,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -155,7 +154,7 @@ class RefreshRotationTest {
     OAuth2Authentication authentication = new OAuth2Authentication(oAuth2Request, tokenSupport.defaultUserAuthentication);
     CompositeToken accessToken = (CompositeToken) tokenServices.createAccessToken(authentication);
 
-    assertNull(UaaTokenUtils.getClaims(accessToken.getValue()).get(CLIENT_AUTH_METHOD));
+    assertThat(UaaTokenUtils.getClaims(accessToken.getValue()), hasEntry(CLIENT_AUTH_METHOD, CLIENT_AUTH_NONE));
     String refreshTokenValue = accessToken.getRefreshToken().getValue();
     assertThat(refreshTokenValue, is(notNullValue()));
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -255,7 +255,7 @@ class UaaTokenServicesTests {
     @Nested
     @DisplayName("when performing the refresh grant type")
     @DefaultTestContext
-    @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa"})
+    @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa", "jwt.token.refresh.rotate=true"})
     @DirtiesContext
     class WhenRefreshGrant {
         @Autowired


### PR DESCRIPTION
Add client_auth_method to access token always but allow refresh (without secret) only if token before was client_auth=none and client has rotate=true for refresh tokens

Refactor feature from https://github.com/cloudfoundry/uaa/pull/2402

During dev/test of https://github.com/cloudfoundry/uaa/pull/2435 found that it is a bad idea to combine the setting at the begin with rotate. So the access_token should have client_auth_method=none always if there was no secret (or empty secret)
Later in refresh flow the check should be done if rotate=true and then allow refresh without secret