### PR TITLE
fix: bearer token in oauth2 UserInfo flow

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -598,7 +598,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             RawExternalOAuthIdentityProviderDefinition narrowedConfig = (RawExternalOAuthIdentityProviderDefinition) config;
 
             HttpHeaders headers = new HttpHeaders();
-            headers.add("Authorization", "token " + idToken);
+            headers.add("Authorization", "Bearer " + idToken);
             headers.add("Accept", "application/json");
 
             URI requestUri;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
@@ -34,8 +34,6 @@ import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationM
 import org.cloudfoundry.identity.uaa.util.TimeServiceImpl;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -137,7 +135,7 @@ public class ExternalOAuthAuthenticationManagerGithubTest {
         mockGithubServer.expect(method(GET))
             .andExpect(requestTo(USER_INFO_URL))
             .andExpect(header(ACCEPT, APPLICATION_JSON_VALUE))
-            .andExpect(header(AUTHORIZATION, "token " + accessToken))
+            .andExpect(header(AUTHORIZATION, "Bearer " + accessToken))
             .andRespond(withSuccess(userInfoResponse, APPLICATION_JSON));
         
         ExternalOAuthCodeToken oauth2Authentication = new ExternalOAuthCodeToken(null, origin, "http://uaa.example.com/login/callback/github", idToken, "accesstoken", "signedrequest");


### PR DESCRIPTION
With that Github (created the userinfo lookup) and other OAuth2 server are compliant

Github: https://docs.github.com/en/rest/users/users ( https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28 )
OAuth2: https://www.oauth.com/oauth2-servers/signing-in-with-google/verifying-the-user-info/

Example
https://github.com/cloudfoundry/uaa/blob/develop/docs/github-oauth2-provider.md