### PR TITLE
[WIP]: Solve issue #2752

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtClientAuthentication.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtClientAuthentication.java
@@ -50,7 +50,7 @@ public class JwtClientAuthentication {
   public static final String GRANT_TYPE = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
   public static final String CLIENT_ASSERTION = "client_assertion";
   public static final String CLIENT_ASSERTION_TYPE = "client_assertion_type";
-  private static final Pattern DYNAMIC_VALUE_PARAMETER_PATTERN = Pattern.compile("^\\$\\{(?<name>[\\w\\-]+)(:+(?<default>[\\w:./=+\\-]+)*+)?}$");
+  private static final Pattern DYNAMIC_VALUE_PARAMETER_PATTERN = Pattern.compile("^\\$\\{(?<name>[\\w\\-]++)(:++(?<default>[\\w:./=+\\-]++)*+)?}$");
 
   // no signature check with invalid algorithms
   private static final Set<Algorithm> NOT_SUPPORTED_ALGORITHMS = Set.of(Algorithm.NONE, JWSAlgorithm.HS256, JWSAlgorithm.HS384, JWSAlgorithm.HS512);


### PR DESCRIPTION
* Read JwtClientAuthentication entries with optional read of system properties/environment
* DB entries can stay with a pattern and a default
* if the property/environment is set this is used

The mechanism should help in key rotation where UAA has different keys in TokenPolicy defined. Until now, you can reference the keys with option kid. This works also in large IdP usages, but the key rotation then could be a problem because of the mass on DB operations to change kid, e.g. key-1 to key-2.

The solution is a mechanism, where kid is defined with a pattern like ${JWT_KEY_ID:key-1} This pattern means, that if JWT_KEY_ID is defined as property or environment variable, this is used, e.g. export JWT_KEY_ID=key-2 && run uaa
or for uaa-bosh-deployment
uaa.catalina_opts: '-DJWT_KEY_ID=key-2'

The idea behind it is, that key rotation can be done with a new deployment on UAA and no extra DB actions are needed. In green/blue deployment the key rotation can be done without DB race conditions.