### PR TITLE
Set default SAML signatureAlgorithm value to SHA256

### DIFF
--- a/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/saml-providers.xml
@@ -302,7 +302,7 @@
     <bean id="fixedHttpMetaDataProvider" class="org.cloudfoundry.identity.uaa.provider.saml.FixedHttpMetaDataProvider" />
 
     <bean id="defaultSamlConfig" class="org.cloudfoundry.identity.uaa.provider.saml.SamlConfigurationBean">
-        <property name="signatureAlgorithm" value="${login.saml.signatureAlgorithm:SHA1}"/>
+        <property name="signatureAlgorithm" value="${login.saml.signatureAlgorithm:SHA256}"/>
     </bean>
 
     <beans profile="fileMetadata">


### PR DESCRIPTION
- For the bean.
- As suggested in review comments in https://github.com/cloudfoundry/uaa/pull/2794.