### PR TITLE
Fix Update of Users with Alias during Login

### DIFF
--- a/docs/UAA-Alias-Entities.md
+++ b/docs/UAA-Alias-Entities.md
@@ -121,7 +121,11 @@ identity zone.
 
 During logon, the information of the matching shadow user is updated with the information from the identity provider 
 (e.g., the ID token in the OpenID Connect flow).
-If this shadow user has an alias, the updated properties are propagated to it. 
+
+If this shadow user has an alias, ...
+- *alias entities enabled:* the updated properties are propagated to the alias.
+- *alias entities disabled:* only the user itself is updated, the alias user is left unchanged.
+  - the alias properties are not changed - original and alias user still reference each other
 
 
 

--- a/docs/UAA-Alias-Entities.md
+++ b/docs/UAA-Alias-Entities.md
@@ -115,9 +115,13 @@ Please note that disabling the flag does not lead to existing entities with alia
 In addition to enabling the alias feature, one must ensure that no groups can be created that would give users inside a 
 custom zone any authorizations in other zones (e.g., `zones.<zone ID>.admin`).
 This can be achieved by using the allow list for groups (`userConfig.allowedGroups`) in the configuration of the 
-identity zone. 
+identity zone.
 
+## User Logon
 
+During logon, the information of the matching shadow user is updated with the information from the identity provider 
+(e.g., the ID token in the OpenID Connect flow).
+If this shadow user has an alias, the updated properties are propagated to it. 
 
 
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/alias/AliasPropertiesInvalidException.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/alias/AliasPropertiesInvalidException.java
@@ -1,0 +1,7 @@
+package org.cloudfoundry.identity.uaa.alias;
+
+public class AliasPropertiesInvalidException extends RuntimeException {
+    public AliasPropertiesInvalidException() {
+        super("The fields 'aliasId' and/or 'aliasZid' are invalid.");
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimUserAliasHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/ScimUserAliasHandler.java
@@ -23,7 +23,7 @@ public class ScimUserAliasHandler extends EntityAliasHandler<ScimUser> {
     private final IdentityProviderProvisioning identityProviderProvisioning;
     private final IdentityZoneManager identityZoneManager;
 
-    protected ScimUserAliasHandler(
+    public ScimUserAliasHandler(
             @Qualifier("identityZoneProvisioning") final IdentityZoneProvisioning identityZoneProvisioning,
             final ScimUserProvisioning scimUserProvisioning,
             final IdentityProviderProvisioning identityProviderProvisioning,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -179,8 +179,13 @@ public class ScimUserBootstrap implements
             newScimUser.setAliasZid(existingUser.getAliasZid());
         }
 
-        // this will also handle the update of the alias user, if necessary
-        scimUserService.updateUser(id, newScimUser);
+        if (aliasEntitiesEnabled) {
+            // update the user and propagate the changes to the alias, if present
+            scimUserService.updateUser(id, newScimUser);
+        } else {
+            // update only the original user, even if it has an alias (the alias properties remain unchanged)
+            scimUserProvisioning.update(id, newScimUser, IdentityZoneHolder.get().getId());
+        }
 
         if (OriginKeys.UAA.equals(newScimUser.getOrigin()) && hasText(updatedUser.getPassword())) { //password is not relevant for non UAA users
             scimUserProvisioning.changePassword(id, null, updatedUser.getPassword(), IdentityZoneHolder.get().getId());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -164,7 +164,18 @@ public class ScimUserBootstrap implements
 
         final ScimUser newScimUser = convertToScimUser(updatedUser);
         newScimUser.setVersion(existingUser.getVersion());
-        scimUserProvisioning.update(id, newScimUser, IdentityZoneHolder.get().getId());
+        newScimUser.setZoneId(existingUser.getZoneId());
+
+        /* the user in the event won't have the alias properties set, we must therefore propagate them from the existing
+         * user, if present */
+        if (hasText(existingUser.getAliasId()) && hasText(existingUser.getAliasZid())) {
+            newScimUser.setAliasId(existingUser.getAliasId());
+            newScimUser.setAliasZid(existingUser.getAliasZid());
+        }
+
+        // this will also handle the update of the alias user, if necessary
+        scimUserService.updateUser(id, newScimUser);
+
         if (OriginKeys.UAA.equals(newScimUser.getOrigin()) && hasText(updatedUser.getPassword())) { //password is not relevant for non UAA users
             scimUserProvisioning.changePassword(id, null, updatedUser.getPassword(), IdentityZoneHolder.get().getId());
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -18,6 +18,7 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -56,6 +57,7 @@ public class ScimUserBootstrap implements
     private final Collection<UaaUser> users;
     private final boolean override;
     private final List<String> usersToDelete;
+    private final boolean aliasEntitiesEnabled;
     private ApplicationEventPublisher publisher;
 
     /**
@@ -63,13 +65,16 @@ public class ScimUserBootstrap implements
      * @param users Users to create
      * @param override Flag to indicate that user accounts can be updated as well as created
      */
-    public ScimUserBootstrap(final ScimUserProvisioning scimUserProvisioning,
-                             final ScimUserService scimUserService,
-                             final ScimGroupProvisioning scimGroupProvisioning,
-                             final ScimGroupMembershipManager membershipManager,
-                             final Collection<UaaUser> users,
-                             @Value("${scim.user.override:false}") final boolean override,
-                             @Value("${delete.users:#{null}}") final List<String> usersToDelete) {
+    public ScimUserBootstrap(
+            final ScimUserProvisioning scimUserProvisioning,
+            final ScimUserService scimUserService,
+            final ScimGroupProvisioning scimGroupProvisioning,
+            final ScimGroupMembershipManager membershipManager,
+            final Collection<UaaUser> users,
+            @Value("${scim.user.override:false}") final boolean override,
+            @Value("${delete.users:#{null}}") final List<String> usersToDelete,
+            @Qualifier("aliasEntitiesEnabled") final boolean aliasEntitiesEnabled
+    ) {
         this.scimUserProvisioning = scimUserProvisioning;
         this.scimUserService = scimUserService;
         this.scimGroupProvisioning = scimGroupProvisioning;
@@ -77,6 +82,7 @@ public class ScimUserBootstrap implements
         this.users = Collections.unmodifiableCollection(users);
         this.override = override;
         this.usersToDelete = usersToDelete;
+        this.aliasEntitiesEnabled = aliasEntitiesEnabled;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -12,6 +12,7 @@ import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
 import org.cloudfoundry.identity.uaa.scim.exception.MemberAlreadyExistsException;
 import org.cloudfoundry.identity.uaa.scim.exception.MemberNotFoundException;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceNotFoundException;
+import org.cloudfoundry.identity.uaa.scim.services.ScimUserService;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.slf4j.Logger;
@@ -49,6 +50,7 @@ public class ScimUserBootstrap implements
     private static final Logger logger = LoggerFactory.getLogger(ScimUserBootstrap.class);
 
     private final ScimUserProvisioning scimUserProvisioning;
+    private final ScimUserService scimUserService;
     private final ScimGroupProvisioning scimGroupProvisioning;
     private final ScimGroupMembershipManager membershipManager;
     private final Collection<UaaUser> users;
@@ -62,12 +64,14 @@ public class ScimUserBootstrap implements
      * @param override Flag to indicate that user accounts can be updated as well as created
      */
     public ScimUserBootstrap(final ScimUserProvisioning scimUserProvisioning,
+                             final ScimUserService scimUserService,
                              final ScimGroupProvisioning scimGroupProvisioning,
                              final ScimGroupMembershipManager membershipManager,
                              final Collection<UaaUser> users,
                              @Value("${scim.user.override:false}") final boolean override,
                              @Value("${delete.users:#{null}}") final List<String> usersToDelete) {
         this.scimUserProvisioning = scimUserProvisioning;
+        this.scimUserService = scimUserService;
         this.scimGroupProvisioning = scimGroupProvisioning;
         this.membershipManager = membershipManager;
         this.users = Collections.unmodifiableCollection(users);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/services/ScimUserService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/services/ScimUserService.java
@@ -1,0 +1,71 @@
+package org.cloudfoundry.identity.uaa.scim.services;
+
+import org.cloudfoundry.identity.uaa.alias.AliasPropertiesInvalidException;
+import org.cloudfoundry.identity.uaa.alias.EntityAliasFailedException;
+import org.cloudfoundry.identity.uaa.scim.ScimUser;
+import org.cloudfoundry.identity.uaa.scim.ScimUserAliasHandler;
+import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class ScimUserService {
+
+    private final ScimUserAliasHandler aliasHandler;
+    private final ScimUserProvisioning scimUserProvisioning;
+    private final IdentityZoneManager identityZoneManager;
+    private final TransactionTemplate transactionTemplate;
+    private final boolean aliasEntitiesEnabled;
+
+    public ScimUserService(
+            final ScimUserAliasHandler aliasHandler,
+            final ScimUserProvisioning scimUserProvisioning,
+            final IdentityZoneManager identityZoneManager,
+            final TransactionTemplate transactionTemplate,
+            @Qualifier("aliasEntitiesEnabled") final boolean aliasEntitiesEnabled
+    ) {
+        this.aliasHandler = aliasHandler;
+        this.scimUserProvisioning = scimUserProvisioning;
+        this.identityZoneManager = identityZoneManager;
+        this.transactionTemplate = transactionTemplate;
+        this.aliasEntitiesEnabled = aliasEntitiesEnabled;
+    }
+
+    public ScimUser updateUser(final String userId, final ScimUser user)
+            throws AliasPropertiesInvalidException, OptimisticLockingFailureException, EntityAliasFailedException {
+        final ScimUser existingScimUser = scimUserProvisioning.retrieve(
+                userId,
+                identityZoneManager.getCurrentIdentityZoneId()
+        );
+        if (!aliasHandler.aliasPropertiesAreValid(user, existingScimUser)) {
+            throw new AliasPropertiesInvalidException();
+        }
+
+        if (!aliasEntitiesEnabled) {
+            // update user without alias handling
+            return scimUserProvisioning.update(userId, user, identityZoneManager.getCurrentIdentityZoneId());
+        }
+
+        // update user and create/update alias, if necessary
+        return updateUserWithAliasHandling(userId, user, existingScimUser);
+    }
+
+    private ScimUser updateUserWithAliasHandling(
+            final String userId,
+            final ScimUser user,
+            final ScimUser existingUser
+    ) {
+        return transactionTemplate.execute(txStatus -> {
+            final ScimUser updatedOriginalUser = scimUserProvisioning.update(
+                    userId,
+                    user,
+                    identityZoneManager.getCurrentIdentityZoneId()
+            );
+            return aliasHandler.ensureConsistencyOfAliasEntity(updatedOriginalUser, existingUser);
+        });
+    }
+
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
@@ -219,7 +219,8 @@ class LoginSamlAuthenticationProviderTests {
                 membershipManager,
                 Collections.emptyList(),
                 false,
-                Collections.emptyList()
+                Collections.emptyList(),
+                false
         );
 
         externalManager = new JdbcScimGroupExternalMembershipManager(jdbcTemplate, dbUtils);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/LoginSamlAuthenticationProviderTests.java
@@ -16,12 +16,14 @@ import org.cloudfoundry.identity.uaa.resources.jdbc.LimitSqlAdapter;
 import org.cloudfoundry.identity.uaa.scim.ScimGroup;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupProvisioning;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
+import org.cloudfoundry.identity.uaa.scim.ScimUserAliasHandler;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.bootstrap.ScimUserBootstrap;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupExternalMembershipManager;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupMembershipManager;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupProvisioning;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimUserProvisioning;
+import org.cloudfoundry.identity.uaa.scim.services.ScimUserService;
 import org.cloudfoundry.identity.uaa.test.TestUtils;
 import org.cloudfoundry.identity.uaa.user.JdbcUaaUserDatabase;
 import org.cloudfoundry.identity.uaa.user.UaaAuthority;
@@ -200,7 +202,25 @@ class LoginSamlAuthenticationProviderTests {
         JdbcScimGroupMembershipManager membershipManager = new JdbcScimGroupMembershipManager(
                 jdbcTemplate, new TimeServiceImpl(), userProvisioning, null, dbUtils);
         membershipManager.setScimGroupProvisioning(groupProvisioning);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(userProvisioning, groupProvisioning, membershipManager, Collections.emptyList(), false, Collections.emptyList());
+
+        final ScimUserAliasHandler aliasHandler = mock(ScimUserAliasHandler.class);
+        when(aliasHandler.aliasPropertiesAreValid(any(), any())).thenReturn(true);
+
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(
+                userProvisioning,
+                new ScimUserService(
+                        aliasHandler,
+                        userProvisioning,
+                        identityZoneManager,
+                        null, // not required since alias is disabled
+                        false
+                ),
+                groupProvisioning,
+                membershipManager,
+                Collections.emptyList(),
+                false,
+                Collections.emptyList()
+        );
 
         externalManager = new JdbcScimGroupExternalMembershipManager(jdbcTemplate, dbUtils);
         externalManager.setScimGroupProvisioning(groupProvisioning);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
@@ -189,7 +189,7 @@ class ScimUserBootstrapTests {
                 .when(publisher).publishEvent(any(EntityDeletedEvent.class));
 
         List<String> usersToDelete = Arrays.asList("joe", "mabel", "non-existent");
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, emptyList(), false, usersToDelete);
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, emptyList(), false, usersToDelete, false);
         bootstrap.setApplicationEventPublisher(publisher);
         bootstrap.afterPropertiesSet();
         bootstrap.onApplicationEvent(mock(ContextRefreshedEvent.class));
@@ -206,7 +206,7 @@ class ScimUserBootstrapTests {
     void slatedForDeleteDoesNotAdd() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         UaaUser mabel = new UaaUser("mabel", "password", "mabel@blah.com", "Mabel", "User");
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Arrays.asList(joe, mabel), false, Arrays.asList("joe", "mabel"));
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Arrays.asList(joe, mabel), false, Arrays.asList("joe", "mabel"), false);
         bootstrap.afterPropertiesSet();
         String zoneId = IdentityZone.getUaaZoneId();
         verify(jdbcScimUserProvisioning, never()).create(any(), eq(zoneId));
@@ -224,7 +224,7 @@ class ScimUserBootstrapTests {
     @Test
     void addedUsersAreVerified() {
         UaaUser uaaJoe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(uaaJoe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(uaaJoe), false, Collections.emptyList(), false);
 
         bootstrap.afterPropertiesSet();
 
@@ -238,7 +238,7 @@ class ScimUserBootstrapTests {
     void canAddUserWithAuthorities() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read"));
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         @SuppressWarnings("unchecked")
         Collection<Map<String, Object>> users = (Collection<Map<String, Object>>) scimUserEndpoints.findUsers("id",
@@ -255,7 +255,7 @@ class ScimUserBootstrapTests {
     void cannotAddUserWithNoPassword() {
         UaaUser joe = new UaaUser("joe", "", "joe@test.org", "Joe", "User", OriginKeys.UAA, null);
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read"));
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         assertThrows(InvalidPasswordException.class, bootstrap::afterPropertiesSet);
     }
 
@@ -263,10 +263,10 @@ class ScimUserBootstrapTests {
     void noOverrideByDefault() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read"));
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         joe = new UaaUser("joe", "password", "joe@test.org", "Joel", "User");
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         @SuppressWarnings("unchecked")
         Collection<Map<String, Object>> users = (Collection<Map<String, Object>>) scimUserEndpoints.findUsers("id",
@@ -283,10 +283,10 @@ class ScimUserBootstrapTests {
     void canOverride() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read"));
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         joe = new UaaUser("joe", "password", "joe@test.org", "Joel", "User");
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         @SuppressWarnings("unchecked")
         Collection<Map<String, Object>> users = (Collection<Map<String, Object>>) scimUserEndpoints.findUsers("id",
@@ -303,10 +303,10 @@ class ScimUserBootstrapTests {
     void canOverrideAuthorities() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read"));
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read,write"));
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         @SuppressWarnings("unchecked")
         Collection<Map<String, Object>> users = (Collection<Map<String, Object>>) scimUserEndpoints.findUsers("id",
@@ -325,11 +325,11 @@ class ScimUserBootstrapTests {
         String joeUserId = "joe" + randomValueStringGenerator.generate();
         UaaUser joe = new UaaUser(joeUserId, "password", "joe@test.org", "Joe", "User");
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid,read"));
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         joe = joe.authorities(AuthorityUtils.commaSeparatedStringToAuthorityList("openid"));
         System.err.println(jdbcTemplate.queryForList("SELECT * FROM group_membership"));
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         List<ScimUser> users = jdbcScimUserProvisioning.query("userName eq \"" + joeUserId + "\"", IdentityZone.getUaaZoneId());
@@ -344,14 +344,14 @@ class ScimUserBootstrapTests {
     void canUpdateUsers() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         joe = joe.modifyOrigin(OriginKeys.UAA);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         String passwordHash = jdbcTemplate.queryForObject("select password from users where username='joe'", new Object[0], String.class);
 
         joe = new UaaUser("joe", "new", "joe@test.org", "Joe", "Bloggs");
         joe = joe.modifyOrigin(OriginKeys.UAA);
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         Collection<ScimUser> users = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId());
         assertEquals(1, users.size());
@@ -452,7 +452,8 @@ class ScimUserBootstrapTests {
                 jdbcScimGroupMembershipManager,
                 Collections.emptyList(),
                 false,
-                Collections.emptyList()
+                Collections.emptyList(),
+                true
         );
     }
 
@@ -485,10 +486,10 @@ class ScimUserBootstrapTests {
     @Test
     void unsuccessfulAttemptToUpdateUsersNotFatal() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         joe = new UaaUser("joe", "new", "joe@test.org", "Joe", "Bloggs");
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         Collection<ScimUser> users = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId());
         assertEquals(1, users.size());
@@ -499,14 +500,14 @@ class ScimUserBootstrapTests {
     void updateUserWithEmptyPasswordDoesNotChangePassword() {
         UaaUser joe = new UaaUser("joe", "password", "joe@test.org", "Joe", "User");
         joe = joe.modifyOrigin(OriginKeys.UAA);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         String passwordHash = jdbcTemplate.queryForObject("select password from users where username='joe'", new Object[0], String.class);
 
         joe = new UaaUser("joe", "", "joe@test.org", "Joe", "Bloggs");
         joe = joe.modifyOrigin(OriginKeys.UAA);
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(joe), true, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         Collection<ScimUser> users = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId());
         assertEquals(1, users.size());
@@ -525,7 +526,7 @@ class ScimUserBootstrapTests {
 
         String username = new RandomValueStringGenerator().generate().toLowerCase();
         UaaUser user = getUaaUser(new String[0], origin, email, firstName, lastName, password, externalId, "not-used-id", username);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         ScimUser existingUser = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId())
@@ -557,7 +558,7 @@ class ScimUserBootstrapTests {
 
         String username = new RandomValueStringGenerator().generate().toLowerCase();
         UaaUser user = getUaaUser(new String[0], origin, email, firstName, lastName, password, externalId, "not-used-id", username);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         ScimUser existingUser = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId())
@@ -602,7 +603,7 @@ class ScimUserBootstrapTests {
         String userId = new RandomValueStringGenerator().generate();
         String username = new RandomValueStringGenerator().generate();
         UaaUser user = getUaaUser(userAuthorities, origin, email, firstName, lastName, password, externalId, userId, username);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         List<ScimUser> users = jdbcScimUserProvisioning.query("userName eq \"" + username + "\" and origin eq \"" + origin + "\"", IdentityZone.getUaaZoneId());
@@ -650,7 +651,7 @@ class ScimUserBootstrapTests {
         String username = new RandomValueStringGenerator().generate();
         UaaUser user = getUaaUser(userAuthorities, origin, email, firstName, lastName, password, externalId, userId, username);
         JdbcScimGroupMembershipManager spy = spy(jdbcScimGroupMembershipManager);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, spy, Collections.singletonList(user), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, spy, Collections.singletonList(user), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         List<ScimUser> users = jdbcScimUserProvisioning.query("userName eq \"" + username + "\" and origin eq \"" + origin + "\"", IdentityZone.getUaaZoneId());
@@ -680,11 +681,11 @@ class ScimUserBootstrapTests {
         String userId = new RandomValueStringGenerator().generate();
         String username = new RandomValueStringGenerator().generate();
         UaaUser user = getUaaUser(new String[0], origin, email, firstName, lastName, password, externalId, userId, username);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         addIdentityProvider(jdbcTemplate, "newOrigin");
-        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Arrays.asList(user, user.modifySource("newOrigin", "")), false, Collections.emptyList());
+        bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Arrays.asList(user, user.modifySource("newOrigin", "")), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
         assertEquals(2, jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId()).size());
     }
@@ -706,7 +707,7 @@ class ScimUserBootstrapTests {
         String userId = new RandomValueStringGenerator().generate();
         String username = new RandomValueStringGenerator().generate();
         UaaUser user = getUaaUser(userAuthorities, origin, email, firstName, lastName, password, externalId, userId, username);
-        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList());
+        ScimUserBootstrap bootstrap = new ScimUserBootstrap(jdbcScimUserProvisioning, scimUserService, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, Collections.singletonList(user), false, Collections.emptyList(), false);
         bootstrap.afterPropertiesSet();
 
         List<ScimUser> scimUsers = jdbcScimUserProvisioning.query("userName eq \"" + username + "\" and origin eq \"" + origin + "\"", IdentityZone.getUaaZoneId());
@@ -758,7 +759,9 @@ class ScimUserBootstrapTests {
                 jdbcScimGroupMembershipManager,
                 Arrays.asList(joe, mabel),
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                false
+        );
         bootstrap.afterPropertiesSet();
     }
 
@@ -789,7 +792,9 @@ class ScimUserBootstrapTests {
                 jdbcScimGroupMembershipManager,
                 Collections.singletonList(user),
                 false,
-                Collections.emptyList());
+                Collections.emptyList(),
+                false
+        );
         bootstrap.afterPropertiesSet();
 
         List<ScimUser> users = jdbcScimUserProvisioning.query("userName eq \"" + username + "\" and origin eq \"" + origin + "\"", IdentityZone.getUaaZoneId());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
@@ -159,12 +159,13 @@ class ScimUserBootstrapTests {
     @Test
     void canDeleteUsersButOnlyInDefaultZone() throws Exception {
         String randomZoneId = "randomZoneId-" + new RandomValueStringGenerator().generate().toLowerCase();
-        canAddUsers(OriginKeys.UAA, IdentityZone.getUaaZoneId(), jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager,
-                scimUserService);
-        canAddUsers(OriginKeys.LDAP, IdentityZone.getUaaZoneId(), jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager,
-                scimUserService);
-        canAddUsers(OriginKeys.UAA, randomZoneId, jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager,
-                scimUserService); //this is just an update of the same two users, zoneId is ignored
+        canAddUsers(OriginKeys.UAA, IdentityZone.getUaaZoneId(), jdbcScimUserProvisioning, jdbcScimGroupProvisioning,
+                jdbcScimGroupMembershipManager, scimUserService);
+        canAddUsers(OriginKeys.LDAP, IdentityZone.getUaaZoneId(), jdbcScimUserProvisioning, jdbcScimGroupProvisioning,
+                jdbcScimGroupMembershipManager, scimUserService);
+        //this is just an update of the same two users, zoneId is ignored
+        canAddUsers(OriginKeys.UAA, randomZoneId, jdbcScimUserProvisioning, jdbcScimGroupProvisioning,
+                jdbcScimGroupMembershipManager, scimUserService);
         List<ScimUser> users = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId());
         assertEquals(4, users.size());
         reset(jdbcScimUserProvisioning);
@@ -204,8 +205,7 @@ class ScimUserBootstrapTests {
 
     @Test
     void canAddUsers() throws Exception {
-        canAddUsers(OriginKeys.UAA, IdentityZone.getUaaZoneId(), jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager,
-                scimUserService);
+        canAddUsers(OriginKeys.UAA, IdentityZone.getUaaZoneId(), jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, scimUserService);
         Collection<ScimUser> users = jdbcScimUserProvisioning.retrieveAll(IdentityZone.getUaaZoneId());
         assertEquals(2, users.size());
     }
@@ -449,14 +449,12 @@ class ScimUserBootstrapTests {
 
     @Test
     void canAddNonExistentGroupThroughEvent() throws Exception {
-        nonExistentGroupThroughEvent(true, jdbcTemplate, jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager,
-                scimUserService);
+        nonExistentGroupThroughEvent(true, jdbcTemplate, jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, scimUserService);
     }
 
     @Test
     void doNotAddNonExistentUsers() throws Exception {
-        nonExistentGroupThroughEvent(false, jdbcTemplate, jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager,
-                scimUserService);
+        nonExistentGroupThroughEvent(false, jdbcTemplate, jdbcScimUserProvisioning, jdbcScimGroupProvisioning, jdbcScimGroupMembershipManager, scimUserService);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
@@ -419,7 +419,7 @@ class ScimUserBootstrapTests {
     }
 
     @Test
-    public void shouldOnlyUpdateOriginalUser_WhenUserHasAliasButAliasEntitiesDisabled() {
+    void shouldOnlyUpdateOriginalUser_WhenUserHasAliasButAliasEntitiesDisabled() {
         // arrange custom zone exists
         final String customZoneId = new AlphanumericRandomValueStringGenerator(8).generate();
         createCustomZone(customZoneId);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsAliasTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsAliasTests.java
@@ -14,6 +14,7 @@ import org.cloudfoundry.identity.uaa.scim.ScimUserAliasHandler;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimException;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceConflictException;
+import org.cloudfoundry.identity.uaa.scim.services.ScimUserService;
 import org.cloudfoundry.identity.uaa.scim.validate.PasswordValidator;
 import org.cloudfoundry.identity.uaa.security.IsSelfCheck;
 import org.cloudfoundry.identity.uaa.util.AlphanumericRandomValueStringGenerator;
@@ -89,6 +90,14 @@ class ScimUserEndpointsAliasTests {
 
     @BeforeEach
     void setUp() {
+        final ScimUserService scimUserService = new ScimUserService(
+                scimUserAliasHandler,
+                scimUserProvisioning,
+                identityZoneManager,
+                transactionTemplate,
+                true // alias entities are enabled
+        );
+
         scimUserEndpoints = new ScimUserEndpoints(
                 identityZoneManager,
                 isSelfCheck,
@@ -100,6 +109,7 @@ class ScimUserEndpointsAliasTests {
                 expiringCodeStore,
                 approvalStore,
                 scimGroupMembershipManager,
+                scimUserService,
                 scimUserAliasHandler,
                 transactionTemplate,
                 true, // alias entities are enabled

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/services/ScimUserServiceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/services/ScimUserServiceTest.java
@@ -1,0 +1,222 @@
+package org.cloudfoundry.identity.uaa.scim.services;
+
+import org.cloudfoundry.identity.uaa.alias.AliasPropertiesInvalidException;
+import org.cloudfoundry.identity.uaa.scim.ScimUser;
+import org.cloudfoundry.identity.uaa.scim.ScimUserAliasHandler;
+import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
+import org.cloudfoundry.identity.uaa.util.AlphanumericRandomValueStringGenerator;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ScimUserServiceTest {
+    @Mock
+    private ScimUserAliasHandler scimUserAliasHandler;
+
+    @Mock
+    private ScimUserProvisioning scimUserProvisioning;
+
+    @Mock
+    private IdentityZoneManager identityZoneManager;
+
+    @Mock
+    private TransactionTemplate transactionTemplate;
+
+    private ScimUserService scimUserService;
+
+    private static final AlphanumericRandomValueStringGenerator RANDOM_STRING_GENERATOR =
+            new AlphanumericRandomValueStringGenerator(8);
+
+    private final String idzId = RANDOM_STRING_GENERATOR.generate();
+    private final String userId = RANDOM_STRING_GENERATOR.generate();
+    private final String origin = RANDOM_STRING_GENERATOR.generate();
+
+    @BeforeEach
+    void setUp() {
+        // mock current IdZ
+        when(identityZoneManager.getCurrentIdentityZoneId()).thenReturn(idzId);
+    }
+
+    /**
+     * Test cases for both alias entities being enabled and disabled.
+     */
+    private abstract class Base {
+        @Test
+        final void testUpdate_ShouldThrow_WhenAliasPropertiesAreInvalid() {
+            // mock existing user
+            final ScimUser existingUser = mock(ScimUser.class);
+            when(scimUserProvisioning.retrieve(userId, idzId)).thenReturn(existingUser);
+
+            // arrange alias properties are invalid
+            final ScimUser user = mock(ScimUser.class);
+            when(scimUserAliasHandler.aliasPropertiesAreValid(user, existingUser)).thenReturn(false);
+
+            assertThatExceptionOfType(AliasPropertiesInvalidException.class)
+                    .isThrownBy(() -> scimUserService.updateUser(userId, user));
+        }
+    }
+
+    @Nested
+    class AliasEntitiesEnabled extends Base {
+        @BeforeEach
+        void setUp() {
+            scimUserService = new ScimUserService(
+                    scimUserAliasHandler,
+                    scimUserProvisioning,
+                    identityZoneManager,
+                    transactionTemplate,
+                    true
+            );
+
+            // mock transaction template
+            lenient().when(transactionTemplate.execute(ArgumentMatchers.any()))
+                    .then(invocationOnMock -> {
+                        final TransactionCallback<?> callback = invocationOnMock.getArgument(0);
+                        return callback.doInTransaction(mock(TransactionStatus.class));
+                    });
+        }
+
+        @Test
+        void testUpdate_ShouldAlsoUpdateAlias_WhenAliasPropertiesAreValid() {
+            // mock existing user
+            final ScimUser existingUser = buildExemplaryUser(userId, idzId, origin);
+            when(scimUserProvisioning.retrieve(userId, idzId)).thenReturn(existingUser);
+
+            // arrange alias properties are valid
+            final ScimUser user = cloneScimUser(existingUser);
+            user.setUserName("%s-updated".formatted(user.getUserName()));
+            when(scimUserAliasHandler.aliasPropertiesAreValid(user, existingUser)).thenReturn(true);
+
+            // arrange update of original user
+            final ScimUser updatedOriginalUser = mock(ScimUser.class);
+            when(scimUserProvisioning.update(userId, user, idzId)).thenReturn(updatedOriginalUser);
+
+            scimUserService.updateUser(userId, user);
+
+            // scimUserProvisioning.update should be called exactly once
+            verify(scimUserProvisioning, times(1)).update(userId, user, idzId);
+
+            // the scim alias handler should be called
+            verify(scimUserAliasHandler, times(1)).ensureConsistencyOfAliasEntity(
+                    updatedOriginalUser,
+                    existingUser
+            );
+        }
+    }
+
+    @Nested
+    class AliasEntitiesDisabled extends Base {
+        @BeforeEach
+        void setUp() {
+            scimUserService = new ScimUserService(
+                    scimUserAliasHandler,
+                    scimUserProvisioning,
+                    identityZoneManager,
+                    transactionTemplate,
+                    false
+            );
+        }
+
+        @Test
+        void testUpdate_ShouldUpdateOnlyOriginalUser_WhenAliasEnabledAndPropertiesAreValid() {
+            // mock existing user
+            final ScimUser existingUser = buildExemplaryUser(userId, idzId, origin);
+            when(scimUserProvisioning.retrieve(userId, idzId)).thenReturn(existingUser);
+
+            // arrange alias properties are valid
+            final ScimUser user = cloneScimUser(existingUser);
+            user.setUserName("%s-updated".formatted(user.getUserName()));
+            when(scimUserAliasHandler.aliasPropertiesAreValid(user, existingUser)).thenReturn(true);
+
+            scimUserService.updateUser(userId, user);
+
+            // scimUserProvisioning.update should be called exactly once
+            verify(scimUserProvisioning, times(1)).update(userId, user, idzId);
+
+            // the scim alias handler should not be called
+            verify(scimUserAliasHandler, never()).ensureConsistencyOfAliasEntity(any(), any());
+        }
+    }
+
+    private static ScimUser buildExemplaryUser(
+            @Nullable final String id,
+            @Nonnull final String idzId,
+            @Nonnull final String origin
+    ) {
+        final ScimUser user = new ScimUser();
+        user.setId(id);
+        user.setZoneId(idzId);
+        user.setName(new ScimUser.Name("John", "Doe"));
+        final String userName = "john.doe." + RANDOM_STRING_GENERATOR.generate();
+        user.setUserName(userName);
+        final ScimUser.Email email = new ScimUser.Email();
+        email.setPrimary(true);
+        email.setValue("%s@example.com".formatted(userName));
+        user.setEmails(singletonList(email));
+        user.setActive(true);
+        user.setOrigin(origin);
+        return user;
+    }
+
+    private static ScimUser cloneScimUser(final ScimUser user) {
+        final ScimUser clone = new ScimUser();
+        clone.setId(user.getId());
+        clone.setExternalId(user.getExternalId());
+        clone.setUserName(user.getUserName());
+        clone.setEmails(user.getEmails().stream().map(it -> {
+            final ScimUser.Email email = new ScimUser.Email();
+            email.setValue(it.getValue());
+            email.setPrimary(it.isPrimary());
+            email.setType(it.getType());
+            return email;
+        }).toList());
+        clone.setName(new ScimUser.Name(user.getName().getGivenName(), user.getName().getFamilyName()));
+        final List<ScimUser.PhoneNumber> clonedPhoneNumbers;
+        if (user.getPhoneNumbers() == null) {
+            clonedPhoneNumbers = null;
+        } else {
+            clonedPhoneNumbers = user.getPhoneNumbers().stream().map(it -> {
+                final ScimUser.PhoneNumber phoneNumber = new ScimUser.PhoneNumber();
+                phoneNumber.setType(it.getType());
+                phoneNumber.setValue(it.getValue());
+                return phoneNumber;
+            }).toList();
+        }
+        clone.setPhoneNumbers(clonedPhoneNumbers);
+        clone.setActive(user.isActive());
+        clone.setOrigin(user.getOrigin());
+        clone.setAliasId(user.getAliasId());
+        clone.setAliasZid(user.getAliasZid());
+        clone.setZoneId(user.getZoneId());
+        clone.setPassword(user.getPassword());
+        clone.setSalt(user.getSalt());
+        clone.setLastLogonTime(user.getLastLogonTime());
+        clone.setPasswordLastModified(user.getPasswordLastModified());
+        clone.setPreviousLogonTime(user.getPreviousLogonTime());
+        return clone;
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsAliasMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsAliasMockMvcTests.java
@@ -14,6 +14,7 @@ import org.cloudfoundry.identity.uaa.scim.ScimMeta;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserAliasHandler;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimUserProvisioning;
+import org.cloudfoundry.identity.uaa.scim.services.ScimUserService;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -55,6 +56,7 @@ public class ScimUserEndpointsAliasMockMvcTests extends AliasMockMvcTestBase {
     private IdentityProviderEndpoints identityProviderEndpoints;
     private ScimUserAliasHandler scimUserAliasHandler;
     private ScimUserEndpoints scimUserEndpoints;
+    private ScimUserService scimUserService;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -64,6 +66,7 @@ public class ScimUserEndpointsAliasMockMvcTests extends AliasMockMvcTestBase {
         identityProviderEndpoints = requireNonNull(webApplicationContext.getBean(IdentityProviderEndpoints.class));
         scimUserAliasHandler = requireNonNull(webApplicationContext.getBean(ScimUserAliasHandler.class));
         scimUserEndpoints = requireNonNull(webApplicationContext.getBean(ScimUserEndpoints.class));
+        scimUserService = requireNonNull(webApplicationContext.getBean(ScimUserService.class));
     }
 
     @Nested
@@ -1707,5 +1710,6 @@ public class ScimUserEndpointsAliasMockMvcTests extends AliasMockMvcTestBase {
         ReflectionTestUtils.setField(identityProviderEndpoints, "aliasEntitiesEnabled", enabled);
         ReflectionTestUtils.setField(scimUserAliasHandler, "aliasEntitiesEnabled", enabled);
         ReflectionTestUtils.setField(scimUserEndpoints, "aliasEntitiesEnabled", enabled);
+        ReflectionTestUtils.setField(scimUserService, "aliasEntitiesEnabled", enabled);
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -32,6 +32,7 @@ import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceConflictExceptio
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceNotFoundException;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupProvisioning;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimUserProvisioning;
+import org.cloudfoundry.identity.uaa.scim.services.ScimUserService;
 import org.cloudfoundry.identity.uaa.scim.validate.PasswordValidator;
 import org.cloudfoundry.identity.uaa.security.IsSelfCheck;
 import org.cloudfoundry.identity.uaa.test.ZoneSeeder;
@@ -216,6 +217,14 @@ class ScimUserEndpointsTests {
                 .then(invocationOnMock -> invocationOnMock.getArgument(0));
         when(scimUserAliasHandler.retrieveAliasEntity(any())).thenReturn(Optional.empty());
 
+        final ScimUserService scimUserService = new ScimUserService(
+                scimUserAliasHandler,
+                jdbcScimUserProvisioning,
+                identityZoneManager,
+                transactionTemplate,
+                false
+        );
+
         scimUserEndpoints = new ScimUserEndpoints(
                 new IdentityZoneManagerImpl(),
                 new IsSelfCheck(null),
@@ -227,6 +236,7 @@ class ScimUserEndpointsTests {
                 null,
                 mockApprovalStore,
                 spiedScimGroupMembershipManager,
+                scimUserService,
                 scimUserAliasHandler,
                 transactionTemplate,
                 false,
@@ -721,7 +731,7 @@ class ScimUserEndpointsTests {
     void whenSettingAnInvalidUserMaxCount_ScimUsersEndpointShouldThrowAnException() {
         assertThrowsWithMessageThat(
                 IllegalArgumentException.class,
-                () -> new ScimUserEndpoints(null, null, null, null, null, null, null, null, null, null, null, null, false, 0),
+                () -> new ScimUserEndpoints(null, null, null, null, null, null, null, null, null, null, null, null, null, false, 0),
                 containsString("Invalid \"userMaxCount\" value (got 0). Should be positive number."));
     }
 
@@ -729,7 +739,7 @@ class ScimUserEndpointsTests {
     void whenSettingANegativeValueUserMaxCount_ScimUsersEndpointShouldThrowAnException() {
         assertThrowsWithMessageThat(
                 IllegalArgumentException.class,
-                () -> new ScimUserEndpoints(null, null, null, null, null, null, null, null, null, null, null, null, false, -1),
+                () -> new ScimUserEndpoints(null, null, null, null, null, null, null, null, null, null, null, null, null, false, -1),
                 containsString("Invalid \"userMaxCount\" value (got -1). Should be positive number."));
     }
 


### PR DESCRIPTION
Whenever a user logs in, their properties, e.g., `externalId`, are updated with the corresponding values from the IdP (e.g., the ID token in case of OIDC).

This update operation does not work for users with an alias. Such users are synchronized with an identical user in a different identity zone and reference each other through the properties `aliasId` and `aliasZid`. 

Since the update operation performed during the login does not handle these alias properties correctly, the user is updated without the changes being propagated to the alias. Furthermore, the alias properties are set to `null`, which breaks the alias reference from this side.