### PR TITLE
Page object refactoring for two additional tests

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -38,7 +38,6 @@ import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.util.RetryRule;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
-import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.flywaydb.core.internal.util.StringUtils;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -445,21 +444,11 @@ public class SamlLoginIT {
 
         provider = IntegrationTestUtils.createOrUpdateProvider(zoneAdminToken, baseUrl, provider);
 
-        webDriver.get(baseUrl + "/login");
-        Assert.assertEquals("Cloud Foundry", webDriver.getTitle());
-        webDriver.findElement(By.xpath("//a[text()='" + provider.getConfig().getLinkText() + "']")).click();
-        webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
-        webDriver.findElement(By.name("username")).clear();
-        webDriver.findElement(By.name("username")).sendKeys(testAccounts.getUserName());
-        webDriver.findElement(By.name("password")).sendKeys(testAccounts.getPassword());
-        webDriver.findElement(By.xpath("//input[@value='Login']")).click();
-        assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString("Where to"));
-
-        webDriver.findElement(By.cssSelector(".dropdown-trigger")).click();
-        webDriver.findElement(By.linkText("Sign Out")).click();
-        webDriver.findElement(By.xpath("//a[text()='" + provider.getConfig().getLinkText() + "']")).click();
-
-        assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString("Where to"));
+        LoginPage.go(webDriver, baseUrl)
+                .startSamlLogin()
+                .login(testAccounts.getUserName(), testAccounts.getPassword())
+                .logout()
+                .automaticSamlLogin();
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -117,6 +117,13 @@ import static org.springframework.security.oauth2.common.util.OAuth2Utils.GRANT_
 @ContextConfiguration(classes = DefaultIntegrationTestConfig.class)
 public class SamlLoginIT {
 
+    public static final String MARISSA4_USERNAME = "marissa4";
+    private static final String MARISSA4_PASSWORD = "saml2";
+    public static final String MARISSA4_EMAIL = "marissa4@test.org";
+    public static final String MARISSA2_USERNAME = "marissa2";
+    private static final String MARISSA2_PASSWORD = "saml2";
+    public static final String MARISSA3_USERNAME = "marissa3";
+    private static final String MARISSA3_PASSWORD = "saml2";
     private static final String SAML_ORIGIN = "simplesamlphp";
     @Autowired @Rule
     public IntegrationTestRule integrationTestRule;
@@ -456,13 +463,13 @@ public class SamlLoginIT {
         createIdentityProvider(SAML_ORIGIN);
         LoginPage.go(webDriver, baseUrl)
                 .startSamlLogin()
-                .login("marissa4", "saml2");
+                .login(MARISSA4_USERNAME, MARISSA4_PASSWORD);
     }
 
     @Test
     public void testFavicon_Should_Not_Save() throws Exception {
         webDriver.get(baseUrl + "/favicon.ico");
-        testSimpleSamlLogin("/login", "Where to?", "marissa4", "saml2");
+        testSimpleSamlLogin("/login", "Where to?", MARISSA4_USERNAME, MARISSA4_PASSWORD);
     }
 
 
@@ -536,13 +543,13 @@ public class SamlLoginIT {
 
     @Test
     public void test_SamlInvitation_Automatic_Redirect_In_Zone2() throws Exception {
-        perform_SamlInvitation_Automatic_Redirect_In_Zone2("marissa2", "saml2", true);
-        perform_SamlInvitation_Automatic_Redirect_In_Zone2("marissa2", "saml2", true);
-        perform_SamlInvitation_Automatic_Redirect_In_Zone2("marissa2", "saml2", true);
+        perform_SamlInvitation_Automatic_Redirect_In_Zone2(MARISSA2_USERNAME, MARISSA2_PASSWORD, true);
+        perform_SamlInvitation_Automatic_Redirect_In_Zone2(MARISSA2_USERNAME, MARISSA2_PASSWORD, true);
+        perform_SamlInvitation_Automatic_Redirect_In_Zone2(MARISSA2_USERNAME, MARISSA2_PASSWORD, true);
 
-        perform_SamlInvitation_Automatic_Redirect_In_Zone2("marissa3", "saml2", false);
-        perform_SamlInvitation_Automatic_Redirect_In_Zone2("marissa3", "saml2", false);
-        perform_SamlInvitation_Automatic_Redirect_In_Zone2("marissa3", "saml2", false);
+        perform_SamlInvitation_Automatic_Redirect_In_Zone2(MARISSA3_USERNAME, MARISSA3_PASSWORD, false);
+        perform_SamlInvitation_Automatic_Redirect_In_Zone2(MARISSA3_USERNAME, MARISSA3_PASSWORD, false);
+        perform_SamlInvitation_Automatic_Redirect_In_Zone2(MARISSA3_USERNAME, MARISSA3_PASSWORD, false);
     }
 
     public void perform_SamlInvitation_Automatic_Redirect_In_Zone2(String username, String password, boolean emptyList) {
@@ -855,8 +862,8 @@ public class SamlLoginIT {
         //we should now be in the Simple SAML PHP site
         webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
         webDriver.findElement(By.name("username")).clear();
-        webDriver.findElement(By.name("username")).sendKeys("marissa4");
-        webDriver.findElement(By.name("password")).sendKeys("saml2");
+        webDriver.findElement(By.name("username")).sendKeys(MARISSA4_USERNAME);
+        webDriver.findElement(By.name("password")).sendKeys(MARISSA4_PASSWORD);
         webDriver.findElement(By.xpath("//input[@value='Login']")).click();
 
         assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString("Where to?"));
@@ -864,7 +871,7 @@ public class SamlLoginIT {
         webDriver.get(zoneUrl + "/logout.do");
 
         //validate that the groups were mapped
-        String samlUserId = IntegrationTestUtils.getUserId(adminTokenInZone, zoneUrl, provider.getOriginKey(), "marissa4@test.org");
+        String samlUserId = IntegrationTestUtils.getUserId(adminTokenInZone, zoneUrl, provider.getOriginKey(), MARISSA4_EMAIL);
         uaaSamlUserGroup = IntegrationTestUtils.getGroup(adminTokenInZone, null, zoneUrl, "uaa.saml.user");
         uaaSamlAdminGroup = IntegrationTestUtils.getGroup(adminTokenInZone, null, zoneUrl, "uaa.saml.admin");
         assertTrue(isMember(samlUserId, uaaSamlUserGroup));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -17,7 +17,6 @@ import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.pageObjects.LoginPage;
-import org.cloudfoundry.identity.uaa.integration.pageObjects.Page;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.integration.util.ScreenshotOnFail;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
@@ -329,10 +328,9 @@ public class SamlLoginIT {
         createIdentityProvider(SAML_ORIGIN);
 
         Long beforeTest = System.currentTimeMillis();
-        new Page(webDriver)
-                .begin(baseUrl)
-                .startSamlLogin()
-                .login(testAccounts.getUserName(), testAccounts.getPassword());
+        LoginPage.go(webDriver, baseUrl)
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(testAccounts.getUserName(), testAccounts.getPassword());
         Long afterTest = System.currentTimeMillis();
 
         String zoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
@@ -345,11 +343,11 @@ public class SamlLoginIT {
         Long beforeTest = System.currentTimeMillis();
         IdentityProvider<SamlIdentityProviderDefinition> provider = createIdentityProvider(SAML_ORIGIN);
         LoginPage.go(webDriver, baseUrl)
-                .startSamlLogin()
-                .login(testAccounts.getUserName(), testAccounts.getPassword())
-                .logout()
-                .startSamlLogin()
-                .login(testAccounts.getUserName(), testAccounts.getPassword())
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(testAccounts.getUserName(), testAccounts.getPassword())
+                .logout_goToLoginPage()
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(testAccounts.getUserName(), testAccounts.getPassword())
                 .hasLastLoginTime();
 
         Long afterTest = System.currentTimeMillis();
@@ -362,12 +360,11 @@ public class SamlLoginIT {
     public void testSingleLogout() throws Exception {
         IdentityProvider<SamlIdentityProviderDefinition> provider = createIdentityProvider(SAML_ORIGIN);
 
-        LoginPage loginPage = new Page(webDriver)
-                .begin(baseUrl)
-                .startSamlLogin()
-                .login(testAccounts.getUserName(), testAccounts.getPassword())
-                .logout();
-        loginPage.startSamlLogin();
+        LoginPage.go(webDriver, baseUrl)
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(testAccounts.getUserName(), testAccounts.getPassword())
+                .logout_goToLoginPage()
+                .clickSamlLink_goToSamlLoginPage();
     }
 
     @Test
@@ -452,18 +449,18 @@ public class SamlLoginIT {
         provider = IntegrationTestUtils.createOrUpdateProvider(zoneAdminToken, baseUrl, provider);
 
         LoginPage.go(webDriver, baseUrl)
-                .startSamlLogin()
-                .login(testAccounts.getUserName(), testAccounts.getPassword())
-                .logout()
-                .automaticSamlLogin();
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(testAccounts.getUserName(), testAccounts.getPassword())
+                .logout_goToLoginPage()
+                .clickSamlLink_goToHomePage();
     }
 
     @Test
     public void testGroupIntegration() throws Exception {
         createIdentityProvider(SAML_ORIGIN);
         LoginPage.go(webDriver, baseUrl)
-                .startSamlLogin()
-                .login(MARISSA4_USERNAME, MARISSA4_PASSWORD);
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(MARISSA4_USERNAME, MARISSA4_PASSWORD);
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -453,7 +453,10 @@ public class SamlLoginIT {
 
     @Test
     public void testGroupIntegration() throws Exception {
-        testSimpleSamlLogin("/login", "Where to?", "marissa4", "saml2");
+        createIdentityProvider(SAML_ORIGIN);
+        LoginPage.go(webDriver, baseUrl)
+                .startSamlLogin()
+                .login("marissa4", "saml2");
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -338,11 +338,14 @@ public class SamlLoginIT {
     public void testSimpleSamlPhpLoginDisplaysLastLogin() throws Exception {
         Long beforeTest = System.currentTimeMillis();
         IdentityProvider<SamlIdentityProviderDefinition> provider = createIdentityProvider(SAML_ORIGIN);
-        login(provider);
-        logout();
-        login(provider);
+        LoginPage.go(webDriver, baseUrl)
+                .startSamlLogin()
+                .login(testAccounts.getUserName(), testAccounts.getPassword())
+                .logout()
+                .startSamlLogin()
+                .login(testAccounts.getUserName(), testAccounts.getPassword())
+                .hasLastLoginTime();
 
-        assertNotNull(webDriver.findElement(By.cssSelector("#last_login_time")));
         Long afterTest = System.currentTimeMillis();
         String zoneAdminToken = IntegrationTestUtils.getClientCredentialsToken(serverRunning, "admin", "adminsecret");
         ScimUser user = IntegrationTestUtils.getUser(zoneAdminToken, baseUrl, SAML_ORIGIN, testAccounts.getEmail());
@@ -1500,22 +1503,6 @@ public class SamlLoginIT {
         def.setIdpEntityAlias("simplesamlphp");
         def.setLinkText("Login with Simple SAML PHP(simplesamlphp)");
         return def;
-    }
-
-    private void logout() {
-        webDriver.findElement(By.cssSelector(".dropdown-trigger")).click();
-        webDriver.findElement(By.linkText("Sign Out")).click();
-    }
-
-    private void login(IdentityProvider<SamlIdentityProviderDefinition> provider) {
-        webDriver.get(baseUrl + "/login");
-        Assert.assertEquals("Cloud Foundry", webDriver.getTitle());
-        webDriver.findElement(By.xpath("//a[text()='" + provider.getConfig().getLinkText() + "']")).click();
-        webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
-        webDriver.findElement(By.name("username")).clear();
-        webDriver.findElement(By.name("username")).sendKeys(testAccounts.getUserName());
-        webDriver.findElement(By.name("password")).sendKeys(testAccounts.getPassword());
-        webDriver.findElement(By.xpath("//input[@value='Login']")).click();
     }
 
     private void CallEmpptyPageAndCheckHttpStatusCode(String errorPath, int codeExpected) throws IOException {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
@@ -1,17 +1,27 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
 import org.hamcrest.Matchers;
+import org.joda.time.DateTime;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.opensaml.xml.encryption.Public;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
+import static org.junit.Assert.assertNotNull;
 
 public class HomePage extends Page {
     public HomePage(WebDriver driver) {
         super(driver);
         assertThat("Should be on the home page", driver.getCurrentUrl(), endsWith("/"));
         assertThat(driver.getPageSource(), Matchers.containsString("Where to?"));
+    }
+
+    public boolean hasLastLoginTime() {
+        WebElement lastLoginTime = driver.findElement(By.id("last_login_time"));
+        String loginTime = lastLoginTime.getText();
+        return loginTime != null && ! loginTime.isBlank();
     }
 }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
@@ -21,7 +21,19 @@ public class LoginPage extends Page {
     // When there is a SAML integration, there is a link to go to a SAML login page instead. This assumes there is
     // only one SAML link.
     public SamlLoginPage startSamlLogin() {
-        driver.findElement(By.className("saml-login-link")).click();
+        clickFirstSamlLoginLink();
         return new SamlLoginPage(driver);
+    }
+
+    // If the SAML IDP has no logout URL in the metadata, logging out of UAA will leave
+    // the IDP still logged in, and when going back to the SAML login page, it will log
+    // the app back in automatically and immediately redirect to the post-login page.
+    public HomePage automaticSamlLogin() {
+        clickFirstSamlLoginLink();
+        return new HomePage(driver);
+    }
+
+    private void clickFirstSamlLoginLink() {
+        driver.findElement(By.className("saml-login-link")).click();
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
@@ -7,6 +7,12 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertThat;
 
 public class LoginPage extends Page {
+
+    static public LoginPage go(WebDriver driver, String baseUrl) {
+        driver.get(baseUrl + "/login");
+        return new LoginPage(driver);
+    }
+
     public LoginPage(WebDriver driver) {
         super(driver);
         assertThat("Should be on the login page", driver.getCurrentUrl(), endsWith("/login"));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
@@ -20,7 +20,7 @@ public class LoginPage extends Page {
 
     // When there is a SAML integration, there is a link to go to a SAML login page instead. This assumes there is
     // only one SAML link.
-    public SamlLoginPage startSamlLogin() {
+    public SamlLoginPage clickSamlLink_goToSamlLoginPage() {
         clickFirstSamlLoginLink();
         return new SamlLoginPage(driver);
     }
@@ -28,7 +28,7 @@ public class LoginPage extends Page {
     // If the SAML IDP has no logout URL in the metadata, logging out of UAA will leave
     // the IDP still logged in, and when going back to the SAML login page, it will log
     // the app back in automatically and immediately redirect to the post-login page.
-    public HomePage automaticSamlLogin() {
+    public HomePage clickSamlLink_goToHomePage() {
         clickFirstSamlLoginLink();
         return new HomePage(driver);
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -2,7 +2,6 @@ package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
 
 public class Page {
     protected WebDriver driver;
@@ -11,12 +10,7 @@ public class Page {
         this.driver = driver;
     }
 
-    public LoginPage begin(String baseUrl) {
-        driver.get(baseUrl + "/login");
-        return new LoginPage(driver);
-    }
-
-    public LoginPage logout() {
+    public LoginPage logout_goToLoginPage() {
         clickLogout();
         return new LoginPage(driver);
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -17,8 +17,12 @@ public class Page {
     }
 
     public LoginPage logout() {
+        clickLogout();
+        return new LoginPage(driver);
+    }
+
+    private void clickLogout() {
         driver.findElement(By.cssSelector(".dropdown-trigger")).click();
         driver.findElement(By.linkText("Sign Out")).click();
-        return new LoginPage(driver);
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
@@ -13,7 +13,7 @@ public class SamlLoginPage extends Page {
         assertThat("Should be on the SAML login page", driver.getCurrentUrl(), containsString("/module.php/core/loginuserpass"));
     }
 
-    public HomePage login(String username, String password) {
+    public HomePage login_goToHomePage(String username, String password) {
         final WebElement usernameElement = driver.findElement(By.name("username"));
         usernameElement.clear();
         usernameElement.sendKeys(username);


### PR DESCRIPTION
This brings two more tests into the page object pattern. As is typical when adding more tests using the page objects, some functionality is added to the page objects, but it wasn't much.

For testSimpleSamlPhpLoginDisplaysLastLogin, this replaces what was already a basic procedural method design for login() and logout() with an object-oriented one. Also, an interaction with webdriver in an assertion is extracted to the appropriate object for possible reuse.

For testSingleLogoutWithNoLogoutUrlOnIDP, it violated the DRY principle fairly thoroughly and the page objects fix that for the webdriver-related interactions. Also, the introduction of the clickSamlLink_goToHomePage() method makes the purpose of the test easier to understand.

Several magic strings for test credentials are replaced with constants, though further refactoring is probably warranted to use a similar mechanism as with test accounts used in other tests in this class and elsewhere.