### PR TITLE
Fix Alias Validation when no Identity Zone ID is set in the Request Body

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandler.java
@@ -33,6 +33,10 @@ public abstract class EntityAliasHandler<T extends EntityWithAlias> {
             @NonNull final T requestBody,
             @Nullable final T existingEntity
     ) {
+        if (!hasText(requestBody.getZoneId())) {
+            throw new IllegalArgumentException("The zone ID of the request body must not be empty.");
+        }
+
         // if the entity already has an alias, the alias properties must not be changed
         final boolean entityAlreadyHasAlias = existingEntity != null && hasText(existingEntity.getAliasZid());
         if (entityAlreadyHasAlias) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
@@ -317,6 +317,8 @@ public class ScimUserEndpoints implements InitializingBean, ApplicationEventPubl
         int version = getVersion(userId, etag);
         user.setVersion(version);
 
+        user.setZoneId(identityZoneManager.getCurrentIdentityZoneId());
+
         final ScimUser existingScimUser = scimUserProvisioning.retrieve(
                 userId,
                 identityZoneManager.getCurrentIdentityZoneId()

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/alias/EntityAliasHandlerValidationTest.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.cloudfoundry.identity.uaa.EntityWithAlias;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -22,7 +23,11 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
 
     protected abstract EntityAliasHandler<T> buildAliasHandler(final boolean aliasEntitiesEnabled);
 
-    protected abstract T buildEntityWithAliasProps(@Nullable final String aliasId, @Nullable final String aliasZid);
+    protected abstract T buildEntityWithAliasProps(
+            @Nullable final String zoneId,
+            @Nullable final String aliasId,
+            @Nullable final String aliasZid
+    );
 
     protected abstract void changeNonAliasProperties(@NonNull final T entity);
 
@@ -48,7 +53,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
         @ParameterizedTest
         @MethodSource("existingEntityArgNoAlias")
         final void shouldReturnFalse_AliasIdSetInReqBody(final ExistingEntityArgument existingEntityArg) {
-            final T requestBody = buildEntityWithAliasProps(UUID.randomUUID().toString(), null);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), UUID.randomUUID().toString(), null);
             final T existingEntity = resolveExistingEntityArgument(existingEntityArg);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
         }
@@ -56,7 +61,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
         @ParameterizedTest
         @MethodSource("existingEntityArgNoAlias")
         final void shouldReturnTrue_BothAliasPropsEmptyInReqBody(final ExistingEntityArgument existingEntityArg) {
-            final T requestBody = buildEntityWithAliasProps(null, null);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, null);
             final T existingEntity = resolveExistingEntityArgument(existingEntityArg);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isTrue();
         }
@@ -70,7 +75,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
         @MethodSource("existingEntityArgNoAlias")
         final void shouldThrowIllegalArgumentException_ZoneIdEmptyInReqBody(final ExistingEntityArgument existingEntityArg) {
             // alias property values are not important here, the zoneId is checked before them
-            final T requestBody = buildEntityWithAliasProps(null, null);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, null);
             setZoneId(requestBody, null);
 
             final T existingEntity = resolveExistingEntityArgument(existingEntityArg);
@@ -89,7 +94,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
 
         protected final T resolveExistingEntityArgument(@NonNull final ExistingEntityArgument existingEntityArgument) {
             if (existingEntityArgument == ENTITY_WITH_EMPTY_ALIAS_PROPS) {
-                return buildEntityWithAliasProps(null, null);
+                return buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, null);
             }
             return null;
         }
@@ -111,42 +116,42 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             final String initialAliasId = UUID.randomUUID().toString();
             final String initialAliasZid = CUSTOM_ZONE_ID;
 
-            final T existingEntity = buildEntityWithAliasProps(initialAliasId, initialAliasZid);
+            final T existingEntity = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), initialAliasId, initialAliasZid);
 
             // (1) both alias props left unchanged
-            T requestBody = buildEntityWithAliasProps(initialAliasId, initialAliasZid);
+            T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), initialAliasId, initialAliasZid);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (2) alias ID unchanged, alias ZID changed
-            requestBody = buildEntityWithAliasProps(initialAliasId, "some-other-zid");
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), initialAliasId, "some-other-zid");
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (3) alias ID unchanged, alias ZID removed
-            requestBody = buildEntityWithAliasProps(initialAliasId, null);
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), initialAliasId, null);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (4) alias ID changed, alias ZID unchanged
-            requestBody = buildEntityWithAliasProps("some-other-id", initialAliasZid);
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), "some-other-id", initialAliasZid);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (5) alias ID changed, alias ZID changed
-            requestBody = buildEntityWithAliasProps("some-other-id", "some-other-zid");
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), "some-other-id", "some-other-zid");
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (6) alias ID changed, alias ZID removed
-            requestBody = buildEntityWithAliasProps("some-other-id", null);
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), "some-other-id", null);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (7) alias ID removed, alias ZID unchanged
-            requestBody = buildEntityWithAliasProps(null, initialAliasZid);
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, initialAliasZid);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (8) alias ID removed, alias ZID changed
-            requestBody = buildEntityWithAliasProps(null, "some-other-zid");
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, "some-other-zid");
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
 
             // (9) alias ID removed, alias ZID removed
-            requestBody = buildEntityWithAliasProps(null, null);
+            requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, null);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
         }
 
@@ -165,9 +170,9 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
 
         @Test
         final void shouldThrow_AliasIdEmptyInExisting() {
-            final T existingEntity = buildEntityWithAliasProps(null, CUSTOM_ZONE_ID);
+            final T existingEntity = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, CUSTOM_ZONE_ID);
 
-            final T requestBody = buildEntityWithAliasProps(null, CUSTOM_ZONE_ID);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, CUSTOM_ZONE_ID);
             changeNonAliasProperties(requestBody);
 
             assertThatIllegalStateException().isThrownBy(() ->
@@ -180,9 +185,9 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             final String initialAliasId = UUID.randomUUID().toString();
             final String initialAliasZid = CUSTOM_ZONE_ID;
 
-            final T existingEntity = buildEntityWithAliasProps(initialAliasId, initialAliasZid);
+            final T existingEntity = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), initialAliasId, initialAliasZid);
 
-            final T requestBody = buildEntityWithAliasProps(initialAliasId, initialAliasZid);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), initialAliasId, initialAliasZid);
             changeNonAliasProperties(requestBody);
 
             final Runnable resetRequestBody = () -> {
@@ -225,9 +230,9 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
         @Test
         final void shouldReturnTrue_AliasPropsUnchangedInReqBody() {
             final String aliasId = UUID.randomUUID().toString();
-            final T existingEntity = buildEntityWithAliasProps(aliasId, CUSTOM_ZONE_ID);
+            final T existingEntity = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), aliasId, CUSTOM_ZONE_ID);
 
-            final T requestBody = buildEntityWithAliasProps(aliasId, CUSTOM_ZONE_ID);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), aliasId, CUSTOM_ZONE_ID);
             changeNonAliasProperties(requestBody);
 
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isTrue();
@@ -246,7 +251,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             final String aliasZid = UUID.randomUUID().toString();
             arrangeZoneDoesNotExist(aliasZid);
 
-            final T requestBody = buildEntityWithAliasProps(null, aliasZid);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, aliasZid);
 
             final T existingEntity = resolveExistingEntityArgument(existingEntityArg);
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
@@ -258,7 +263,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             final String aliasZid = UUID.randomUUID().toString();
             arrangeZoneExists(aliasZid);
 
-            final T requestBody = buildEntityWithAliasProps(null, aliasZid);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, aliasZid);
             setZoneId(requestBody, aliasZid);
 
             final T existingEntity = resolveExistingEntityArgument(existingEntityArg);
@@ -271,7 +276,7 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             final String aliasZid = UUID.randomUUID().toString();
             arrangeZoneExists(aliasZid);
 
-            final T requestBody = buildEntityWithAliasProps(null, aliasZid);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, aliasZid);
             setZoneId(requestBody, UUID.randomUUID().toString());
 
             final T existingEntity = resolveExistingEntityArgument(existingEntityArg);
@@ -290,10 +295,11 @@ public abstract class EntityAliasHandlerValidationTest<T extends EntityWithAlias
             final String initialAliasZid = CUSTOM_ZONE_ID;
 
             final T existingEntity = buildEntityWithAliasProps(
+                    IdentityZone.getUaaZoneId(),
                     UUID.randomUUID().toString(),
                     initialAliasZid
             );
-            final T requestBody = buildEntityWithAliasProps(null, initialAliasZid);
+            final T requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, initialAliasZid);
 
             assertThat(aliasHandler.aliasPropertiesAreValid(requestBody, existingEntity)).isFalse();
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/IdentityProviderAliasHandlerValidationTest.java
@@ -15,6 +15,7 @@ import java.util.stream.Stream;
 
 import org.cloudfoundry.identity.uaa.alias.EntityAliasHandler;
 import org.cloudfoundry.identity.uaa.alias.EntityAliasHandlerValidationTest;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.ZoneDoesNotExistsException;
 import org.junit.jupiter.api.Nested;
@@ -44,7 +45,11 @@ public class IdentityProviderAliasHandlerValidationTest extends EntityAliasHandl
     }
 
     @Override
-    protected IdentityProvider<?> buildEntityWithAliasProps(@Nullable final String aliasId, @Nullable final String aliasZid) {
+    protected IdentityProvider<?> buildEntityWithAliasProps(
+            @Nullable final String zoneId,
+            @Nullable final String aliasId,
+            @Nullable final String aliasZid
+    ) {
         final IdentityProvider<AbstractIdentityProviderDefinition> idp = new IdentityProvider<>();
         idp.setName("example");
         idp.setOriginKey("example");
@@ -52,6 +57,7 @@ public class IdentityProviderAliasHandlerValidationTest extends EntityAliasHandl
         idp.setIdentityZoneId(UAA);
         idp.setAliasId(aliasId);
         idp.setAliasZid(aliasZid);
+        setZoneId(idp, zoneId);
         return idp;
     }
 
@@ -61,7 +67,7 @@ public class IdentityProviderAliasHandlerValidationTest extends EntityAliasHandl
     }
 
     @Override
-    protected void setZoneId(@NonNull final IdentityProvider<?> entity, @NonNull final String zoneId) {
+    protected void setZoneId(@NonNull final IdentityProvider<?> entity, @Nullable final String zoneId) {
         entity.setIdentityZoneId(zoneId);
     }
 
@@ -89,7 +95,7 @@ public class IdentityProviderAliasHandlerValidationTest extends EntityAliasHandl
                 final String aliasZid = UUID.randomUUID().toString();
                 arrangeZoneExists(aliasZid);
 
-                final IdentityProvider<?> requestBody = buildEntityWithAliasProps(null, aliasZid);
+                final IdentityProvider<?> requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, aliasZid);
                 requestBody.setIdentityZoneId(UAA);
                 requestBody.setType(typeAliasNotSupported);
 
@@ -113,7 +119,7 @@ public class IdentityProviderAliasHandlerValidationTest extends EntityAliasHandl
                 final String aliasZid = UUID.randomUUID().toString();
                 arrangeZoneExists(aliasZid);
 
-                final IdentityProvider<?> requestBody = buildEntityWithAliasProps(null, aliasZid);
+                final IdentityProvider<?> requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, aliasZid);
                 requestBody.setIdentityZoneId(UAA);
                 requestBody.setType(typeAliasSupported);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/ScimUserAliasHandlerValidationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/ScimUserAliasHandlerValidationTest.java
@@ -14,6 +14,7 @@ import org.cloudfoundry.identity.uaa.alias.EntityAliasHandlerValidationTest;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.util.AlphanumericRandomValueStringGenerator;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.ZoneDoesNotExistsException;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
@@ -51,7 +52,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
     }
 
     @Override
-    protected ScimUser buildEntityWithAliasProps(final String aliasId, final String aliasZid) {
+    protected ScimUser buildEntityWithAliasProps(final String zoneId, final String aliasId, final String aliasZid) {
         final ScimUser scimUser = new ScimUser();
 
         scimUser.setDisplayName("Some Displayname");
@@ -62,6 +63,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
         scimUser.setAliasId(aliasId);
         scimUser.setAliasZid(aliasZid);
 
+        setZoneId(scimUser, zoneId);
         return scimUser;
     }
 
@@ -121,7 +123,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
 
                 arrangeCurrentIdz(zone1);
 
-                final ScimUser requestBody = buildEntityWithAliasProps(null, zone2);
+                final ScimUser requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, zone2);
                 requestBody.setZoneId(zone1);
                 final String origin = RANDOM_STRING_GENERATOR.generate();
                 requestBody.setOrigin(origin);
@@ -166,7 +168,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
 
                 arrangeCurrentIdz(zone1);
 
-                final ScimUser requestBody = buildEntityWithAliasProps(null, zone2);
+                final ScimUser requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, zone2);
                 requestBody.setZoneId(zone1);
                 final String origin = RANDOM_STRING_GENERATOR.generate();
                 requestBody.setOrigin(origin);
@@ -201,7 +203,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
                 // should always be true
                 assertThat(aliasZidIdp).isNotEqualTo(customZoneId);
 
-                final ScimUser requestBody = buildEntityWithAliasProps(null, customZoneId);
+                final ScimUser requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, customZoneId);
                 requestBody.setZoneId(UAA);
                 final String origin = RANDOM_STRING_GENERATOR.generate();
                 requestBody.setOrigin(origin);
@@ -249,7 +251,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
 
                 arrangeCurrentIdz(zone1);
 
-                final ScimUser requestBody = buildEntityWithAliasProps(null, zone2);
+                final ScimUser requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, zone2);
                 requestBody.setZoneId(zone1);
                 final String origin = RANDOM_STRING_GENERATOR.generate();
                 requestBody.setOrigin(origin);
@@ -298,7 +300,7 @@ class ScimUserAliasHandlerValidationTest extends EntityAliasHandlerValidationTes
 
                 arrangeCurrentIdz(zone1);
 
-                final ScimUser requestBody = buildEntityWithAliasProps(null, zone2);
+                final ScimUser requestBody = buildEntityWithAliasProps(IdentityZone.getUaaZoneId(), null, zone2);
                 requestBody.setZoneId(zone1);
                 final String origin = RANDOM_STRING_GENERATOR.generate();
                 requestBody.setOrigin(origin);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsAliasMockMvcTests.java
@@ -1003,7 +1003,6 @@ public class ScimUserEndpointsAliasMockMvcTests extends AliasMockMvcTestBase {
                  * This test case checks whether the alias creation still works, even when the zone ID property is not
                  * explicitly set in the request body.
                  */
-                @Test
                 void shouldAccept_ShouldCreateNewAlias_NoZoneIdSet(
                         final IdentityZone zone1,
                         final IdentityZone zone2


### PR DESCRIPTION
During the validation of the alias properties, we perform the check whether an alias is created to the same zone as the original entity (in this case, the request is rejected).

Since the SCIM user update endpoint does not require the identity zone ID property to be set in the request body, we got a NullPointerException there.

This PR adds an additional validation step and ensures that the identity zone ID property is set in the user update call.