### PR TITLE
Setup latest stable go runtime for codeql and bump go to 1.21.6

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,6 +40,13 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Go
+      id: go
+      uses: actions/setup-go@v5
+      with:
+        go-version: stable
+      if: ${{ matrix.language == 'go' }}
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v3

--- a/k8s/go.mod
+++ b/k8s/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/uaa
 
-go 1.21
+go 1.21.6
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
Should solve

CodeQL scanning, which failed
https://github.com/cloudfoundry/uaa/security/code-scanning/tools/CodeQL/status

and in addition

https://github.com/cloudfoundry/uaa/pull/2676

