### PR TITLE
fix: always rotate refresh tokens for public clients

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/refresh/RefreshTokenCreator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/refresh/RefreshTokenCreator.java
@@ -165,8 +165,8 @@ public class RefreshTokenCreator {
         this.timeService = timeService;
     }
 
-    public boolean shouldRotateRefreshTokens() {
-        return getActiveTokenPolicy().isRefreshTokenRotate();
+    public boolean shouldRotateRefreshTokens(String clientAuth) {
+        return getActiveTokenPolicy().isRefreshTokenRotate() || CLIENT_AUTH_NONE.equals(clientAuth);
     }
 
     private Map<String, Object> getRefreshedTokenMap(Claims claims) {
@@ -174,9 +174,9 @@ public class RefreshTokenCreator {
         return claims.getClaimMap();
     }
 
-    public String createRefreshTokenValue(JwtTokenSignedByThisUAA jwtToken, Claims claims) {
+    public String createRefreshTokenValue(JwtTokenSignedByThisUAA jwtToken, Claims claims, String clientAuth) {
         String refreshTokenValue;
-        if (shouldRotateRefreshTokens()) {
+        if (shouldRotateRefreshTokens(clientAuth)) {
             refreshTokenValue = JwtHelper.encode(getRefreshedTokenMap(claims), getActiveKeyInfo()).getEncoded();
         } else {
             refreshTokenValue = jwtToken.getJwt().getEncoded();


### PR DESCRIPTION
When refreshing a token, always rotate for public clients, thus not requiring rotation to be enabled for all clients and preventing the possible error condition for public clients.