### PR TITLE
refactor: use page objects for favicon test

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.integration.pageObjects.FaviconElement;
 import org.cloudfoundry.identity.uaa.integration.pageObjects.LoginPage;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.integration.util.ScreenshotOnFail;
@@ -465,8 +466,11 @@ public class SamlLoginIT {
 
     @Test
     public void testFavicon_Should_Not_Save() throws Exception {
-        webDriver.get(baseUrl + "/favicon.ico");
-        testSimpleSamlLogin("/login", "Where to?", MARISSA4_USERNAME, MARISSA4_PASSWORD);
+        createIdentityProvider(SAML_ORIGIN);
+        FaviconElement.getDefaultIcon(webDriver, baseUrl);
+        LoginPage.go(webDriver, baseUrl)
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToHomePage(MARISSA4_USERNAME, MARISSA4_PASSWORD);
     }
 
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/FaviconElement.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/FaviconElement.java
@@ -1,14 +1,14 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
-import org.hamcrest.Matchers;
 import org.openqa.selenium.WebDriver;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertThat;
 
 public class FaviconElement extends Page {
 
-    // The favicon.ico URL is not present on the server because we specify a custom icon URL
+    // The favicon.ico image is not present on the server because we specify a custom icon URL
     // in the headers, but browsers try to hit it and tests need to hit this default URL.
     static public FaviconElement getDefaultIcon(WebDriver driver, String baseUrl) {
         driver.get(baseUrl + "/favicon.ico");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/FaviconElement.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/FaviconElement.java
@@ -19,6 +19,6 @@ public class FaviconElement extends Page {
     public FaviconElement(WebDriver driver) {
         super(driver);
         assertThat("Should be on the favicon image", driver.getCurrentUrl(), endsWith("/favicon.ico"));
-        assertThat(driver.getPageSource(), Matchers.containsString("Something went amiss."));
+        assertThat(driver.getPageSource(), containsString("Something went amiss."));
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/FaviconElement.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/FaviconElement.java
@@ -1,0 +1,24 @@
+package org.cloudfoundry.identity.uaa.integration.pageObjects;
+
+import org.hamcrest.Matchers;
+import org.openqa.selenium.WebDriver;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.Assert.assertThat;
+
+public class FaviconElement extends Page {
+
+    // The favicon.ico URL is not present on the server because we specify a custom icon URL
+    // in the headers, but browsers try to hit it and tests need to hit this default URL.
+    static public FaviconElement getDefaultIcon(WebDriver driver, String baseUrl) {
+        driver.get(baseUrl + "/favicon.ico");
+        return new FaviconElement(driver);
+    }
+
+    // Expect a 404 error when landing on the favicon URL.
+    public FaviconElement(WebDriver driver) {
+        super(driver);
+        assertThat("Should be on the favicon image", driver.getCurrentUrl(), endsWith("/favicon.ico"));
+        assertThat(driver.getPageSource(), Matchers.containsString("Something went amiss."));
+    }
+}


### PR DESCRIPTION
* The purpose of this test was difficult to understand until I temporarily removed the code that fixed the bug that this test is testing for.
* It should now be easier to understand why this test exists.