### PR TITLE
fix: /info docs test expectation

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointDocs.java
@@ -38,6 +38,7 @@ import static org.springframework.restdocs.payload.JsonFieldType.ARRAY;
 import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
 import static org.springframework.restdocs.payload.JsonFieldType.OBJECT;
 import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.JsonFieldType.VARIES;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
@@ -59,7 +60,7 @@ class LoginInfoEndpointDocs extends EndpointDocs {
                 fieldWithPath("commit_id").type(STRING).description("The GIT sha for the UAA version"),
                 fieldWithPath("timestamp").type(STRING).description("JSON timestamp for the commit of the UAA version"),
                 fieldWithPath("idpDefinitions").optional().type(OBJECT).description("A list of alias/url pairs of SAML IDP providers configured. Each url is the starting point to initiate the authentication process for the SAML identity provider."),
-                fieldWithPath("idpDefinitions.*").optional().type(STRING).description("The URL to initiate the authentication process for the SAML identity provider."),
+                fieldWithPath("idpDefinitions.*").optional().type(VARIES).description("The URL to initiate the authentication process for the SAML identity provider."),
                 fieldWithPath("links").type(OBJECT).description("A list of alias/url pairs of configured action URLs for the UAA"),
                 fieldWithPath("links.login").type(STRING).description("The link to the login host alias of the UAA"),
                 fieldWithPath("links.uaa").type(STRING).description("The link to the uaa alias host of the UAA"),

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointDocs.java
@@ -59,7 +59,7 @@ class LoginInfoEndpointDocs extends EndpointDocs {
                 fieldWithPath("commit_id").type(STRING).description("The GIT sha for the UAA version"),
                 fieldWithPath("timestamp").type(STRING).description("JSON timestamp for the commit of the UAA version"),
                 fieldWithPath("idpDefinitions").optional().type(OBJECT).description("A list of alias/url pairs of SAML IDP providers configured. Each url is the starting point to initiate the authentication process for the SAML identity provider."),
-                fieldWithPath("idpDefinitions.*").optional().type(ARRAY).description("A list of alias/url pairs of SAML IDP providers configured. Each url is the starting point to initiate the authentication process for the SAML identity provider."),
+                fieldWithPath("idpDefinitions.*").optional().type(STRING).description("The URL to initiate the authentication process for the SAML identity provider."),
                 fieldWithPath("links").type(OBJECT).description("A list of alias/url pairs of configured action URLs for the UAA"),
                 fieldWithPath("links.login").type(STRING).description("The link to the login host alias of the UAA"),
                 fieldWithPath("links.uaa").type(STRING).description("The link to the uaa alias host of the UAA"),


### PR DESCRIPTION
- the value of "idpDefinitions.*" of /info response is in reality a String, not an array. Here is how it looks like:
```
 "idpDefinitions": {
    "testsaml-redirect-binding": "http://localhost:8080/uaa/saml/discovery?returnIDParam=idp&entityID=cloudfoundry-saml-login&idp=testsaml-redirect-binding&isPassive=true",
    "testsaml-post-binding": "http://localhost:8080/uaa/saml/discovery?returnIDParam=idp&entityID=cloudfoundry-saml-login&idp=testsaml-post-binding&isPassive=true"
  },
```
which is consistent with the description of "idpDefinitions" field: "A list of alias/url pairs of SAML IDP providers configured. Each url is the starting point to initiate the authentication process for the SAML identity provider."

- previously, this test is passing only because the test uaa.yml used in this test contains no IDP configs; but once you input some valid IDP configs, this test would fail since the value is actually a String.

- also clarify the description text