### PR TITLE
 Fix issue #2917

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/ExternalLoginAuthenticationManager.java
@@ -137,7 +137,7 @@ public class ExternalLoginAuthenticationManager<ExternalAuthenticationDetails> i
             if (!isAddNewShadowUser()) {
                 throw new AccountNotPreCreatedException("The user account must be pre-created. Please contact your system administrator.");
             }
-            publish(new NewUserAuthenticatedEvent(userFromRequest));
+            publish(new NewUserAuthenticatedEvent(userFromRequest.authorities(List.of())));
             try {
                 userFromDb = userDatabase.retrieveUserByName(userFromRequest.getUsername(), getOrigin());
             } catch (UsernameNotFoundException ex) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUser.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/user/UaaUser.java
@@ -229,7 +229,7 @@ public class UaaUser {
         if (!values.contains(UaaAuthority.UAA_USER)) {
             values.add(UaaAuthority.UAA_USER);
         }
-        return new UaaUser(id, username, getPassword(), email, values, givenName, familyName, created, modified, origin, externalId, verified, zoneId, salt, passwordLastModified);
+        return new UaaUser(new UaaUserPrototype(this).withAuthorities(values));
     }
 
     @Override

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -355,6 +355,7 @@ public class OIDCLoginIT {
 
         ScimGroup updatedCreatedGroup = IntegrationTestUtils.getGroup(adminToken, subdomain, baseUrl, createdGroup.getDisplayName());
         assertTrue(isMember(user.getId(), updatedCreatedGroup));
+        assertTrue("Expect group members to have origin: " + user.getOrigin(), updatedCreatedGroup.getMembers().stream().allMatch(p -> user.getOrigin().equals(p.getOrigin())));
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -865,8 +865,11 @@ public class SamlLoginIT {
         String samlUserId = IntegrationTestUtils.getUserId(adminTokenInZone, zoneUrl, provider.getOriginKey(), MARISSA4_EMAIL);
         uaaSamlUserGroup = IntegrationTestUtils.getGroup(adminTokenInZone, null, zoneUrl, "uaa.saml.user");
         uaaSamlAdminGroup = IntegrationTestUtils.getGroup(adminTokenInZone, null, zoneUrl, "uaa.saml.admin");
+        IdentityProvider<SamlIdentityProviderDefinition> finalProvider = provider;
         assertTrue(isMember(samlUserId, uaaSamlUserGroup));
+        assertTrue("Expect saml user members to have origin: " + finalProvider.getOriginKey(), uaaSamlUserGroup.getMembers().stream().allMatch(p -> finalProvider.getOriginKey().equals(p.getOrigin())));
         assertTrue(isMember(samlUserId, uaaSamlAdminGroup));
+        assertTrue("Expect admin members to have origin: " + finalProvider.getOriginKey(), uaaSamlAdminGroup.getMembers().stream().allMatch(p -> finalProvider.getOriginKey().equals(p.getOrigin())));
 
     }
 


### PR DESCRIPTION
Perform shadow user creation (NewUserAuthenticatedEvent)
without authorities creation, but rely on event
ExternalGroupAuthorizationEvent later.

Includes: IT for testing a fix of issue https://github.com/cloudfoundry/uaa/issues/2917