### PR TITLE
fix: Couple of failing test cases due to `500 INTERNAL_SERVER_ERROR` …

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaSamlPrincipal.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaSamlPrincipal.java
@@ -14,6 +14,7 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.ToString;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
@@ -29,6 +30,8 @@ import java.io.Serializable;
  * The SAML Logout Handlers check if the Principal is an instance of Saml2AuthenticatedPrincipal to handle SAML Logout.
  */
 @ToString(callSuper = true)
+@JsonIgnoreProperties({"relyingPartyRegistrationId", "sessionIndexes",
+        "attributes"})
 public class UaaSamlPrincipal extends UaaPrincipal implements Saml2AuthenticatedPrincipal, Serializable {
     public UaaSamlPrincipal(UaaUser user) {
         super(user);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -944,7 +944,6 @@ public class SamlLoginIT {
     }
 
     @Test
-    @Disabled("SAML test fails: Requires zones and logout")
     void samlLoginCustomUserAttributesAndRolesInIDToken() throws Exception {
 
         final String COST_CENTER = "costCenter";
@@ -1100,7 +1099,6 @@ public class SamlLoginIT {
     }
 
     @Test
-    @Disabled("SAML test fails: Requires zones and logout")
     void samlLoginEmailInIDTokenWhenUserIDIsNotEmail() {
 
         //ensure we are able to resolve DNS for hostname testzone1.localhost
@@ -1139,6 +1137,7 @@ public class SamlLoginIT {
         samlIdentityProviderDefinition.addAttributeMapping(EMAIL_ATTRIBUTE_NAME, "emailAddress");
 
         IdentityProvider<SamlIdentityProviderDefinition> provider = new IdentityProvider<>();
+        provider.setIdentityZoneId(zoneId);
         provider.setType(OriginKeys.SAML);
         provider.setActive(true);
         provider.setConfig(samlIdentityProviderDefinition);


### PR DESCRIPTION
…from `/oauth/token` endpoint

- Stepping through the server code revealed that an exception was thrown as follows:
```
org.cloudfoundry.identity.uaa.util.JsonUtils$JsonUtilException: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "relyingPartyRegistrationId" (class org.cloudfoundry.identity.uaa.authentication.UaaPrincipal), not marked as ignorable (6 known properties: "origin", "zoneId", "id", "email", "externalId", "name"])
at [Source: REDACTED (StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION disabled); line: 1, column: 205] (through reference chain: org.cloudfoundry.identity.uaa.authentication.UaaPrincipal["relyingPartyRegistrationId"])
```
- Added a `jackson` annotation to ignore the 3 properties in UaaSamlPrincipal that were causing the `UnrecognizedPropertyException`.
- Added back a line that sets zoneId in a test case, which apparently had been removed by mistake.

[#187986233]
[#187986220]