### PR TITLE
exclude vulnerable indirect dep xalan

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     }
     implementation(libraries.springSecuritySaml) {
         exclude(module: "bcprov-ext-jdk15on")
+        exclude(module: "xalan") // exclude vulnerable xalan 2.7.2 (see: CVE-2022-34169)
     }
     implementation(libraries.springSessionJdbc)
 

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -80,7 +80,9 @@ dependencies {
     testImplementation(libraries.springTest)
     testImplementation(libraries.springSecurityJwt)
     testImplementation(libraries.springSecurityLdap)
-    testImplementation(libraries.springSecuritySaml)
+    testImplementation(libraries.springSecuritySaml) {
+        exclude(module: "xalan") // exclude vulnerable xalan 2.7.2 (see: CVE-2022-34169)
+    }
     testImplementation(libraries.springSecurityTest)
     testImplementation(libraries.mockito)
     testImplementation(libraries.tomcatJdbc)


### PR DESCRIPTION
- a vulnerable xalan version (2.7.2; CVE-2022-34169) is brought in by the saml library we use: org.springframework.security.extensions:spring-security-saml2-core which has reached EOL (we are replacing it for develop branch, but not 74.5.x branch). So this xalan would not be bumped by spring-security-saml2-core anymore.
- so to address this CVE scan result (CVE-2022-34169), exclude this indirect dep, like develop branch does: https://github.com/cloudfoundry/uaa/commit/061bee94cc3bc0e4d40ade7dc2d8949af46e9274
- note: excluding a dep of a library we use carries the risk of failure if we trigger a code path in the library that depends on the dep. The fact all tests are passing + the fact that this exclude has been applied in develop branch for more than 1 year give us enough confidence that this exclude would not introduce a failure.

[#186948853]