### PR TITLE
log tracing

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -15,6 +15,7 @@ versions.springSecuritySamlVersion = "1.0.10.RELEASE"
 versions.tomcatCargoVersion = "9.0.79"
 versions.guavaVersion = "32.1.2-jre"
 versions.seleniumVersion = "4.11.0"
+versions.braveVersion = "5.16.0"
 
 // Versions we're overriding from the Spring Boot Bom (Dependabot does not issue PRs to bump these versions, so we need to manually bump them)
 ext["mariadb.version"] = "2.7.9" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
@@ -38,6 +39,8 @@ libraries.aspectJRt = "org.aspectj:aspectjrt"
 libraries.aspectJWeaver = "org.aspectj:aspectjweaver"
 libraries.bouncyCastlePkix = "org.bouncycastle:bcpkix-jdk18on:${versions.bouncyCastleVersion}"
 libraries.bouncyCastleProv = "org.bouncycastle:bcprov-jdk18on:${versions.bouncyCastleVersion}"
+libraries.braveInstrumentationSpringWebmvc = "io.zipkin.brave:brave-instrumentation-spring-webmvc:${versions.braveVersion}"
+libraries.braveContextSlf4j = "io.zipkin.brave:brave-context-slf4j:${versions.braveVersion}"
 libraries.commonsIo = "commons-io:commons-io:2.13.0"
 libraries.dumbster = "dumbster:dumbster:1.6"
 libraries.eclipseJgit = "org.eclipse.jgit:org.eclipse.jgit:6.6.0.202305301015-r"

--- a/scripts/cargo/log4j2.properties
+++ b/scripts/cargo/log4j2.properties
@@ -2,7 +2,7 @@ status = error
 dest = err
 name = UaaLog
 
-property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
+property.log_pattern=[%d{yyyy-MM-dd'T'HH:mm:ss.nnnnnn}{GMT+0}Z] uaa%X{context} - %pid [%t] - [%X{traceId},%X{spanId}] .... %5p --- %c{1}: %replace{%m}{(?<=password=|client_secret=)([^&]*)}{<redacted>}%n
 
 appender.uaaDefaultAppender.type = File
 appender.uaaDefaultAppender.name = UaaDefaultAppender

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     implementation(libraries.javaxXmlBindApi)
     implementation(libraries.glassfishJaxb)
 
+    implementation(libraries.braveInstrumentationSpringWebmvc)
+    implementation(libraries.braveContextSlf4j)
+
     providedCompile(libraries.tomcatEmbed)
 
     testImplementation(identityServer.sourceSets.test.output)

--- a/uaa/src/main/java/org/cloudfoundry/identity/uaa/TracingAutoConfiguration.java
+++ b/uaa/src/main/java/org/cloudfoundry/identity/uaa/TracingAutoConfiguration.java
@@ -54,11 +54,6 @@ public class TracingAutoConfiguration {
             .build();
   }
 
-  /** Allows someone to add tags to a span if a trace is in progress. */
-  @Bean SpanCustomizer spanCustomizer(Tracing tracing) {
-    return CurrentSpanCustomizer.create(tracing);
-  }
-
   /** Decides how to name and tag spans. By default they are named the same as the http method. */
   @Bean HttpTracing httpTracing(Tracing tracing) {
     return HttpTracing.create(tracing);
@@ -67,17 +62,6 @@ public class TracingAutoConfiguration {
   /** Creates server spans for HTTP requests */
   @Bean Filter tracingFilter(HttpTracing httpTracing) {
     return TracingFilter.create(httpTracing);
-  }
-
-  /** Adds MVC Controller tags to server spans */
-  @Bean WebMvcConfigurer tracingWebMvcConfigurer(
-          final SpanCustomizingAsyncHandlerInterceptor webMvcTracingCustomizer) {
-    return new WebMvcConfigurerAdapter() {
-      /** Adds application-defined web controller details to HTTP server spans */
-      @Override public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(webMvcTracingCustomizer);
-      }
-    };
   }
 }
 

--- a/uaa/src/main/java/org/cloudfoundry/identity/uaa/TracingAutoConfiguration.java
+++ b/uaa/src/main/java/org/cloudfoundry/identity/uaa/TracingAutoConfiguration.java
@@ -1,0 +1,83 @@
+package org.cloudfoundry.identity.uaa;
+
+import javax.servlet.Filter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+import brave.CurrentSpanCustomizer;
+import brave.SpanCustomizer;
+import brave.Tracing;
+import brave.context.slf4j.MDCScopeDecorator;
+import brave.http.HttpTracing;
+import brave.propagation.CurrentTraceContext;
+import brave.propagation.CurrentTraceContext.ScopeDecorator;
+import brave.propagation.ThreadLocalCurrentTraceContext;
+import brave.servlet.TracingFilter;
+import brave.spring.webmvc.SpanCustomizingAsyncHandlerInterceptor;
+
+/** This adds tracing configuration to any web mvc controllers or rest template clients. */
+@Configuration
+// Importing a class is effectively the same as declaring bean methods
+@Import(SpanCustomizingAsyncHandlerInterceptor.class)
+public class TracingAutoConfiguration {
+
+  /** Allows log patterns to use {@code %{traceId}} {@code %{spanId}} and {@code %{userName}} */
+  @Bean ScopeDecorator correlationScopeDecorator() {
+    return MDCScopeDecorator.newBuilder()
+            .build();
+  }
+
+  /** Propagates trace context between threads. */
+  @Bean CurrentTraceContext currentTraceContext(ScopeDecorator correlationScopeDecorator) {
+    return ThreadLocalCurrentTraceContext.newBuilder()
+            .addScopeDecorator(correlationScopeDecorator)
+            .build();
+  }
+
+  /** Controls aspects of tracing such as the service name that shows up in the UI */
+  @Bean Tracing tracing(
+          @Value("${brave.localServiceName:uaa}") String serviceName,
+          @Value("${brave.supportsJoin:true}") boolean supportsJoin,
+          @Value("${brave.traceId128Bit:false}") boolean traceId128Bit,
+          CurrentTraceContext currentTraceContext) {
+    return Tracing.newBuilder()
+            .localServiceName(serviceName)
+            .supportsJoin(supportsJoin)
+            .traceId128Bit(traceId128Bit)
+            .currentTraceContext(currentTraceContext)
+            .build();
+  }
+
+  /** Allows someone to add tags to a span if a trace is in progress. */
+  @Bean SpanCustomizer spanCustomizer(Tracing tracing) {
+    return CurrentSpanCustomizer.create(tracing);
+  }
+
+  /** Decides how to name and tag spans. By default they are named the same as the http method. */
+  @Bean HttpTracing httpTracing(Tracing tracing) {
+    return HttpTracing.create(tracing);
+  }
+
+  /** Creates server spans for HTTP requests */
+  @Bean Filter tracingFilter(HttpTracing httpTracing) {
+    return TracingFilter.create(httpTracing);
+  }
+
+  /** Adds MVC Controller tags to server spans */
+  @Bean WebMvcConfigurer tracingWebMvcConfigurer(
+          final SpanCustomizingAsyncHandlerInterceptor webMvcTracingCustomizer) {
+    return new WebMvcConfigurerAdapter() {
+      /** Adds application-defined web controller details to HTTP server spans */
+      @Override public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(webMvcTracingCustomizer);
+      }
+    };
+  }
+}
+

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -204,23 +204,25 @@
         </property>
         <property name="additionalFilters">
             <map>
-                <entry value-ref="metricsFilter"
+                <entry value-ref="tracingFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(0)}"/>
-                <entry value-ref="headerFilter"
+                <entry value-ref="metricsFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(1)}"/>
-                <entry value-ref="contentSecurityPolicyFilter"
+                <entry value-ref="headerFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(2)}"/>
-                <entry value-ref="utf8ConversionFilter"
+                <entry value-ref="contentSecurityPolicyFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(3)}"/>
-                <entry value-ref="limitedModeUaaFilter"
+                <entry value-ref="utf8ConversionFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(4)}"/>
-                <entry value-ref="identityZoneResolvingFilter"
+                <entry value-ref="limitedModeUaaFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(5)}"/>
-                <entry value-ref="corsFilter"
+                <entry value-ref="identityZoneResolvingFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(6)}"/>
+                <entry value-ref="corsFilter"
+                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(7)}"/>
                 <!-- Add in a flag that removes id_token from /oauth/authorize requests-->
                 <entry value-ref="disableIdTokenResponseFilter"
-                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(7)}"/>
+                       key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).position(8)}"/>
                 <!-- Zone switcher goes *after* class OAuth2AuthenticationProcessingFilter as it requires a token to be present to work -->
                 <entry value-ref="identityZoneSwitchingFilter"
                        key="#{T(org.cloudfoundry.identity.uaa.security.web.SecurityFilterChainPostProcessor.FilterPosition).after(@oauth2TokenParseFilter)}"/>


### PR DESCRIPTION
This implements log tracing, where log messages will now include a trace ID and span ID that's either sent in from the API client or otherwise auto-generated. This allows for improved debugging, so transactions can be correlated between different web services that use the same trace ID. In the example below, ` - [ace36bc5bdccffef,ace36bc5bdccffef]` is the part that is added:

`[2023-08-16T00:56:46.060135Z] uaa - 13 [https-jsse-nio-8443-exec-1] - [ace36bc5bdccffef,ace36bc5bdccffef] .... DEBUG --- UaaMetricsFilter: Successfully matched URI: /oauth/token to a group: /oauth-oidc`

In some code paths, like startup and rate limiting where the filter that implements log tracing isn't run, the trace and span IDs may be blank:

`[2023-08-17T01:53:42.790149Z] uaa/uaa - 17490 [main] - [,] ....  INFO --- SpringSecurityCoreVersion: You are running with Spring Security Core 5.7.10`

See also a [related change for uaa-release](https://github.com/cloudfoundry/uaa-release/pull/652) to update the log4j format there.

NOTE: This could be a breaking change for any stakeholder who parses UAA logs, because this add information to the middle of each log line in uaa.log.

[#185000950]