### PR TITLE
Bump Spring Security Core to 5.7.12 overriding default Spring Security 2.7.18 that uses 5.7.11

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,6 +7,7 @@ versions.bouncyCastleVersion = "1.77"
 versions.commonsioVersion = "2.16.0"
 versions.hamcrestVersion = "2.2"
 versions.springBootVersion = "2.7.18"
+versions.springSecurityCore = "5.7.12"
 versions.springSecurityJwtVersion = "1.1.1.RELEASE"
 versions.springSecurityOAuthVersion = "2.5.2.RELEASE"
 versions.springSecuritySamlVersion = "1.0.10.RELEASE" // this lib has reached EOL in 2021, must be replaced (https://spring.io/projects/spring-security-saml#support)
@@ -24,6 +25,9 @@ ext["snakeyaml.version"] = "2.2" // Needed to resolve CVEs in internal spring-bo
 ext["jackson-bom.version"] = "2.16.2" // Bumping to latest version because of compatibility to snakeyaml 2.0
 ext["spring-framework.version"] = "5.3.33" // Bumping to latest version 5 patch
 ext["selenium.version"] = "${versions.seleniumVersion}"
+//  spring-boot 2.7.18 provides spring-security 5.7.11, which has CVE-2024-22257. So, override that with spring-security
+//  5.7 latest patch version. This should be removed once spring-boot version is bumped.
+ext['spring-security.version'] = "${versions.springSecurityCore}"
 
 ext {
     tomcatVersion = "${versions.tomcatVersion}"


### PR DESCRIPTION
spring-boot 2.7.18 provides spring-security 5.7.11, which has CVE-2024-22257. So, override that with spring-security 5.7 latest patch version. This should be removed once spring-boot version is bumped.

[#187358387]