### PR TITLE
test clean-up: switch back to using standard simplesamlPHP server URL

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
@@ -86,7 +86,7 @@ import static org.springframework.util.StringUtils.hasText;
 
 public class IntegrationTestUtils {
 
-    public static final String SIMPLESAMLPHP_UAA_ACCEPTANCE = "http://simplesamlphp2.uaa-acceptance.cf-app.com";
+    public static final String SIMPLESAMLPHP_UAA_ACCEPTANCE = "http://simplesamlphp.uaa-acceptance.cf-app.com";
     public static final String SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR =
         "//h1[contains(text(), 'Enter your username and password')]";
     public static final String SAML_AUTH_SOURCE = "example-userpass";


### PR DESCRIPTION
This reverts commit cb1ca3578cc5a9ce33fd0ed2c884081105f1c1ff.

- reverting because we have fully replaced the old server (http://simplesamlphp.uaa-acceptance.cf-app.com is now the simplesamlPHP v2)