### PR TITLE
feat: clean up unused DB table service_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ List of relations
  public | schema_version                | table    | root
  public | sec_audit                     | table    | root
  public | sec_audit_id_seq              | sequence | root
- public | service_provider              | table    | root
  public | spring_session                | table    | root
  public | spring_session_attributes     | table    | root
  public | user_google_mfa_credentials   | table    | root

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_105__Drop_Table_service_provider.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/hsqldb/V4_105__Drop_Table_service_provider.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS service_provider;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_105__Drop_Table_service_provider.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/mysql/V4_105__Drop_Table_service_provider.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS service_provider;

--- a/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_105__Drop_Table_service_provider.sql
+++ b/server/src/main/resources/org/cloudfoundry/identity/uaa/db/postgresql/V4_105__Drop_Table_service_provider.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS service_provider;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
@@ -59,7 +59,6 @@ public class TestUtils {
         jdbcTemplate.update("DELETE FROM oauth_code");
         jdbcTemplate.update("DELETE FROM revocable_tokens");
         jdbcTemplate.update("DELETE FROM sec_audit");
-        jdbcTemplate.update("DELETE FROM service_provider");
         jdbcTemplate.update("DELETE FROM user_info");
         jdbcTemplate.update("DELETE FROM users");
         jdbcTemplate.update("DELETE FROM mfa_providers");


### PR DESCRIPTION
- This table was added for the UAA-as-SAML-IDP feature (https://github.com/cloudfoundry/uaa/commit/b93c87aa210097539a5778448cec5ca281b5de17)
- This feature has been removed: https://github.com/cloudfoundry/uaa/pull/2638. Hence this table is now unused.
- The "DROP TABLE IF EXISTS" syntax would not error out if the table does not exist, compared to just "DROP TABLE".
- Also clean up docs and a test util that reference this table.

[#182118433]