### PR TITLE
Add label text to all form controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
+<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link >
 
 [![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/archives/C03FXANBV)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link >
+<link href="https://raw.github.com/clownfart/Markdown-CSS/master/markdown.css" rel="stylesheet"></link>
 
 [![slack.cloudfoundry.org](https://slack.cloudfoundry.org/badge.svg)](https://cloudfoundry.slack.com/archives/C03FXANBV)
 

--- a/server/src/main/resources/templates/web/accounts/new_activation_email.html
+++ b/server/src/main/resources/templates/web/accounts/new_activation_email.html
@@ -27,9 +27,9 @@
             </div>
             <input type="hidden" name="client_id" th:value="${client_id}"/>
             <input type="hidden" name="redirect_uri" th:value="${redirect_uri}"/>
-            <input name="email" type="email" placeholder="Enter your email" autofocus="autofocus" required="required" class="form-control"/>
-            <input name="password" type="password" required="required" placeholder="Password" autocomplete="off" class="form-control"/>
-            <input name="password_confirmation" type="password" required="required" placeholder="Confirm" autocomplete="off" class="form-control"/>
+            <input name="email" type="email" placeholder="Enter your email" aria-label="Enter your email" autofocus="autofocus" required="required" class="form-control"/>
+            <input name="password" type="password" required="required" placeholder="Password" aria-label="Password" autocomplete="off" class="form-control"/>
+            <input name="password_confirmation" type="password" required="required" placeholder="Confirm" aria-label="Confirm" autocomplete="off" class="form-control"/>
 
             <label th:if="${consent_text}" style="margin-bottom: 20px">
                 <input name="does_user_consent" type="checkbox" style="display: inline">

--- a/server/src/main/resources/templates/web/change_email.html
+++ b/server/src/main/resources/templates/web/change_email.html
@@ -18,7 +18,7 @@
             </div>
             <input type="hidden" name="client_id" th:value="${client_id}"/>
             <input type="hidden" name="redirect_uri" th:value="${redirect_uri}"/>
-            <input name="newEmail" type="email" placeholder="New Email Address" autocomplete="off" class="form-control"/>
+            <input name="newEmail" type="email" placeholder="New Email Address" aria-label="New Email Address" autocomplete="off" class="form-control"/>
             <input type="submit" value="Send Verification Link" class="island-button"/>
         </form>
     </div>

--- a/server/src/main/resources/templates/web/change_password.html
+++ b/server/src/main/resources/templates/web/change_password.html
@@ -14,9 +14,9 @@
         <form th:action="@{/change_password.do}" method="post" novalidate="novalidate">
             <div th:if="${message}" th:text="${message}" class="error-message"></div>
             <div th:if="${message_code}" th:text="#{'change_password.' + ${message_code}}" class="error-message"></div>
-            <input name="current_password" type="password" placeholder="Current password" autocomplete="off" autofocus="autofocus" class="form-control"/>
-            <input name="new_password" type="password" placeholder="New password" autocomplete="off" class="form-control"/>
-            <input name="confirm_password" type="password" placeholder="Confirm new password" autocomplete="off" class="form-control"/>
+            <input name="current_password" type="password" placeholder="Current password" aria-label="Current password" autocomplete="off" autofocus="autofocus" class="form-control"/>
+            <input name="new_password" type="password" placeholder="New password" aria-label="New password" autocomplete="off" class="form-control"/>
+            <input name="confirm_password" type="password" placeholder="Confirm new password" aria-label="Confirm new password" autocomplete="off" class="form-control"/>
             <input type="submit" value="Change password" class="island-button"/>
         </form>
     </div>

--- a/server/src/main/resources/templates/web/force_password_change.html
+++ b/server/src/main/resources/templates/web/force_password_change.html
@@ -8,8 +8,8 @@
         <div th:text="|Email: ${email}|" class="email-display">Email: user@example.com</div>
         <form th:action="@{/force_password_change}" method="post" novalidate="novalidate">
             <div th:if="${message}" th:text="${message}" class="error-message"></div>
-            <input name="password" type="password" placeholder="New Password" autocomplete="off" class="form-control"/>
-            <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
+            <input name="password" type="password" placeholder="New Password" aria-label="New Password" autocomplete="off" class="form-control"/>
+            <input name="password_confirmation" type="password" placeholder="Confirm" aria-label="Confirm New Password" autocomplete="off" class="form-control"/>
             <input type="submit" value="Create new password" class="island-button"/>
         </form>
     </div>

--- a/server/src/main/resources/templates/web/forgot_password.html
+++ b/server/src/main/resources/templates/web/forgot_password.html
@@ -8,7 +8,7 @@
             <div th:if="${message}" th:text="${message}" class="error-message"></div>
             <input type="hidden" name="client_id" th:value="${client_id}"/>
             <input type="hidden" name="redirect_uri" th:value="${redirect_uri}"/>
-            <input name="username" type="text" placeholder="Username" autofocus="autofocus" class="form-control"/>
+            <input name="username" type="text" placeholder="Username" aria-label="Username" autofocus="autofocus" class="form-control"/>
             <input type="submit" value="Send reset password link" class="forgot-password-button"/>
         </form>
         <a href="/login" th:href="@{/login}" class="link-lowlight">Back to Sign In</a>

--- a/server/src/main/resources/templates/web/idp_discovery/email.html
+++ b/server/src/main/resources/templates/web/idp_discovery/email.html
@@ -18,7 +18,7 @@
 
     <div class="form-group email_address_field">
         <div style="height: 42px">
-            <input class="form-control" id="email" name="email" autofocus="true" placeholder="Email or Username" style="width: 100%; float: left"/>
+            <input class="form-control" id="email" name="email" autofocus="true" placeholder="Email or Username" aria-label="Email or Username" style="width: 100%; float: left"/>
         </div>
         <input th:if="${param.login_hint}"
                th:unless="${login_hint}"

--- a/server/src/main/resources/templates/web/idp_discovery/origin.html
+++ b/server/src/main/resources/templates/web/idp_discovery/origin.html
@@ -15,7 +15,7 @@
         <form action="/origin-chooser" th:action="@{/origin-chooser}" method="post" role="form">
             <input th:name="login_hint"
                    th:type="text"
-                   class="form-control" placeholder="Enter the origin key of your identity provider" style="margin-top:20px"/>
+                   class="form-control" placeholder="Enter the origin key of your identity provider" aria-label="Enter the origin key of your identity provider" style="margin-top:20px"/>
             <input type="submit" value="Sign in with alternative identity provider" class="btn btn-highlight btn-block btn-lg" style="margin-top:20px"/>
         </form>
     </div>

--- a/server/src/main/resources/templates/web/idp_discovery/password.html
+++ b/server/src/main/resources/templates/web/idp_discovery/password.html
@@ -3,8 +3,8 @@
 <div layout:fragment="page-content">
     <form action="/login.do" th:action="@{/login.do}" method="post" role="form" _lpchecked="1">
         <div class="form-group">
-            <input class="form-control" id="username" name="username" th:attr="autofocus=${email == null}" th:value="${email}" placeholder="Username" style="margin-top:20px"/>
-            <input class="form-control" id="password" name="password" th:attr="autofocus=${email != null}" type="password" placeholder="Password" style="margin-top:20px"/>
+            <input class="form-control" id="username" name="username" th:attr="autofocus=${email == null}" th:value="${email}" placeholder="Username" aria-label="Username" style="margin-top:20px"/>
+            <input class="form-control" id="password" name="password" th:attr="autofocus=${email != null}" type="password" placeholder="Password" aria-label="Password" style="margin-top:20px"/>
             <input th:if="${login_hint}"
                    th:name="login_hint"
                    th:type="hidden"

--- a/server/src/main/resources/templates/web/invitations/accept_invite.html
+++ b/server/src/main/resources/templates/web/invitations/accept_invite.html
@@ -18,8 +18,8 @@
           <th:block th:if="${provider == 'uaa'}">
             <form th:action="@{/invitations/accept.do}" method="post" novalidate="novalidate">
                 <input name="code" type="hidden" value="code" th:value="${code}"/>
-                <input name="password" type="password" placeholder="Password" autocomplete="off" class="form-control"/>
-                <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
+                <input name="password" type="password" placeholder="Password" aria-label="Password" autocomplete="off" class="form-control"/>
+                <input name="password_confirmation" type="password" placeholder="Confirm" aria-label="Confirm Password" autocomplete="off" class="form-control"/>
 
                 <label th:if="${consent_text}" style="margin-bottom: 20px">
                     <input name="does_user_consent" type="checkbox" style="display: inline">
@@ -36,8 +36,8 @@
                 <form th:action="@{/invitations/accept_enterprise.do}" method="post" novalidate="novalidate">
                     <input name="enterprise_email" type="hidden" th:value="${email}"/>
                     <input name="code" type="hidden" value="code" th:value="${code}"/>
-                    <input name="enterprise_username" type="text" placeholder="Username" autocomplete="off" class="form-control"/>
-                    <input name="enterprise_password" type="password" placeholder="Password" autocomplete="off" class="form-control"/>
+                    <input name="enterprise_username" type="text" placeholder="Username" aria-label="Username" autocomplete="off" class="form-control"/>
+                    <input name="enterprise_password" type="password" placeholder="Password" aria-label="Password" autocomplete="off" class="form-control"/>
                     <input type="submit" value="Sign in" class="island-button"/>
                 </form>
             </th:block>

--- a/server/src/main/resources/templates/web/login.html
+++ b/server/src/main/resources/templates/web/login.html
@@ -29,6 +29,7 @@
                    th:type="${prompt.value[0]}"
                    th:placeholder="${prompt.value[1]}"
                    th:attr="autocomplete=${(prompt.value[0] == 'password') ? 'off' : null}"
+                   th:aria-label="${prompt.value[1]}"
                    class="form-control"/>
             <input type="submit" value="Sign in" class="island-button"/>
             <input th:if="${session.SPRING_SECURITY_SAVED_REQUEST}"

--- a/server/src/main/resources/templates/web/mfa/enter_code.html
+++ b/server/src/main/resources/templates/web/mfa/enter_code.html
@@ -34,7 +34,7 @@
         </p>
         <form th:action="@{/login/mfa/verify.do}" method="post" novalidate="novalidate">
             <div class="page">
-                <input name="code" type="number" placeholder="XXX-XXX" autofocus="autofocus" class="form-control mrs txt-c em-high" maxlength="6"/>
+                <input name="code" type="number" placeholder="XXX-XXX" aria-label="Google Authentication Code" autofocus="autofocus" class="form-control mrs txt-c em-high" maxlength="6"/>
                 <button id= "verify_code_btn" type="submit" class="btn btn-highlight mlxl">Verify</button>
             </div>
             <div th:if="${error}" th:text="${error}" class="error-color mtl"></div>

--- a/server/src/main/resources/templates/web/reset_password.html
+++ b/server/src/main/resources/templates/web/reset_password.html
@@ -12,8 +12,8 @@
             <input type="hidden" name="username" th:value="${username}"/>
             <div th:if="${message_code}" th:text="#{'reset_password.' + ${message_code}}" class="error-message"></div>
             <div th:if="${message}" th:text="${message}" class="error-message"></div>
-            <input name="password" type="password" placeholder="New Password" autocomplete="off" class="form-control"/>
-            <input name="password_confirmation" type="password" placeholder="Confirm" autocomplete="off" class="form-control"/>
+            <input name="password" type="password" placeholder="New Password" aria-label="New Password" autocomplete="off" class="form-control"/>
+            <input name="password_confirmation" type="password" placeholder="Confirm" aria-label="Confirm New Password" autocomplete="off" class="form-control"/>
             <input type="submit" value="Create new password" class="island-button"/>
         </form>
     </div>

--- a/uaa/slate/source/layouts/layout.erb
+++ b/uaa/slate/source/layouts/layout.erb
@@ -99,7 +99,7 @@ under the License.
 
       <% if current_page.data.search %>
         <div class="search">
-          <input type="text" class="search" id="input-search" placeholder="Search">
+          <input type="text" class="search" id="input-search" placeholder="Search" aria-label="Search">
         </div>
         <ul class="search-results"></ul>
       <% end %>


### PR DESCRIPTION
Previously, placeholder text has been used to represent the label for form controls. This allows visual users to tell what content to enter in specific form controls. However, screen readers generally expect an explicit label to be associated with form controls.

Rather redesign all pages to add `<label>` elements for each control, this adds the `aria-label` attribute to each form control. This should allow screen readers to properly announce controls as the page is read.