### PR TITLE
fix client admin rest call with empty secret - alternative PR

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PasswordValidatorUtil.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PasswordValidatorUtil.java
@@ -51,8 +51,8 @@ public final class PasswordValidatorUtil {
                                               MessageResolver messageResolver) {
         List<Rule> rules = new ArrayList<>();
 
-        //length is always a rule. We do not allow blank password
-        int minLength = Math.max(1, policy.getMinLength());
+        //length is always a rule
+        int minLength = Math.max(0, policy.getMinLength());
         int maxLength = policy.getMaxLength()>0 ? policy.getMaxLength() : Integer.MAX_VALUE;
         rules.add(new LengthRule(minLength, maxLength));
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PasswordValidatorUtil.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PasswordValidatorUtil.java
@@ -51,8 +51,7 @@ public final class PasswordValidatorUtil {
                                               MessageResolver messageResolver) {
         List<Rule> rules = new ArrayList<>();
 
-        //length is always a rule
-        int minLength = Math.max(0, policy.getMinLength());
+        int minLength = policy.getMinLength()>0 ? policy.getMinLength() : 0;
         int maxLength = policy.getMaxLength()>0 ? policy.getMaxLength() : Integer.MAX_VALUE;
         rules.add(new LengthRule(minLength, maxLength));
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidatorTests.java
@@ -47,19 +47,10 @@ class UaaPasswordPolicyValidatorTests {
     }
 
     @Test
-    void min_password_length_is_always_1_if_set_to_0() {
-        policy.setMinLength(0);
+    void min_password_length_is_1() {
+        policy.setMinLength(1);
         validatePassword("", "Password must be at least 1 characters in length.");
-        validatePassword(null, "Password must be at least 1 characters in length.");
     }
-
-    @Test
-    void min_password_length_is_always_1_if_not_set() {
-        policy.setMinLength(-1);
-        validatePassword("", "Password must be at least 1 characters in length.");
-        validatePassword(null, "Password must be at least 1 characters in length.");
-    }
-
 
     @Test
     void testValidateSuccess() {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -37,13 +37,13 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     }
 
     @Test
-    void testEmptyClientSecretAllowed() {
+    void defaultPolicyAcceptsEmptySecret() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
         validator.validate(TEST_EMPTY_SECRET);
     }
 
     @Test
-    void testEmptyClientSecretForbidden() {
+    void strictPolicyRejectsEmptySecret() {
         zone.getConfig().setClientSecretPolicy(strictPolicy);
         assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_EMPTY_SECRET));
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -37,9 +37,13 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     }
 
     @Test
-    void testEmptyClientSecret() {
+    void testEmptyClientSecretAllowed() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
         validator.validate(TEST_SECRET_1);
+    }
+
+    @Test
+    void testEmptyClientSecretForbidden() {
         zone.getConfig().setClientSecretPolicy(strictPolicy);
         assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_SECRET_1));
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -17,7 +17,7 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     private ClientSecretPolicy defaultPolicy = new ClientSecretPolicy(0,255,0,0,0,0,6);
     private ClientSecretPolicy strictPolicy = new ClientSecretPolicy(6,10,1,1,1,1,6);
 
-    private static final String TEST_SECRET_1 = "";
+    private static final String TEST_EMPTY_SECRET = "";
     private static final String TEST_SECRET_2 = "testsecret";
     private static final String TEST_SECRET_3 = "VFNTTDEgMB4GA1UEAxMXZnNzLnN0YWdlLmdlY29tcGFueIb3DQEBAQUADDwDG6wkBY" +
             "sJSqbSYpw0c76bUB1x5e46eiroRZdU2BEWiQJ9yxV95gGNsdLH1105iubzc9dbxavGIYM9s/+qJRf6WfwDU7VQsURCqIN8eUtnPU808" +
@@ -39,13 +39,13 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     @Test
     void testEmptyClientSecretAllowed() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
-        validator.validate(TEST_SECRET_1);
+        validator.validate(TEST_EMPTY_SECRET);
     }
 
     @Test
     void testEmptyClientSecretForbidden() {
         zone.getConfig().setClientSecretPolicy(strictPolicy);
-        assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_SECRET_1));
+        assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_EMPTY_SECRET));
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -39,6 +39,8 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     @Test
     void testEmptyClientSecret() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
+        validator.validate(TEST_SECRET_1);
+        zone.getConfig().setClientSecretPolicy(strictPolicy);
         assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_SECRET_1));
     }
 

--- a/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
@@ -35,7 +35,7 @@
     </bean>
 
     <bean id="globalPasswordPolicy" class="org.cloudfoundry.identity.uaa.provider.PasswordPolicy">
-        <constructor-arg name="minLength" value="${password.policy.global.minLength:1}"/>
+        <constructor-arg name="minLength" value="${password.policy.global.minLength:0}"/>
         <constructor-arg name="maxLength" value="${password.policy.global.maxLength:255}"/>
         <constructor-arg name="requireUpperCaseCharacter"
                          value="${password.policy.global.requireUpperCaseCharacter:0}"/>

--- a/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/scim-endpoints.xml
@@ -35,7 +35,7 @@
     </bean>
 
     <bean id="globalPasswordPolicy" class="org.cloudfoundry.identity.uaa.provider.PasswordPolicy">
-        <constructor-arg name="minLength" value="${password.policy.global.minLength:0}"/>
+        <constructor-arg name="minLength" value="${password.policy.global.minLength:1}"/>
         <constructor-arg name="maxLength" value="${password.policy.global.maxLength:255}"/>
         <constructor-arg name="requireUpperCaseCharacter"
                          value="${password.policy.global.requireUpperCaseCharacter:0}"/>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.identity.uaa.oauth.client.SecretChangeRequest;
 import org.cloudfoundry.identity.uaa.resources.SearchResults;
 import org.cloudfoundry.identity.uaa.test.TestAccountSetup;
 import org.cloudfoundry.identity.uaa.test.UaaTestAccounts;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.ClientSecretPolicy;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -163,6 +164,21 @@ public class ClientAdminEndpointsIntegrationTests {
         client.setClientSecret("primarySecret");
         client.setSecondaryClientSecret("secondarySecret");
         client.setAuthorizedGrantTypes(List.of("client_credentials"));
+
+        ResponseEntity<Void> result = serverRunning.getRestTemplate()
+                .exchange(serverRunning.getUrl("/oauth/clients"), HttpMethod.POST,
+                        new HttpEntity<>(client, headers), Void.class);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+    }
+
+    @Test
+    public void createClientWithEmptySecret() {
+        OAuth2AccessToken token = getClientCredentialsAccessToken("clients.admin");
+        HttpHeaders headers = getAuthenticatedHeaders(token);
+        var client = new ClientDetailsCreation();
+        client.setClientId(new RandomValueStringGenerator().generate());
+        client.setClientSecret(UaaStringUtils.EMPTY_STRING);
+        client.setAuthorizedGrantTypes(List.of("password"));
 
         ResponseEntity<Void> result = serverRunning.getRestTemplate()
                 .exchange(serverRunning.getUrl("/oauth/clients"), HttpMethod.POST,


### PR DESCRIPTION
This PR simply uses PasswordValidatorUtil but set the password minLength to 1 which was the default because it was in code The minLength for clients should be 0 and this was the case before

Same Tests as before, means, with Default Policy the empty secret is allowed, with the strictPolicy not, see testEmptyClientSecret