### PR TITLE
New saml 20240430

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         mavenCentral()
         gradlePluginPortal()
         maven {
+
             url("https://plugins.gradle.org/m2/")
         }
     }
@@ -64,6 +65,15 @@ subprojects {
         exclude(group: "org.apache.directory.server", module: "apacheds-protocol-ldap")
         exclude(group: "org.skyscreamer", module: "jsonassert")
         exclude(group: "com.vaadin.external.google", module: "android-json")
+
+        resolutionStrategy {
+            resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'org.opensaml' && details.requested.name.startsWith("opensaml-")) {
+                    details.useVersion "${versions.opensaml}"
+                    details.because 'Spring Security 5.8.x allows OpenSAML 3 or 4. OpenSAML 3 has reached its end-of-life. Spring Security 6 drops support for 3, using 4.'
+                }
+            }
+        }
     }
 
     dependencies {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -19,7 +19,7 @@ versions.seleniumVersion = "4.18.1"
 versions.braveVersion = "6.0.3"
 versions.jacksonVersion = "2.17.1"
 versions.jsonPathVersion = "2.9.0"
-versions.opensaml = "4.0.1"
+versions.opensaml = "4.0.1" // Spring Security 5.8.x allows OpenSAML 3 or 4. OpenSAML 3 has reached its end-of-life. Spring Security 6 drops support for 3, using 4.
 
 // Versions we're overriding from the Spring Boot Bom (Dependabot does not issue PRs to bump these versions, so we need to manually bump them)
 ext["mariadb.version"] = "2.7.12" // Bumping to v3 breaks some pipeline jobs (and compatibility with Amazon Aurora MySQL), so pinning to v2 for now. v2 (current version) is stable and will be supported until about September 2025 (https://mariadb.com/kb/en/about-mariadb-connector-j/).
@@ -133,9 +133,6 @@ libraries.orgJson = "org.json:json:20240303"
 libraries.owaspEsapi = "org.owasp.esapi:esapi:2.5.3.1"
 libraries.jodaTime = "joda-time:joda-time:2.12.7"
 libraries.apacheHttpClient = "org.apache.httpcomponents:httpclient:4.5.14"
-libraries.opensamlCore = "org.opensaml:opensaml-core:${versions.opensaml}"
-libraries.opensamlApi = "org.opensaml:opensaml-saml-api:${versions.opensaml}"
-libraries.opensamlImpl = "org.opensaml:opensaml-saml-impl:${versions.opensaml}"
 
 // gradle plugins
 libraries.testRetryPlugin = "org.gradle:test-retry-gradle-plugin:1.5.9"

--- a/scripts/kill_uaa.sh
+++ b/scripts/kill_uaa.sh
@@ -1,3 +1,34 @@
 #!/usr/bin/env bash
 
-jps | grep Bootstrap | cut -f 1 -d' ' | xargs kill -HUP 
+# Search for jps command in the following order:
+# 1. jenv
+# 2. JAVA_HOME
+# 3. PATH
+find_jps_command() {
+  if command -v jenv >/dev/null; then
+    echo "$(jenv which jps)"
+  elif [ -n "${JAVA_HOME}" ]; then
+    echo "$JAVA_HOME/bin/jps"
+  elif command -v jps >/dev/null; then
+    echo jps
+  else
+    echo "jps command not found"
+    exit 1
+  fi
+}
+
+function main() {
+  local jps_command
+  jps_command=$(find_jps_command)
+
+  while $jps_command | grep Bootstrap; do
+    $jps_command | grep Bootstrap | cut -f 1 -d' ' | xargs kill -HUP
+    echo "Waiting for Bootstrap to finish"
+    sleep 1
+  done
+
+  $jps_command | grep Bootstrap
+
+}
+
+main "$@"

--- a/scripts/tail_uaa_log
+++ b/scripts/tail_uaa_log
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
 function main() {
-  local port="8080"
+  local port=${PORT:-8080}
   local log_file_path="${TMPDIR}uaa-${port}/logs/uaa.log"
+  local tailArg="${1:--F}"
 
   echo "Tailing log for UAA listening on '${port}':"
-  echo "# tail -F ${log_file_path}"
+  echo "# tail ${tailArg} ${log_file_path}"
   echo ""
 
-  tail -F "${log_file_path}"
+  tail ${tailArg} "${log_file_path}"
 }
 
-main
+main "$@"

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -27,9 +27,6 @@ dependencies {
         exclude(module: "jna")
     }
     implementation(project(":cloudfoundry-identity-statsd-lib"))
-    implementation(libraries.opensamlCore)
-    implementation(libraries.opensamlApi)
-    implementation(libraries.opensamlImpl)
     implementation(libraries.springBootStarter)
     implementation(libraries.springBootStarterWeb)
     implementation(libraries.springSecurityOauth) {


### PR DESCRIPTION
- fix: multiple versions of the opensaml library

> Spring Security 5.8.x allows OpenSAML 3 or 4. OpenSAML 3 has reached its end-of-life. Spring Security 6 drops support for 3, using 4.
> See https://docs.spring.io/spring-security/reference/5.8/migration/servlet/saml2.html#_use_opensaml_4


- allow args to tail_uaa_log
- kill_uaa loops until killed