### PR TITLE
fix: only convert client auth method root claim

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -491,8 +491,11 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
     private static Map<String, Object> addRootClaimEntry(Map<String, Object> additionalRootClaims, String entry, String value) {
         Map<String, Object> claims = additionalRootClaims != null ? additionalRootClaims : new HashMap<>();
-        // set externally none as client_auth_method if internally empty
-        claims.put(entry, CLIENT_AUTH_EMPTY.equals(value) ? CLIENT_AUTH_NONE : value);
+        if (CLIENT_AUTH_METHOD.equals(entry)) {
+            // set externally none as client_auth_method if internally empty
+            value = CLIENT_AUTH_EMPTY.equals(value) ? CLIENT_AUTH_NONE : value;
+        }
+        claims.put(entry, value);
         return claims;
     }
 


### PR DESCRIPTION
Minor correction to apply the desired conversion from emtpy to none only to the client auth method root claim.