### PR TITLE
fix client admin rest call with empty secret

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
@@ -16,7 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.messageResolver;
-import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.validator;
+import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.userValidator;
 
 /**
  * ****************************************************************************
@@ -62,7 +62,7 @@ public class UaaPasswordPolicyValidator implements PasswordValidator {
             policy = idpDefinition.getPasswordPolicy();
         }
 
-        org.passay.PasswordValidator validator = validator(policy, messageResolver);
+        org.passay.PasswordValidator validator = userValidator(policy, messageResolver);
         RuleResult result = validator.validate(new PasswordData((password != null) ? password : ""));
         if (!result.isValid()) {
             List<String> errorMessages = new LinkedList<>(validator.getMessages(result));

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PasswordValidatorUtil.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PasswordValidatorUtil.java
@@ -46,13 +46,23 @@ public final class PasswordValidatorUtil {
         }
     }
 
+    public static PasswordValidator secretValidator(GenericPasswordPolicy<?> policy,
+        MessageResolver messageResolver) {
+        return internalValidator(policy, 0, messageResolver);
+    }
 
-    public static PasswordValidator validator(GenericPasswordPolicy<?> policy,
+    public static PasswordValidator userValidator(GenericPasswordPolicy<?> policy,
+        MessageResolver messageResolver) {
+        return internalValidator(policy, 1, messageResolver);
+    }
+
+    private static PasswordValidator internalValidator(GenericPasswordPolicy<?> policy,
+                                              int minimumLength,
                                               MessageResolver messageResolver) {
         List<Rule> rules = new ArrayList<>();
 
-        //length is always a rule. We do not allow blank password
-        int minLength = Math.max(1, policy.getMinLength());
+        //length is always a rule. We do not allow blank password, but a blank secret
+        int minLength = Math.max(minimumLength, policy.getMinLength());
         int maxLength = policy.getMaxLength()>0 ? policy.getMaxLength() : Integer.MAX_VALUE;
         rules.add(new LengthRule(minLength, maxLength));
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidator.java
@@ -23,7 +23,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.messageResolver;
-import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.validator;
+import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.secretValidator;
 
 
 
@@ -82,8 +82,7 @@ public class ZoneAwareClientSecretPolicyValidator implements ClientSecretValidat
             clientSecretPolicy = zone.getConfig().getClientSecretPolicy();
         }
 
-        PasswordValidator clientSecretValidator = validator(clientSecretPolicy,
-                                                        messageResolver);
+        PasswordValidator clientSecretValidator = secretValidator(clientSecretPolicy, messageResolver);
         RuleResult result = clientSecretValidator.validate(new PasswordData(clientSecret));
         if (!result.isValid()) {
             List<String> errorMessages = new LinkedList<>(clientSecretValidator.getMessages(result));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -37,8 +37,14 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     }
 
     @Test
-    void testEmptyClientSecret() {
+    void testEmptyClientSecretAllowed() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
+        validator.validate(TEST_SECRET_1);
+    }
+
+    @Test
+    void testEmptyClientSecretForbidden() {
+        zone.getConfig().setClientSecretPolicy(strictPolicy);
         assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_SECRET_1));
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -17,7 +17,7 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     private ClientSecretPolicy defaultPolicy = new ClientSecretPolicy(0,255,0,0,0,0,6);
     private ClientSecretPolicy strictPolicy = new ClientSecretPolicy(6,10,1,1,1,1,6);
 
-    private static final String TEST_SECRET_1 = "";
+    private static final String TEST_EMPTY_SECRET = "";
     private static final String TEST_SECRET_2 = "testsecret";
     private static final String TEST_SECRET_3 = "VFNTTDEgMB4GA1UEAxMXZnNzLnN0YWdlLmdlY29tcGFueIb3DQEBAQUADDwDG6wkBY" +
             "sJSqbSYpw0c76bUB1x5e46eiroRZdU2BEWiQJ9yxV95gGNsdLH1105iubzc9dbxavGIYM9s/+qJRf6WfwDU7VQsURCqIN8eUtnPU808" +
@@ -39,13 +39,13 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     @Test
     void testEmptyClientSecretAllowed() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
-        validator.validate(TEST_SECRET_1);
+        validator.validate(TEST_EMPTY_SECRET);
     }
 
     @Test
     void testEmptyClientSecretForbidden() {
         zone.getConfig().setClientSecretPolicy(strictPolicy);
-        assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_SECRET_1));
+        assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_EMPTY_SECRET));
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.identity.uaa.oauth.client.SecretChangeRequest;
 import org.cloudfoundry.identity.uaa.resources.SearchResults;
 import org.cloudfoundry.identity.uaa.test.TestAccountSetup;
 import org.cloudfoundry.identity.uaa.test.UaaTestAccounts;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.ClientSecretPolicy;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -167,6 +168,21 @@ public class ClientAdminEndpointsIntegrationTests {
         ResponseEntity<Void> result = serverRunning.getRestTemplate()
                 .exchange(serverRunning.getUrl("/oauth/clients"), HttpMethod.POST,
                         new HttpEntity<>(client, headers), Void.class);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+    }
+
+    @Test
+    public void createClientWithEmptySecret() {
+        OAuth2AccessToken token = getClientCredentialsAccessToken("clients.admin");
+        HttpHeaders headers = getAuthenticatedHeaders(token);
+        var client = new ClientDetailsCreation();
+        client.setClientId(new RandomValueStringGenerator().generate());
+        client.setClientSecret(UaaStringUtils.EMPTY_STRING);
+        client.setAuthorizedGrantTypes(List.of("password"));
+
+        ResponseEntity<Void> result = serverRunning.getRestTemplate()
+            .exchange(serverRunning.getUrl("/oauth/clients"), HttpMethod.POST,
+                new HttpEntity<>(client, headers), Void.class);
         assertEquals(HttpStatus.CREATED, result.getStatusCode());
     }
 


### PR DESCRIPTION
Empty client secret is allowed if client secret policy allows it.
Error says 1 char is needed, this is wrong

Why 2 validators, distinguish between user and client policy validation.

For users 1 minimum char for a password might be ok, for a client definitely not.
The empty secret should be treated as public, but we cannot disallow it.

Therefore, this here is a fix for a regression introduced with 76.22.0.