### PR TITLE
Identity provider key caching behavior causing lookup conflict

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/common/exceptions/InvalidTokenSignatureException.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/common/exceptions/InvalidTokenSignatureException.java
@@ -1,0 +1,14 @@
+package org.cloudfoundry.identity.uaa.oauth.common.exceptions;
+
+@SuppressWarnings("serial")
+public class InvalidTokenSignatureException extends InvalidTokenException {
+
+	public InvalidTokenSignatureException(String msg, Throwable t) {
+		super(msg, t);
+	}
+
+	public InvalidTokenSignatureException(String msg) {
+		super(msg);
+	}
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/cache/StaleUrlCache.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/cache/StaleUrlCache.java
@@ -49,6 +49,11 @@ public class StaleUrlCache implements UrlContentCache {
         .maximumSize(maxEntries).ticker(ticker).build(new UrlCacheLoader(timeService));
   }
 
+  public void invalidate(String uri, final RestTemplate template, final HttpMethod method,
+                         HttpEntity<?> requestEntity) {
+    cache.invalidate(new UriRequest(uri, template, method, requestEntity));
+  }
+
   @Override
   public byte[] getUrlContent(String uri, final RestTemplate template) {
     return getUrlContent(uri, template, HttpMethod.GET, null);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/cache/UrlContentCache.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/cache/UrlContentCache.java
@@ -42,6 +42,8 @@ public interface UrlContentCache {
      */
     byte[] getUrlContent(String uri, final RestTemplate template, final HttpMethod method, HttpEntity<?> requestEntity);
 
+    void invalidate(String uri, final RestTemplate template, final HttpMethod method, HttpEntity<?> requestEntity);
+
     /**
      * Clears the cache unconditionally
      */

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/InvalidSignatureHashException.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/InvalidSignatureHashException.java
@@ -1,0 +1,14 @@
+package org.cloudfoundry.identity.uaa.oauth;
+
+public class InvalidSignatureHashException extends InvalidSignatureException {
+
+  private static final long serialVersionUID = 5458857726949999613L;
+
+  public InvalidSignatureHashException(String message) {
+    super(message);
+  }
+
+  public InvalidSignatureHashException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtHelper.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtHelper.java
@@ -27,6 +27,7 @@ import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
 import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import org.cloudfoundry.identity.uaa.oauth.InvalidSignatureException;
+import org.cloudfoundry.identity.uaa.oauth.InvalidSignatureHashException;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
@@ -258,7 +259,9 @@ class JwtImpl implements Jwt {
         jwtProcessor.getJWSVerifierFactory().getJCAContext().setProvider(BouncyCastleFIPSProviderSingleton.getInstance());
         try {
             return jwtProcessor.process(jwtAssertion, null);
-        } catch (BadJWSException | BadJWTException jwtException) { // signature failed
+        } catch (BadJWSException jwsException) {
+            throw new InvalidSignatureHashException("Invalid signature hash", jwsException);
+        } catch(BadJWTException jwtException) {
             throw new InvalidSignatureException("Unauthorized token", jwtException);
         } catch (KeyLengthException ke ) {
             return UaaMacSigner.verify(jwtAssertion.getParsedString(), jwkSet);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAA.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAA.java
@@ -26,6 +26,8 @@ import java.util.stream.Collectors;
 import javax.validation.constraints.NotNull;
 
 import com.nimbusds.jwt.JWTClaimsSet;
+import org.cloudfoundry.identity.uaa.oauth.InvalidSignatureHashException;
+import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenSignatureException;
 import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
 import org.cloudfoundry.identity.uaa.oauth.jwt.ChainedSignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.jwt.SignatureVerifier;
@@ -131,6 +133,9 @@ public abstract class JwtTokenSignedByThisUAA {
     public JwtTokenSignedByThisUAA checkSignature(Verifier verifier) {
         try {
             this.tokenJwt.verifySignature(verifier);
+        } catch (InvalidSignatureHashException ex) {
+            logger.debug("Invalid token (signature hash invalid)", ex);
+            throw new InvalidTokenSignatureException("Invalid signature hash.", new UnauthorizedClientException(token));
         } catch (RuntimeException ex) {
             logger.debug("Invalid token (could not verify signature)", ex);
             throw new InvalidTokenException("Could not verify token signature.", new UnauthorizedClientException(token));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -30,6 +30,8 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenException;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.text.ParseException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -184,7 +186,7 @@ public class ExternalOAuthAuthenticationManagerTest {
         throws ParseException, JOSEException {
         oidcConfig.setIssuer(tokenEndpointBuilder.getTokenEndpoint(IdentityZoneHolder.get()));
         expectedException.expect(InvalidTokenException.class);
-        expectedException.expectMessage("Could not verify token signature.");
+        expectedException.expectMessage("Invalid signature hash.");
 
         Map<String, Object> header = map(
                 entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.RS256.getName()),

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcherTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcherTest.java
@@ -128,6 +128,28 @@ class OidcMetadataFetcherTest {
                     any(), any(), any(), any()
                 );
         }
+
+        @Test
+        void shouldInvalidateCacheWhenForceFetch() throws OidcMetadataFetchingException, MalformedURLException {
+            definition.setTokenKeyUrl(new URL("http://should.be.updated"));
+            definition.setSkipSslValidation(false);
+
+            when(urlContentCache.getUrlContent(anyString(), any(RestTemplate.class), any(HttpMethod.class), any(HttpEntity.class)))
+                    .thenReturn("{\"keys\":[{\"alg\":\"RS256\",\"e\":\"e\",\"kid\":\"id\",\"kty\":\"RSA\",\"n\":\"n\"}]}".getBytes());
+
+            metadataDiscoverer.forceFetchWebKeySet(definition);
+            metadataDiscoverer.forceFetchWebKeySet(definition);
+
+            verify(urlContentCache, times(2))
+                    .invalidate(
+                            any(), any(), any(), any()
+                    );
+
+            verify(urlContentCache, times(2))
+                    .getUrlContent(
+                            any(), any(), any(), any()
+                    );
+        }
     }
 
     @Nested

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAATest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAATest.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.identity.uaa.client.InMemoryClientDetailsService;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
+import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenSignatureException;
 import org.cloudfoundry.identity.uaa.oauth.jwt.ChainedSignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.jwt.SignatureVerifier;
 import org.cloudfoundry.identity.uaa.oauth.jwt.UaaMacSigner;
@@ -530,7 +531,7 @@ public class JwtTokenSignedByThisUAATest {
     public void tokenSignedWithDifferentKey() throws KeyLengthException {
         signer = new UaaMacSigner(new SecretKeySpec("some_other_key".getBytes(), "HS256"));
 
-        expectedException.expect(InvalidTokenException.class);
+        expectedException.expect(InvalidTokenSignatureException.class);
 
         buildAccessTokenValidator(getToken(), new KeyInfoService("https://localhost"))
                 .checkSignature(verifier);


### PR DESCRIPTION
Problem:
UAA caches the key from Identity provider. The default cache eviction time is 10 minutes. When the Identity provider changes the key, the UAA may end up with stale key in the cache. All the token validations will fail during stale key period.

Resolution:
In case of signature validation failure, invalidate the cache and retrieve the latest/current key from Identity Provider and use it for validation. This behaviour is applicable for all signature validation failure.

Another potential solution considered:
Provide an endpoint or update existing endpoint that enables Identity provider to trigger cache invalidation upon key change.

Testing done:
Unit test and IT added
Manual testing done by deploying a UAA and an Idenity provider.