### PR TITLE
Remove direct usage of commons-httpclient 3.1

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -131,7 +131,6 @@ libraries.xmlSecurity = "org.apache.santuario:xmlsec:4.0.2"
 libraries.orgJson = "org.json:json:20240303"
 libraries.owaspEsapi = "org.owasp.esapi:esapi:2.5.3.1"
 libraries.jodaTime = "joda-time:joda-time:2.12.7"
-libraries.commonsHttpClient = "commons-httpclient:commons-httpclient:3.1"
 libraries.apacheHttpClient = "org.apache.httpcomponents:httpclient:4.5.14"
 
 // gradle plugins

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -30,7 +30,6 @@ dependencies {
         exclude(module: "xalan")
     }
     implementation(libraries.jodaTime)
-    implementation(libraries.commonsHttpClient)
     implementation(libraries.xmlSecurity)
     implementation(libraries.springSessionJdbc)
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationFilter.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.provider.oauth;
 
-import org.apache.commons.httpclient.util.URIUtil;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
 import org.cloudfoundry.identity.uaa.login.AccountSavingAuthenticationSuccessHandler;
@@ -92,7 +92,7 @@ public class ExternalOAuthAuthenticationFilter implements Filter {
   private boolean authenticationWasSuccessful(
       final HttpServletRequest request,
       final HttpServletResponse response) throws IOException {
-    final String origin = URIUtil.getName(String.valueOf(request.getRequestURL()));
+    final String origin = FilenameUtils.getName(request.getRequestURI());
     final String code = request.getParameter("code");
     final String idToken = request.getParameter("id_token");
     final String accessToken = request.getParameter("access_token");

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -86,7 +86,9 @@ dependencies {
     testImplementation(libraries.springSessionJdbc)
     testImplementation(libraries.springTest)
     testImplementation(libraries.springSecurityLdap)
-    testImplementation(libraries.springSecuritySaml)
+    testImplementation(libraries.springSecuritySaml) {
+        exclude(module: "commons-httpclient")
+    }
     testImplementation(libraries.springSecurityTest)
     testImplementation(libraries.springBootStarterMail)
     testImplementation(libraries.mockito)
@@ -95,7 +97,6 @@ dependencies {
     testImplementation(libraries.greenmail)
     testImplementation(libraries.jodaTime)
     testImplementation(libraries.commonsIo)
-    testImplementation(libraries.commonsHttpClient)
     testImplementation(libraries.owaspEsapi)
     testImplementation(libraries.apacheHttpClient)
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.identity.uaa.mock.token;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -22,7 +23,6 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.servlet.http.HttpSession;
 
-import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -38,7 +38,6 @@ import org.springframework.security.oauth2.common.exceptions.InvalidTokenExcepti
 import org.springframework.security.oauth2.common.util.OAuth2Utils;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.test.context.TestPropertySource;
@@ -55,12 +54,12 @@ import org.springframework.web.util.UriUtils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.commons.collections4.map.HashedMap;
-import org.apache.commons.httpclient.util.URIUtil;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.login.util.RandomValueStringGenerator;
 import org.cloudfoundry.identity.uaa.mock.util.OAuthToken;
@@ -1542,7 +1541,7 @@ public class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         UriComponents locationComponents = UriComponentsBuilder.fromUri(URI.create(mvcResult.getResponse().getHeader("Location"))).build();
         MultiValueMap<String, String> queryParams = locationComponents.getQueryParams();
-        String errorMessage = URIUtil.encodeQuery("scim.write is invalid. Please use a valid scope name in the request");
+        String errorMessage = UriUtils.encodeQuery("scim.write is invalid. Please use a valid scope name in the request", Charset.defaultCharset());
         assertFalse(queryParams.containsKey("scope"));
         assertEquals(errorMessage, queryParams.getFirst("error_description"));
     }
@@ -1571,7 +1570,7 @@ public class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         UriComponents locationComponents = UriComponentsBuilder.fromUri(URI.create(mvcResult.getResponse().getHeader("Location"))).build();
         MultiValueMap<String, String> queryParams = locationComponents.getQueryParams();
-        String errorMessage = URIUtil.encodeQuery("[something.else] is invalid. This user is not allowed any of the requested scopes");
+        String errorMessage = UriUtils.encodeQuery("[something.else] is invalid. This user is not allowed any of the requested scopes", Charset.defaultCharset());
         assertFalse(queryParams.containsKey("scope"));
         assertEquals(errorMessage, queryParams.getFirst("error_description"));
     }


### PR DESCRIPTION
See details of https://github.com/cloudfoundry/uaa/issues/2691

Sonar
https://sonarcloud.io/summary/new_code?id=cloudfoundry-identity-parent&pullRequest=2826

opensaml and spring-security-saml2 still use it