### PR TITLE
fix: allow to delete a relyingPartySecret on IdP

### DIFF
--- a/uaa/slateCustomizations/source/index.html.md.erb
+++ b/uaa/slateCustomizations/source/index.html.md.erb
@@ -1236,6 +1236,45 @@ _Error Codes_
 | 403        | Forbidden - Insufficient scope                                        |
 | 422        | Unprocessable Entity - Invalid config                                 |
 
+## Delete Secret
+
+<aside class="success">
+  Added in UAA 77.10.0
+</aside>
+<br/>
+Delete a secret from the OAuth2 / OIDC IdP configuration only, because these providers support usages without a secret.
+<br/>
+
+<%= render('IdentityProviderEndpointDocs/createOAuthIdentityProviderThenDeleteSecret/curl-request.md') %>
+<%= render('IdentityProviderEndpointDocs/createOAuthIdentityProviderThenDeleteSecret/http-request.md') %>
+<%= render('IdentityProviderEndpointDocs/createOAuthIdentityProviderThenDeleteSecret/http-response.md') %>
+
+_Path Parameters_
+
+<%= render('IdentityProviderEndpointDocs/createOAuthIdentityProviderThenDeleteSecret/path-parameters.md') %>
+
+_Request Headers_
+
+<%= render('IdentityProviderEndpointDocs/createOAuthIdentityProviderThenDeleteSecret/request-headers.md') %>
+
+<aside class="notice">
+  This example is for OAuth2 and OIDC identity providers <br/>
+  For a standard IdP the result of auth_method will be none, because the removal of the secret
+  lead to public flow.<br/>
+  If jwtClientAuthentication section is configured, then after this call, the result of auth_method is private_key_jwt.<br/>
+  If you want set again a secret or change the current secret, please use patch call, e.g. Change Secret<br/>
+</aside>
+
+_Request and Response Fields_
+
+<%= render('IdentityProviderEndpointDocs/createOAuthIdentityProviderThenDeleteSecret/response-fields.md') %>
+
+_Error Codes_
+
+| Error Code | Description                                                           |
+|------------|-----------------------------------------------------------------------|
+| 403        | Forbidden - Insufficient scope                                        |
+| 422        | Unprocessable Entity - Invalid config                                 |
 
 # Users
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -106,7 +106,6 @@ import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.snippet.Attributes;
 import org.springframework.restdocs.snippet.Snippet;
-import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.springframework.test.web.servlet.ResultActions;
 
 class IdentityProviderEndpointDocs extends EndpointDocs {
@@ -1089,6 +1088,25 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
                         responseFields));
 
 
+    }
+
+    @Test
+    void createOAuthIdentityProviderThenDeleteSecret() throws Exception {
+        IdentityProvider identityProvider = identityProviderProvisioning.retrieveByOrigin("my-oauth2-provider", IdentityZoneHolder.get().getId());
+
+        mockMvc.perform(delete("/identity-providers/{id}/secret", identityProvider.getId())
+                .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andDo(document("{ClassName}/{methodName}",
+                preprocessResponse(prettyPrint()),
+                pathParameters(parameterWithName("id").description(ID_DESC)
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("Bearer token containing `zones.<zone id>.admin` or `uaa.admin` or `idps.write` (only in the same zone that you are a user of)"),
+                    IDENTITY_ZONE_ID_HEADER,
+                    IDENTITY_ZONE_SUBDOMAIN_HEADER
+                ),
+                responseFields(getCommonProviderFieldsAnyType())));
     }
 
     @Test


### PR DESCRIPTION
Extract the delete change into an own PR, because this missing method is really a bug / issue in UAA. A UAA operator cannot remove a secret currently, but there are situation where this is needed, e.g. public flows or change to private_key_jwt.

Example to delete a secret, e.g. from DOC:

curl 'http://localhost/identity-providers/ba820e42-7bbf-445a-a241-bb49d61b8512/secret' -i -X DELETE \
    -H 'Authorization: Bearer 8b8a49f6186d4995af427ea59b40e8f8'