### PR TITLE
clean-up: IdentityZone samlConfig properties for UAA-as-SAML-IdP feature

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/SamlConfig.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/SamlConfig.java
@@ -31,23 +31,12 @@ import static org.springframework.util.StringUtils.hasText;
 public class SamlConfig {
     public static final String LEGACY_KEY_ID = "legacy-saml-key";
 
-    private boolean assertionSigned = true;
     private boolean requestSigned = true;
     private boolean wantAssertionSigned = true;
-    private boolean wantAuthnRequestSigned = false;
-    private int assertionTimeToLiveSeconds = 600;
     private String activeKeyId;
     private Map<String, SamlKey> keys = new HashMap<>();
     private String entityID;
     private boolean disableInResponseToCheck = false;
-
-    public boolean isAssertionSigned() {
-        return assertionSigned;
-    }
-
-    public void setAssertionSigned(boolean assertionSigned) {
-        this.assertionSigned = assertionSigned;
-    }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public String getEntityID() {
@@ -109,22 +98,6 @@ public class SamlConfig {
             legacyKey.setPassphrase(privateKeyPassword);
             keys.put(LEGACY_KEY_ID, legacyKey);
         }
-    }
-
-    public boolean isWantAuthnRequestSigned() {
-        return wantAuthnRequestSigned;
-    }
-
-    public void setWantAuthnRequestSigned(boolean wantAuthnRequestSigned) {
-        this.wantAuthnRequestSigned = wantAuthnRequestSigned;
-    }
-
-    public int getAssertionTimeToLiveSeconds() {
-        return assertionTimeToLiveSeconds;
-    }
-
-    public void setAssertionTimeToLiveSeconds(int assertionTimeToLiveSeconds) {
-        this.assertionTimeToLiveSeconds = assertionTimeToLiveSeconds;
     }
 
     @JsonProperty("certificate")

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/zone/SamlConfigTest.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/zone/SamlConfigTest.java
@@ -21,7 +21,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.security.cert.CertificateException;
 import java.util.Map;
 
 import static java.util.Collections.EMPTY_MAP;

--- a/model/src/test/resources/org/cloudfoundry/identity/uaa/zone/SampleIdentityZone.json
+++ b/model/src/test/resources/org/cloudfoundry/identity/uaa/zone/SampleIdentityZone.json
@@ -25,11 +25,8 @@
       }
     },
     "samlConfig": {
-      "assertionSigned": true,
       "requestSigned": true,
       "wantAssertionSigned": true,
-      "wantAuthnRequestSigned": false,
-      "assertionTimeToLiveSeconds": 600,
       "keys": {
       },
       "disableInResponseToCheck": true

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointDocs.java
@@ -71,12 +71,9 @@ class IdentityZoneEndpointDocs extends EndpointDocs {
     private static final String REFRESH_TOKEN_ROTATE = "If true, uaa will issue a new refresh token value in grant type refresh_token. Defaults to `false`.";
     private static final String JWT_REVOCABLE_DESC = "Set to true if JWT tokens should be stored in the token store, and thus made individually revocable. Opaque tokens are always stored and revocable.";
     private static final String ENTITY_ID_DESC = "Unique ID of the SAML2 entity";
-    private static final String ASSERTION_SIGNED_DESC = "If `true`, the SAML provider will sign all assertions";
     private static final String WANT_ASSERTION_SIGNED_DESC = "Exposed SAML metadata property. If `true`, all assertions received by the SAML provider must be signed. Defaults to `true`.";
     private static final String REQUEST_SIGNED_DESC = "Exposed SAML metadata property. If `true`, the service provider will sign all outgoing authentication requests. Defaults to `true`.";
-    private static final String WANT_AUTHN_REQUEST_SIGNED_DESC = "If `true`, the authentication request from the partner service provider must be signed.";
     private static final String SAML_DISABLE_IN_RESPONSE_TO_DESC = "If `true`, this zone will not validate the `InResponseToField` part of an incoming IDP assertion. Please see https://docs.spring.io/spring-security-saml/docs/current/reference/html/chapter-troubleshooting.html";
-    private static final String ASSERTION_TIME_TO_LIVE_SECONDS_DESC = "The lifetime of a SAML assertion in seconds. Defaults to 600.";
     private static final String CERTIFICATE_DESC = "Exposed SAML metadata property. The certificate used to verify the authenticity all communications.";
     private static final String PRIVATE_KEY_DESC = "Exposed SAML metadata property. The SAML provider's private key.";
     private static final String PRIVATE_KEY_PASSWORD_DESC = "Exposed SAML metadata property. The SAML provider's private key password. Reserved for future use.";
@@ -241,11 +238,8 @@ class IdentityZoneEndpointDocs extends EndpointDocs {
                 fieldWithPath("config.tokenPolicy.refreshTokenFormat").type(STRING).description(REFRESH_TOKEN_FORMAT).attributes(key("constraints").value("Optional")),
 
                 fieldWithPath("config.samlConfig.disableInResponseToCheck").description(SAML_DISABLE_IN_RESPONSE_TO_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("config.samlConfig.assertionSigned").description(ASSERTION_SIGNED_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.wantAssertionSigned").description(WANT_ASSERTION_SIGNED_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.requestSigned").description(REQUEST_SIGNED_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("config.samlConfig.wantAuthnRequestSigned").description(WANT_AUTHN_REQUEST_SIGNED_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("config.samlConfig.assertionTimeToLiveSeconds").description(ASSERTION_TIME_TO_LIVE_SECONDS_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.entityID").type(STRING).description(ENTITY_ID_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.certificate").type(STRING).description(CERTIFICATE_DESC).attributes(key("constraints").value("Deprecated")),
                 fieldWithPath("config.samlConfig.privateKey").type(STRING).description(PRIVATE_KEY_DESC).attributes(key("constraints").value("Deprecated")),
@@ -400,11 +394,8 @@ class IdentityZoneEndpointDocs extends EndpointDocs {
                 fieldWithPath("[].config.clientSecretPolicy.requireSpecialCharacter").type(NUMBER).description(SECRET_POLICY_SPECIAL_CHAR).attributes(key("constraints").value("Required when `clientSecretPolicy` in the config is not null")),
 
                 fieldWithPath("[].config.samlConfig.disableInResponseToCheck").description(SAML_DISABLE_IN_RESPONSE_TO_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("[].config.samlConfig.assertionSigned").description(ASSERTION_SIGNED_DESC),
                 fieldWithPath("[].config.samlConfig.wantAssertionSigned").description(WANT_ASSERTION_SIGNED_DESC),
                 fieldWithPath("[].config.samlConfig.requestSigned").description(REQUEST_SIGNED_DESC),
-                fieldWithPath("[].config.samlConfig.wantAuthnRequestSigned").description(WANT_AUTHN_REQUEST_SIGNED_DESC),
-                fieldWithPath("[].config.samlConfig.assertionTimeToLiveSeconds").description(ASSERTION_TIME_TO_LIVE_SECONDS_DESC),
                 fieldWithPath("[].config.samlConfig.entityID").optional().type(STRING).description(ENTITY_ID_DESC),
                 fieldWithPath("[].config.samlConfig.certificate").type(STRING).description(CERTIFICATE_DESC).attributes(key("constraints").value("Deprecated")),
 
@@ -552,11 +543,8 @@ class IdentityZoneEndpointDocs extends EndpointDocs {
                 fieldWithPath("config.clientSecretPolicy.requireSpecialCharacter").type(NUMBER).description(SECRET_POLICY_SPECIAL_CHAR).attributes(key("constraints").value("Required when `clientSecretPolicy` in the config is not null")),
 
                 fieldWithPath("config.samlConfig.disableInResponseToCheck").description(SAML_DISABLE_IN_RESPONSE_TO_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("config.samlConfig.assertionSigned").description(ASSERTION_SIGNED_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.wantAssertionSigned").description(WANT_ASSERTION_SIGNED_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.requestSigned").description(REQUEST_SIGNED_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("config.samlConfig.wantAuthnRequestSigned").description(WANT_AUTHN_REQUEST_SIGNED_DESC).attributes(key("constraints").value("Optional")),
-                fieldWithPath("config.samlConfig.assertionTimeToLiveSeconds").description(ASSERTION_TIME_TO_LIVE_SECONDS_DESC).attributes(key("constraints").value("Optional")),
 
                 fieldWithPath("config.samlConfig.entityID").description(ENTITY_ID_DESC).attributes(key("constraints").value("Optional")),
                 fieldWithPath("config.samlConfig.certificate").type(STRING).description(CERTIFICATE_DESC).attributes(key("constraints").value("Deprecated")),
@@ -740,11 +728,8 @@ class IdentityZoneEndpointDocs extends EndpointDocs {
                 fieldWithPath("config.clientSecretPolicy.requireSpecialCharacter").type(NUMBER).description(SECRET_POLICY_SPECIAL_CHAR).attributes(key("constraints").value("Required when `clientSecretPolicy` in the config is not null")),
 
                 fieldWithPath("config.samlConfig.disableInResponseToCheck").description(SAML_DISABLE_IN_RESPONSE_TO_DESC),
-                fieldWithPath("config.samlConfig.assertionSigned").description(ASSERTION_SIGNED_DESC),
                 fieldWithPath("config.samlConfig.wantAssertionSigned").description(WANT_ASSERTION_SIGNED_DESC),
                 fieldWithPath("config.samlConfig.requestSigned").description(REQUEST_SIGNED_DESC),
-                fieldWithPath("config.samlConfig.wantAuthnRequestSigned").description(WANT_AUTHN_REQUEST_SIGNED_DESC),
-                fieldWithPath("config.samlConfig.assertionTimeToLiveSeconds").description(ASSERTION_TIME_TO_LIVE_SECONDS_DESC),
 
                 fieldWithPath("config.samlConfig.entityID").type(STRING).description(ENTITY_ID_DESC),
                 fieldWithPath("config.samlConfig.certificate").type(STRING).description(CERTIFICATE_DESC).attributes(key("constraints").value("Deprecated")),

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
@@ -774,16 +774,12 @@ class IdentityZoneEndpointsMockMvcTests {
 
         SamlConfig samlConfig = created.getConfig().getSamlConfig();
 
-
-        samlConfig.setAssertionTimeToLiveSeconds(77);
-
         samlConfig.setPrivateKey(null);
         samlConfig.setPrivateKeyPassword(null);
         updateZone(created, HttpStatus.OK, identityClientToken);
 
         IdentityZone updated = provisioning.retrieve(created.getId());
         SamlConfig updatedSamlConfig = updated.getConfig().getSamlConfig();
-        assertEquals(77, samlConfig.getAssertionTimeToLiveSeconds());
         assertEquals(serviceProviderCertificate, updatedSamlConfig.getCertificate());
         assertEquals(serviceProviderKey, updatedSamlConfig.getPrivateKey());
         assertEquals(serviceProviderKeyPassword, updatedSamlConfig.getPrivateKeyPassword());
@@ -796,8 +792,6 @@ class IdentityZoneEndpointsMockMvcTests {
         IdentityZone created = createZone(id, HttpStatus.CREATED, identityClientToken, new IdentityZoneConfiguration());
 
         SamlConfig samlConfig = created.getConfig().getSamlConfig();
-
-        samlConfig.setAssertionTimeToLiveSeconds(77);
 
         samlConfig.setCertificate(KeyWithCertTest.invalidCert);
         samlConfig.setPrivateKey(null);
@@ -812,8 +806,6 @@ class IdentityZoneEndpointsMockMvcTests {
         IdentityZone created = createZone(id, HttpStatus.CREATED, identityClientToken, new IdentityZoneConfiguration());
 
         SamlConfig samlConfig = created.getConfig().getSamlConfig();
-
-        samlConfig.setAssertionTimeToLiveSeconds(77);
 
         samlConfig.setCertificate(null);
         samlConfig.setPrivateKey(serviceProviderKey);


### PR DESCRIPTION
- As they are now obsolete because the UAA-as-SAML-IDP feature had been removed.
- Removed the properties from samlConfig.

[#187986019]