### PR TITLE
Prevent Update and Delete of Entities with Alias if Alias Feature is disabled

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
@@ -225,6 +225,9 @@ public abstract class EntityAliasHandler<T extends EntityWithAlias> {
     protected abstract T cloneEntity(final T originalEntity);
 
     public final Optional<T> retrieveAliasEntity(final T originalEntity) {
+        if (!hasText(originalEntity.getAliasId()) || !hasText(originalEntity.getAliasZid())) {
+            return Optional.empty();
+        }
         return retrieveEntity(originalEntity.getAliasId(), originalEntity.getAliasZid());
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
@@ -37,8 +37,8 @@ public abstract class EntityAliasHandler<T extends EntityWithAlias> {
         final boolean entityAlreadyHasAlias = existingEntity != null && hasText(existingEntity.getAliasZid());
         if (entityAlreadyHasAlias) {
             if (!aliasEntitiesEnabled) {
-                // if the feature is disabled, we only allow setting both alias properties to null
-                return !hasText(requestBody.getAliasId()) && !hasText(requestBody.getAliasZid());
+                // reject ANY update of an entity with an existing alias if the feature is disabled
+                return false;
             }
 
             if (!hasText(existingEntity.getAliasId())) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
@@ -115,6 +115,10 @@ public abstract class EntityAliasHandler<T extends EntityWithAlias> {
      *                                    'aliasZid' does not exist
      * @throws EntityAliasFailedException if 'aliasId' and 'aliasZid' are set in the original entity, but the
      *                                    referenced alias entity could not be found
+     * @throws IllegalStateException      if {@code existingEntity} has an alias and 'aliasEntitiesEnabled' is set to
+     *                                    {@code false}
+     * @throws IllegalStateException      if a new alias is about to be created, i.e., {@code originalEntity} has a
+     *                                    non-empty 'aliasZid', and 'aliasEntitiesEnabled' is set to {@code false}
      */
     public final T ensureConsistencyOfAliasEntity(
             @NonNull final T originalEntity,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
@@ -188,7 +188,7 @@ public class IdentityProviderEndpoints implements ApplicationEventPublisherAware
         // reject deletion if the IdP has an alias, but alias feature is disabled
         final boolean idpHasAlias = hasText(existing.getAliasZid()) || hasText(existing.getAliasId());
         if (idpHasAlias && !aliasEntitiesEnabled) {
-            return new ResponseEntity<>(BAD_REQUEST);
+            return new ResponseEntity<>(UNPROCESSABLE_ENTITY);
         }
 
         // delete the IdP

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
@@ -186,7 +186,7 @@ public class IdentityProviderEndpoints implements ApplicationEventPublisherAware
         }
 
         // reject deletion if the IdP has an alias, but alias feature is disabled
-        final boolean idpHasAlias = hasText(existing.getAliasZid()) || hasText(existing.getAliasId());
+        final boolean idpHasAlias = hasText(existing.getAliasZid());
         if (idpHasAlias && !aliasEntitiesEnabled) {
             return new ResponseEntity<>(UNPROCESSABLE_ENTITY);
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
@@ -185,11 +185,19 @@ public class IdentityProviderEndpoints implements ApplicationEventPublisherAware
             return new ResponseEntity<>(UNPROCESSABLE_ENTITY);
         }
 
+        // reject deletion if the IdP has an alias, but alias feature is disabled
+        final boolean idpHasAlias = hasText(existing.getAliasZid()) || hasText(existing.getAliasId());
+        if (idpHasAlias && !aliasEntitiesEnabled) {
+            return new ResponseEntity<>(BAD_REQUEST);
+        }
+
+        // delete the IdP
         existing.setSerializeConfigRaw(rawConfig);
         publisher.publishEvent(new EntityDeletedEvent<>(existing, authentication, identityZoneId));
         redactSensitiveData(existing);
 
-        if (hasText(existing.getAliasZid()) && hasText(existing.getAliasId())) {
+        // delete the alias IdP if present
+        if (idpHasAlias) {
             final Optional<IdentityProvider<?>> aliasIdpOpt = idpAliasHandler.retrieveAliasEntity(existing);
             if (aliasIdpOpt.isEmpty()) {
                 // ignore dangling reference to alias
@@ -202,16 +210,6 @@ public class IdentityProviderEndpoints implements ApplicationEventPublisherAware
             }
 
             final IdentityProvider<?> aliasIdp = aliasIdpOpt.get();
-            if (!aliasEntitiesEnabled) {
-                // if alias entities are not enabled, just break the reference
-                aliasIdp.setAliasId(null);
-                aliasIdp.setAliasZid(null);
-                identityProviderProvisioning.update(aliasIdp, aliasIdp.getIdentityZoneId());
-
-                return new ResponseEntity<>(existing, OK);
-            }
-
-            // also delete the alias IdP
             aliasIdp.setSerializeConfigRaw(rawConfig);
             publisher.publishEvent(new EntityDeletedEvent<>(aliasIdp, authentication, identityZoneId));
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerValidationTest.java
@@ -87,7 +87,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
         }
 
         @Test
-        final void shouldReturnFalse_NotBothAliasPropsEmptyInReqBody() {
+        final void shouldReturnFalse_UpdatesOfEntitiesWithExistingAliasForbidden() {
             final String initialAliasId = UUID.randomUUID().toString();
             final String initialAliasZid = CUSTOM_ZONE_ID;
 
@@ -124,16 +124,10 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             // (8) alias ID removed, alias ZID changed
             requestBody = buildEntityWithAliasProps(null, "some-other-zid");
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
-        }
 
-        @Test
-        final void shouldReturnTrue_BothAliasPropsEmptyInReqBody() {
-            final T existingEntity = buildEntityWithAliasProps(
-                    UUID.randomUUID().toString(),
-                    CUSTOM_ZONE_ID
-            );
-            final T requestBody = buildEntityWithAliasProps(null, null);
-            assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isTrue();
+            // (9) alias ID removed, alias ZID removed
+            requestBody = buildEntityWithAliasProps(null, null);
+            assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpointsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpointsTest.java
@@ -685,7 +685,7 @@ class IdentityProviderEndpointsTest {
                 );
 
                 // deletion should be rejected
-                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+                assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
             }
 
             private Pair<IdentityProvider<?>, IdentityProvider<?>> arrangeIdpWithAliasExists(final String zone1Id, final String zone2Id) {

--- a/uaa/slateCustomizations/source/index.html.md.erb
+++ b/uaa/slateCustomizations/source/index.html.md.erb
@@ -1173,11 +1173,10 @@ _Request and Response Fields_
 
 _Error Codes_
 
-| Error Code | Description                                                                          |
-|------------|--------------------------------------------------------------------------------------|
-| 403        | Forbidden - Insufficient scope                                                       |
-| 422        | Unprocessable Entity - Invalid config                                                |
-| 422        | Unprocessable Entity - updating IdP with alias while `aliasEntitiesEnabled` is false |
+| Error Code | Description                                                                                            |
+|------------|--------------------------------------------------------------------------------------------------------|
+| 403        | Forbidden - Insufficient scope                                                                         |
+| 422        | Unprocessable Entity - Invalid config or updating IdP with alias while `aliasEntitiesEnabled` is false |
 
 ## Delete
 
@@ -1203,11 +1202,10 @@ _Response Fields_
 
 _Error Codes_
 
-| Error Code | Description                                                                          |
-|------------|--------------------------------------------------------------------------------------|
-| 403        | Forbidden - Insufficient scope                                                       |
-| 422        | Unprocessable Entity                                                                 |
-| 422        | Unprocessable Entity - deleting IdP with alias while `aliasEntitiesEnabled` is false |
+| Error Code | Description                                                                                |
+|------------|--------------------------------------------------------------------------------------------|
+| 403        | Forbidden - Insufficient scope                                                             |
+| 422        | Unprocessable Entity (e.g., deleting IdP with alias while `aliasEntitiesEnabled` is false) |
 
 ## Force password change for Users
 <%= render('IdentityProviderEndpointDocs/patchIdentityProviderStatus/curl-request.md') %>

--- a/uaa/slateCustomizations/source/index.html.md.erb
+++ b/uaa/slateCustomizations/source/index.html.md.erb
@@ -1173,10 +1173,11 @@ _Request and Response Fields_
 
 _Error Codes_
 
-| Error Code | Description                                                           |
-|------------|-----------------------------------------------------------------------|
-| 403        | Forbidden - Insufficient scope                                        |
-| 422        | Unprocessable Entity - Invalid config                                 |
+| Error Code | Description                                                                          |
+|------------|--------------------------------------------------------------------------------------|
+| 403        | Forbidden - Insufficient scope                                                       |
+| 422        | Unprocessable Entity - Invalid config                                                |
+| 422        | Unprocessable Entity - updating IdP with alias while `aliasEntitiesEnabled` is false |
 
 ## Delete
 
@@ -1202,10 +1203,11 @@ _Response Fields_
 
 _Error Codes_
 
-| Error Code | Description                                                           |
-|------------|-----------------------------------------------------------------------|
-| 403        | Forbidden - Insufficient scope                                        |
-| 422        | Unprocessable Entity                                                  |
+| Error Code | Description                                                                          |
+|------------|--------------------------------------------------------------------------------------|
+| 403        | Forbidden - Insufficient scope                                                       |
+| 422        | Unprocessable Entity                                                                 |
+| 422        | Unprocessable Entity - deleting IdP with alias while `aliasEntitiesEnabled` is false |
 
 ## Force password change for Users
 <%= render('IdentityProviderEndpointDocs/patchIdentityProviderStatus/curl-request.md') %>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -798,16 +798,16 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                 }
 
                 @Test
-                void shouldAccept_SetOnlyAliasPropertiesToNull_UaaToCustomZone() throws Throwable {
-                    shouldAccept_SetOnlyAliasPropertiesToNull(IdentityZone.getUaa(), customZone);
+                void shouldReject_SetOnlyAliasPropertiesToNull_UaaToCustomZone() throws Throwable {
+                    shouldReject_SetOnlyAliasPropertiesToNull(IdentityZone.getUaa(), customZone);
                 }
 
                 @Test
-                void shouldAccept_SetOnlyAliasPropertiesToNull_CustomToUaaZone() throws Throwable {
-                    shouldAccept_SetOnlyAliasPropertiesToNull(customZone, IdentityZone.getUaa());
+                void shouldReject_SetOnlyAliasPropertiesToNull_CustomToUaaZone() throws Throwable {
+                    shouldReject_SetOnlyAliasPropertiesToNull(customZone, IdentityZone.getUaa());
                 }
 
-                private void shouldAccept_SetOnlyAliasPropertiesToNull(
+                private void shouldReject_SetOnlyAliasPropertiesToNull(
                         final IdentityZone zone1,
                         final IdentityZone zone2
                 ) throws Throwable {
@@ -824,12 +824,7 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                     // change non-alias property without setting alias properties to null
                     originalIdp.setAliasId(null);
                     originalIdp.setAliasZid(null);
-                    final IdentityProvider<?> updatedIdp = updateIdp(zone1, originalIdp);
-                    assertThat(updatedIdp.getAliasId()).isBlank();
-                    assertThat(updatedIdp.getAliasZid()).isBlank();
-
-                    // the alias IdP should have its reference removed
-                    assertReferenceWasRemovedFromAlias(initialAliasId, initialAliasZid);
+                    shouldRejectUpdate(zone1, originalIdp, HttpStatus.UNPROCESSABLE_ENTITY);
                 }
 
                 @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -1198,13 +1198,6 @@ class IdentityProviderEndpointsAliasMockMvcTests {
         }
     }
 
-    private void assertReferenceWasRemovedFromAlias(final String aliasId, final String aliasZid) throws Exception {
-        final Optional<IdentityProvider<?>> aliasIdpAfterDeletion = readIdpFromZoneIfExists(aliasZid, aliasId);
-        assertThat(aliasIdpAfterDeletion).isPresent();
-        assertThat(aliasIdpAfterDeletion.get().getAliasId()).isBlank();
-        assertThat(aliasIdpAfterDeletion.get().getAliasZid()).isBlank();
-    }
-
     private static void assertIdpReferencesOtherIdp(final IdentityProvider<?> idp, final IdentityProvider<?> referencedIdp) {
         assertThat(idp).isNotNull();
         assertThat(referencedIdp).isNotNull();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -139,8 +139,7 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                 final Optional<IdentityProvider<?>> createdIdp = allIdps.stream()
                         .filter(it -> it.getOriginKey().equals(existingIdp.getOriginKey()))
                         .findFirst();
-                assertThat(createdIdp).isPresent();
-                assertThat(createdIdp.get()).isEqualTo(existingIdp);
+                assertThat(createdIdp).isPresent().contains(existingIdp);
                 assertThat(createdIdp.get().getAliasZid()).isEqualTo(zone2.getId());
             }
         }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -921,16 +921,16 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                 }
 
                 @Test
-                void shouldAccept_ShouldIgnoreDanglingReference_UaaToCustomZone() throws Throwable {
-                    shouldAccept_ShouldIgnoreDanglingReference(IdentityZone.getUaa(), customZone);
+                void shouldReject_EvenIfAliasReferenceIsBroken_UaaToCustomZone() throws Throwable {
+                    shouldReject_EvenIfAliasReferenceIsBroken(IdentityZone.getUaa(), customZone);
                 }
 
                 @Test
-                void shouldAccept_ShouldIgnoreDanglingReference_CustomToUaaZone() throws Throwable {
-                    shouldAccept_ShouldIgnoreDanglingReference(customZone, IdentityZone.getUaa());
+                void shouldReject_EvenIfAliasReferenceIsBroken_CustomToUaaZone() throws Throwable {
+                    shouldReject_EvenIfAliasReferenceIsBroken(customZone, IdentityZone.getUaa());
                 }
 
-                private void shouldAccept_ShouldIgnoreDanglingReference(
+                private void shouldReject_EvenIfAliasReferenceIsBroken(
                         final IdentityZone zone1,
                         final IdentityZone zone2
                 ) throws Throwable {
@@ -942,14 +942,9 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                     // create dangling reference by removing alias IdP directly in DB
                     deleteIdpViaDb(existingIdp.getOriginKey(), zone2.getId());
 
-                    // update original IdP
-                    existingIdp.setAliasId(null);
-                    existingIdp.setAliasZid(null);
+                    // try to update IdP -> should still fail, even if the alias reference is broken
                     existingIdp.setName("some-new-name");
-                    final IdentityProvider<?> updatedIdp = updateIdp(zone1, existingIdp);
-                    assertThat(updatedIdp.getName()).isEqualTo("some-new-name");
-                    assertThat(updatedIdp.getAliasId()).isBlank();
-                    assertThat(updatedIdp.getAliasZid()).isBlank();
+                    shouldRejectUpdate(zone1, existingIdp, HttpStatus.UNPROCESSABLE_ENTITY);
                 }
 
                 @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -1179,7 +1179,7 @@ class IdentityProviderEndpointsAliasMockMvcTests {
 
                 // delete IdP in zone 1 -> should be rejected since alias feature is disabled
                 final MvcResult deleteResult = deleteIdpAndReturnResult(zone1, id);
-                assertThat(deleteResult.getResponse().getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                assertThat(deleteResult.getResponse().getStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
             }
         }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -861,16 +861,16 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                 }
 
                 @Test
-                void shouldAccept_ShouldIgnoreAliasIdOfExistingIdpMissing_UaaToCustomZone() throws Throwable {
-                    shouldAccept_ShouldIgnoreAliasIdOfExistingIdpMissing(IdentityZone.getUaa(), customZone);
+                void shouldReject_AliasIdOfExistingIdpMissing_UaaToCustomZone() throws Throwable {
+                    shouldReject_AliasIdOfExistingIdpMissing(IdentityZone.getUaa(), customZone);
                 }
 
                 @Test
-                void shouldAccept_ShouldIgnoreAliasIdOfExistingIdpMissing_CustomToUaaZone() throws Throwable {
-                    shouldAccept_ShouldIgnoreAliasIdOfExistingIdpMissing(customZone, IdentityZone.getUaa());
+                void shouldReject_AliasIdOfExistingIdpMissing_CustomToUaaZone() throws Throwable {
+                    shouldReject_AliasIdOfExistingIdpMissing(customZone, IdentityZone.getUaa());
                 }
 
-                private void shouldAccept_ShouldIgnoreAliasIdOfExistingIdpMissing(
+                private void shouldReject_AliasIdOfExistingIdpMissing(
                         final IdentityZone zone1,
                         final IdentityZone zone2
                 ) throws Throwable {
@@ -892,17 +892,7 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                     existingIdp.setAliasId(null);
                     existingIdp.setAliasZid(null);
                     existingIdp.setName("some-new-name");
-                    final IdentityProvider<?> updatedIdp = updateIdp(zone1, existingIdp);
-                    assertThat(updatedIdp.getName()).isEqualTo("some-new-name");
-                    assertThat(updatedIdp.getAliasId()).isBlank();
-                    assertThat(updatedIdp.getAliasZid()).isBlank();
-
-                    // alias IdP should still exist and not be modified
-                    final Optional<IdentityProvider<?>> aliasIdp = readIdpViaDb(initialAliasId, zone2.getId());
-                    assertThat(aliasIdp).isPresent();
-                    assertThat(aliasIdp.get().getAliasId()).isNotBlank().isEqualTo(existingIdp.getId());
-                    assertThat(aliasIdp.get().getAliasZid()).isNotBlank().isEqualTo(existingIdp.getIdentityZoneId());
-                    assertThat(aliasIdp.get().getName()).isNotBlank().isEqualTo(initialName);
+                    shouldRejectUpdate(zone1, existingIdp, HttpStatus.UNPROCESSABLE_ENTITY);
                 }
 
                 @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsAliasMockMvcTests.java
@@ -833,16 +833,16 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                 }
 
                 @Test
-                void shouldAccept_SetAliasPropertiesToNullAndChangeOtherProperties_UaaToCustomZone() throws Throwable {
-                    shouldAccept_SetAliasPropertiesToNullAndChangeOtherProperties(IdentityZone.getUaa(), customZone);
+                void shouldReject_SetAliasPropertiesToNullAndChangeOtherProperties_UaaToCustomZone() throws Throwable {
+                    shouldReject_SetAliasPropertiesToNullAndChangeOtherProperties(IdentityZone.getUaa(), customZone);
                 }
 
                 @Test
-                void shouldAccept_SetAliasPropertiesToNullAndChangeOtherProperties_CustomToUaaZone() throws Throwable {
-                    shouldAccept_SetAliasPropertiesToNullAndChangeOtherProperties(customZone, IdentityZone.getUaa());
+                void shouldReject_SetAliasPropertiesToNullAndChangeOtherProperties_CustomToUaaZone() throws Throwable {
+                    shouldReject_SetAliasPropertiesToNullAndChangeOtherProperties(customZone, IdentityZone.getUaa());
                 }
 
-                private void shouldAccept_SetAliasPropertiesToNullAndChangeOtherProperties(
+                private void shouldReject_SetAliasPropertiesToNullAndChangeOtherProperties(
                         final IdentityZone zone1,
                         final IdentityZone zone2
                 ) throws Throwable {
@@ -858,21 +858,11 @@ class IdentityProviderEndpointsAliasMockMvcTests {
                     final String initialName = originalIdp.getName();
                     assertThat(initialName).isNotBlank();
 
-                    // change non-alias property without setting alias properties to null
+                    // should reject update
                     originalIdp.setAliasId(null);
                     originalIdp.setAliasZid(null);
                     originalIdp.setName("some-new-name");
-                    final IdentityProvider<?> updatedIdp = updateIdp(zone1, originalIdp);
-                    assertThat(updatedIdp.getAliasId()).isBlank();
-                    assertThat(updatedIdp.getAliasZid()).isBlank();
-                    assertThat(updatedIdp.getName()).isEqualTo("some-new-name");
-
-                    // apart from the alias reference being removed, the alias IdP should be left unchanged
-                    final Optional<IdentityProvider<?>> aliasIdpAfterUpdate = readIdpFromZoneIfExists(zone2.getId(), initialAliasId);
-                    assertThat(aliasIdpAfterUpdate).isPresent();
-                    assertThat(aliasIdpAfterUpdate.get().getAliasId()).isBlank();
-                    assertThat(aliasIdpAfterUpdate.get().getAliasZid()).isBlank();
-                    assertThat(aliasIdpAfterUpdate.get().getName()).isEqualTo(initialName);
+                    shouldRejectUpdate(zone1, originalIdp, HttpStatus.UNPROCESSABLE_ENTITY);
                 }
 
                 @Test


### PR DESCRIPTION
see issue #2505 

Prevent update and deletion of identity providers that have an alias if the alias feature is disabled again (i.e., `aliasEntitiesEnabled` is set to `false`).