### PR TITLE
fix: load static resources from default zone if zone not found

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.zone;
 
+import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -36,6 +37,7 @@ import java.util.Set;
 public class IdentityZoneResolvingFilter extends OncePerRequestFilter implements InitializingBean {
 
     private final IdentityZoneProvisioning dao;
+    private final Set<String> staticResources = Set.of("/resources/", "/vendor/font-awesome/");
     private Set<String> defaultZoneHostnames = new HashSet<>();
     private Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -63,7 +65,7 @@ public class IdentityZoneResolvingFilter extends OncePerRequestFilter implements
         }
         if (identityZone == null) {
             // skip filter to static resources in order to serve images and css in case of invalid zones
-            boolean isStaticResource = request.getRequestURI().startsWith("/resources/") || request.getRequestURI().startsWith("/uaa/resources/");
+            boolean isStaticResource = staticResources.stream().anyMatch(UaaUrlUtils.getRequestPath(request)::startsWith);
             if(isStaticResource) {
                 filterChain.doFilter(request, response);
                 return;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
@@ -63,7 +63,7 @@ public class IdentityZoneResolvingFilter extends OncePerRequestFilter implements
         }
         if (identityZone == null) {
             // skip filter to static resources in order to serve images and css in case of invalid zones
-            boolean isStaticResource = request.getRequestURI().startsWith("/uaa/resources/");
+            boolean isStaticResource = request.getRequestURI().startsWith("/resources/") || request.getRequestURI().startsWith("/uaa/resources/");
             if(isStaticResource) {
                 filterChain.doFilter(request, response);
                 return;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
@@ -90,21 +90,25 @@ class IdentityZoneResolvingFilterTests {
 
     @Test
     public void serveStaticContent_InCase_RetrievingZoneFails_local() throws Exception {
-        checkStaticContent("/uaa/resources/css/application.css");
+        checkStaticContent("/uaa", "/resources/css/application.css");
+        checkStaticContent("/uaa", "/vendor/font-awesome/css/font-awesome.min.css");
     }
 
     @Test
     public void serveStaticContent_InCase_RetrievingZoneFails() throws Exception {
-        checkStaticContent("/resources/css/application.css");
+        checkStaticContent(null, "/resources/css/application.css");
+        checkStaticContent(null, "/vendor/font-awesome/css/font-awesome.min.css");
     }
 
-    private void checkStaticContent(String path) throws Exception {
+    private void checkStaticContent(String context, String path) throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         String incomingSubdomain = "not_a_zone";
         String uaaHostname = "uaa.mycf.com";
         String incomingHostname = incomingSubdomain+"."+uaaHostname;
         request.setServerName(incomingHostname);
-        request.setRequestURI(path);
+        request.setRequestURI(context + path);
+        request.setContextPath(context);
+        request.setServletPath(path);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         MockFilterChain filterChain = new MockFilterChain() {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
@@ -89,13 +89,13 @@ class IdentityZoneResolvingFilterTests {
     }
 
     @Test
-    public void serveStaticContent_InCase_RetrievingZoneFails_local() throws Exception {
+    void serveStaticContent_InCase_RetrievingZoneFails_local() throws Exception {
         checkStaticContent("/uaa", "/resources/css/application.css");
         checkStaticContent("/uaa", "/vendor/font-awesome/css/font-awesome.min.css");
     }
 
     @Test
-    public void serveStaticContent_InCase_RetrievingZoneFails() throws Exception {
+    void serveStaticContent_InCase_RetrievingZoneFails() throws Exception {
         checkStaticContent(null, "/resources/css/application.css");
         checkStaticContent(null, "/vendor/font-awesome/css/font-awesome.min.css");
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilterTests.java
@@ -89,13 +89,22 @@ class IdentityZoneResolvingFilterTests {
     }
 
     @Test
+    public void serveStaticContent_InCase_RetrievingZoneFails_local() throws Exception {
+        checkStaticContent("/uaa/resources/css/application.css");
+    }
+
+    @Test
     public void serveStaticContent_InCase_RetrievingZoneFails() throws Exception {
+        checkStaticContent("/resources/css/application.css");
+    }
+
+    private void checkStaticContent(String path) throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
         String incomingSubdomain = "not_a_zone";
         String uaaHostname = "uaa.mycf.com";
         String incomingHostname = incomingSubdomain+"."+uaaHostname;
         request.setServerName(incomingHostname);
-        request.setRequestURI("/uaa/resources/css/application.css");
+        request.setRequestURI(path);
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         MockFilterChain filterChain = new MockFilterChain() {


### PR DESCRIPTION
This was already addressed with #979, but the fix there only works for a local setup. In a typical productive deployment, the path is not starting with /uaa/, so the check need to be adopted to work in both local environment and a deployment.