### PR TITLE
Refactor: Load UserConfig as bean

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityProviderBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityProviderBootstrap.java
@@ -13,7 +13,6 @@
 package org.cloudfoundry.identity.uaa.impl.config;
 
 
-import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
@@ -23,10 +23,9 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneValidator;
 import org.cloudfoundry.identity.uaa.zone.InvalidIdentityZoneDetailsException;
 import org.cloudfoundry.identity.uaa.zone.TokenPolicy;
+import org.cloudfoundry.identity.uaa.zone.UserConfig;
 import org.springframework.beans.factory.InitializingBean;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -63,9 +62,7 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
 
     private boolean accountChooserEnabled;
 
-    private Collection<String> defaultUserGroups;
-
-    private Collection<String> allowedUserGroups;
+    private UserConfig defaultUserConfig;
 
     private IdentityZoneValidator validator = (config, mode) -> config;
     private Map<String, Object> branding;
@@ -92,6 +89,7 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         definition.setIdpDiscoveryEnabled(idpDiscoveryEnabled);
         definition.setAccountChooserEnabled(accountChooserEnabled);
         definition.setDefaultIdentityProvider(defaultIdentityProvider);
+        definition.setUserConfig(defaultUserConfig);
 
         samlKeys = ofNullable(samlKeys).orElse(EMPTY_MAP);
         for (Map.Entry<String, Map<String,String>> entry : samlKeys.entrySet()) {
@@ -126,14 +124,6 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
 
         BrandingInformation brandingInfo = JsonUtils.convertValue(branding, BrandingInformation.class);
         definition.setBranding(brandingInfo);
-
-        if (defaultUserGroups!=null) {
-            definition.getUserConfig().setDefaultGroups(new LinkedList<>(defaultUserGroups));
-        }
-
-        if (allowedUserGroups!=null) {
-            definition.getUserConfig().setAllowedGroups(new LinkedList<>(allowedUserGroups));
-        }
 
         identityZone.setConfig(definition);
 
@@ -235,19 +225,15 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         return branding;
     }
 
-    public void setDefaultUserGroups(Collection<String> defaultUserGroups) {
-        this.defaultUserGroups = defaultUserGroups;
-    }
-
-    public void setAllowedUserGroups(Collection<String> allowedUserGroups) {
-        this.allowedUserGroups = allowedUserGroups;
-    }
-
     public boolean isDisableSamlInResponseToCheck() {
         return disableSamlInResponseToCheck;
     }
 
     public void setDisableSamlInResponseToCheck(boolean disableSamlInResponseToCheck) {
         this.disableSamlInResponseToCheck = disableSamlInResponseToCheck;
+    }
+
+    public void setDefaultUserConfig(final UserConfig defaultUserConfig) {
+        this.defaultUserConfig = defaultUserConfig;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -16,6 +16,7 @@ import org.cloudfoundry.identity.uaa.zone.InvalidIdentityZoneDetailsException;
 import org.cloudfoundry.identity.uaa.zone.JdbcIdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.SamlConfig;
 import org.cloudfoundry.identity.uaa.zone.TokenPolicy;
+import org.cloudfoundry.identity.uaa.zone.UserConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -167,8 +168,10 @@ public class IdentityZoneConfigurationBootstrapTests {
 
     @Test
     void testDefaultGroups() throws Exception {
+        UserConfig defaultUserConfig = new UserConfig();
         String[] groups = {"group1", "group2", "group3"};
-        bootstrap.setDefaultUserGroups(Arrays.asList(groups));
+        defaultUserConfig.setDefaultGroups(Arrays.asList(groups));
+        bootstrap.setDefaultUserConfig(defaultUserConfig);
         bootstrap.afterPropertiesSet();
         IdentityZone uaa = provisioning.retrieve(IdentityZone.getUaaZoneId());
         assertThat(uaa.getConfig().getUserConfig().getDefaultGroups(), containsInAnyOrder(groups));
@@ -176,9 +179,11 @@ public class IdentityZoneConfigurationBootstrapTests {
 
     @Test
     void testAllowedGroups() throws Exception {
+        UserConfig defaultUserConfig = new UserConfig();
         String[] groups = {"group1", "group2", "group3"};
-        bootstrap.setDefaultUserGroups(Arrays.asList(groups));
-        bootstrap.setAllowedUserGroups(Arrays.asList(groups));
+        defaultUserConfig.setDefaultGroups(Arrays.asList(groups));
+        defaultUserConfig.setAllowedGroups(Arrays.asList(groups));
+        bootstrap.setDefaultUserConfig(defaultUserConfig);
         bootstrap.afterPropertiesSet();
         IdentityZone uaa = provisioning.retrieve(IdentityZone.getUaaZoneId());
         assertThat(uaa.getConfig().getUserConfig().resultingAllowedGroups(), containsInAnyOrder(groups));

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -453,6 +453,13 @@
 
     <bean id="oauthIdpDefinitions" factory-bean="oauthIdpConfigurator" factory-method="getProviders"/>
 
+    <bean id="defaultUserConfig" class="org.cloudfoundry.identity.uaa.zone.UserConfig">
+        <property name="defaultGroups" ref="defaultUserAuthorities"/>
+        <property name="allowedGroups" value="${login.allowedGroups:#{null}}"/>
+        <property name="checkOriginEnabled" value="${login.checkOriginEnabled:false}"/>
+        <property name="maxUsers" value="${login.maxUsers:-1}"/>
+    </bean>
+
     <bean id="identityZoneConfigurationBootstrap"
           class="org.cloudfoundry.identity.uaa.impl.config.IdentityZoneConfigurationBootstrap">
         <property name="validator" ref="identityZoneValidator"/>
@@ -482,7 +489,7 @@
                            @config['login']['saml']==null ? null :
                            @config['login']['saml']['keys']}"/>
         <property name="disableSamlInResponseToCheck" value="${login.saml.disableInResponseToCheck:false}"/>
-        <property name="defaultUserGroups" ref="defaultUserAuthorities"/>
+        <property name="defaultUserConfig" ref="defaultUserConfig"/>
         <property name="defaultIdentityProvider" value="${login.defaultIdentityProvider:#{null}}"/>
     </bean>
 


### PR DESCRIPTION
Goal: identityZoneConfigurationBootstrap should not get to many attributes, but load the user config itself and allow there to have extra options

Example: login.checkOriginEnabled is not yet possible to set in CF global because it is / was hidden in the identityZoneConfigurationBootstrap bean. With UserConfig bean allow all options to be configured.

Open: uaa-release should be adopted as well