### PR TITLE
fix: generate email if it is the empty string on external login

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
@@ -245,8 +245,8 @@ public class ExternalLoginAuthenticationManager<ExternalAuthenticationDetails> i
             }
         }
 
-        if (email == null) {
-            email = generateEmailIfNull(name);
+        if (StringUtils.isEmpty(email)) {
+            email = generateEmailIfNullOrEmpty(name);
         }
 
         String givenName = null;
@@ -278,7 +278,7 @@ public class ExternalLoginAuthenticationManager<ExternalAuthenticationDetails> i
         return new UaaUser(userPrototype);
     }
 
-    protected String generateEmailIfNull(String name) {
+    protected String generateEmailIfNullOrEmpty(String name) {
         String email;
         if (name != null) {
             if (name.contains("@")) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -380,8 +380,8 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             Object verifiedObj = claims.get(emailVerifiedClaim == null ? "email_verified" : emailVerifiedClaim);
             boolean verified =  verifiedObj instanceof Boolean ? (Boolean)verifiedObj: false;
 
-            if (email == null) {
-                email = generateEmailIfNull(username);
+            if (!StringUtils.hasText(email)) {
+                email = generateEmailIfNullOrEmpty(username);
             }
 
             logger.debug(String.format("Returning user data for username:%s, email:%s", username, email));


### PR DESCRIPTION
If the email is the empty string, treat it as null and generate one.