### PR TITLE
Import refactor for SAML

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -129,6 +129,7 @@ libraries.nimbusJwt = "com.nimbusds:nimbus-jose-jwt:9.37.3"
 libraries.xmlSecurity = "org.apache.santuario:xmlsec:4.0.1"
 libraries.orgJson = "org.json:json:20231013"
 libraries.spingSamlEsapiDependencyVersion = "org.owasp.esapi:esapi:2.5.3.1"
+libraries.jodaTime = "joda-time:joda-time:2.12.6"
 
 // gradle plugins
 libraries.testRetryPlugin = "org.gradle:test-retry-gradle-plugin:1.5.8"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -128,7 +128,7 @@ libraries.zxing = "com.google.zxing:javase:3.5.2"
 libraries.nimbusJwt = "com.nimbusds:nimbus-jose-jwt:9.37.3"
 libraries.xmlSecurity = "org.apache.santuario:xmlsec:4.0.1"
 libraries.orgJson = "org.json:json:20231013"
-libraries.spingSamlEsapiDependencyVersion = "org.owasp.esapi:esapi:2.5.3.1"
+libraries.owaspEsapi = "org.owasp.esapi:esapi:2.5.3.1"
 libraries.jodaTime = "joda-time:joda-time:2.12.6"
 libraries.commonsHttpClient = "commons-httpclient:commons-httpclient:3.1"
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -130,6 +130,7 @@ libraries.xmlSecurity = "org.apache.santuario:xmlsec:4.0.1"
 libraries.orgJson = "org.json:json:20231013"
 libraries.spingSamlEsapiDependencyVersion = "org.owasp.esapi:esapi:2.5.3.1"
 libraries.jodaTime = "joda-time:joda-time:2.12.6"
+libraries.commonsHttpClient = "commons-httpclient:commons-httpclient:3.1"
 
 // gradle plugins
 libraries.testRetryPlugin = "org.gradle:test-retry-gradle-plugin:1.5.8"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -31,7 +31,7 @@ dependencies {
         exclude(module: "xalan")
     }
     implementation(libraries.jodaTime)
-    implementation 'commons-httpclient:commons-httpclient:3.1'
+    implementation(libraries.commonsHttpClient)
     implementation(libraries.xmlSecurity)
     implementation(libraries.springSessionJdbc)
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -30,6 +30,8 @@ dependencies {
         exclude(module: "bcprov-ext-jdk15on")
         exclude(module: "xalan")
     }
+    implementation(libraries.jodaTime)
+    implementation 'commons-httpclient:commons-httpclient:3.1'
     implementation(libraries.xmlSecurity)
     implementation(libraries.springSessionJdbc)
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation(libraries.springSecurityCore)
     implementation(libraries.springSecurityWeb)
     implementation(libraries.springBootStarterMail)
-    implementation(libraries.spingSamlEsapiDependencyVersion) {
+    implementation(libraries.owaspEsapi) {
         transitive = false
     }
     implementation(libraries.springSecuritySaml) {

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -118,6 +118,8 @@ dependencies {
 
     testImplementation(libraries.jsonPathAssert)
     testImplementation(libraries.guavaTestLib)
+
+    implementation(libraries.commonsIo)
 }
 
 configurations.all {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.authentication.manager;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.authentication.AccountNotPreCreatedException;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/mfa/JdbcUserGoogleMfaCredentialsProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/mfa/JdbcUserGoogleMfaCredentialsProvisioning.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mfa;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.audit.event.SystemDeletable;
 import org.cloudfoundry.identity.uaa.cypto.EncryptionKeyService;
 import org.cloudfoundry.identity.uaa.cypto.EncryptionServiceException;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/LegacyRedirectResolver.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/LegacyRedirectResolver.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.oauth.beans;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProvider.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.provider.saml;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.authentication.event.IdentityProviderAuthenticationSuccessEvent;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabase.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/JdbcUaaUserDatabase.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.user;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.cloudfoundry.identity.uaa.util.beans.DbUtils;
 import org.cloudfoundry.identity.uaa.db.DatabaseUrlModifier;
 import org.cloudfoundry.identity.uaa.db.Vendor;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneEndpointsClientDetailsValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneEndpointsClientDetailsValidator.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.zone;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.client.ClientDetailsValidator;
 import org.cloudfoundry.identity.uaa.client.InvalidClientDetailsException;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/db/TestSchemaValidation.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/db/TestSchemaValidation.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.db;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/LimitSqlAdapterFactoryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/LimitSqlAdapterFactoryTest.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.resources.jdbc;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.extensions.SpringProfileCleanupExtension;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidatorTests.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.scim.validate;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/RandomParametersJunitExtension.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/RandomParametersJunitExtension.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.test;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -97,6 +97,7 @@ dependencies {
     testImplementation(libraries.greenmail)
     testImplementation(libraries.jodaTime)
     testImplementation(libraries.commonsIo)
+    testImplementation(libraries.commonsHttpClient)
 }
 
 ext {

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -95,6 +95,7 @@ dependencies {
     testImplementation(libraries.tomcatJdbc)
     testImplementation(libraries.springRestdocs)
     testImplementation(libraries.greenmail)
+    testImplementation(libraries.jodaTime)
 }
 
 ext {

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     testImplementation(libraries.springRestdocs)
     testImplementation(libraries.greenmail)
     testImplementation(libraries.jodaTime)
+    testImplementation(libraries.commonsIo)
 }
 
 ext {

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -98,6 +98,7 @@ dependencies {
     testImplementation(libraries.jodaTime)
     testImplementation(libraries.commonsIo)
     testImplementation(libraries.commonsHttpClient)
+    testImplementation(libraries.owaspEsapi)
 }
 
 ext {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointDocs.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.clients;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.login.util.RandomValueStringGenerator;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientConstants;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/mfa_provider/MfaProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/mfa_provider/MfaProviderEndpointDocs.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.mfa_provider;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.cloudfoundry.identity.uaa.login.util.RandomValueStringGenerator;
 import org.cloudfoundry.identity.uaa.mfa.GoogleMfaProviderConfig;
 import org.cloudfoundry.identity.uaa.mfa.MfaProvider;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -13,7 +13,7 @@
 package org.cloudfoundry.identity.uaa.mock.providers;
 
 import org.apache.commons.collections.map.HashedMap;
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.login.Prompt;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.mock.providers;
 
-import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.lang3.ArrayUtils;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsMockMvcTests.java
@@ -13,7 +13,7 @@
 package org.cloudfoundry.identity.uaa.mock.providers;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.audit.AuditEventType;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.mock.token;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.apache.commons.collections.map.HashedMap;
+import org.apache.commons.collections4.map.HashedMap;
 import org.apache.commons.httpclient.util.URIUtil;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.warrenstrange.googleauth.GoogleAuthenticator;
 import com.warrenstrange.googleauth.GoogleAuthenticatorConfig;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.identity.uaa.audit.event.AbstractUaaEvent;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -7,7 +7,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.bouncycastle.util.Strings;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.approval.Approval;
 import org.cloudfoundry.identity.uaa.approval.JdbcApprovalStore;
@@ -230,7 +229,7 @@ class UaaTokenServicesTests {
 
     @Test
     void ensureJKUHeaderIsSetWhenBuildingAnAccessToken() {
-        AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, GRANT_TYPE_CLIENT_CREDENTIALS, Strings.split(clientScopes, ','));
+        AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, GRANT_TYPE_CLIENT_CREDENTIALS, clientScopes.split(","));
 
         OAuth2Authentication authentication = new OAuth2Authentication(authorizationRequest.createOAuth2Request(), null);
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
@@ -2,7 +2,7 @@ package org.cloudfoundry.identity.uaa.scim.endpoints;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;


### PR DESCRIPTION
These refactors will prepare the code for removing the old Spring SAML extension library. There are several libraries that are brought in only as a result of having the SAML extension library. These changes decouple these libraries that aren't directly related to SAML, by declaring them explicitly.

Changes made with the help of @peterhaochen47.