### PR TITLE
Passcode test refactor

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -17,6 +17,7 @@ import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.pageObjects.LoginPage;
+import org.cloudfoundry.identity.uaa.integration.pageObjects.PasscodePage;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.integration.util.ScreenshotOnFail;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
@@ -240,7 +241,11 @@ public class SamlLoginIT {
 
     @Test
     public void testSimpleSamlPhpPasscodeRedirect() throws Exception {
-        testSimpleSamlLogin("/passcode", "Temporary Authentication Code");
+        createIdentityProvider(SAML_ORIGIN);
+
+        PasscodePage.requestPasscode_goToLoginPage(webDriver, baseUrl)
+                .clickSamlLink_goToSamlLoginPage()
+                .login_goToPasscodePage(testAccounts.getUserName(), testAccounts.getPassword());
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
@@ -1,20 +1,19 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
 import org.hamcrest.Matchers;
-import org.joda.time.DateTime;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.opensaml.xml.encryption.Public;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.assertNotNull;
 
 public class HomePage extends Page {
+    static final protected String urlPath = "/";
+
     public HomePage(WebDriver driver) {
         super(driver);
-        assertThat("Should be on the home page", driver.getCurrentUrl(), endsWith("/"));
+        validateUrl(driver, endsWith(urlPath));
         assertThat(driver.getPageSource(), Matchers.containsString("Where to?"));
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/HomePage.java
@@ -1,11 +1,10 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
-import org.hamcrest.Matchers;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 
 public class HomePage extends Page {
@@ -14,7 +13,7 @@ public class HomePage extends Page {
     public HomePage(WebDriver driver) {
         super(driver);
         validateUrl(driver, endsWith(urlPath));
-        assertThat(driver.getPageSource(), Matchers.containsString("Where to?"));
+        validatePageSource(driver, containsString("Where to?"));
     }
 
     public boolean hasLastLoginTime() {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
@@ -9,14 +9,14 @@ public class LoginPage extends Page {
 
     static final protected String urlPath = "/login";
 
-    static public LoginPage go(WebDriver driver, String baseUrl) {
-        driver.get(baseUrl + urlPath);
-        return new LoginPage(driver);
-    }
-
     public LoginPage(WebDriver driver) {
         super(driver);
         validateUrl(driver, endsWith(urlPath));
+    }
+
+    static public LoginPage go(WebDriver driver, String baseUrl) {
+        driver.get(baseUrl + urlPath);
+        return new LoginPage(driver);
     }
 
     // When there is a SAML integration, there is a link to go to a SAML login page instead. This assumes there is

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/LoginPage.java
@@ -4,18 +4,19 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
 import static org.hamcrest.Matchers.endsWith;
-import static org.junit.Assert.assertThat;
 
 public class LoginPage extends Page {
 
+    static final protected String urlPath = "/login";
+
     static public LoginPage go(WebDriver driver, String baseUrl) {
-        driver.get(baseUrl + "/login");
+        driver.get(baseUrl + urlPath);
         return new LoginPage(driver);
     }
 
     public LoginPage(WebDriver driver) {
         super(driver);
-        assertThat("Should be on the login page", driver.getCurrentUrl(), endsWith("/login"));
+        validateUrl(driver, endsWith(urlPath));
     }
 
     // When there is a SAML integration, there is a link to go to a SAML login page instead. This assumes there is

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -1,13 +1,20 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
+import org.hamcrest.Matcher;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+
+import static org.junit.Assert.assertThat;
 
 public class Page {
     protected WebDriver driver;
 
     public Page(WebDriver driver) {
         this.driver = driver;
+    }
+
+    protected static void validateUrl(WebDriver driver, Matcher urlMatcher) {
+        assertThat("URL validation failed", driver.getCurrentUrl(), urlMatcher);
     }
 
     public LoginPage logout_goToLoginPage() {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -17,6 +17,10 @@ public class Page {
         assertThat("URL validation failed", driver.getCurrentUrl(), urlMatcher);
     }
 
+    protected static void validatePageSource(WebDriver driver, Matcher matcher) {
+        assertThat(driver.getPageSource(), matcher);
+    }
+
     public LoginPage logout_goToLoginPage() {
         clickLogout();
         return new LoginPage(driver);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
@@ -9,14 +9,14 @@ import static org.junit.Assert.assertThat;
 public class PasscodePage extends Page {
     static final protected String urlPath = "/passcode";
 
-    static public LoginPage requestPasscode_goToLoginPage(WebDriver driver, String baseUrl) {
-        driver.get(baseUrl + urlPath);
-        return new LoginPage(driver);
-    }
-
     public PasscodePage(WebDriver driver) {
         super(driver);
         validateUrl(driver, endsWith(urlPath));
         assertThat(driver.getPageSource(), containsString("Temporary Authentication Code"));
+    }
+
+    static public LoginPage requestPasscode_goToLoginPage(WebDriver driver, String baseUrl) {
+        driver.get(baseUrl + urlPath);
+        return new LoginPage(driver);
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
@@ -7,15 +7,16 @@ import static org.hamcrest.Matchers.endsWith;
 import static org.junit.Assert.assertThat;
 
 public class PasscodePage extends Page {
+    static final protected String urlPath = "/passcode";
 
     static public LoginPage requestPasscode_goToLoginPage(WebDriver driver, String baseUrl) {
-        driver.get(baseUrl + "/passcode");
+        driver.get(baseUrl + urlPath);
         return new LoginPage(driver);
     }
 
     public PasscodePage(WebDriver driver) {
         super(driver);
-        assertThat("Should be on the passcode page", driver.getCurrentUrl(), endsWith("/passcode"));
+        validateUrl(driver, endsWith(urlPath));
         assertThat(driver.getPageSource(), containsString("Temporary Authentication Code"));
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
+import org.hamcrest.Matcher;
 import org.openqa.selenium.WebDriver;
 
 import static org.hamcrest.Matchers.containsString;
@@ -12,7 +13,7 @@ public class PasscodePage extends Page {
     public PasscodePage(WebDriver driver) {
         super(driver);
         validateUrl(driver, endsWith(urlPath));
-        assertThat(driver.getPageSource(), containsString("Temporary Authentication Code"));
+        validatePageSource(driver, containsString("Temporary Authentication Code") );
     }
 
     static public LoginPage requestPasscode_goToLoginPage(WebDriver driver, String baseUrl) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/PasscodePage.java
@@ -1,0 +1,21 @@
+package org.cloudfoundry.identity.uaa.integration.pageObjects;
+
+import org.openqa.selenium.WebDriver;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.Assert.assertThat;
+
+public class PasscodePage extends Page {
+
+    static public LoginPage requestPasscode_goToLoginPage(WebDriver driver, String baseUrl) {
+        driver.get(baseUrl + "/passcode");
+        return new LoginPage(driver);
+    }
+
+    public PasscodePage(WebDriver driver) {
+        super(driver);
+        assertThat("Should be on the passcode page", driver.getCurrentUrl(), endsWith("/passcode"));
+        assertThat(driver.getPageSource(), containsString("Temporary Authentication Code"));
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
@@ -5,12 +5,14 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 
 public class SamlLoginPage extends Page {
+    // This is on the saml server, not the UAA server
+    static final protected String urlPath = "/module.php/core/loginuserpass";
+
     public SamlLoginPage(WebDriver driver) {
         super(driver);
-        assertThat("Should be on the SAML login page", driver.getCurrentUrl(), containsString("/module.php/core/loginuserpass"));
+        validateUrl(driver, containsString(urlPath));
     }
 
     public HomePage login_goToHomePage(String username, String password) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/SamlLoginPage.java
@@ -14,11 +14,20 @@ public class SamlLoginPage extends Page {
     }
 
     public HomePage login_goToHomePage(String username, String password) {
+        sendLoginCredentials(username, password);
+        return new HomePage(driver);
+    }
+
+    public PasscodePage login_goToPasscodePage(String username, String password) {
+        sendLoginCredentials(username, password);
+        return new PasscodePage(driver);
+    }
+
+    private void sendLoginCredentials(String username, String password) {
         final WebElement usernameElement = driver.findElement(By.name("username"));
         usernameElement.clear();
         usernameElement.sendKeys(username);
         driver.findElement(By.name("password")).sendKeys(password);
         driver.findElement(By.id("submit_button")).click();
-        return new HomePage(driver);
     }
 }


### PR DESCRIPTION
This applies the page object strategy to the testSimpleSamlPhpPasscodeRedirect test. This required using a factory method to start the interaction on the passcode page that immediately redirects to the login page (requestPasscode_goToLoginPage) because the pattern I'm using here is that a constructor will expect it to land on the passcode page.

Also included a bit of code improvement in the page objects.