### PR TITLE
validate secrets only with text

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidator.java
@@ -18,6 +18,7 @@ import org.passay.PasswordData;
 import org.passay.PasswordValidator;
 import org.passay.PropertiesMessageResolver;
 import org.passay.RuleResult;
+import org.springframework.util.StringUtils;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -71,7 +72,7 @@ public class ZoneAwareClientSecretPolicyValidator implements ClientSecretValidat
 
     @Override
     public void validate(String clientSecret) throws InvalidClientSecretException {
-        if(clientSecret == null) {
+        if(!StringUtils.hasText(clientSecret)) {
             return;
         }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneAwareClientSecretPolicyValidatorTests.java
@@ -39,7 +39,7 @@ class ZoneAwareClientSecretPolicyValidatorTests {
     @Test
     void testEmptyClientSecret() {
         zone.getConfig().setClientSecretPolicy(defaultPolicy);
-        assertThrows(InvalidClientSecretException.class, () -> validator.validate(TEST_SECRET_1));
+        validator.validate(TEST_SECRET_1);
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
@@ -25,6 +25,7 @@ import org.cloudfoundry.identity.uaa.oauth.client.SecretChangeRequest;
 import org.cloudfoundry.identity.uaa.resources.SearchResults;
 import org.cloudfoundry.identity.uaa.test.TestAccountSetup;
 import org.cloudfoundry.identity.uaa.test.UaaTestAccounts;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.ClientSecretPolicy;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -163,6 +164,21 @@ public class ClientAdminEndpointsIntegrationTests {
         client.setClientSecret("primarySecret");
         client.setSecondaryClientSecret("secondarySecret");
         client.setAuthorizedGrantTypes(List.of("client_credentials"));
+
+        ResponseEntity<Void> result = serverRunning.getRestTemplate()
+                .exchange(serverRunning.getUrl("/oauth/clients"), HttpMethod.POST,
+                        new HttpEntity<>(client, headers), Void.class);
+        assertEquals(HttpStatus.CREATED, result.getStatusCode());
+    }
+
+    @Test
+    public void createClientWithEmptySecret() {
+        OAuth2AccessToken token = getClientCredentialsAccessToken("clients.admin");
+        HttpHeaders headers = getAuthenticatedHeaders(token);
+        var client = new ClientDetailsCreation();
+        client.setClientId(new RandomValueStringGenerator().generate());
+        client.setClientSecret(UaaStringUtils.EMPTY_STRING);
+        client.setAuthorizedGrantTypes(List.of("password"));
 
         ResponseEntity<Void> result = serverRunning.getRestTemplate()
                 .exchange(serverRunning.getUrl("/oauth/clients"), HttpMethod.POST,


### PR DESCRIPTION
This fixes client creation rest call with empty secret.
Empty client secret is allowed via YAML setting already, but
in a REST call there is an error:
Client Secret must be at least 1 characters in length.

Why this occurs: There is a policy validator for user and client
policy validation.

For users, a minimum of 1 char for a password might be ok,
for a client not. A secret can be empty.

Before 76.22.0 a missing secret in a client creation call was defaulted
to an empty secret, but with https://github.com/cloudfoundry/uaa/pull/2455
this was fixed. The fix prevented the creation with an empty secret.

Therefore, this here is a fix for a regression introduced with 76.22.0.
It simply prevents the policy validation if the secret is without text
(null or empty).

Fix for issue https://github.com/cloudfoundry/uaa/issues/2570