### PR TITLE
Refactor tests for EntityAliasHandler.ensureConsistencyOfAliasEntity

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -34,7 +34,7 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
 
     protected final String customZoneId = UUID.randomUUID().toString();
 
-    protected abstract class Base {
+    private abstract class Base {
         protected EntityAliasHandler<T> aliasHandler;
 
         @BeforeEach
@@ -46,7 +46,7 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         protected abstract boolean isAliasFeatureEnabled();
     }
 
-    protected abstract class NoExistingAliasBase extends Base {
+    private abstract class NoExistingAliasBase extends Base {
         @Test
         final void shouldIgnore_AliasZidEmptyInOriginalEntity() {
             final T originalEntity = buildEntityWithAliasProperties(null, null);
@@ -58,16 +58,32 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         }
     }
 
-    protected abstract class NoExistingAlias_AliasFeatureEnabled {
+    protected abstract class NoExistingAlias_AliasFeatureEnabled extends NoExistingAliasBase {
+        @Override
+        protected final boolean isAliasFeatureEnabled() {
+            return true;
+        }
     }
 
-    protected abstract class NoExistingAlias_AliasFeatureDisabled {
+    protected abstract class NoExistingAlias_AliasFeatureDisabled extends NoExistingAliasBase {
+        @Override
+        protected final boolean isAliasFeatureEnabled() {
+            return false;
+        }
     }
 
-    protected abstract class ExistingAlias_AliasFeatureEnabled {
+    protected abstract class ExistingAlias_AliasFeatureEnabled extends Base {
+        @Override
+        protected final boolean isAliasFeatureEnabled() {
+            return true;
+        }
     }
 
-    protected abstract class ExistingAlias_AliasFeatureDisabled {
+    protected abstract class ExistingAlias_AliasFeatureDisabled extends Base {
+        @Override
+        protected final boolean isAliasFeatureEnabled() {
+            return false;
+        }
     }
 
     protected static class EntityWithAliasMatcher<T extends EntityWithAlias> implements ArgumentMatcher<T> {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
+import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatcher;
 import org.springframework.lang.Nullable;
@@ -15,7 +16,18 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
 
     protected abstract T buildEntityWithAliasProperties(@Nullable final String aliasId, @Nullable final String aliasZid);
 
+    /**
+     * Change one or more properties (but neither 'aliasId' nor 'aliasZid') of the given entity.
+     */
+    protected abstract void changeNonAliasProperties(final T entity);
+
     protected abstract void arrangeZoneDoesNotExist(final String zoneId);
+
+    /**
+     * Check whether the given two entities are equal. This method is required since the {@link ScimUser} class does not
+     * implement an {@code equals} method that is precise enough.
+     */
+    protected abstract boolean entitiesAreEqual(final T entity1, final T entity2);
 
     protected final String customZoneId = UUID.randomUUID().toString();
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -8,6 +8,10 @@ import org.mockito.ArgumentMatcher;
 import org.springframework.lang.Nullable;
 
 public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
+    protected abstract T shallowCloneEntity(final T entity);
+
+    protected abstract T buildEntityWithAliasProperties(@Nullable final String aliasId, @Nullable final String aliasZid);
+
     protected final String customZoneId = UUID.randomUUID().toString();
 
     protected abstract class NoExistingAlias_AliasFeatureEnabled {
@@ -21,8 +25,6 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
 
     protected abstract class ExistingAlias_AliasFeatureDisabled {
     }
-
-    protected abstract T buildEntityWithAliasProperties(@Nullable final String aliasId, @Nullable final String aliasZid);
 
     protected static class EntityWithAliasMatcher<T extends EntityWithAlias> implements ArgumentMatcher<T> {
         private final String zoneId;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -4,10 +4,13 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.ArgumentMatcher;
 import org.springframework.lang.Nullable;
 
 public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
+    protected abstract EntityAliasHandler<T> buildAliasHandler(final boolean aliasEntitiesEnabled);
+
     protected abstract T shallowCloneEntity(final T entity);
 
     protected abstract T buildEntityWithAliasProperties(@Nullable final String aliasId, @Nullable final String aliasZid);
@@ -15,6 +18,18 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
     protected abstract void arrangeZoneDoesNotExist(final String zoneId);
 
     protected final String customZoneId = UUID.randomUUID().toString();
+
+    protected abstract class Base {
+        protected EntityAliasHandler<T> aliasHandler;
+
+        @BeforeEach
+        final void setUp() {
+            final boolean aliasEntitiesEnabled = isAliasFeatureEnabled();
+            this.aliasHandler = buildAliasHandler(aliasEntitiesEnabled);
+        }
+
+        protected abstract boolean isAliasFeatureEnabled();
+    }
 
     protected abstract class NoExistingAlias_AliasFeatureEnabled {
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.alias;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -66,6 +67,19 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         @Override
         protected final boolean isAliasFeatureEnabled() {
             return true;
+        }
+
+        @Test
+        final void shouldThrow_WhenAliasZidSetButZoneDoesNotExist() {
+            final T existingEntity = buildEntityWithAliasProperties(null, null);
+            final T originalEntity = shallowCloneEntity(existingEntity);
+            originalEntity.setAliasZid(customZoneId);
+
+            arrangeZoneDoesNotExist(customZoneId);
+
+            assertThatExceptionOfType(EntityAliasFailedException.class).isThrownBy(() ->
+                    aliasHandler.ensureConsistencyOfAliasEntity(originalEntity, existingEntity)
+            );
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -104,6 +104,18 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         }
 
         @Test
+        final void shouldThrow_EvenIfNoAliasPropertyIsChanged() {
+            final T existingEntity = buildEntityWithAliasProperties(UUID.randomUUID().toString(), customZoneId);
+
+            final T originalEntity = shallowCloneEntity(existingEntity);
+            changeNonAliasProperties(originalEntity);
+
+            assertThatIllegalStateException().isThrownBy(() ->
+                    aliasHandler.ensureConsistencyOfAliasEntity(originalEntity, existingEntity)
+            ).withMessage("Performing update on entity with alias while alias feature is disabled.");
+        }
+
+        @Test
         final void shouldThrow_AliasPropertiesSetToNull() {
             final T existingEntity = buildEntityWithAliasProperties(UUID.randomUUID().toString(), customZoneId);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -1,11 +1,14 @@
 package org.cloudfoundry.identity.uaa.alias;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.springframework.lang.Nullable;
 
@@ -41,6 +44,18 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         }
 
         protected abstract boolean isAliasFeatureEnabled();
+    }
+
+    protected abstract class NoExistingAliasBase extends Base {
+        @Test
+        final void shouldIgnore_AliasZidEmptyInOriginalEntity() {
+            final T originalEntity = buildEntityWithAliasProperties(null, null);
+            final T existingEntity = shallowCloneEntity(originalEntity);
+            changeNonAliasProperties(existingEntity);
+
+            final T result = aliasHandler.ensureConsistencyOfAliasEntity(originalEntity, existingEntity);
+            assertThat(entitiesAreEqual(result, originalEntity)).isTrue();
+        }
     }
 
     protected abstract class NoExistingAlias_AliasFeatureEnabled {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -26,6 +26,10 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
 
     protected abstract void arrangeZoneDoesNotExist(final String zoneId);
 
+    protected abstract void arrangeEntityExists(final String id, final String zoneId, final T entity);
+
+    protected abstract void arrangeEntityDoesNotExist(final String id, final String zoneId);
+
     /**
      * Check whether the given two entities are equal. This method is required since the {@link ScimUser} class does not
      * implement an {@code equals} method that is precise enough.

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -6,4 +6,16 @@ import org.cloudfoundry.identity.uaa.EntityWithAlias;
 
 public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
     protected final String customZoneId = UUID.randomUUID().toString();
+
+    protected abstract class NoExistingAlias_AliasFeatureEnabled {
+    }
+
+    protected abstract class NoExistingAlias_AliasFeatureDisabled {
+    }
+
+    protected abstract class ExistingAlias_AliasFeatureEnabled {
+    }
+
+    protected abstract class ExistingAlias_AliasFeatureDisabled {
+    }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -1,8 +1,10 @@
 package org.cloudfoundry.identity.uaa.alias;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
+import org.mockito.ArgumentMatcher;
 
 public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
     protected final String customZoneId = UUID.randomUUID().toString();
@@ -17,5 +19,25 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
     }
 
     protected abstract class ExistingAlias_AliasFeatureDisabled {
+    }
+
+    protected static class EntityWithAliasMatcher<T extends EntityWithAlias> implements ArgumentMatcher<T> {
+        private final String zoneId;
+        private final String id;
+        private final String aliasId;
+        private final String aliasZid;
+
+        public EntityWithAliasMatcher(final String zoneId, final String id, final String aliasId, final String aliasZid) {
+            this.zoneId = zoneId;
+            this.id = id;
+            this.aliasId = aliasId;
+            this.aliasZid = aliasZid;
+        }
+
+        @Override
+        public boolean matches(final T argument) {
+            return Objects.equals(id, argument.getId()) && Objects.equals(zoneId, argument.getZoneId())
+                    && Objects.equals(aliasId, argument.getAliasId()) && Objects.equals(aliasZid, argument.getAliasZid());
+        }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -1,0 +1,6 @@
+package org.cloudfoundry.identity.uaa.alias;
+
+import org.cloudfoundry.identity.uaa.EntityWithAlias;
+
+public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -1,6 +1,9 @@
 package org.cloudfoundry.identity.uaa.alias;
 
+import java.util.UUID;
+
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
 
 public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
+    protected final String customZoneId = UUID.randomUUID().toString();
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.alias;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.util.Objects;
 import java.util.UUID;
@@ -87,6 +88,17 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         @Override
         protected final boolean isAliasFeatureEnabled() {
             return false;
+        }
+
+        @Test
+        final void shouldThrow_WhenAliasZidSet() {
+            final T existingEntity = buildEntityWithAliasProperties(null, null);
+            final T originalEntity = shallowCloneEntity(existingEntity);
+            originalEntity.setAliasZid(customZoneId);
+
+            assertThatIllegalStateException().isThrownBy(() ->
+                    aliasHandler.ensureConsistencyOfAliasEntity(originalEntity, existingEntity)
+            ).withMessage("Trying to create a new alias while alias feature is disabled.");
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -102,6 +102,20 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         protected final boolean isAliasFeatureEnabled() {
             return false;
         }
+
+        @Test
+        final void shouldThrow_AliasPropertiesSetToNull() {
+            final T existingEntity = buildEntityWithAliasProperties(UUID.randomUUID().toString(), customZoneId);
+
+            final T originalEntity = shallowCloneEntity(existingEntity);
+            changeNonAliasProperties(originalEntity);
+            originalEntity.setAliasId(null);
+            originalEntity.setAliasZid(null);
+
+            assertThatIllegalStateException().isThrownBy(() ->
+                    aliasHandler.ensureConsistencyOfAliasEntity(originalEntity, existingEntity)
+            ).withMessage("Performing update on entity with alias while alias feature is disabled.");
+        }
     }
 
     protected static class EntityWithAliasMatcher<T extends EntityWithAlias> implements ArgumentMatcher<T> {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -95,6 +95,22 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
         protected final boolean isAliasFeatureEnabled() {
             return true;
         }
+
+        @Test
+        final void shouldThrow_WhenReferencedAliasEntityAndAliasZoneDoNotExist() {
+            final String aliasId = UUID.randomUUID().toString();
+
+            final T existingEntity = buildEntityWithAliasProperties(aliasId, customZoneId);
+            final T originalEntity = shallowCloneEntity(existingEntity);
+            changeNonAliasProperties(originalEntity);
+
+            arrangeEntityDoesNotExist(aliasId, customZoneId);
+            arrangeZoneDoesNotExist(customZoneId);
+
+            assertThatExceptionOfType(EntityAliasFailedException.class).isThrownBy(() ->
+                    aliasHandler.ensureConsistencyOfAliasEntity(originalEntity, existingEntity)
+            );
+        }
     }
 
     protected abstract class ExistingAlias_AliasFeatureDisabled extends Base {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -12,6 +12,8 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
 
     protected abstract T buildEntityWithAliasProperties(@Nullable final String aliasId, @Nullable final String aliasZid);
 
+    protected abstract void arrangeZoneDoesNotExist(final String zoneId);
+
     protected final String customZoneId = UUID.randomUUID().toString();
 
     protected abstract class NoExistingAlias_AliasFeatureEnabled {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerEnsureConsistencyTest.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
 import org.mockito.ArgumentMatcher;
+import org.springframework.lang.Nullable;
 
 public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWithAlias> {
     protected final String customZoneId = UUID.randomUUID().toString();
@@ -20,6 +21,8 @@ public abstract class EntityAliasHandlerEnsureConsistencyTest<T extends EntityWi
 
     protected abstract class ExistingAlias_AliasFeatureDisabled {
     }
+
+    protected abstract T buildEntityWithAliasProperties(@Nullable final String aliasId, @Nullable final String aliasZid);
 
     protected static class EntityWithAliasMatcher<T extends EntityWithAlias> implements ArgumentMatcher<T> {
         private final String zoneId;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -11,7 +11,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.alias.EntityAliasFailedException;
@@ -23,7 +22,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -150,12 +148,12 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 createdAliasIdp.setAliasId(originalIdpId);
                 createdAliasIdp.setAliasZid(UAA);
                 when(identityProviderProvisioning.create(
-                        argThat(new IdpWithAliasMatcher(customZoneId, null, originalIdpId, UAA)),
+                        argThat(new EntityWithAliasMatcher<>(customZoneId, null, originalIdpId, UAA)),
                         eq(customZoneId)
                 )).thenReturn(createdAliasIdp);
 
                 // mock update of original IdP
-                when(identityProviderProvisioning.update(argThat(new IdpWithAliasMatcher(UAA, originalIdpId, newAliasIdpId, customZoneId)), eq(UAA)))
+                when(identityProviderProvisioning.update(argThat(new EntityWithAliasMatcher<>(UAA, originalIdpId, newAliasIdpId, customZoneId)), eq(UAA)))
                         .then(invocationOnMock -> invocationOnMock.getArgument(0));
 
                 final IdentityProvider<?> result = idpAliasHandler.ensureConsistencyOfAliasEntity(
@@ -170,26 +168,6 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 verify(identityProviderProvisioning).update(originalIdpCaptor.capture(), eq(UAA));
                 final IdentityProvider<?> updatedOriginalIdp = originalIdpCaptor.getValue();
                 assertThat(updatedOriginalIdp.getAliasId()).isEqualTo(newAliasIdpId);
-            }
-
-            private static class IdpWithAliasMatcher implements ArgumentMatcher<IdentityProvider<?>> {
-                private final String identityZoneId;
-                private final String id;
-                private final String aliasId;
-                private final String aliasZid;
-
-                public IdpWithAliasMatcher(final String identityZoneId, final String id, final String aliasId, final String aliasZid) {
-                    this.identityZoneId = identityZoneId;
-                    this.id = id;
-                    this.aliasId = aliasId;
-                    this.aliasZid = aliasZid;
-                }
-
-                @Override
-                public boolean matches(final IdentityProvider<?> argument) {
-                    return Objects.equals(id, argument.getId()) && Objects.equals(identityZoneId, argument.getIdentityZoneId())
-                            && Objects.equals(aliasId, argument.getAliasId()) && Objects.equals(aliasZid, argument.getAliasZid());
-                }
             }
         }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -153,21 +153,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
         @Nested
         class AliasFeatureDisabled extends ExistingAlias_AliasFeatureDisabled {
-            @Test
-            void shouldThrow_IfExistingEntityHasAlias() {
-                final String aliasIdpId = UUID.randomUUID().toString();
-
-                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
-
-                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
-                originalIdp.setAliasId(null);
-                originalIdp.setAliasZid(null);
-                originalIdp.setName("some-new-name");
-
-                assertThatIllegalStateException().isThrownBy(() ->
-                        aliasHandler.ensureConsistencyOfAliasEntity(originalIdp, existingIdp)
-                ).withMessage("Performing update on entity with alias while alias feature is disabled.");
-            }
+            // all tests defined in superclass
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -101,8 +101,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 when(identityProviderProvisioning.retrieve(aliasIdpId, customZoneId)).thenReturn(null);
 
                 // alias zone does not exist
-                when(identityZoneProvisioning.retrieve(customZoneId))
-                        .thenThrow(new ZoneDoesNotExistsException("zone does not exist"));
+                arrangeZoneDoesNotExist(customZoneId);
 
                 assertThatExceptionOfType(EntityAliasFailedException.class).isThrownBy(() ->
                         idpAliasHandler.ensureConsistencyOfAliasEntity(originalIdp, existingIdp)
@@ -211,8 +210,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 final IdentityProvider<?> requestBody = shallowCloneEntity(existingIdp);
                 requestBody.setAliasZid(customZoneId);
 
-                when(identityZoneProvisioning.retrieve(customZoneId))
-                        .thenThrow(new ZoneDoesNotExistsException("zone does not exist"));
+                arrangeZoneDoesNotExist(customZoneId);
 
                 assertThatExceptionOfType(EntityAliasFailedException.class).isThrownBy(() ->
                         idpAliasHandler.ensureConsistencyOfAliasEntity(requestBody, existingIdp)
@@ -285,5 +283,11 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         existingIdp.setAliasId(aliasId);
         existingIdp.setAliasZid(aliasZid);
         return existingIdp;
+    }
+
+    @Override
+    protected void arrangeZoneDoesNotExist(final String zoneId) {
+        when(identityZoneProvisioning.retrieve(zoneId))
+                .thenThrow(new ZoneDoesNotExistsException("zone does not exist"));
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -176,20 +176,6 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         @Nested
         class AliasFeatureEnabled extends NoExistingAlias_AliasFeatureEnabled {
             @Test
-            void shouldThrow_WhenAliasZoneDoesNotExist() {
-                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
-
-                final IdentityProvider<?> requestBody = shallowCloneEntity(existingIdp);
-                requestBody.setAliasZid(customZoneId);
-
-                arrangeZoneDoesNotExist(customZoneId);
-
-                assertThatExceptionOfType(EntityAliasFailedException.class).isThrownBy(() ->
-                        aliasHandler.ensureConsistencyOfAliasEntity(requestBody, existingIdp)
-                );
-            }
-
-            @Test
             void shouldCreateNewAliasIdp_WhenAliasZoneExistsAndAliasPropertiesAreSet() {
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -134,30 +134,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     class NoExistingAlias {
         @Nested
         class AliasFeatureEnabled extends NoExistingAlias_AliasFeatureEnabled {
-            @Test
-            void shouldCreateNewAliasIdp_WhenAliasZoneExistsAndAliasPropertiesAreSet() {
-                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
-
-                final IdentityProvider<?> requestBody = shallowCloneEntity(existingIdp);
-                requestBody.setAliasZid(customZoneId);
-
-                final String aliasIdpId = UUID.randomUUID().toString();
-                when(identityProviderProvisioning.create(any(), eq(customZoneId))).then(invocationOnMock -> {
-                    final IdentityProvider<?> idp = invocationOnMock.getArgument(0);
-                    idp.setId(aliasIdpId);
-                    return idp;
-                });
-
-                when(identityProviderProvisioning.update(any(), eq(UAA)))
-                        .then(invocationOnMock -> invocationOnMock.getArgument(0));
-
-                final IdentityProvider<?> result = aliasHandler.ensureConsistencyOfAliasEntity(
-                        requestBody,
-                        existingIdp
-                );
-                assertThat(result.getAliasId()).isEqualTo(aliasIdpId);
-                assertThat(result.getAliasZid()).isEqualTo(customZoneId);
-            }
+            // all tests defined in superclass
         }
 
         @Nested
@@ -204,6 +181,21 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     protected void arrangeZoneDoesNotExist(final String zoneId) {
         when(identityZoneProvisioning.retrieve(zoneId))
                 .thenThrow(new ZoneDoesNotExistsException("zone does not exist"));
+    }
+
+    @Override
+    protected void mockUpdateEntity(final String zoneId) {
+        when(identityProviderProvisioning.update(any(), eq(zoneId)))
+                .then(invocationOnMock -> invocationOnMock.getArgument(0));
+    }
+
+    @Override
+    protected void mockCreateEntity(final String newId, final String zoneId) {
+        when(identityProviderProvisioning.create(any(), eq(customZoneId))).then(invocationOnMock -> {
+            final IdentityProvider<?> idp = invocationOnMock.getArgument(0);
+            idp.setId(newId);
+            return idp;
+        });
     }
 
     @Override

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -45,12 +45,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     @Nested
     class ExistingAlias {
         @Nested
-        class AliasFeatureEnabled extends Base {
-            @Override
-            protected boolean isAliasFeatureEnabled() {
-                return true;
-            }
-
+        class AliasFeatureEnabled extends ExistingAlias_AliasFeatureEnabled {
             @Test
             void shouldPropagateChangesToExistingAlias() {
                 final String aliasIdpId = UUID.randomUUID().toString();
@@ -157,12 +152,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         }
 
         @Nested
-        class AliasFeatureDisabled extends Base {
-            @Override
-            protected boolean isAliasFeatureEnabled() {
-                return false;
-            }
-
+        class AliasFeatureDisabled extends ExistingAlias_AliasFeatureDisabled {
             @Test
             void shouldThrow_IfExistingEntityHasAlias() {
                 final String aliasIdpId = UUID.randomUUID().toString();
@@ -184,12 +174,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     @Nested
     class NoExistingAlias {
         @Nested
-        class AliasFeatureEnabled extends NoExistingAliasBase {
-            @Override
-            protected boolean isAliasFeatureEnabled() {
-                return true;
-            }
-
+        class AliasFeatureEnabled extends NoExistingAlias_AliasFeatureEnabled {
             @Test
             void shouldThrow_WhenAliasZoneDoesNotExist() {
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
@@ -231,11 +216,8 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         }
 
         @Nested
-        class AliasFeatureDisabled extends NoExistingAliasBase {
-            @Override
-            protected boolean isAliasFeatureEnabled() {
-                return false;
-            }
+        class AliasFeatureDisabled extends NoExistingAlias_AliasFeatureDisabled {
+            // all tests defined in superclass
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -1,8 +1,6 @@
 package org.cloudfoundry.identity.uaa.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OIDC10;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.UAA;
 import static org.mockito.ArgumentMatchers.any;
@@ -14,7 +12,6 @@ import static org.mockito.Mockito.when;
 import java.util.Objects;
 import java.util.UUID;
 
-import org.cloudfoundry.identity.uaa.alias.EntityAliasFailedException;
 import org.cloudfoundry.identity.uaa.alias.EntityAliasHandler;
 import org.cloudfoundry.identity.uaa.alias.EntityAliasHandlerEnsureConsistencyTest;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
@@ -78,27 +75,6 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 assertThat(capturedAliasIdp.getId()).isEqualTo(aliasIdpId);
                 assertThat(capturedAliasIdp.getIdentityZoneId()).isEqualTo(customZoneId);
                 assertThat(capturedAliasIdp.getName()).isEqualTo(newName);
-            }
-
-            @Test
-            void shouldThrow_WhenReferencedAliasIdpAndAliasZoneDoesNotExist() {
-                final String aliasIdpId = UUID.randomUUID().toString();
-
-                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
-
-                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
-                final String newName = "some-new-name";
-                originalIdp.setName(newName);
-
-                // dangling reference -> referenced alias IdP not present
-                arrangeEntityDoesNotExist(aliasIdpId, customZoneId);
-
-                // alias zone does not exist
-                arrangeZoneDoesNotExist(customZoneId);
-
-                assertThatExceptionOfType(EntityAliasFailedException.class).isThrownBy(() ->
-                        aliasHandler.ensureConsistencyOfAliasEntity(originalIdp, existingIdp)
-                );
             }
 
             @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -59,11 +59,11 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
                 final String originalIdpId = existingIdp.getId();
 
-                final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
                 final String newName = "some-new-name";
                 originalIdp.setName(newName);
 
-                final IdentityProvider<?> aliasIdp = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> aliasIdp = shallowCloneEntity(existingIdp);
                 aliasIdp.setId(aliasIdpId);
                 aliasIdp.setIdentityZoneId(customZoneId);
                 aliasIdp.setAliasId(originalIdpId);
@@ -93,7 +93,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
 
-                final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
                 final String newName = "some-new-name";
                 originalIdp.setName(newName);
 
@@ -119,7 +119,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 );
                 final String originalIdpId = existingIdp.getId();
 
-                final IdentityProvider<?> requestBody = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> requestBody = shallowCloneEntity(existingIdp);
                 final String newName = "some-new-name";
                 requestBody.setName(newName);
 
@@ -127,7 +127,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 when(identityProviderProvisioning.retrieve(initialAliasIdpId, customZoneId)).thenReturn(null);
 
                 // mock alias IdP creation
-                final IdentityProvider<?> createdAliasIdp = shallowCloneIdp(requestBody);
+                final IdentityProvider<?> createdAliasIdp = shallowCloneEntity(requestBody);
                 final String newAliasIdpId = UUID.randomUUID().toString();
                 createdAliasIdp.setId(newAliasIdpId);
                 createdAliasIdp.setIdentityZoneId(customZoneId);
@@ -170,7 +170,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
 
-                final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
                 originalIdp.setAliasId(null);
                 originalIdp.setAliasZid(null);
                 originalIdp.setName("some-new-name");
@@ -189,7 +189,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
             void shouldIgnore_AliasZidEmptyInOriginalIdp() {
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 
-                final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
                 originalIdp.setName("some-new-name");
 
                 final IdentityProvider<?> result = idpAliasHandler.ensureConsistencyOfAliasEntity(originalIdp, existingIdp);
@@ -208,7 +208,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
             void shouldThrow_WhenAliasZoneDoesNotExist() {
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 
-                final IdentityProvider<?> requestBody = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> requestBody = shallowCloneEntity(existingIdp);
                 requestBody.setAliasZid(customZoneId);
 
                 when(identityZoneProvisioning.retrieve(customZoneId))
@@ -223,7 +223,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
             void shouldCreateNewAliasIdp_WhenAliasZoneExistsAndAliasPropertiesAreSet() {
                 final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 
-                final IdentityProvider<?> requestBody = shallowCloneIdp(existingIdp);
+                final IdentityProvider<?> requestBody = shallowCloneEntity(existingIdp);
                 requestBody.setAliasZid(customZoneId);
 
                 final String aliasIdpId = UUID.randomUUID().toString();
@@ -258,10 +258,9 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         ReflectionTestUtils.setField(idpAliasHandler, "aliasEntitiesEnabled", enabled);
     }
 
-    private static <T extends AbstractIdentityProviderDefinition> IdentityProvider<T> shallowCloneIdp(
-            final IdentityProvider<T> idp
-    ) {
-        final IdentityProvider<T> cloneIdp = new IdentityProvider<>();
+    @Override
+    protected IdentityProvider<?> shallowCloneEntity(final IdentityProvider<?> idp) {
+        final IdentityProvider<AbstractIdentityProviderDefinition> cloneIdp = new IdentityProvider<>();
         cloneIdp.setId(idp.getId());
         cloneIdp.setName(idp.getName());
         cloneIdp.setOriginKey(idp.getOriginKey());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.alias.EntityAliasFailedException;
@@ -281,8 +282,18 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     }
 
     @Override
+    protected void changeNonAliasProperties(final IdentityProvider<?> entity) {
+        entity.setName("some-new-name");
+    }
+
+    @Override
     protected void arrangeZoneDoesNotExist(final String zoneId) {
         when(identityZoneProvisioning.retrieve(zoneId))
                 .thenThrow(new ZoneDoesNotExistsException("zone does not exist"));
+    }
+
+    @Override
+    protected boolean entitiesAreEqual(final IdentityProvider<?> entity1, final IdentityProvider<?> entity2) {
+        return Objects.equals(entity1, entity2);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -183,19 +183,6 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
     @Nested
     class NoExistingAlias {
-        abstract class NoExistingAliasBase extends Base {
-            @Test
-            void shouldIgnore_AliasZidEmptyInOriginalIdp() {
-                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
-
-                final IdentityProvider<?> originalIdp = shallowCloneEntity(existingIdp);
-                originalIdp.setName("some-new-name");
-
-                final IdentityProvider<?> result = aliasHandler.ensureConsistencyOfAliasEntity(originalIdp, existingIdp);
-                assertThat(result).isEqualTo(originalIdp);
-            }
-        }
-
         @Nested
         class AliasFeatureEnabled extends NoExistingAliasBase {
             @Override

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -1,8 +1,8 @@
 package org.cloudfoundry.identity.uaa.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OIDC10;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.UAA;
 import static org.mockito.ArgumentMatchers.any;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -36,8 +36,6 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     private IdentityProviderProvisioning identityProviderProvisioning;
     private IdentityProviderAliasHandler idpAliasHandler;
 
-    private final String customZoneId = UUID.randomUUID().toString();
-
     @BeforeEach
     void setUp() {
         idpAliasHandler = new IdentityProviderAliasHandler(

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 import org.cloudfoundry.identity.uaa.alias.EntityAliasFailedException;
+import org.cloudfoundry.identity.uaa.alias.EntityAliasHandlerEnsureConsistencyTest;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.ZoneDoesNotExistsException;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +29,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
-public class IdentityProviderAliasHandlerEnsureConsistencyTest {
+public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAliasHandlerEnsureConsistencyTest<IdentityProvider<?>> {
     @Mock
     private IdentityZoneProvisioning identityZoneProvisioning;
     @Mock

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -1,8 +1,8 @@
 package org.cloudfoundry.identity.uaa.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OIDC10;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.UAA;
 import static org.mockito.ArgumentMatchers.any;
@@ -55,14 +55,9 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
             @Test
             void shouldPropagateChangesToExistingAlias() {
                 final String aliasIdpId = UUID.randomUUID().toString();
-                final String originalIdpId = UUID.randomUUID().toString();
 
-                final IdentityProvider<?> existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                existingIdp.setId(originalIdpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(aliasIdpId);
-                existingIdp.setAliasZid(customZoneId);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
+                final String originalIdpId = existingIdp.getId();
 
                 final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
                 final String newName = "some-new-name";
@@ -95,14 +90,8 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
             @Test
             void shouldThrow_WhenReferencedAliasIdpAndAliasZoneDoesNotExist() {
                 final String aliasIdpId = UUID.randomUUID().toString();
-                final String originalIdpId = UUID.randomUUID().toString();
 
-                final IdentityProvider<?> existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                existingIdp.setId(originalIdpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(aliasIdpId);
-                existingIdp.setAliasZid(customZoneId);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
 
                 final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
                 final String newName = "some-new-name";
@@ -123,15 +112,12 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
             @Test
             void shouldFixDanglingReferenceByCreatingNewAliasIdp() {
                 final String initialAliasIdpId = UUID.randomUUID().toString();
-                final String originalIdpId = UUID.randomUUID().toString();
 
-                final IdentityProvider existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                existingIdp.setConfig(new OIDCIdentityProviderDefinition());
-                existingIdp.setId(originalIdpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(initialAliasIdpId);
-                existingIdp.setAliasZid(customZoneId);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(
+                        initialAliasIdpId,
+                        customZoneId
+                );
+                final String originalIdpId = existingIdp.getId();
 
                 final IdentityProvider<?> requestBody = shallowCloneIdp(existingIdp);
                 final String newName = "some-new-name";
@@ -180,15 +166,9 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
             @Test
             void shouldThrow_IfExistingEntityHasAlias() {
-                final String idpId = UUID.randomUUID().toString();
                 final String aliasIdpId = UUID.randomUUID().toString();
 
-                final IdentityProvider<?> existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                existingIdp.setId(idpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(aliasIdpId);
-                existingIdp.setAliasZid(customZoneId);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(aliasIdpId, customZoneId);
 
                 final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
                 originalIdp.setAliasId(null);
@@ -207,13 +187,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         abstract class NoExistingAliasBase {
             @Test
             void shouldIgnore_AliasZidEmptyInOriginalIdp() {
-                final IdentityProvider<?> existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                final String idpId = UUID.randomUUID().toString();
-                existingIdp.setId(idpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(null);
-                existingIdp.setAliasZid(null);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 
                 final IdentityProvider<?> originalIdp = shallowCloneIdp(existingIdp);
                 originalIdp.setName("some-new-name");
@@ -232,13 +206,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
             @Test
             void shouldThrow_WhenAliasZoneDoesNotExist() {
-                final IdentityProvider<?> existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                final String idpId = UUID.randomUUID().toString();
-                existingIdp.setId(idpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(null);
-                existingIdp.setAliasZid(null);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 
                 final IdentityProvider<?> requestBody = shallowCloneIdp(existingIdp);
                 requestBody.setAliasZid(customZoneId);
@@ -253,13 +221,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
 
             @Test
             void shouldCreateNewAliasIdp_WhenAliasZoneExistsAndAliasPropertiesAreSet() {
-                final IdentityProvider<?> existingIdp = new IdentityProvider<>();
-                existingIdp.setType(OIDC10);
-                final String idpId = UUID.randomUUID().toString();
-                existingIdp.setId(idpId);
-                existingIdp.setIdentityZoneId(UAA);
-                existingIdp.setAliasId(null);
-                existingIdp.setAliasZid(null);
+                final IdentityProvider<?> existingIdp = buildEntityWithAliasProperties(null, null);
 
                 final IdentityProvider<?> requestBody = shallowCloneIdp(existingIdp);
                 requestBody.setAliasZid(customZoneId);
@@ -313,5 +275,16 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
         cloneIdp.setActive(idp.isActive());
         assertThat(cloneIdp).isEqualTo(idp);
         return cloneIdp;
+    }
+
+    @Override
+    protected IdentityProvider<?> buildEntityWithAliasProperties(final String aliasId, final String aliasZid) {
+        final IdentityProvider<?> existingIdp = new IdentityProvider<>();
+        existingIdp.setType(OIDC10);
+        existingIdp.setId(UUID.randomUUID().toString());
+        existingIdp.setIdentityZoneId(UAA);
+        existingIdp.setAliasId(aliasId);
+        existingIdp.setAliasZid(aliasZid);
+        return existingIdp;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerEnsureConsistencyTest.java
@@ -62,7 +62,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 aliasIdp.setIdentityZoneId(customZoneId);
                 aliasIdp.setAliasId(originalIdpId);
                 aliasIdp.setAliasZid(UAA);
-                when(identityProviderProvisioning.retrieve(aliasIdpId, customZoneId)).thenReturn(aliasIdp);
+                arrangeEntityExists(aliasIdpId, customZoneId, aliasIdp);
 
                 final IdentityProvider<?> result = aliasHandler.ensureConsistencyOfAliasEntity(
                         originalIdp,
@@ -92,7 +92,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 originalIdp.setName(newName);
 
                 // dangling reference -> referenced alias IdP not present
-                when(identityProviderProvisioning.retrieve(aliasIdpId, customZoneId)).thenReturn(null);
+                arrangeEntityDoesNotExist(aliasIdpId, customZoneId);
 
                 // alias zone does not exist
                 arrangeZoneDoesNotExist(customZoneId);
@@ -117,7 +117,7 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
                 requestBody.setName(newName);
 
                 // dangling reference -> referenced alias IdP not present
-                when(identityProviderProvisioning.retrieve(initialAliasIdpId, customZoneId)).thenReturn(null);
+                arrangeEntityDoesNotExist(initialAliasIdpId, customZoneId);
 
                 // mock alias IdP creation
                 final IdentityProvider<?> createdAliasIdp = shallowCloneEntity(requestBody);
@@ -259,6 +259,16 @@ public class IdentityProviderAliasHandlerEnsureConsistencyTest extends EntityAli
     protected void arrangeZoneDoesNotExist(final String zoneId) {
         when(identityZoneProvisioning.retrieve(zoneId))
                 .thenThrow(new ZoneDoesNotExistsException("zone does not exist"));
+    }
+
+    @Override
+    protected void arrangeEntityExists(final String id, final String zoneId, final IdentityProvider<?> entity) {
+        when(identityProviderProvisioning.retrieve(id, zoneId)).thenReturn(entity);
+    }
+
+    @Override
+    protected void arrangeEntityDoesNotExist(final String id, final String zoneId) {
+        when(identityProviderProvisioning.retrieve(id, zoneId)).thenReturn(null);
     }
 
     @Override


### PR DESCRIPTION
see issue #2505 

Preparation for #2769; adds superclass to existing unit test class for IdentityProviderAliasHandler that can be re-used for the ScimUserAliasHandler.