### PR TITLE
Update account menu for keyboard accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
+<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link >
 
 [![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/archives/C03FXANBV)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link >
+<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
 
 [![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/archives/C03FXANBV)
 

--- a/server/src/main/resources/templates/web/nav.html
+++ b/server/src/main/resources/templates/web/nav.html
@@ -10,11 +10,11 @@
 </head>
 <th:block layout:fragment="nav">
     <div class="nav">
-        <div class="dropdown-trigger">
+        <button type="button" class="dropdown-trigger" aria-expanded="false" aria-controls="nav-dropdown-content">
             <span sec:authentication="name">user@example.com</span>
             <i class="fa fa-chevron-down"></i>
-        </div>
-        <ul class="dropdown-content">
+        </button>
+        <ul class="dropdown-content" id="nav-dropdown-content">
             <li><a href="/profile" th:href="@{/profile}">Account Settings</a></li>
             <li><a href="/logout.do" th:href="@{/logout.do}">Sign Out</a></li>
         </ul>

--- a/uaa/src/main/webapp/resources/javascripts/nav.js
+++ b/uaa/src/main/webapp/resources/javascripts/nav.js
@@ -2,6 +2,7 @@ $(document).ready(function() {
   $(".dropdown-trigger").click(function() {
     var $el = $(this);
     $el.toggleClass("open");
+    $el.attr('aria-expanded', $el.hasClass("open"));
     $el.next(".dropdown-content").toggleClass("open");
   });
 });

--- a/uaa/src/main/webapp/resources/oss/stylesheets/application.css
+++ b/uaa/src/main/webapp/resources/oss/stylesheets/application.css
@@ -8778,9 +8778,15 @@ input {
   color: #9faaad; }
 
 .dropdown-trigger {
+  background: transparent;
+  border: none;
+  color: inherit;
   cursor: pointer;
+  display: block;
   padding: 4px 24px 4px 8px;
-  position: relative; }
+  position: relative;
+  text-align: left;
+  width: 100%; }
 
 .dropdown-content {
   position: absolute;


### PR DESCRIPTION
Previously, the dropdown account menu in the top right could only be used by clicking on it using a mouse. People who use screen readers, such as those who are blind or have low-vision, require the ability to navigate and interact using keyboard-only. These users cannot use a mouse for user interaction.

Now, the account menu can be interacted with using keyboard. It uses the `aria-expanded` and `aria-controls` to provide better feedback to screen readers about whether the menu is opened or closed.