### PR TITLE
feature: Handle icorrect SAML response

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
@@ -112,7 +112,8 @@ public class SamlAuthenticationFilterConfig {
     @Bean
     Filter saml2WebSsoAuthenticationFilter(AuthenticationProvider samlAuthenticationProvider,
                                            RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
-                                           SecurityContextRepository securityContextRepository) {
+                                           SecurityContextRepository securityContextRepository,
+                                           SamlLoginAuthenticationFailureHandler samlLoginAuthenticationFailureHandler) {
 
         RelyingPartyRegistrationResolver relyingPartyRegistrationResolver = new RelayStateRelyingPartyRegistrationResolver(relyingPartyRegistrationRepository);
         Saml2AuthenticationTokenConverter saml2AuthenticationTokenConverter = new Saml2AuthenticationTokenConverter(relyingPartyRegistrationResolver);
@@ -122,8 +123,17 @@ public class SamlAuthenticationFilterConfig {
         saml2WebSsoAuthenticationFilter.setAuthenticationManager(authenticationManager);
         saml2WebSsoAuthenticationFilter.setSecurityContextRepository(securityContextRepository);
         saml2WebSsoAuthenticationFilter.setFilterProcessesUrl(BACKWARD_COMPATIBLE_ASSERTION_CONSUMER_FILTER_PROCESSES_URI);
+        saml2WebSsoAuthenticationFilter.setAuthenticationFailureHandler(samlLoginAuthenticationFailureHandler);
 
         return saml2WebSsoAuthenticationFilter;
+    }
+
+    @Bean
+    public SamlLoginAuthenticationFailureHandler getSamlLoginAuthenticationFailureHandler() {
+        SamlLoginAuthenticationFailureHandler handler =
+                new SamlLoginAuthenticationFailureHandler();
+        handler.setDefaultFailureUrl("/saml_error");
+        return handler;
     }
 
     @Autowired

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -342,7 +342,6 @@ public class SamlLoginIT {
     }
 
     @Test
-    @Disabled("SAML test fails: Requires zones")
     void incorrectResponseFromSamlIdpShowErrorFromSaml() {
         String zoneId = "testzone3";
         String zoneUrl = baseUrl.replace("localhost", "%s.localhost".formatted(zoneId));
@@ -389,7 +388,7 @@ public class SamlLoginIT {
         HomePage.tryToGoHome_redirectsToLoginPage(webDriver, zoneUrl)
                 .clickSamlLink_goesToSamlLoginPage(SAML_ORIGIN)
                 .login_goesToSamlErrorPage(testAccounts.getUserName(), testAccounts.getPassword())
-                .validatePageSource(containsString("No local entity found for alias invalid, verify your configuration"));
+                .validatePageSource(containsString("Invalid destination"));
     }
 
     @Test


### PR DESCRIPTION
- Set the `Saml2WebSsoAuthenticationFilter`'s `AuthenticationFailureHandler` to the custom failure handler.
- Updated the test case's page source validation condition to check for the string that is based on the new exception message.

[#187986112]