### PR TITLE
fix: error go: download go1.21 for linux/amd64: toolchain not available

### DIFF
--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -1,6 +1,8 @@
 module github.com/cloudfoundry/uaa
 
-go 1.21.0
+go 1.21
+
+toolchain go1.21.0
 
 require (
 	github.com/onsi/ginkgo v1.16.5

--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/uaa
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
https://github.com/golang/go/issues/62278