### PR TITLE
fix: exclude unused vulnerable transitive deps

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,7 +25,9 @@ dependencies {
     implementation(libraries.spingSamlEsapiDependencyVersion) {
         transitive = false
     }
-    implementation(libraries.springSecuritySaml)
+    implementation(libraries.springSecuritySaml) {
+        exclude(module: "bcprov-ext-jdk15on")
+    }
     implementation(libraries.springSessionJdbc)
 
     implementation(libraries.springSecurityOauth) {
@@ -100,6 +102,7 @@ dependencies {
 configurations.all {
     exclude(group: "org.beanshell", module: "bsh-core")
     exclude(group: "org.apache-extras.beanshell", module: "bsh")
+    exclude(group: "org.bouncycastle", module: "bcprov-jdk15on")
 }
 
 jar {


### PR DESCRIPTION
- bcprov-jdk15on and bcprov-ext-jdk15on have been flagged with many CVEs: CVE-2020-15522, CVE-2020-0187, CVE-2020-26939, CVE-2023-33201 for the latter, and CVE-2020-0187, CVE-2023-33201 for the former.
- these transitive deps are not used in UAA or in the library codepaths invoked by UAA, so excluding them to address these CVEs.
- following these 2 commits in the develop branch: https://github.com/cloudfoundry/uaa/commit/8bdb525f0ab002463a385be3daf6180b5b2b3737 and https://github.com/cloudfoundry/uaa/commit/214e1cb20d953bd80790ae78c60e8444352fc0d1
- gradle doc on the exclude statement: https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html#sec:excluding-transitive-deps