### PR TITLE
fix sonar issue: Utility classes should not have public constructors

### DIFF
--- a/metrics-data/src/main/java/org/cloudfoundry/identity/uaa/metrics/MetricsUtil.java
+++ b/metrics-data/src/main/java/org/cloudfoundry/identity/uaa/metrics/MetricsUtil.java
@@ -18,6 +18,11 @@ package org.cloudfoundry.identity.uaa.metrics;
 public class MetricsUtil {
     public static final String GLOBAL_GROUP = "uaa.global.metrics";
 
+    // Utility classes should not have public constructors
+    private MetricsUtil() {
+        throw new IllegalStateException("Utility class");
+    }
+
     public static double addAverages(double oldCount,
                                      double oldAverage,
                                      double newCount,


### PR DESCRIPTION
https://sonarcloud.io/project/issues?resolved=false&id=cloudfoundry-identity-parent&open=AYBVU3K88w5rn7tLsf1n