### PR TITLE
refactor: avoid indirect dep from EOL lib spring-security-saml2-core

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation(libraries.springWeb)
     implementation(libraries.springSecurityCore)
     implementation(libraries.springSecurityWeb)
+    implementation(libraries.springSecurityConfig)
     implementation(libraries.springBootStarterMail)
     implementation(libraries.owaspEsapi) {
         transitive = false


### PR DESCRIPTION
- AuthorizationServerBeanDefinitionParser depends on spring-security-config, which before this commmit comes indirectly from spring-security-saml2-core (which is an EOL lib we will soon replace); hence instead, in this commit, import spring-security-config directly