### PR TITLE
Fix Version Handling during Update of User with Alias

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimUserAliasHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimUserAliasHandler.java
@@ -61,6 +61,9 @@ public class ScimUserAliasHandler extends EntityAliasHandler<ScimUser> {
         newAliasEntity.setPasswordLastModified(existingAliasEntity.getPasswordLastModified());
         newAliasEntity.setLastLogonTime(existingAliasEntity.getLastLogonTime());
         newAliasEntity.setPreviousLogonTime(existingAliasEntity.getPreviousLogonTime());
+
+        // the version field might differ between the original user and its alias -> use value of existing alias
+        newAliasEntity.setVersion(existingAliasEntity.getVersion());
     }
 
     private Optional<IdentityProvider<?>> retrieveIdpByOrigin(final String originKey, final String zoneId) {


### PR DESCRIPTION
During testing of the alias feature, we discovered that subsequent updates of users with an alias will fail because the version field is not handled correctly. When building the alias entity for the "original" user, the version property is not set and therefore treated as zero. However, when the alias entity was updated previously, its version field is no longer zero and the alias update fails.