### PR TITLE
backfill tests: SAML SP metadata

### DIFF
--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -405,9 +405,9 @@ login:
     #Local/SP metadata - requests signed
     signRequest: true
     #Local/SP metadata - want incoming assertions signed
-    #wantAssertionSigned: true
+    wantAssertionSigned: true
     #Algorithm for SAML signatures. Defaults to SHA1.  Accepts SHA1, SHA256, SHA512
-    #signatureAlgorithm: SHA256
+    signatureAlgorithm: SHA256
     socket:
       # URL metadata fetch - pool timeout
       connectionManagerTimeout: 10000

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -217,6 +217,8 @@ public class SamlLoginIT {
         // login.saml.signatureAlgorithm
         assertThat(metadataXml, containsString(
                 "<ds:DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\"/>"));
+        assertThat(metadataXml, containsString(
+                "<ds:SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/>"));
         // login.saml.signRequest
         assertThat(metadataXml, containsString("AuthnRequestsSigned=\"true\""));
         // login.saml.wantAssertionSigned

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -218,7 +218,7 @@ public class SamlLoginIT {
         assertThat(metadataXml, containsString(
                 "<ds:DigestMethod Algorithm=\"http://www.w3.org/2001/04/xmlenc#sha256\"/>"));
         assertThat(metadataXml, containsString(
-                "<ds:SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha1\"/>"));
+                "<ds:SignatureMethod Algorithm=\"http://www.w3.org/2001/04/xmldsig-more#rsa-sha256\"/>"));
         // login.saml.signRequest
         assertThat(metadataXml, containsString("AuthnRequestsSigned=\"true\""));
         // login.saml.wantAssertionSigned


### PR DESCRIPTION
- in preparation for replacing the EOL spring saml extension lib with spring security core saml, adding more test coverage on the SAML SP metadata
- tests that SAML SP metadata matches the UAA configs (in the context of this test, the UAA configs are from the local uaa.yml used to start a local server)
- also explicitly declare some SAML-SP-related fields in the said local uaa.yml to make the inputs to the test clearer

[#186986697]