### PR TITLE
Fix regression in identity-provider endpoint

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderEndpoints.java
@@ -223,7 +223,7 @@ public class IdentityProviderEndpoints implements ApplicationEventPublisherAware
             SamlIdentityProviderDefinition definition = ObjectUtils.castInstance(body.getConfig(), SamlIdentityProviderDefinition.class);
             definition.setZoneId(zoneId);
             definition.setIdpEntityAlias(body.getOriginKey());
-            samlConfigurator.validateSamlIdentityProviderDefinition(definition, false);
+            definition.setIdpEntityId(samlConfigurator.validateSamlIdentityProviderDefinition(definition, false));
             body.setConfig(definition);
         }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.provider;
 
 import static java.sql.Types.VARCHAR;
+import static org.cloudfoundry.identity.uaa.util.UaaStringUtils.isNotEmpty;
 
 import org.cloudfoundry.identity.uaa.audit.event.SystemDeletable;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -218,15 +219,21 @@ public class JdbcIdentityProviderProvisioning implements IdentityProviderProvisi
                 switch (identityProvider.getType()) {
                     case OriginKeys.SAML:
                         definition = JsonUtils.readValue(config, SamlIdentityProviderDefinition.class);
-                        Optional.ofNullable(definition).map(SamlIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIdpEntityId(externId));
+                        if (isNotEmpty(externId)) {
+                            Optional.ofNullable(definition).map(SamlIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIdpEntityId(externId));
+                        }
                         break;
                     case OriginKeys.OAUTH20:
                         definition = JsonUtils.readValue(config, RawExternalOAuthIdentityProviderDefinition.class);
-                        Optional.ofNullable(definition).map(RawExternalOAuthIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externId));
+                        if (isNotEmpty(externId)) {
+                            Optional.ofNullable(definition).map(RawExternalOAuthIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externId));
+                        }
                         break;
                     case OriginKeys.OIDC10:
                         definition = JsonUtils.readValue(config, OIDCIdentityProviderDefinition.class);
-                        Optional.ofNullable(definition).map(OIDCIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externId));
+                        if (isNotEmpty(externId)) {
+                            Optional.ofNullable(definition).map(OIDCIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externId));
+                        }
                         break;
                     case OriginKeys.UAA:
                         definition = JsonUtils.readValue(config, UaaIdentityProviderDefinition.class);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
@@ -167,18 +167,22 @@ public class JdbcIdentityProviderProvisioning implements IdentityProviderProvisi
         if (!StringUtils.hasText(provider.getIdentityZoneId())) {
             throw new DataIntegrityViolationException("Identity zone ID must be set.");
         }
-        String externId = null;
+        String externalKey = null;
         //ensure that SAML IDPs have redundant fields synchronized
         if (OriginKeys.SAML.equals(provider.getType()) && provider.getConfig() != null) {
             SamlIdentityProviderDefinition saml = ObjectUtils.castInstance(provider.getConfig(), SamlIdentityProviderDefinition.class);
             saml.setIdpEntityAlias(provider.getOriginKey());
             saml.setZoneId(provider.getIdentityZoneId());
             provider.setConfig(saml);
-            externId = saml.getIdpEntityId();
+            externalKey = saml.getIdpEntityId();
         } else if (provider.getConfig() instanceof AbstractExternalOAuthIdentityProviderDefinition<?> externalOAuthIdentityProviderDefinition) {
-            externId = externalOAuthIdentityProviderDefinition.getIssuer();
+            if (isNotEmpty(externalOAuthIdentityProviderDefinition.getIssuer())) {
+                externalKey = externalOAuthIdentityProviderDefinition.getIssuer();
+            } else {
+                externalKey = externalOAuthIdentityProviderDefinition.getTokenUrl().toString();
+            }
         }
-        return externId;
+        return externalKey;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
@@ -176,11 +176,7 @@ public class JdbcIdentityProviderProvisioning implements IdentityProviderProvisi
             provider.setConfig(saml);
             externalKey = saml.getIdpEntityId();
         } else if (provider.getConfig() instanceof AbstractExternalOAuthIdentityProviderDefinition<?> externalOAuthIdentityProviderDefinition) {
-            if (isNotEmpty(externalOAuthIdentityProviderDefinition.getIssuer())) {
-                externalKey = externalOAuthIdentityProviderDefinition.getIssuer();
-            } else {
-                externalKey = externalOAuthIdentityProviderDefinition.getTokenUrl().toString();
-            }
+            externalKey = externalOAuthIdentityProviderDefinition.getIssuer();
         }
         return externalKey;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioning.java
@@ -213,26 +213,26 @@ public class JdbcIdentityProviderProvisioning implements IdentityProviderProvisi
             identityProvider.setActive(rs.getBoolean(pos++));
             identityProvider.setAliasId(rs.getString(pos++));
             identityProvider.setAliasZid(rs.getString(pos++));
-            String externId = rs.getString(pos);
+            String externalKey = rs.getString(pos);
             if (StringUtils.hasText(config)) {
                 AbstractIdentityProviderDefinition definition;
                 switch (identityProvider.getType()) {
                     case OriginKeys.SAML:
                         definition = JsonUtils.readValue(config, SamlIdentityProviderDefinition.class);
-                        if (isNotEmpty(externId)) {
-                            Optional.ofNullable(definition).map(SamlIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIdpEntityId(externId));
+                        if (isNotEmpty(externalKey)) {
+                            Optional.ofNullable(definition).map(SamlIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIdpEntityId(externalKey));
                         }
                         break;
                     case OriginKeys.OAUTH20:
                         definition = JsonUtils.readValue(config, RawExternalOAuthIdentityProviderDefinition.class);
-                        if (isNotEmpty(externId)) {
-                            Optional.ofNullable(definition).map(RawExternalOAuthIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externId));
+                        if (isNotEmpty(externalKey)) {
+                            Optional.ofNullable(definition).map(RawExternalOAuthIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externalKey));
                         }
                         break;
                     case OriginKeys.OIDC10:
                         definition = JsonUtils.readValue(config, OIDCIdentityProviderDefinition.class);
-                        if (isNotEmpty(externId)) {
-                            Optional.ofNullable(definition).map(OIDCIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externId));
+                        if (isNotEmpty(externalKey)) {
+                            Optional.ofNullable(definition).map(OIDCIdentityProviderDefinition.class::cast).ifPresent(e -> e.setIssuer(externalKey));
                         }
                         break;
                     case OriginKeys.UAA:

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioningTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioningTests.java
@@ -16,6 +16,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -219,12 +221,12 @@ class JdbcIdentityProviderProvisioningTests {
     }
 
     @Test
-    void retrieveOAuth2IdentityProviderWithoutExternalId() {
-        String issuerURI = "https://oauth2.issuer.domain.org";
+    void retrieveOAuth2IdentityProviderWithoutExternalId() throws MalformedURLException {
+        String tokenEndPointUrl = "https://oauth2.issuer.domain.org";
         IdentityProvider<RawExternalOAuthIdentityProviderDefinition> idp = MultitenancyFixture.identityProvider(origin, uaaZoneId);
         String providerDescription = "Test Description";
         RawExternalOAuthIdentityProviderDefinition rawExternalOAuthIdentityProviderDefinition = new RawExternalOAuthIdentityProviderDefinition();
-        rawExternalOAuthIdentityProviderDefinition.setIssuer(issuerURI);
+        rawExternalOAuthIdentityProviderDefinition.setTokenUrl(URI.create(tokenEndPointUrl).toURL());
         idp.setConfig(rawExternalOAuthIdentityProviderDefinition);
         idp.getConfig().setProviderDescription(providerDescription);
         idp.setType(OAUTH20);
@@ -237,7 +239,9 @@ class JdbcIdentityProviderProvisioningTests {
         assertEquals(idp.getType(), readAgain.getType());
         assertEquals(providerDescription, readAgain.getConfig().getProviderDescription());
         RawExternalOAuthIdentityProviderDefinition readAgainConfig = (RawExternalOAuthIdentityProviderDefinition) readAgain.getConfig();
-        assertEquals(issuerURI, readAgainConfig.getIssuer());
+        assertNotNull(tokenEndPointUrl, readAgainConfig.getTokenUrl().toString());
+        // oauth2 allows to omit issuer, but tokenEncPointUrl is used then for check, e.g. checkIssuer in JwtTokenSignedByThisUAA
+        assertNull(readAgainConfig.getIssuer());
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioningTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioningTests.java
@@ -16,8 +16,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
@@ -221,12 +219,12 @@ class JdbcIdentityProviderProvisioningTests {
     }
 
     @Test
-    void retrieveOAuth2IdentityProviderWithoutExternalId() throws MalformedURLException {
-        String tokenEndPointUrl = "https://oauth2.issuer.domain.org";
+    void retrieveOAuth2IdentityProviderWithoutExternalId() {
+        String issuerURI = "https://oauth2.issuer.domain.org";
         IdentityProvider<RawExternalOAuthIdentityProviderDefinition> idp = MultitenancyFixture.identityProvider(origin, uaaZoneId);
         String providerDescription = "Test Description";
         RawExternalOAuthIdentityProviderDefinition rawExternalOAuthIdentityProviderDefinition = new RawExternalOAuthIdentityProviderDefinition();
-        rawExternalOAuthIdentityProviderDefinition.setTokenUrl(URI.create(tokenEndPointUrl).toURL());
+        rawExternalOAuthIdentityProviderDefinition.setIssuer(issuerURI);
         idp.setConfig(rawExternalOAuthIdentityProviderDefinition);
         idp.getConfig().setProviderDescription(providerDescription);
         idp.setType(OAUTH20);
@@ -239,9 +237,7 @@ class JdbcIdentityProviderProvisioningTests {
         assertEquals(idp.getType(), readAgain.getType());
         assertEquals(providerDescription, readAgain.getConfig().getProviderDescription());
         RawExternalOAuthIdentityProviderDefinition readAgainConfig = (RawExternalOAuthIdentityProviderDefinition) readAgain.getConfig();
-        assertNotNull(tokenEndPointUrl, readAgainConfig.getTokenUrl().toString());
-        // OAuth2 allows to omit issuer, but tokenEncPointUrl is used then for check, e.g. checkIssuer in JwtTokenSignedByThisUAA
-        assertNull(readAgainConfig.getIssuer());
+        assertEquals(issuerURI, readAgainConfig.getIssuer());
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioningTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/JdbcIdentityProviderProvisioningTests.java
@@ -240,7 +240,7 @@ class JdbcIdentityProviderProvisioningTests {
         assertEquals(providerDescription, readAgain.getConfig().getProviderDescription());
         RawExternalOAuthIdentityProviderDefinition readAgainConfig = (RawExternalOAuthIdentityProviderDefinition) readAgain.getConfig();
         assertNotNull(tokenEndPointUrl, readAgainConfig.getTokenUrl().toString());
-        // oauth2 allows to omit issuer, but tokenEncPointUrl is used then for check, e.g. checkIssuer in JwtTokenSignedByThisUAA
+        // OAuth2 allows to omit issuer, but tokenEncPointUrl is used then for check, e.g. checkIssuer in JwtTokenSignedByThisUAA
         assertNull(readAgainConfig.getIssuer());
     }
 


### PR DESCRIPTION
Issue:
If existing entries in identity-provider with new external_key the field is null, which is expected. If external_key is null, this must not overwrite the issuer in rest endpoint, but it does

For SAML there is no issue, because here the entityId is really new in REST output and in DB. For OIDC and OAuth2 the issuer was used in REST already and there was no check before overwrite it from external_key.