### PR TITLE
Add config to control whether to perform "OpenID Connect RP-Initiated Logout" when using an external OIDC provider

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractExternalOAuthIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/AbstractExternalOAuthIdentityProviderDefinition.java
@@ -46,6 +46,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
     private String userPropagationParameter;
     private OAuthGroupMappingMode groupMappingMode;
     private boolean pkce = true;
+    private boolean performRpInitiatedLogout = true;
 
     public URL getAuthUrl() {
         return authUrl;
@@ -214,6 +215,14 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
         return this.pkce;
     }
 
+    public boolean isPerformRpInitiatedLogout() {
+        return performRpInitiatedLogout;
+    }
+
+    public void setPerformRpInitiatedLogout(boolean performRpInitiatedLogout) {
+        this.performRpInitiatedLogout = performRpInitiatedLogout;
+    }
+
     @JsonIgnore
     public Class getParameterizedClass() {
         ParameterizedType parameterizedType =
@@ -247,6 +256,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
         if (!Objects.equals(userPropagationParameter, that.userPropagationParameter)) return false;
         if (!Objects.equals(groupMappingMode, that.groupMappingMode)) return false;
         if (pkce != that.pkce) return false;
+        if (performRpInitiatedLogout != that.performRpInitiatedLogout) return false;
         return Objects.equals(responseType, that.responseType);
 
     }
@@ -271,6 +281,7 @@ public abstract class AbstractExternalOAuthIdentityProviderDefinition<T extends 
         result = 31 * result + (groupMappingMode != null ? groupMappingMode.hashCode() : 0);
         result = 31 * result + (responseType != null ? responseType.hashCode() : 0);
         result = 31 * result + (pkce ? 1 : 0);
+        result = 31 * result + (performRpInitiatedLogout ? 1 : 0);
         return result;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
@@ -47,11 +47,12 @@ public class ZoneAwareWhitelistLogoutHandler implements LogoutSuccessHandler {
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         AbstractExternalOAuthIdentityProviderDefinition oauthConfig = externalOAuthLogoutHandler.getOAuthProviderForAuthentication(authentication);
         String logoutUrl = externalOAuthLogoutHandler.getLogoutUrl(oauthConfig);
+        Boolean shouldPerformRpInitiatedLogout = externalOAuthLogoutHandler.getPerformRpInitiatedLogout(oauthConfig);
 
-        if (logoutUrl == null) {
-            getZoneHandler().onLogoutSuccess(request, response, authentication);
-        } else {
+        if (shouldPerformRpInitiatedLogout && logoutUrl != null) {
             externalOAuthLogoutHandler.onLogoutSuccess(request, response, authentication);
+        } else {
+            getZoneHandler().onLogoutSuccess(request, response, authentication);
         }
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
@@ -47,7 +47,7 @@ public class ZoneAwareWhitelistLogoutHandler implements LogoutSuccessHandler {
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         AbstractExternalOAuthIdentityProviderDefinition oauthConfig = externalOAuthLogoutHandler.getOAuthProviderForAuthentication(authentication);
         String logoutUrl = externalOAuthLogoutHandler.getLogoutUrl(oauthConfig);
-        Boolean shouldPerformRpInitiatedLogout = externalOAuthLogoutHandler.getPerformRpInitiatedLogout(oauthConfig);
+        boolean shouldPerformRpInitiatedLogout = externalOAuthLogoutHandler.getPerformRpInitiatedLogout(oauthConfig);
 
         if (shouldPerformRpInitiatedLogout && logoutUrl != null) {
             externalOAuthLogoutHandler.onLogoutSuccess(request, response, authentication);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
@@ -17,6 +17,7 @@ package org.cloudfoundry.identity.uaa.authentication;
 
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
 import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthLogoutHandler;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -45,7 +46,7 @@ public class ZoneAwareWhitelistLogoutHandler implements LogoutSuccessHandler {
 
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        AbstractExternalOAuthIdentityProviderDefinition oauthConfig = externalOAuthLogoutHandler.getOAuthProviderForAuthentication(authentication);
+        AbstractExternalOAuthIdentityProviderDefinition<OIDCIdentityProviderDefinition> oauthConfig = externalOAuthLogoutHandler.getOAuthProviderForAuthentication(authentication);
         String logoutUrl = externalOAuthLogoutHandler.getLogoutUrl(oauthConfig);
         boolean shouldPerformRpInitiatedLogout = externalOAuthLogoutHandler.getPerformRpInitiatedLogout(oauthConfig);
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
@@ -124,7 +124,7 @@ public class ExternalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     return config.getLinks().getLogout().getRedirectUrl();
   }
 
-  public boolean getPerformRpInitiatedLogout(AbstractExternalOAuthIdentityProviderDefinition oauthConfig) {
+  public boolean getPerformRpInitiatedLogout(AbstractExternalOAuthIdentityProviderDefinition<OIDCIdentityProviderDefinition> oauthConfig) {
     if (oauthConfig == null) {
       return false;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
@@ -123,4 +123,11 @@ public class ExternalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     }
     return config.getLinks().getLogout().getRedirectUrl();
   }
+
+  public Boolean getPerformRpInitiatedLogout(AbstractExternalOAuthIdentityProviderDefinition oauthConfig) {
+    if (oauthConfig == null) {
+      return false;
+    }
+    return oauthConfig.isPerformRpInitiatedLogout();
+  }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
@@ -124,7 +124,7 @@ public class ExternalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     return config.getLinks().getLogout().getRedirectUrl();
   }
 
-  public Boolean getPerformRpInitiatedLogout(AbstractExternalOAuthIdentityProviderDefinition oauthConfig) {
+  public boolean getPerformRpInitiatedLogout(AbstractExternalOAuthIdentityProviderDefinition oauthConfig) {
     if (oauthConfig == null) {
       return false;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
@@ -166,6 +166,9 @@ public class OauthIDPWrapperFactoryBean {
         if (idpDefinitionMap.get("clientAuthInBody") instanceof Boolean) {
             idpDefinition.setClientAuthInBody((boolean)idpDefinitionMap.get("clientAuthInBody"));
         }
+        if (idpDefinitionMap.get("performRpInitiatedLogout") instanceof Boolean) {
+            idpDefinition.setPerformRpInitiatedLogout((boolean)idpDefinitionMap.get("performRpInitiatedLogout"));
+        }
     }
 
     private static Map<String, String> parseAdditionalParameters(Map<String, Object> idpDefinitionMap) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
@@ -163,10 +163,19 @@ public class ZoneAwareWhitelistLogoutHandlerTests {
     }
 
     @Test
-    public void test_exteral_logout() throws ServletException, IOException {
+    public void test_external_logout() throws ServletException, IOException {
         when(oAuthLogoutHandler.getLogoutUrl(null)).thenReturn("");
+        when(oAuthLogoutHandler.getPerformRpInitiatedLogout(null)).thenReturn(true);
         handler.onLogoutSuccess(request, response, null);
         verify(oAuthLogoutHandler, times(1)).onLogoutSuccess(request, response, null);
+    }
+
+    @Test
+    public void test_does_not_external_logout() throws ServletException, IOException {
+        when(oAuthLogoutHandler.getLogoutUrl(null)).thenReturn("");
+        when(oAuthLogoutHandler.getPerformRpInitiatedLogout(null)).thenReturn(false);
+        handler.onLogoutSuccess(request, response, null);
+        verify(oAuthLogoutHandler, times(0)).onLogoutSuccess(request, response, null);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
@@ -179,6 +179,14 @@ public class ZoneAwareWhitelistLogoutHandlerTests {
     }
 
     @Test
+    public void test_does_not_external_logout_when_logout_url_is_null() throws ServletException, IOException {
+        when(oAuthLogoutHandler.getLogoutUrl(null)).thenReturn(null);
+        when(oAuthLogoutHandler.getPerformRpInitiatedLogout(null)).thenReturn(true);
+        handler.onLogoutSuccess(request, response, null);
+        verify(oAuthLogoutHandler, times(0)).onLogoutSuccess(request, response, null);
+    }
+
+    @Test
     public void test_logout() throws ServletException, IOException {
         handler.onLogoutSuccess(request, response, null);
         verify(oAuthLogoutHandler, times(0)).onLogoutSuccess(request, response, null);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandlerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandlerTest.java
@@ -134,4 +134,15 @@ class ExternalOAuthLogoutHandlerTest {
   void getNullOAuthProviderForAuthentication() {
     assertEquals(null, oAuthLogoutHandler.getOAuthProviderForAuthentication(null));
   }
+
+  @Test
+  void getPerformRpInitiatedLogout() {
+    oAuthIdentityProviderDefinition.setPerformRpInitiatedLogout(true);
+    assertEquals(true, oAuthLogoutHandler.getPerformRpInitiatedLogout(oAuthIdentityProviderDefinition));
+
+    oAuthIdentityProviderDefinition.setPerformRpInitiatedLogout(false);
+    assertEquals(false, oAuthLogoutHandler.getPerformRpInitiatedLogout(oAuthIdentityProviderDefinition));
+
+    assertEquals(false, oAuthLogoutHandler.getPerformRpInitiatedLogout(null));
+  }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
@@ -234,4 +234,18 @@ public class OauthIdentityProviderDefinitionFactoryBeanTest {
         Map<String, String> receivedParameters = ((OIDCIdentityProviderDefinition) factoryBean.getProviders().get(0).getProvider().getConfig()).getAdditionalAuthzParameters();
         assertEquals(0, receivedParameters.size());
     }
+
+    @Test
+    public void testPerformRpInitiatedLogoutTrue() {
+        idpDefinitionMap.put("performRpInitiatedLogout", true);
+        factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
+        assertTrue(providerDefinition.isPerformRpInitiatedLogout());
+    }
+
+    @Test
+    public void testPerformRpInitiatedLogoutFalse() {
+        idpDefinitionMap.put("performRpInitiatedLogout", false);
+        factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
+        assertFalse(providerDefinition.isPerformRpInitiatedLogout());
+    }
 }

--- a/uaa/slateCustomizations/source/index.html.md.erb
+++ b/uaa/slateCustomizations/source/index.html.md.erb
@@ -635,7 +635,7 @@ _Error Codes_
 ## Logout.do
 
 The logout endpoint is meant to be used by applications to log the user out of the UAA session. UAA will only log a user out of the UAA session if they also hit this endpoint, and may also perform Single Logout with SAML providers if configured to do so.
-UAA will also log users out of OIDC proxied authenticated sessions based on [OpenID Connect Session Management](https://openid.net/specs/openid-connect-session-1_0.html).
+UAA may also log users out of OIDC proxied authenticated sessions based on [OpenID Connect Session Management](https://openid.net/specs/openid-connect-session-1_0.html) if configured to do so.
 The recommendation for application authors is to:
 
 * provide a local logout feature specific to the client application

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -569,6 +569,18 @@ public class OIDCLoginIT {
         Assert.assertThat("URL validation failed", webDriver.getCurrentUrl(), endsWith("/login"));
     }
 
+    @Test
+    public void successfulUaaLogoutDoesNotTriggerExternalOIDCProviderLogout_whenConfiguredNotTo() {
+        identityProvider.getConfig().setPerformRpInitiatedLogout(false);
+        updateProvider();
+
+        validateSuccessfulOIDCLogin(zoneUrl, testAccounts.getUserName(), testAccounts.getPassword());
+
+        String externalOIDCProviderLoginPage = baseUrl;
+        webDriver.get(externalOIDCProviderLoginPage);
+        Assert.assertThat(webDriver.getPageSource(), containsString("Where to?"));
+    }
+
     private String getRefreshTokenResponse(ServerRunning serverRunning, String refreshToken) {
         MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
         formData.add("client_id", zoneClient.getClientId());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -569,7 +569,8 @@ public class OIDCLoginIT {
 
         String externalOIDCProviderLoginPage = baseUrl;
         webDriver.get(externalOIDCProviderLoginPage);
-        Assert.assertThat("URL validation failed", webDriver.getCurrentUrl(), endsWith("/login"));
+        Assert.assertThat("Did not land on the external OIDC provider login page (as an unauthenticated user).",
+                webDriver.getCurrentUrl(), endsWith("/login"));
     }
 
     @Test
@@ -581,7 +582,8 @@ public class OIDCLoginIT {
 
         String externalOIDCProviderLoginPage = baseUrl;
         webDriver.get(externalOIDCProviderLoginPage);
-        Assert.assertThat(webDriver.getPageSource(), containsString("Where to?"));
+        Assert.assertThat("Did not land on the external OIDC provider home page (as an authenticated user).",
+                webDriver.getPageSource(), containsString("Where to?"));
     }
 
     private String getRefreshTokenResponse(ServerRunning serverRunning, String refreshToken) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -561,7 +561,10 @@ public class OIDCLoginIT {
     }
 
     @Test
-    public void successfulUaaLogoutTriggersExternalOIDCProviderLogout() {
+    public void successfulUaaLogoutTriggersExternalOIDCProviderLogout_whenConfiguredTo() {
+        identityProvider.getConfig().setPerformRpInitiatedLogout(true);
+        updateProvider();
+
         validateSuccessfulOIDCLogin(zoneUrl, testAccounts.getUserName(), testAccounts.getPassword());
 
         String externalOIDCProviderLoginPage = baseUrl;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -88,6 +88,7 @@ import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDef
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -181,6 +182,7 @@ public class OIDCLoginIT {
         config.setTokenKeyUrl(new URL(urlBase + "/token_key"));
         config.setIssuer(urlBase + "/oauth/token");
         config.setUserInfoUrl(new URL(urlBase + "/userinfo"));
+        config.setLogoutUrl(new URL(urlBase + "/logout.do"));
 
         config.setShowLinkText(true);
         config.setLinkText("My OIDC Provider");
@@ -556,6 +558,15 @@ public class OIDCLoginIT {
 
         assertThat(webDriver.getCurrentUrl(), containsString("error=invalid_request"));
         assertThat(webDriver.getCurrentUrl(), containsString("error_description=Missing%20response_type%20in%20authorization%20request"));
+    }
+
+    @Test
+    public void successfulUaaLogoutTriggersExternalOIDCProviderLogout() {
+        validateSuccessfulOIDCLogin(zoneUrl, testAccounts.getUserName(), testAccounts.getPassword());
+
+        String externalOIDCProviderLoginPage = baseUrl;
+        webDriver.get(externalOIDCProviderLoginPage);
+        Assert.assertThat("URL validation failed", webDriver.getCurrentUrl(), endsWith("/login"));
     }
 
     private String getRefreshTokenResponse(ServerRunning serverRunning, String refreshToken) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -457,6 +457,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
         definition.setAttributeMappings(getAttributeMappingMap());
         definition.setUserPropagationParameter("username");
         definition.setPkce(true);
+        definition.setPerformRpInitiatedLogout(true);
         identityProvider.setConfig(definition);
         identityProvider.setSerializeConfigRaw(true);
 
@@ -478,6 +479,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
                 fieldWithPath("config.responseType").optional("code").type(STRING).description("Response type for the authorize request, will be sent to OAuth server, defaults to `code`"),
                 fieldWithPath("config.clientAuthInBody").optional(false).type(BOOLEAN).description("Sends the client credentials in the token retrieval call as body parameters instead of a Basic Authorization header."),
                 fieldWithPath("config.pkce").optional(true).type(BOOLEAN).description("A flag controlling whether PKCE (RFC 7636) is active in authorization code flow when requesting tokens from the external provider."),
+                fieldWithPath("config.performRpInitiatedLogout").optional(true).type(BOOLEAN).description("A flag controlling whether to log out of the external provider after a successful UAA logout per [OIDC RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)"),
                 fieldWithPath("config.issuer").optional(null).type(STRING).description("The OAuth 2.0 token issuer. This value is used to validate the issuer inside the token."),
                 fieldWithPath("config.userPropagationParameter").optional("username").type(STRING).description("Name of the request parameter that is used to pass a known username when redirecting to this identity provider from the account chooser"),
                 fieldWithPath("config.attributeMappings.user_name").optional("sub").type(STRING).description("Map `user_name` to the attribute for user name in the provider assertion or token. The default for OpenID Connect is `sub`"),
@@ -528,6 +530,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
         definition.setRelyingPartySecret("secret");
         definition.setShowLinkText(false);
         definition.setPkce(true);
+        definition.setPerformRpInitiatedLogout(true);
         definition.setAttributeMappings(getAttributeMappingMap());
         definition.setUserPropagationParameter("username");
         definition.setExternalGroupsWhitelist(Collections.singletonList("uaa.user"));
@@ -555,6 +558,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
                 fieldWithPath("config.checkTokenUrl").optional(null).type(OBJECT).description("Reserved for future OAuth/OIDC use."),
                 fieldWithPath("config.clientAuthInBody").optional(false).type(BOOLEAN).description("Only effective if relyingPartySecret is defined. Sends the client credentials in the token retrieval call as body parameters instead of a Basic Authorization header. It is recommended to set `jwtClientAuthentication:true` instead."),
                 fieldWithPath("config.pkce").optional(true).type(BOOLEAN).description("A flag controlling whether PKCE (RFC 7636) is active in authorization code flow when requesting tokens from the external provider."),
+                fieldWithPath("config.performRpInitiatedLogout").optional(true).type(BOOLEAN).description("A flag controlling whether to log out of the external provider after a successful UAA logout per [OIDC RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)"),
                 fieldWithPath("config.userInfoUrl").optional(null).type(OBJECT).description("Reserved for future OIDC use.  This can be left blank if a discovery URL is provided. If both are provided, this property overrides the discovery URL."),
                 fieldWithPath("config.logoutUrl").optional(null).type(OBJECT).description("OIDC logout endpoint. This can be left blank if a discovery URL is provided. If both are provided, this property overrides the discovery URL."),
                 fieldWithPath("config.responseType").optional("code").type(STRING).description("Response type for the authorize request, defaults to `code`, but can be `code id_token` if the OIDC server can return an id_token as a query parameter in the redirect."),


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/uaa/issues/2589

Notes for reviewer:
* refactors of the impacted classes/code path will be in a different PR, so this PR would be easier to review.
* reasons for the config name `performRpInitiatedLogout`:
  * The exact language of [the spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
  * Follow the pattern of the other boolean configs of this endpoint: starting with a verb
  * alternatives considered: `SSOLogout`, `performSSOLogoutOnIdpAfterUAALogout`, `triggerExternalOIDCProviderLogout` etc. 