### PR TITLE
fix: saml signatureAlgorithm in AuthnRequest

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlConfigurationBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlConfigurationBean.java
@@ -27,6 +27,10 @@ public class SamlConfigurationBean implements InitializingBean {
     signatureAlgorithm = s;
   }
 
+  public SignatureAlgorithm getSignatureAlgorithm() {
+    return signatureAlgorithm;
+  }
+
   @Override
   public void afterPropertiesSet() {
     BasicSecurityConfiguration config = (BasicSecurityConfiguration) Configuration.getGlobalSecurityConfiguration();

--- a/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
@@ -301,6 +301,10 @@
 
     <bean id="fixedHttpMetaDataProvider" class="org.cloudfoundry.identity.uaa.provider.saml.FixedHttpMetaDataProvider" />
 
+    <bean id="defaultSamlConfig" class="org.cloudfoundry.identity.uaa.provider.saml.SamlConfigurationBean">
+        <property name="signatureAlgorithm" value="${login.saml.signatureAlgorithm:SHA1}"/>
+    </bean>
+
     <beans profile="fileMetadata">
         <bean id="metaDataUrl" class="java.lang.String">
             <constructor-arg value="${login.idpMetadataFile:null}"/>

--- a/uaa/src/test/resources/test/config/saml-algorithm-sha256.yml
+++ b/uaa/src/test/resources/test/config/saml-algorithm-sha256.yml
@@ -1,0 +1,3 @@
+login:
+  saml:
+    signatureAlgorithm: SHA256

--- a/uaa/src/test/resources/test/config/saml-algorithm-sha512.yml
+++ b/uaa/src/test/resources/test/config/saml-algorithm-sha512.yml
@@ -1,0 +1,3 @@
+login:
+  saml:
+    signatureAlgorithm: SHA512


### PR DESCRIPTION
* This fixes a regression introduced in commit https://github.com/cloudfoundry/uaa/commit/d10922a8f606b7d4ed8a7eb6bc585d9226e70f9e where we stopped reading the signatureAlgorithm from the properties file and only used the SHA1 default.

[#187250012]