### PR TITLE
Make it easier to find test failures in CI output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,12 +91,13 @@ subprojects {
         jvmArgs += ["-Xmx1024m", "-XX:+StartAttachListener", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/var/log/uaa-tests.hprof"]
 
         retry {
-            def retryFailOnPassedAfterRetry = Boolean.parseBoolean(
+            def failOnPassedAfterRetrySystemProperty = Boolean.parseBoolean(
                     System.getProperty("failOnPassedAfterRetry", "false"));
-            if (!retryFailOnPassedAfterRetry)
+            if (!failOnPassedAfterRetrySystemProperty)
                 logger.warn("retry: Flaky tests will not make the test run fail because failOnPassedAfterRetry is false.")
 
-            failOnPassedAfterRetry = retryFailOnPassedAfterRetry
+            // Configure the retry extension
+            failOnPassedAfterRetry = failOnPassedAfterRetrySystemProperty
             maxFailures = Integer.parseInt(System.getProperty("maxFailures", "3"))
             maxRetries = Integer.parseInt(System.getProperty("maxRetries", "1"))
         }

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ subprojects {
             def retryFailOnPassedAfterRetry = Boolean.parseBoolean(
                     System.getProperty("failOnPassedAfterRetry", "false"));
             if (!retryFailOnPassedAfterRetry)
-                logger.warn("retry: Failed tests are to be retried and considered as passed if the retry passes.")
+                logger.warn("retry: Flaky tests will not make the test run fail because failOnPassedAfterRetry is false.")
 
             failOnPassedAfterRetry = retryFailOnPassedAfterRetry
             maxFailures = Integer.parseInt(System.getProperty("maxFailures", "3"))

--- a/metrics-data/src/test/java/org/cloudfoundry/identity/uaa/util/JsonUtilsTest.java
+++ b/metrics-data/src/test/java/org/cloudfoundry/identity/uaa/util/JsonUtilsTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 class JsonUtilsTest {
   private static final String jsonTestObjectString = "{\"pattern\":\"/pattern\",\"group\":\"group\",\"limit\":1000,\"category\":\"category\"}";
@@ -69,13 +69,10 @@ class JsonUtilsTest {
 
   @Test
   void testSerializeExcludingPropertiesInnerCallFails() {
-    Map<String, String> groupProperties = JsonUtils.readValue(jsonTestObjectString, new TypeReference<Map<String, String>>() {});
-    try {
-      JsonUtils.serializeExcludingProperties(groupProperties, "limit.unkonwn");
-      fail("not expected");
-    } catch (Exception e) {
-      assertTrue(e instanceof JsonUtils.JsonUtilException);
-    }
+    Map<String, String> groupProperties = JsonUtils.readValue(jsonTestObjectString, new TypeReference<>() {});
+    assertThrows(JsonUtils.JsonUtilException.class, () -> {
+      JsonUtils.serializeExcludingProperties(groupProperties, "limit.unknown");
+    });
   }
 
   @Test

--- a/metrics-data/src/test/java/org/cloudfoundry/identity/uaa/util/JsonUtilsTest.java
+++ b/metrics-data/src/test/java/org/cloudfoundry/identity/uaa/util/JsonUtilsTest.java
@@ -68,7 +68,7 @@ class JsonUtilsTest {
   }
 
   @Test
-  void testSerializeExcludingPropertiesInnerCallFailed() {
+  void testSerializeExcludingPropertiesInnerCallFails() {
     Map<String, String> groupProperties = JsonUtils.readValue(jsonTestObjectString, new TypeReference<Map<String, String>>() {});
     try {
       JsonUtils.serializeExcludingProperties(groupProperties, "limit.unkonwn");


### PR DESCRIPTION
Searching for "FAILURE" in the CI output in a browser (case insensitive) to find failed tests always finds things that aren't test failures. This PR applies the principle of never logging the word "failure" except when JUnit is reporting a test failure. 

"Fail" is still ok to include in method names and other output.

Two additional refactors in the affected code are also included.