### PR TITLE
feat: Return a sorted IdP list

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -451,7 +451,7 @@ public class LoginInfoEndpoint {
             boolean fieldUsernameShow,
             boolean linkCreateAccountShow
     ) {
-        Comparator sortingByLinkText = Comparator.comparing(SamlIdentityProviderDefinition::getLinkText);
+        Comparator<SamlIdentityProviderDefinition> sortingByLinkText = Comparator.comparing(SamlIdentityProviderDefinition::getLinkText);
         model.addAttribute(LINK_CREATE_ACCOUNT_SHOW, linkCreateAccountShow);
         model.addAttribute(FIELD_USERNAME_SHOW, fieldUsernameShow);
         model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values().stream().sorted(sortingByLinkText).toList());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -457,7 +457,7 @@ public class LoginInfoEndpoint {
         model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values().stream().sorted(sortingByLinkText).toList());
         Map<String, String> oauthLinks = new HashMap<>();
         ofNullable(oauthIdentityProviders).orElse(emptyMap()).entrySet().stream()
-                .filter(e.getValue() != null && e -> e.getValue().isShowLinkText() && e.getValue() != null && e.getKey() != null)
+                .filter(e -> e.getValue() != null && e.getValue().isShowLinkText() && e.getKey() != null)
                 .forEach(e ->
                         oauthLinks.put(
                                 externalOAuthProviderConfigurator.getIdpAuthenticationUrl(

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -457,7 +457,7 @@ public class LoginInfoEndpoint {
         model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values().stream().sorted(sortingByLinkText).toList());
         Map<String, String> oauthLinks = new HashMap<>();
         ofNullable(oauthIdentityProviders).orElse(emptyMap()).entrySet().stream()
-                .filter(e -> e.getValue().isShowLinkText() && e.getValue() != null && e.getKey() != null)
+                .filter(e.getValue() != null && e -> e.getValue().isShowLinkText() && e.getValue() != null && e.getKey() != null)
                 .forEach(e ->
                         oauthLinks.put(
                                 externalOAuthProviderConfigurator.getIdpAuthenticationUrl(

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -451,7 +451,7 @@ public class LoginInfoEndpoint {
             boolean fieldUsernameShow,
             boolean linkCreateAccountShow
     ) {
-        Comparator<SamlIdentityProviderDefinition> sortingByLinkText = Comparator.comparing(SamlIdentityProviderDefinition::getLinkText);
+        Comparator<SamlIdentityProviderDefinition> sortingByLinkText = Comparator.comparing(SamlIdentityProviderDefinition::getLinkText, String.CASE_INSENSITIVE_ORDER);
         model.addAttribute(LINK_CREATE_ACCOUNT_SHOW, linkCreateAccountShow);
         model.addAttribute(FIELD_USERNAME_SHOW, fieldUsernameShow);
         model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values().stream().sorted(sortingByLinkText).toList());
@@ -467,7 +467,7 @@ public class LoginInfoEndpoint {
                                 e.getValue().getLinkText()
                         )
                 );
-        model.addAttribute(OAUTH_LINKS, oauthLinks.entrySet().stream().sorted(Map.Entry.comparingByValue()).toList());
+        model.addAttribute(OAUTH_LINKS, oauthLinks.entrySet().stream().sorted(Map.Entry.comparingByValue(String::compareToIgnoreCase)).toList());
         model.addAttribute("clientName", clientName);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -10,6 +10,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -450,9 +451,10 @@ public class LoginInfoEndpoint {
             boolean fieldUsernameShow,
             boolean linkCreateAccountShow
     ) {
+        Comparator sortingByLinkText = Comparator.comparing(SamlIdentityProviderDefinition::getLinkText);
         model.addAttribute(LINK_CREATE_ACCOUNT_SHOW, linkCreateAccountShow);
         model.addAttribute(FIELD_USERNAME_SHOW, fieldUsernameShow);
-        model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values());
+        model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values().stream().sorted(sortingByLinkText).toList());
         Map<String, String> oauthLinks = new HashMap<>();
         ofNullable(oauthIdentityProviders).orElse(emptyMap()).entrySet().stream()
                 .filter(e -> e.getValue().isShowLinkText())
@@ -465,7 +467,7 @@ public class LoginInfoEndpoint {
                                 e.getValue().getLinkText()
                         )
                 );
-        model.addAttribute(OAUTH_LINKS, oauthLinks);
+        model.addAttribute(OAUTH_LINKS, oauthLinks.entrySet().stream().sorted(Map.Entry.comparingByValue()).toList());
         model.addAttribute("clientName", clientName);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -457,7 +457,7 @@ public class LoginInfoEndpoint {
         model.addAttribute(IDP_DEFINITIONS, samlIdentityProviders.values().stream().sorted(sortingByLinkText).toList());
         Map<String, String> oauthLinks = new HashMap<>();
         ofNullable(oauthIdentityProviders).orElse(emptyMap()).entrySet().stream()
-                .filter(e -> e.getValue().isShowLinkText())
+                .filter(e -> e.getValue().isShowLinkText() && e.getValue() != null && e.getKey() != null)
                 .forEach(e ->
                         oauthLinks.put(
                                 externalOAuthProviderConfigurator.getIdpAuthenticationUrl(

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -839,6 +839,7 @@ class LoginInfoEndpointTests {
 
         Collection<Map<String, String>> idpDefinitions = (Collection<Map<String, String>>) extendedModelMap.asMap().get("oauthLinks");
         assertEquals(2, idpDefinitions.size());
+        // Expect this always on top of list because of sorting
         assertEquals("my-OIDC-idp1", ((Map.Entry<String, String>) idpDefinitions.iterator().next()).getValue());
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -827,9 +827,9 @@ class LoginInfoEndpointTests {
         when(clientDetailsService.loadClientByClientId("client-id", "uaa")).thenReturn(clientDetails);
 
         List<IdentityProvider> clientAllowedIdps = new LinkedList<>();
-        clientAllowedIdps.add(createOIDCIdentityProvider("my-OIDC-idp1"));
-        clientAllowedIdps.add(createOIDCIdentityProvider("my-OIDC-idp2"));
         clientAllowedIdps.add(createOIDCIdentityProvider("my-OIDC-idp3"));
+        clientAllowedIdps.add(createOIDCIdentityProvider("my-OIDC-idp2"));
+        clientAllowedIdps.add(createOIDCIdentityProvider("my-OIDC-idp1"));
 
         when(mockIdentityProviderProvisioning.retrieveAll(eq(true), anyString())).thenReturn(clientAllowedIdps);
 
@@ -837,8 +837,9 @@ class LoginInfoEndpointTests {
 
         endpoint.loginForHtml(extendedModelMap, null, request, singletonList(MediaType.TEXT_HTML));
 
-        Map<String, AbstractExternalOAuthIdentityProviderDefinition> idpDefinitions = (Map<String, AbstractExternalOAuthIdentityProviderDefinition>) extendedModelMap.asMap().get("oauthLinks");
+        Collection<Map<String, String>> idpDefinitions = (Collection<Map<String, String>>) extendedModelMap.asMap().get("oauthLinks");
         assertEquals(2, idpDefinitions.size());
+        assertEquals("my-OIDC-idp1", ((Map.Entry<String, String>) idpDefinitions.iterator().next()).getValue());
     }
 
     @Test
@@ -1243,7 +1244,7 @@ class LoginInfoEndpointTests {
 
         endpoint.loginForHtml(extendedModelMap, null, mockHttpServletRequest, Collections.singletonList(MediaType.TEXT_HTML));
 
-        assertFalse(((Map)extendedModelMap.get("oauthLinks")).isEmpty());
+        assertFalse(((Collection<Map<String, String>>)extendedModelMap.get("oauthLinks")).isEmpty());
     }
 
     @Test
@@ -1701,7 +1702,7 @@ class LoginInfoEndpointTests {
         assertEquals("{\"origin\":\"uaa\"}", extendedModelMap.get("login_hint"));
         assertEquals("login", redirect);
 
-        Map<String, String> oauthLinks = (Map<String, String>) extendedModelMap.get("oauthLinks");
+        Collection<Map<String, String>> oauthLinks = (Collection<Map<String, String>>) extendedModelMap.get("oauthLinks");
         assertEquals(1, oauthLinks.size());
     }
 
@@ -1812,6 +1813,7 @@ class LoginInfoEndpointTests {
         OIDCIdentityProviderDefinition definition = new OIDCIdentityProviderDefinition();
         definition.setAuthUrl(new URL("https://" + originKey + ".com"));
         definition.setRelyingPartySecret("client-secret");
+        definition.setLinkText(originKey);
         oidcIdentityProvider.setConfig(definition);
 
         return oidcIdentityProvider;


### PR DESCRIPTION
Sort the IdP list returned to thymeleaf
Sort always by login link text and ignore case of link text
Do not sort the JSON list but only HTML page

see
https://cloudfoundry.slack.com/archives/C03FXANBV/p1721916411577139