### PR TITLE
bump go to 1.21.6

### DIFF
--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/uaa
 
-go 1.21
+go 1.21.6
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
Routine bump in the minimum Go version.

[#186765938]