### PR TITLE
refactor: reduce test dependency on EOL lib

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/security/X509ExpiryCheckingTrustManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/security/X509ExpiryCheckingTrustManagerTest.java
@@ -17,7 +17,7 @@ package org.cloudfoundry.identity.uaa.security;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.security.saml.trust.X509TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.X509Certificate;


### PR DESCRIPTION
- instead of using org.springframework.security.saml.trust.X509TrustManager which is provided by a saml lib that has reached EOL, use a more standard/generic X509TrustManager.

[#186958651]