### PR TITLE
Revert "Merge pull request #2718 from cloudfoundry/feat/healthzDataba…

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -1,18 +1,13 @@
 package org.cloudfoundry.identity.uaa.health;
 
-import javax.servlet.http.HttpServletResponse;
-import javax.sql.DataSource;
-
-import java.sql.Connection;
-import java.sql.Statement;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Simple controller that just returns "ok" in a request body for the purposes
@@ -23,13 +18,10 @@ import org.springframework.web.bind.annotation.ResponseBody;
 public class HealthzEndpoint {
     private static Logger logger = LoggerFactory.getLogger(HealthzEndpoint.class);
     private volatile boolean stopping = false;
-    private volatile Boolean wasLastConnectionSuccessful = null;
-    private DataSource dataSource;
 
     public HealthzEndpoint(
             @Value("${uaa.shutdown.sleep:10000}") final long sleepTime,
-            final Runtime runtime,
-            final DataSource dataSource) {
+            final Runtime runtime) {
         Thread shutdownHook = new Thread(() -> {
             stopping = true;
             logger.warn("Shutdown hook received, future requests to this endpoint will return 503");
@@ -43,7 +35,6 @@ public class HealthzEndpoint {
             }
         });
         runtime.addShutdownHook(shutdownHook);
-        this.dataSource = dataSource;
     }
 
     @GetMapping("/healthz")
@@ -54,28 +45,8 @@ public class HealthzEndpoint {
             response.setStatus(503);
             return "stopping\n";
         } else {
-            if (wasLastConnectionSuccessful == null) {
-                return "UAA running. Database status unknown.\n";
-            }
-
-            if (wasLastConnectionSuccessful) {
-                return "ok. Database connection successful.\n";
-            } else {
-                response.setStatus(503);
-                return "Database Connection failed.\n";
-            }
+            return "ok\n";
         }
     }
 
-    @Scheduled(fixedRateString = "${uaa.health.db.rate:10000}")
-    void isDataSourceConnectionAvailable() {
-        try (Connection c = dataSource.getConnection(); Statement statement = c.createStatement()) {
-            statement.execute("SELECT 1 from identity_zone;"); //"SELECT 1;" Not supported by HSQLDB
-            wasLastConnectionSuccessful = true;
-            return;
-        } catch (Exception ex) {
-            logger.error("Could not establish connection to DB - " + ex.getMessage());
-        }
-        wasLastConnectionSuccessful = false;
-    }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/HealthzEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/HealthzEndpointTests.java
@@ -1,25 +1,18 @@
-package org.cloudfoundry.identity.uaa.health;
+package org.cloudfoundry.identity.uaa.web;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import javax.sql.DataSource;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-
+import org.cloudfoundry.identity.uaa.health.HealthzEndpoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class HealthzEndpointTests {
 
@@ -28,19 +21,11 @@ class HealthzEndpointTests {
     private HealthzEndpoint endpoint;
     private MockHttpServletResponse response;
     private Thread shutdownHook;
-    private DataSource dataSource;
-    private Connection connection;
-    private Statement statement;
 
     @BeforeEach
-    void setUp() throws SQLException {
+    void setUp() {
         Runtime mockRuntime = mock(Runtime.class);
-        dataSource = mock(DataSource.class);
-        connection = mock(Connection.class);
-        statement = mock(Statement.class);
-        when(dataSource.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, dataSource);
+        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime);
         response = new MockHttpServletResponse();
 
         ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);
@@ -50,20 +35,7 @@ class HealthzEndpointTests {
 
     @Test
     void getHealthz() {
-        assertEquals("UAA running. Database status unknown.\n", endpoint.getHealthz(response));
-    }
-
-    @Test
-    void getHealthz_connectionSuccess() {
-        endpoint.isDataSourceConnectionAvailable();
-        assertEquals("ok. Database connection successful.\n", endpoint.getHealthz(response));
-    }
-    @Test
-    void getHealthz_connectionFailed() throws SQLException {
-        when(statement.execute(anyString())).thenThrow(new SQLException());
-        endpoint.isDataSourceConnectionAvailable();
-        assertEquals("Database Connection failed.\n", endpoint.getHealthz(response));
-        assertEquals(503, response.getStatus());
+        assertEquals("ok\n", endpoint.getHealthz(response));
     }
 
     @Test
@@ -82,8 +54,7 @@ class HealthzEndpointTests {
         @BeforeEach
         void setUp() {
             Runtime mockRuntime = mock(Runtime.class);
-            DataSource dataSource = mock(DataSource.class);
-            endpoint = new HealthzEndpoint(-1, mockRuntime, dataSource);
+            endpoint = new HealthzEndpoint(-1, mockRuntime);
             response = new MockHttpServletResponse();
 
             ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/HealthzEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/HealthzEndpointIntegrationTests.java
@@ -42,7 +42,6 @@ public class HealthzEndpointIntegrationTests {
 
         String body = response.getBody();
         assertTrue(body.contains("ok"));
-        assertTrue(body.contains("Database connection successful"));
 
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/HealthzIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/HealthzIT.java
@@ -53,6 +53,6 @@ public class HealthzIT {
     @Test
     public void testHealthz() {
         webDriver.get(baseUrl + "/healthz");
-        Assert.assertEquals("ok. Database connection successful.", webDriver.findElement(By.tagName("body")).getText());
+        Assert.assertEquals("ok", webDriver.findElement(By.tagName("body")).getText());
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/config/HealthzShouldNotBeProtectedMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/config/HealthzShouldNotBeProtectedMockMvcTests.java
@@ -90,7 +90,7 @@ class HealthzShouldNotBeProtectedMockMvcTests {
         void healthzIsNotRejected(MockHttpServletRequestBuilder getRequest) throws Exception {
             mockMvc.perform(getRequest)
                     .andExpect(status().isOk())
-                    .andExpect(content().string("ok. Database connection successful.\n"));
+                    .andExpect(content().string("ok\n"));
         }
 
         @Test
@@ -128,7 +128,7 @@ class HealthzShouldNotBeProtectedMockMvcTests {
         void healthzIsNotRejected(MockHttpServletRequestBuilder getRequest) throws Exception {
             mockMvc.perform(getRequest)
                     .andExpect(status().isOk())
-                    .andExpect(content().string("ok. Database connection successful.\n"));
+                    .andExpect(content().string("ok\n"));
         }
 
         @Test


### PR DESCRIPTION
…seCheck"

- As it is the likely cause of currnet deployment errors in CI.

This reverts commit 5b930a0ff8b2a73a4debc9ba6811c2b4f0fc1e28, reversing changes made to 065da3a6863120ceb106f5c114ea2f6878b75c26.

UAA post-start script is failing in multiple UAA pipeline jobs, including [uaa-bosh-release-test job build 188](https://bosh.ci.cloudfoundry.org/teams/uaa/pipelines/uaa-acceptance-gcp/jobs/uaa-bosh-release-test/builds/118) as follows for example:
```
Task 6 | 10:46:05 | L executing post-start: uaa/766a8b15-6a41-47b4-ae86-7d4e7aa6de14 (0) (canary) (00:12:18)
                  L Error: Action Failed get_task: Task e593962b-fa16-479c-7b4c-b713dd5f881d result: 1 of 2 post-start scripts failed. Failed Jobs: uaa. Successful Jobs: bosh-dns.
Task 6 | 10:56:05 | Error: Action Failed get_task: Task e593962b-fa16-479c-7b4c-b713dd5f881d result: 1 of 2 post-start scripts failed. Failed Jobs: uaa. Successful Jobs: bosh-dns.
```
~~Just to confirm that reverting the change will resolve the CI issue for now.~~
However, then I realize this PR check won't trigger `uaa-release-tests` job that is failing. So will actually have to merge this to `develop` to see the effects of the reverting. Or do a PR of uaa-release to use this PR branch as UAA source, or temporarily modifying the CI job to use this branch, but I do not really  want to go through that process myself. I'd rather let the original committer to handle the issue.
For now, I will not merge this revert PR to `develop` myself, but ask you to consider options, including merging this PR to revert the change, another PR to resolve the issue, etc.