### PR TITLE
feat: Use Database availability as indicator for /healthz response

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -55,7 +55,7 @@ public class HealthzEndpoint {
             return "stopping\n";
         } else {
             if (wasLastConnectionSuccessful == null) {
-                return "No Check done.\n";
+                return "UAA running. Database status unknown.\n";
             }
 
             if (wasLastConnectionSuccessful) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -59,7 +59,7 @@ public class HealthzEndpoint {
             }
 
             if (wasLastConnectionSuccessful) {
-                return "ok\n";
+                return "ok. Database connection successful.\n";
             } else {
                 response.setStatus(503);
                 return "Database Connection failed.\n";

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -1,13 +1,18 @@
 package org.cloudfoundry.identity.uaa.health;
 
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-
-import javax.servlet.http.HttpServletResponse;
 
 /**
  * Simple controller that just returns "ok" in a request body for the purposes
@@ -18,10 +23,13 @@ import javax.servlet.http.HttpServletResponse;
 public class HealthzEndpoint {
     private static Logger logger = LoggerFactory.getLogger(HealthzEndpoint.class);
     private volatile boolean stopping = false;
+    private volatile Boolean wasLastConnectionSuccessful = null;
+    private DataSource dataSource;
 
     public HealthzEndpoint(
             @Value("${uaa.shutdown.sleep:10000}") final long sleepTime,
-            final Runtime runtime) {
+            final Runtime runtime,
+            final DataSource dataSource) {
         Thread shutdownHook = new Thread(() -> {
             stopping = true;
             logger.warn("Shutdown hook received, future requests to this endpoint will return 503");
@@ -35,6 +43,7 @@ public class HealthzEndpoint {
             }
         });
         runtime.addShutdownHook(shutdownHook);
+        this.dataSource = dataSource;
     }
 
     @GetMapping("/healthz")
@@ -45,8 +54,28 @@ public class HealthzEndpoint {
             response.setStatus(503);
             return "stopping\n";
         } else {
-            return "ok\n";
+            if (wasLastConnectionSuccessful == null) {
+                return "No Check done.\n";
+            }
+
+            if (wasLastConnectionSuccessful) {
+                return "ok\n";
+            } else {
+                response.setStatus(503);
+                return "Database Connection failed.\n";
+            }
         }
     }
 
+    @Scheduled(fixedRateString = "${uaa.health.db.rate:10000}")
+    void isDataSourceConnectionAvailable() {
+        try (Connection c = dataSource.getConnection(); Statement statement = c.createStatement()) {
+            statement.execute("SELECT 1 from identity_zone;"); //"SELECT 1;" Not supported by HSQLDB
+            wasLastConnectionSuccessful = true;
+            return;
+        } catch (Exception ex) {
+            logger.error("Could not establish connection to DB - " + ex.getMessage());
+        }
+        wasLastConnectionSuccessful = false;
+    }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
@@ -50,7 +50,7 @@ class HealthzEndpointTests {
 
     @Test
     void getHealthz() {
-        assertEquals("No Check done.\n", endpoint.getHealthz(response));
+        assertEquals("UAA running. Database status unknown.\n", endpoint.getHealthz(response));
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
@@ -56,7 +56,7 @@ class HealthzEndpointTests {
     @Test
     void getHealthz_connectionSuccess() {
         endpoint.isDataSourceConnectionAvailable();
-        assertEquals("ok\n", endpoint.getHealthz(response));
+        assertEquals("ok. Database connection successful.\n", endpoint.getHealthz(response));
     }
     @Test
     void getHealthz_connectionFailed() throws SQLException {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
@@ -1,18 +1,25 @@
-package org.cloudfoundry.identity.uaa.web;
-
-import org.cloudfoundry.identity.uaa.health.HealthzEndpoint;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.springframework.mock.web.MockHttpServletResponse;
+package org.cloudfoundry.identity.uaa.health;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.sql.DataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class HealthzEndpointTests {
 
@@ -21,11 +28,19 @@ class HealthzEndpointTests {
     private HealthzEndpoint endpoint;
     private MockHttpServletResponse response;
     private Thread shutdownHook;
+    private DataSource dataSource;
+    private Connection connection;
+    private Statement statement;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws SQLException {
         Runtime mockRuntime = mock(Runtime.class);
-        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime);
+        dataSource = mock(DataSource.class);
+        connection = mock(Connection.class);
+        statement = mock(Statement.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.createStatement()).thenReturn(statement);
+        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, dataSource);
         response = new MockHttpServletResponse();
 
         ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);
@@ -35,7 +50,20 @@ class HealthzEndpointTests {
 
     @Test
     void getHealthz() {
+        assertEquals("No Check done.\n", endpoint.getHealthz(response));
+    }
+
+    @Test
+    void getHealthz_connectionSuccess() {
+        endpoint.isDataSourceConnectionAvailable();
         assertEquals("ok\n", endpoint.getHealthz(response));
+    }
+    @Test
+    void getHealthz_connectionFailed() throws SQLException {
+        when(statement.execute(anyString())).thenThrow(new SQLException());
+        endpoint.isDataSourceConnectionAvailable();
+        assertEquals("Database Connection failed.\n", endpoint.getHealthz(response));
+        assertEquals(503, response.getStatus());
     }
 
     @Test
@@ -54,7 +82,8 @@ class HealthzEndpointTests {
         @BeforeEach
         void setUp() {
             Runtime mockRuntime = mock(Runtime.class);
-            endpoint = new HealthzEndpoint(-1, mockRuntime);
+            DataSource dataSource = mock(DataSource.class);
+            endpoint = new HealthzEndpoint(-1, mockRuntime, dataSource);
             response = new MockHttpServletResponse();
 
             ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/HealthzEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/HealthzEndpointIntegrationTests.java
@@ -42,6 +42,7 @@ public class HealthzEndpointIntegrationTests {
 
         String body = response.getBody();
         assertTrue(body.contains("ok"));
+        assertTrue(body.contains("Database connection successful"));
 
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/HealthzIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/HealthzIT.java
@@ -53,6 +53,6 @@ public class HealthzIT {
     @Test
     public void testHealthz() {
         webDriver.get(baseUrl + "/healthz");
-        Assert.assertEquals("ok", webDriver.findElement(By.tagName("body")).getText());
+        Assert.assertEquals("ok. Database connection successful.", webDriver.findElement(By.tagName("body")).getText());
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/config/HealthzShouldNotBeProtectedMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/config/HealthzShouldNotBeProtectedMockMvcTests.java
@@ -90,7 +90,7 @@ class HealthzShouldNotBeProtectedMockMvcTests {
         void healthzIsNotRejected(MockHttpServletRequestBuilder getRequest) throws Exception {
             mockMvc.perform(getRequest)
                     .andExpect(status().isOk())
-                    .andExpect(content().string("ok\n"));
+                    .andExpect(content().string("ok. Database connection successful.\n"));
         }
 
         @Test
@@ -128,7 +128,7 @@ class HealthzShouldNotBeProtectedMockMvcTests {
         void healthzIsNotRejected(MockHttpServletRequestBuilder getRequest) throws Exception {
             mockMvc.perform(getRequest)
                     .andExpect(status().isOk())
-                    .andExpect(content().string("ok\n"));
+                    .andExpect(content().string("ok. Database connection successful.\n"));
         }
 
         @Test


### PR DESCRIPTION
In one of our landscapes we recently saw, that the UAA /healthz endpoint will respond with ok even if the UAA Database is completely down (and hence none of the other requests to the UAA will work).

This PR aims to consider the DB availability in the response of the /healthz endpoint. 
As the requests to /healthz are time critical and should not take over a second, the actual DB check is done in a scheduled background task that is trying to establish a new DB connection and execute a statement. This task is executed every 10 seconds by default (time is configurable) and the /healthz endpoint will read the flag whether the last connection was successful.

When the DB connection works, the status is kept as it was before. When there has not been a DB check (usually only during startup), the status will still be 200, but the message will change until there has been a DB connection check.
A failed DB connection will result in a 503 status code along with an error message, indicating that the DB connection check failed.