### PR TITLE
refactor: remove a SAML dependency

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenTestSupport.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenTestSupport.java
@@ -324,7 +324,7 @@ public class TokenTestSupport {
         UaaAuthentication userAuthentication = new UaaAuthentication(uaaPrincipal, null, defaultUserAuthorities, new HashSet<>(Arrays.asList("group1", "group2")), Collections.EMPTY_MAP, null, true, System.currentTimeMillis(), System.currentTimeMillis() + 1000l * 60l);
         Set<String> amr = new HashSet<>(Arrays.asList("ext", "mfa", "rba"));
         userAuthentication.setAuthenticationMethods(amr);
-        userAuthentication.setAuthContextClassRef(new HashSet<>(Collections.singletonList(AuthnContext.PASSWORD_AUTHN_CTX)));
+        userAuthentication.setAuthContextClassRef(new HashSet<>(Collections.singletonList("some test ACR")));
 
         HashMap<String, String> requestParams = Maps.newHashMap();
         requestParams.put("grant_type", GRANT_TYPE_PASSWORD);


### PR DESCRIPTION
* We are getting rid of this constant because it is in the SAML extension library that we are trying to remove.

* As far as we can tell, this ACR doesn't need to be any specific string. The set just needs to contain one element.

[#186822654](https://www.pivotaltracker.com/story/show/186822654)