### PR TITLE
fix: Integration test bootstrap fixed

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestAccountSetup.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestAccountSetup.java
@@ -91,6 +91,8 @@ public class TestAccountSetup extends TestWatchman {
         return user;
     }
 
+    public UaaTestAccounts getTestAccounts() { return testAccounts; }
+
     private void initializeIfNecessary(FrameworkMethod method, Object target) {
         OAuth2ProtectedResourceDetails resource = testAccounts.getAdminClientCredentialsResource();
         OAuth2RestTemplate client = createRestTemplate(resource, new DefaultAccessTokenRequest());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CfScimUserEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CfScimUserEndpointIntegrationTests.java
@@ -64,7 +64,7 @@ public class CfScimUserEndpointIntegrationTests {
     public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     @BeforeOAuth2Context
     @OAuth2ContextConfiguration(OAuth2ContextConfiguration.ClientCredentials.class)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CfUserIdTranslationEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CfUserIdTranslationEndpointIntegrationTests.java
@@ -64,7 +64,7 @@ public class CfUserIdTranslationEndpointIntegrationTests {
     public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     @BeforeOAuth2Context
     @OAuth2ContextConfiguration(OAuth2ContextConfiguration.ClientCredentials.class)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/IdentityZoneEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/IdentityZoneEndpointsIntegrationTests.java
@@ -55,10 +55,10 @@ public class IdentityZoneEndpointsIntegrationTests {
     private UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.standard(serverRunning);
+    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     private RestTemplate client;
     private String zoneId;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/LoginServerSecurityIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/LoginServerSecurityIntegrationTests.java
@@ -80,7 +80,7 @@ public class LoginServerSecurityIntegrationTests {
     public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     private MultiValueMap<String, String> params = new LinkedMultiValueMap<String, String>();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OpenIdTokenAuthorizationWithApprovalIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OpenIdTokenAuthorizationWithApprovalIntegrationTests.java
@@ -67,10 +67,10 @@ public class OpenIdTokenAuthorizationWithApprovalIntegrationTests {
     private UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     private RestTemplate client;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/PasswordChangeEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/PasswordChangeEndpointIntegrationTests.java
@@ -62,7 +62,7 @@ public class PasswordChangeEndpointIntegrationTests {
     public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     private RestOperations client;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimGroupEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimGroupEndpointsIntegrationTests.java
@@ -92,10 +92,11 @@ public class ScimGroupEndpointsIntegrationTests {
     private UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
+
 
     private RestTemplate client;
     private List<ScimGroup> scimGroups;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimUserEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimUserEndpointsIntegrationTests.java
@@ -63,11 +63,12 @@ public class ScimUserEndpointsIntegrationTests {
 
     private UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
-    @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
 
     @Rule
     public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+
+    @Rule
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     private RestTemplate client;
     private List<ScimUser> scimUsers;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/UserInfoEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/UserInfoEndpointIntegrationTests.java
@@ -40,10 +40,10 @@ public class UserInfoEndpointIntegrationTests {
     private UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     /**
      * tests a happy-day flow of the <code>/userinfo</code> endpoint

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/AppApprovalIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/AppApprovalIT.java
@@ -55,10 +55,10 @@ public class AppApprovalIT {
     UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     public RestOperations restTemplate;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SessionLossDuringOauthFlowIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SessionLossDuringOauthFlowIT.java
@@ -54,10 +54,10 @@ public class SessionLossDuringOauthFlowIT {
     UaaTestAccounts testAccounts = UaaTestAccounts.standard(serverRunning);
 
     @Rule
-    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccounts);
+    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
 
     @Rule
-    public TestAccountSetup testAccountSetup = TestAccountSetup.standard(serverRunning, testAccounts);
+    public OAuth2ContextSetup context = OAuth2ContextSetup.withTestAccounts(serverRunning, testAccountSetup);
 
     public RestOperations restTemplate;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/test/OAuth2ContextSetup.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/test/OAuth2ContextSetup.java
@@ -16,6 +16,7 @@ import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.token.AccessTokenProvider;
 import org.cloudfoundry.identity.uaa.oauth.token.AccessTokenRequest;
 import org.cloudfoundry.identity.uaa.oauth.token.DefaultAccessTokenRequest;
+import org.cloudfoundry.identity.uaa.test.TestAccountSetup;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.internal.AssumptionViolatedException;
@@ -64,6 +65,7 @@ public class OAuth2ContextSetup extends TestWatchman {
 	private final RestTemplateHolder clientHolder;
 
 	private final TestAccounts testAccounts;
+	private final TestAccountSetup testAccountSetup;
 
 	private OAuth2AccessToken accessToken;
 
@@ -102,8 +104,8 @@ public class OAuth2ContextSetup extends TestWatchman {
 	 * @return a rule that wraps test methods in an OAuth2 context
 	 */
 	public static OAuth2ContextSetup withTestAccounts(RestTemplateHolder clientHolder,
-			TestAccounts testAccounts) {
-		return new OAuth2ContextSetup(clientHolder, testAccounts, null);
+			TestAccountSetup testAccountSetup) {
+		return new OAuth2ContextSetup(clientHolder, testAccountSetup, null);
 	}
 
 	/**
@@ -130,9 +132,10 @@ public class OAuth2ContextSetup extends TestWatchman {
 	}
 
 	private OAuth2ContextSetup(RestTemplateHolder clientHolder,
-			TestAccounts testAccounts, Environment environment) {
+			TestAccountSetup testAccountSetup, Environment environment) {
 		this.clientHolder = clientHolder;
-		this.testAccounts = testAccounts;
+		this.testAccountSetup = testAccountSetup;
+		this.testAccounts = testAccountSetup.getTestAccounts();
 		this.environment = environment;
 	}
 
@@ -237,6 +240,8 @@ public class OAuth2ContextSetup extends TestWatchman {
 	}
 
 	private void initializeIfNecessary(FrameworkMethod method, final Object target) {
+
+		testAccountSetup.apply(null, method, target);
 
 		final TestClass testClass = new TestClass(target.getClass());
 		OAuth2ContextConfiguration contextConfiguration = findOAuthContextConfiguration(


### PR DESCRIPTION
These tests need a bootstraping which is not in the test itself but externally. This means, these tests cannot be executed standalone, which is bad. If another test runs before, then these tests can run as well, therefore it has not been found before. Normally we run all tests in a suite.

Found the issue, when running LoginServerSecurityIntegrationTests standalone .... because this is the failing test from SAML refactoring