### PR TITLE
fix: use OIDC standard claims, if result from mapping is null

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -370,11 +370,11 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             Map<String, Object> claims = authenticationData.getClaims();
 
             String username = authenticationData.getUsername();
-            String givenName =  getMappedClaim(givenNameClaim, "given_name", claims);
-            String familyName = getMappedClaim(familyNameClaim, "family_name", claims);
-            String phoneNumber = getMappedClaim(phoneClaim, "phone_number", claims);
-            String email = getMappedClaim(emailClaim, "email",claims);
-            Object verifiedObj = claims.get(emailVerifiedClaim == null ? "email_verified" : emailVerifiedClaim);
+            String givenName =  getMappedClaim(givenNameClaim, ClaimConstants.GIVEN_NAME, claims);
+            String familyName = getMappedClaim(familyNameClaim, ClaimConstants.FAMILY_NAME, claims);
+            String phoneNumber = getMappedClaim(phoneClaim, ClaimConstants.PHONE_NUMBER, claims);
+            String email = getMappedClaim(emailClaim, ClaimConstants.EMAIL,claims);
+            Object verifiedObj = claims.get(emailVerifiedClaim == null ? ClaimConstants.EMAIL_VERIFIED : emailVerifiedClaim);
             boolean verified =  verifiedObj instanceof Boolean ? (Boolean)verifiedObj: false;
 
             if (email == null) {
@@ -405,29 +405,52 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         return null;
     }
 
-    private String getMappedClaim(String externalName, String internalName, Map<String, Object> claims) {
-        String claimName = isNull(externalName) ? internalName : externalName;
+    private String getMappedClaim(String externalName, String oidcName, Map<String, Object> claims) {
+        String claimValue = null;
+        BadCredentialsException exception = null;
+        String claimName = isNull(externalName) ? oidcName : externalName;
         Object claimObject = claims.get(claimName);
 
         if (isNull(claimObject)) {
-            return null;
+            Object oidcClaim = getOidcClaim(externalName, oidcName, claims, claimName);
+            if (isNull(oidcClaim)) {
+                return null;
+            }
+            claimObject = oidcClaim;
         }
         if (claimObject instanceof String) {
-            return (String) claimObject;
-        }
-        if (claimObject instanceof Collection) {
+            claimValue = (String) claimObject;
+        } else if (claimObject instanceof Collection) {
             Set<String> entry = ((Collection<?>) claimObject).stream().map(String.class::cast).collect(Collectors.toSet());
-            if (entry.size() == 1 ) {
-                return entry.stream().collect(Collectors.toList()).get(0);
+            if (entry.size() == 1) {
+                claimValue = entry.stream().collect(Collectors.toList()).get(0);
             } else if (entry.isEmpty()) {
                 return null;
             } else {
                 logger.warn("Claim mapping for {} attribute is ambiguous. ({}) ", claimName, entry.size());
-                throw new BadCredentialsException("Claim mapping for " + internalName + " attribute is ambiguous");
+                exception = new BadCredentialsException("Claim mapping for " + oidcName + " attribute is ambiguous");
             }
         }
-        logger.warn("Claim attribute {} cannot be mapped because of invalid type {} ", claimName, claimObject.getClass().getSimpleName());
-        throw new BadCredentialsException("External token attribute " + claimName + " cannot be mapped to user attribute " + internalName);
+        if (isNull(claimValue)) {
+            Object oidcClaim = getOidcClaim(externalName, oidcName, claims, claimName);
+            if (oidcClaim instanceof String) {
+                claimValue = (String) oidcClaim;
+            } else {
+                logger.warn("Claim attribute {} cannot be mapped because of invalid type {} ", claimName,
+                    ofNullable(claimObject).map(Object::getClass).map(Class::getSimpleName).orElse("unknown"));
+                throw exception != null ? exception :
+                    new BadCredentialsException("External token attribute " + claimName + " cannot be mapped to user attribute " + oidcName);
+            }
+        }
+        return claimValue;
+    }
+
+    // OIDC standard claims, see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+    private static Object getOidcClaim(String externalName, String oidcName, Map<String, Object> claims, String claimName) {
+        if (claimName.equals(externalName)) {
+            return claims.get(oidcName);
+        }
+        return null;
     }
 
     private List<? extends GrantedAuthority> extractExternalOAuthUserAuthorities(Map<String, Object> attributeMappings, Map<String, Object> claims) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -431,7 +431,7 @@ public class ExternalOAuthAuthenticationManagerTest {
     }
 
     @Test
-    public void getUser_doesNotThrowWhenIdTokenMappingIsArrayButAlsoOidcStandardClaims() {
+    public void getUser_doesNotReturnNullWhenIdTokenMappingIsNotAvailableButAlsoOidcStandardClaims() {
         Map<String, Object> header = map(
             entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.HS256.getName()),
             entry(HeaderParameterNames.KEY_ID, OIDC_PROVIDER_KEY)
@@ -441,8 +441,6 @@ public class ExternalOAuthAuthenticationManagerTest {
             entry("family_name", "Foo"),
             entry("given_name", "Bar"),
             entry("email", "bar.foo@domain.org"),
-            entry("external_family_name", Arrays.asList("foo", "Foo")),
-            entry("external_given_name", Arrays.asList("bar", "Bar")),
             entry(ISS, oidcConfig.getIssuer()),
             entry(AUD, "uaa-relying-party"),
             entry(EXPIRY_IN_SECONDS, ((int) (System.currentTimeMillis()/1000L)) + 60),


### PR DESCRIPTION
With https://github.com/cloudfoundry/uaa/pull/1925 there was a fix already, however using custom claims can lead to error situations. With this fix, that error situations are prevented if standard claims in id_token, e.g. custom attribute is not in token, but family_name and given_name are also in the token as string. This fix is for OIDC IdP integration, therefore it makes sense to use as fallback also OIDC standard claims.