### PR TITLE
Fix audience type

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtHelper.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtHelper.java
@@ -5,8 +5,10 @@ import com.nimbusds.jose.Header;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSObject;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.KeyLengthException;
+import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.bc.BouncyCastleFIPSProviderSingleton;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
@@ -20,7 +22,6 @@ import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.proc.BadJWTException;
 import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
@@ -149,8 +150,8 @@ class JwtHeader {
 class JwtImpl implements Jwt {
 
     private static final String INVALID_TOKEN = "Invalid token";
-    private final String parsedJwtObject;
-    private final JWT signedJwtObject;
+    private final JWT parsedJwtObject;
+    private final JWSObject signedJwsObject;
     private final JwtHeader header;
     private final CharSequence content;
     private final JWSSigner signature;
@@ -170,9 +171,9 @@ class JwtImpl implements Jwt {
         try {
             this.claimsSet = JWTClaimsSet.parse(Optional.ofNullable(payLoad).orElseThrow(() -> new JOSEException("Payload null")));
             JWSHeader joseHeader = JWSHeader.parse(JsonUtils.convertValue(header.parameters, HashMap.class));
-            SignedJWT signedJWT = new SignedJWT(joseHeader, claimsSet);
-            signedJWT.sign(signature);
-            signedJwtObject = signedJWT;
+            JWSObject jwsObject = new JWSObject(joseHeader, new Payload(payLoad));
+            jwsObject.sign(signature);
+            signedJwsObject = jwsObject;
         } catch (ParseException | JOSEException e) {
             throw new InvalidTokenException(INVALID_TOKEN, e);
         }
@@ -182,11 +183,11 @@ class JwtImpl implements Jwt {
         if (!StringUtils.hasLength(token)) {
             throw new InsufficientAuthenticationException("Unable to decode expected id_token");
         }
+        this.signedJwsObject = null;
         try {
-            this.signedJwtObject = JWTParser.parse(token);
-            this.claimsSet = signedJwtObject.getJWTClaimsSet();
-            this.header = new JwtHeader(JsonUtils.convertValue(signedJwtObject.getHeader().toJSONObject(), HeaderParameters.class));
-            this.parsedJwtObject = token;
+            this.parsedJwtObject =  JWTParser.parse(token);
+            this.claimsSet = parsedJwtObject.getJWTClaimsSet();
+            this.header = new JwtHeader(JsonUtils.convertValue(parsedJwtObject.getHeader().toJSONObject(), HeaderParameters.class));
         } catch (ParseException e) {
             throw new InvalidTokenException(INVALID_TOKEN, e);
         }
@@ -200,14 +201,14 @@ class JwtImpl implements Jwt {
      */
     @Override
     public void verifySignature(Verifier verifier) {
-        if (signedJwtObject != null && verifier instanceof SignatureVerifier signatureVerifier) {
-            validateClientJWToken(signedJwtObject, signatureVerifier.getJwkSet());
+        if (parsedJwtObject != null && verifier instanceof SignatureVerifier signatureVerifier) {
+            validateClientJWToken(parsedJwtObject, signatureVerifier.getJwkSet());
             return;
-        } else if (signedJwtObject != null && verifier instanceof ChainedSignatureVerifier chainedSignatureVerifier) {
+        } else if (parsedJwtObject != null && verifier instanceof ChainedSignatureVerifier chainedSignatureVerifier) {
             Exception last = new InvalidSignatureException("No matching keys found.");
             for (SignatureVerifier delegate : chainedSignatureVerifier.getDelegates()) {
                 try {
-                    validateClientJWToken(signedJwtObject, delegate.getJwkSet(((JWSHeader) signedJwtObject.getHeader()).getKeyID()));
+                    validateClientJWToken(parsedJwtObject, delegate.getJwkSet(((JWSHeader) parsedJwtObject.getHeader()).getKeyID()));
                     //success
                     return;
                 } catch (Exception e) {
@@ -230,7 +231,7 @@ class JwtImpl implements Jwt {
 
     @Override
     public String getEncoded() {
-        return isJwtParsedOrCreated() ? parsedJwtObject : getEncodedSignedJwt();
+        return isJwtParsedOrCreated() ? parsedJwtObject.serialize() : getEncodedSignedJwt();
     }
 
     private boolean isJwtParsedOrCreated() {
@@ -238,7 +239,7 @@ class JwtImpl implements Jwt {
     }
 
     private String getEncodedSignedJwt() {
-        return signature != null && signedJwtObject != null ? signedJwtObject.serialize() : "";
+        return signature != null && signedJwsObject != null ? signedJwsObject.serialize() : "";
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtHelper.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtHelper.java
@@ -153,7 +153,6 @@ class JwtImpl implements Jwt {
     private final JWT parsedJwtObject;
     private final JWSObject signedJwsObject;
     private final JwtHeader header;
-    private final CharSequence content;
     private final JWSSigner signature;
     private final JWTClaimsSet claimsSet;
 
@@ -167,11 +166,9 @@ class JwtImpl implements Jwt {
         this.header = header;
         this.signature = signature;
         this.parsedJwtObject = null;
-        this.content = null;
         try {
             this.claimsSet = JWTClaimsSet.parse(Optional.ofNullable(payLoad).orElseThrow(() -> new JOSEException("Payload null")));
-            JWSHeader joseHeader = JWSHeader.parse(JsonUtils.convertValue(header.parameters, HashMap.class));
-            JWSObject jwsObject = new JWSObject(joseHeader, new Payload(payLoad));
+            JWSObject jwsObject = new JWSObject(JWSHeader.parse(JsonUtils.convertValue(header.parameters, HashMap.class)), new Payload(payLoad));
             jwsObject.sign(signature);
             signedJwsObject = jwsObject;
         } catch (ParseException | JOSEException e) {
@@ -183,7 +180,6 @@ class JwtImpl implements Jwt {
         if (!StringUtils.hasLength(token)) {
             throw new InsufficientAuthenticationException("Unable to decode expected id_token");
         }
-        this.signedJwsObject = null;
         try {
             this.parsedJwtObject =  JWTParser.parse(token);
             this.claimsSet = parsedJwtObject.getJWTClaimsSet();
@@ -191,7 +187,7 @@ class JwtImpl implements Jwt {
         } catch (ParseException e) {
             throw new InvalidTokenException(INVALID_TOKEN, e);
         }
-        this.content = null;
+        this.signedJwsObject = null;
         this.signature = null;
     }
     /**
@@ -221,7 +217,7 @@ class JwtImpl implements Jwt {
     }
 
     public String getClaims() {
-        return content != null ? String.valueOf(content) : claimsSet.toString();
+        return claimsSet.toString();
     }
 
     @Override

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/ChainedSignatureVerifierTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/ChainedSignatureVerifierTests.java
@@ -88,31 +88,31 @@ public class ChainedSignatureVerifierTests {
     @Test
     public void test_single_key_valid() {
         verifier = new ChainedSignatureVerifier(new JsonWebKeySet<>(Collections.singletonList(validKey)));
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
     }
 
     @Test(expected = InvalidSignatureException.class)
     public void test_single_key_invalid() {
         verifier = new ChainedSignatureVerifier(new JsonWebKeySet<>(Collections.singletonList(invalidKey)));
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
     }
 
     @Test
     public void test_multi_key_first_valid() {
         verifier = new ChainedSignatureVerifier(new JsonWebKeySet<>(Arrays.asList(validKey, invalidKey)));
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
     }
 
     @Test
     public void test_multi_key_last_valid() {
         verifier = new ChainedSignatureVerifier(new JsonWebKeySet<>(Arrays.asList(invalidKey, validKey)));
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
     }
 
     @Test(expected = InvalidSignatureException.class)
     public void test_multi_key_invalid() {
         verifier = new ChainedSignatureVerifier(new JsonWebKeySet<>(Arrays.asList(invalidKey, invalidKey)));
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
     }
 
     @Test
@@ -210,7 +210,7 @@ public class ChainedSignatureVerifierTests {
         JsonWebKey jsonWebKey = new JsonWebKey(p);
 
         verifier = new ChainedSignatureVerifier(new JsonWebKeySet<>(Arrays.asList(validKey, jsonWebKey)));
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
         List<SignatureVerifier> delegates = new ArrayList((List<SignatureVerifier>) ReflectionTestUtils.getField(verifier, verifier.getClass(), "delegates"));
         assertNotNull(delegates);
         assertEquals(2, delegates.size());
@@ -221,7 +221,7 @@ public class ChainedSignatureVerifierTests {
         SignatureVerifier macSigner = mock(SignatureVerifier.class);
         delegates.add(macSigner);
         ReflectionTestUtils.setField(verifier, "delegates", delegates);
-        signedValidContent.verifySignature(verifier);
+        JwtHelper.decode(signedValidContent.getEncoded()).verifySignature(verifier);
         Mockito.verifyNoInteractions(macSigner);
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/CommonSignerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/CommonSignerTest.java
@@ -110,7 +110,7 @@ public class CommonSignerTest {
     }
 
     @Test
-    public void test_mac_signing_options() throws JOSEException, ParseException {
+    public void test_mac_signing_options() {
         CommonSigner signer = new CommonSigner(null, macSigningKey, "http://localhost/uaa");
         assertEquals(UaaMacSigner.SUPPORTED_ALGORITHMS, signer.supportedJWSAlgorithms());
         assertNotNull(signer.getJCAContext());
@@ -134,7 +134,7 @@ public class CommonSignerTest {
     }
 
     @Test
-    public void test_uaa_singing_with_single_aud_value() throws JOSEException, ParseException {
+    public void test_uaa_singing_with_single_aud_value() throws ParseException {
         // given
         Map<String, Object> objectMap = Map.of("sub","1234567890", "name", "John Doe", "aud", Arrays.asList("single"));
         // when


### PR DESCRIPTION
* Preserve array for aud claim
* Refactor from SignedJWT to JWSObject , which is more generic and does not modify internal object

includes tests from https://github.com/cloudfoundry/uaa/pull/2756
