### PR TITLE
fix: UAA 74.5 is vulnerable to CVE-2024-22243

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -22,6 +22,7 @@ ext["flyway.version"] = "7.15.0" // flyway 8+ drops support for mysql 5.7
 ext["mariadb.version"] = "2.7.11" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
 ext["snakeyaml.version"] = "2.2" // Needed to resolve CVEs in internal spring-boot 2.7.12 inclusion of snakeyaml
 ext["jackson-bom.version"] = "2.16.1" // Bumping to latest version because of compatibility to snakeyaml 2.0
+ext["spring-framework.version"] = "5.3.32" // Bumping to latest version 5 patch for CVE-2024-22243
 ext["selenium.version"] = "${versions.seleniumVersion}"
 
 ext {


### PR DESCRIPTION
- Because it depends on Spring Framework 5.3.31 and uses UriComponentsBuilder.
- So bumped Spring Framework to 5.3.32 per https://spring.io/security/cve-2024-22243.