### PR TITLE
Rearchitect two integration tests to use page objects

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -16,6 +16,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.integration.pageObjects.LoginPage;
+import org.cloudfoundry.identity.uaa.integration.pageObjects.Page;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.integration.util.ScreenshotOnFail;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
@@ -51,7 +53,6 @@ import org.openqa.selenium.Cookie;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeDriver;
 import org.opensaml.saml2.core.AuthnContext;
 import org.opensaml.xml.ConfigurationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,7 +100,6 @@ import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDef
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.USER_ATTRIBUTE_PREFIX;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1526,66 +1526,5 @@ public class SamlLoginIT {
         cn.setRequestMethod("GET");
         cn.connect();
         assertEquals("Check status code from " + errorPath + " is " + codeExpected, cn.getResponseCode(), codeExpected);
-    }
-}
-
-class Page {
-    protected WebDriver driver;
-
-    Page() {
-        this(new ChromeDriver());
-    }
-
-    Page(WebDriver driver) {
-        this.driver = driver;
-    }
-
-    public LoginPage begin(String baseUrl) {
-        driver.get(baseUrl + "/login");
-        return new LoginPage(driver);
-    }
-
-    public LoginPage logout() {
-        driver.findElement(By.cssSelector(".dropdown-trigger")).click();
-        driver.findElement(By.linkText("Sign Out")).click();
-        return new LoginPage(driver);
-    }
-}
-
-class HomePage extends Page {
-    HomePage(WebDriver driver) {
-        super(driver);
-        assertThat("Should be on the home page", driver.getCurrentUrl(), endsWith("/"));
-        assertThat(driver.getPageSource(), Matchers.containsString("Where to?"));
-    }
-}
-
-class LoginPage extends Page {
-    LoginPage(WebDriver driver) {
-        super(driver);
-        assertThat("Should be on the login page", driver.getCurrentUrl(), endsWith("/login"));
-    }
-
-    // When there is a SAML integration, there is a link to go to a SAML login page instead. This assumes there is
-    // only one SAML link.
-    SamlLoginPage startSamlLogin() {
-        driver.findElement(By.className("saml-login-link")).click();
-        return new SamlLoginPage(driver);
-    }
-}
-
-class SamlLoginPage extends Page {
-    SamlLoginPage(WebDriver driver) {
-        super(driver);
-        assertThat("Should be on the SAML login page", driver.getCurrentUrl(), containsString("/module.php/core/loginuserpass"));
-    }
-
-    public HomePage login(String username, String password) {
-        final WebElement usernameElement = driver.findElement(By.name("username"));
-        usernameElement.clear();
-        usernameElement.sendKeys(username);
-        driver.findElement(By.name("password")).sendKeys(password);
-        driver.findElement(By.id("submit_button")).click();
-        return new HomePage(driver);
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -329,7 +329,6 @@ public class SamlLoginIT {
                 .login(testAccounts.getUserName(), testAccounts.getPassword());
         Long afterTest = System.currentTimeMillis();
 
-        IntegrationTestUtils.validateAccountChooserCookie(baseUrl, webDriver, IdentityZoneHolder.get());
         String zoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
         ScimUser user = IntegrationTestUtils.getUser(zoneAdminToken, baseUrl, SAML_ORIGIN, testAccounts.getEmail());
         IntegrationTestUtils.validateUserLastLogon(user, beforeTest, afterTest);
@@ -359,7 +358,6 @@ public class SamlLoginIT {
                 .startSamlLogin()
                 .login(testAccounts.getUserName(), testAccounts.getPassword())
                 .logout();
-        IntegrationTestUtils.validateAccountChooserCookie(baseUrl, webDriver, IdentityZoneHolder.get());
         loginPage.startSamlLogin();
     }
 
@@ -489,7 +487,6 @@ public class SamlLoginIT {
         webDriver.findElement(By.name("password")).sendKeys(password);
         webDriver.findElement(By.xpath("//input[@value='Login']")).click();
         assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString(lookfor));
-        IntegrationTestUtils.validateAccountChooserCookie(baseUrl, webDriver, IdentityZoneHolder.get());
     }
 
     protected IdentityProvider<SamlIdentityProviderDefinition> createIdentityProvider(String originKey) throws Exception {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -320,9 +320,16 @@ public class SamlLoginIT {
 
     @Test
     public void testSimpleSamlPhpLogin() throws Exception {
+        createIdentityProvider(SAML_ORIGIN);
+
         Long beforeTest = System.currentTimeMillis();
-        testSimpleSamlLogin("/login", "Where to?");
+        new Page(webDriver)
+                .begin(baseUrl)
+                .startSamlLogin()
+                .login(testAccounts.getUserName(), testAccounts.getPassword());
         Long afterTest = System.currentTimeMillis();
+
+        IntegrationTestUtils.validateAccountChooserCookie(baseUrl, webDriver, IdentityZoneHolder.get());
         String zoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
         ScimUser user = IntegrationTestUtils.getUser(zoneAdminToken, baseUrl, SAML_ORIGIN, testAccounts.getEmail());
         IntegrationTestUtils.validateUserLastLogon(user, beforeTest, afterTest);
@@ -1570,7 +1577,7 @@ class LoginPage extends Page {
 class SamlLoginPage extends Page {
     SamlLoginPage(WebDriver driver) {
         super(driver);
-        assertThat("Should be on the SAML login page", driver.getCurrentUrl(), containsString("/module.php/core/loginuserpass?"));
+        assertThat("Should be on the SAML login page", driver.getCurrentUrl(), containsString("/module.php/core/loginuserpass"));
     }
 
     public HomePage login(String username, String password) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
@@ -1,0 +1,17 @@
+package org.cloudfoundry.identity.uaa.integration.pageObjects;
+
+import org.hamcrest.Matchers;
+import org.openqa.selenium.WebDriver;
+import org.opensaml.xml.encryption.Public;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+
+public class HomePage extends Page {
+    public HomePage(WebDriver driver) {
+        super(driver);
+        assertThat("Should be on the home page", driver.getCurrentUrl(), endsWith("/"));
+        assertThat(driver.getPageSource(), Matchers.containsString("Where to?"));
+    }
+}
+

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
@@ -1,0 +1,21 @@
+package org.cloudfoundry.identity.uaa.integration.pageObjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.Assert.assertThat;
+
+public class LoginPage extends Page {
+    public LoginPage(WebDriver driver) {
+        super(driver);
+        assertThat("Should be on the login page", driver.getCurrentUrl(), endsWith("/login"));
+    }
+
+    // When there is a SAML integration, there is a link to go to a SAML login page instead. This assumes there is
+    // only one SAML link.
+    public SamlLoginPage startSamlLogin() {
+        driver.findElement(By.className("saml-login-link")).click();
+        return new SamlLoginPage(driver);
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -1,0 +1,24 @@
+package org.cloudfoundry.identity.uaa.integration.pageObjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+
+public class Page {
+    protected WebDriver driver;
+
+    public Page(WebDriver driver) {
+        this.driver = driver;
+    }
+
+    public LoginPage begin(String baseUrl) {
+        driver.get(baseUrl + "/login");
+        return new LoginPage(driver);
+    }
+
+    public LoginPage logout() {
+        driver.findElement(By.cssSelector(".dropdown-trigger")).click();
+        driver.findElement(By.linkText("Sign Out")).click();
+        return new LoginPage(driver);
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
@@ -1,0 +1,24 @@
+package org.cloudfoundry.identity.uaa.integration.pageObjects;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class SamlLoginPage extends Page {
+    public SamlLoginPage(WebDriver driver) {
+        super(driver);
+        assertThat("Should be on the SAML login page", driver.getCurrentUrl(), containsString("/module.php/core/loginuserpass"));
+    }
+
+    public HomePage login(String username, String password) {
+        final WebElement usernameElement = driver.findElement(By.name("username"));
+        usernameElement.clear();
+        usernameElement.sendKeys(username);
+        driver.findElement(By.name("password")).sendKeys(password);
+        driver.findElement(By.id("submit_button")).click();
+        return new HomePage(driver);
+    }
+}


### PR DESCRIPTION
This uses the page object pattern to improve two integration tests that use Selenium to drive Chrome. This could eventually be used to make all of the Selenium tests easier to maintain with less code duplication. This also abstracts most of the Selenium API away from the test cases.