### PR TITLE
fix: support id_token_hint parameter on oidc logout

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthentication.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthentication.java
@@ -48,6 +48,7 @@ public class UaaAuthentication implements Authentication, Serializable {
     private Set<String> authenticationMethods;
     private Set<String> authContextClassRef;
     private Long lastLoginSuccessTime;
+    private String idpIdToken;
 
     private Map userAttributes;
 
@@ -182,6 +183,14 @@ public class UaaAuthentication implements Authentication, Serializable {
         }
 
         return true;
+    }
+
+    public String getIdpIdToken() {
+        return this.idpIdToken;
+    }
+
+    public void setIdpIdToken(final String idpIdToken) {
+        this.idpIdToken = idpIdToken;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationDeserializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationDeserializer.java
@@ -43,6 +43,7 @@ public class UaaAuthenticationDeserializer extends JsonDeserializer<UaaAuthentic
         long authenticatedTime = -1;
         boolean authenticated = false;
         long previousLoginSuccessTime = -1;
+        String idpIdToken = null;
         Map<String,List<String>> userAttributes = EMPTY_MAP;
         while (jp.nextToken() != JsonToken.END_OBJECT) {
             if (jp.getCurrentToken() == JsonToken.FIELD_NAME) {
@@ -72,6 +73,8 @@ public class UaaAuthenticationDeserializer extends JsonDeserializer<UaaAuthentic
                     authNContextClassRef = jp.readValueAs(new TypeReference<Set<String>>() {});
                 } else if (PREVIOIUS_LOGIN_SUCCESS_TIME.equals(fieldName)){
                     previousLoginSuccessTime = jp.getLongValue();
+                } else if (IDP_ID_TOKEN.equals(fieldName)){
+                    idpIdToken = jp.readValueAs(new TypeReference<String>() {});
                 }
             }
         }
@@ -90,6 +93,7 @@ public class UaaAuthenticationDeserializer extends JsonDeserializer<UaaAuthentic
         uaaAuthentication.setAuthenticationMethods(authenticationMethods);
         uaaAuthentication.setAuthContextClassRef(authNContextClassRef);
         uaaAuthentication.setLastLoginSuccessTime(previousLoginSuccessTime);
+        uaaAuthentication.setIdpIdToken(idpIdToken);
         return uaaAuthentication;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationJsonBase.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationJsonBase.java
@@ -32,6 +32,7 @@ public interface UaaAuthenticationJsonBase {
     String AUTHENTICATION_METHODS = "authenticationMethods";
     String AUTHN_CONTEXT_CLASS_REF = "authContextClassRef";
     String PREVIOIUS_LOGIN_SUCCESS_TIME = "previousLoginSuccessTime";
+    String IDP_ID_TOKEN = "idpIdToken";
     String NULL_STRING = "null";
 
     default Set<String> serializeAuthorites(Collection<? extends GrantedAuthority> authorities) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationSerializer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationSerializer.java
@@ -36,6 +36,7 @@ public class UaaAuthenticationSerializer extends JsonSerializer<UaaAuthenticatio
         gen.writeObjectField(USER_ATTRIBUTES, value.getUserAttributesAsMap());
         gen.writeObjectField(AUTHENTICATION_METHODS, value.getAuthenticationMethods());
         gen.writeObjectField(AUTHN_CONTEXT_CLASS_REF, value.getAuthContextClassRef());
+        gen.writeObjectField(IDP_ID_TOKEN, value.getIdpIdToken());
         gen.writeEndObject();
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandler.java
@@ -65,7 +65,7 @@ public class ZoneAwareWhitelistLogoutHandler implements LogoutSuccessHandler {
         if (logoutUrl == null) {
             return getZoneHandler().determineTargetUrl(request, response);
         } else {
-            return externalOAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, logoutUrl, oauthConfig);
+            return externalOAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, logoutUrl, oauthConfig, authentication);
         }
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -353,6 +353,10 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             authentication.setAuthenticationMethods(new HashSet<>());
         }
         authentication.getAuthenticationMethods().add("oauth");
+        ExternalOAuthCodeToken externalOAuthCodeToken = (ExternalOAuthCodeToken) request;
+        if (externalOAuthCodeToken.getIdToken() != null) {
+        	authentication.setIdpIdToken(externalOAuthCodeToken.getIdToken());
+        }
         super.populateAuthenticationAttributes(authentication, request, authenticationData);
     }
 
@@ -557,6 +561,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     protected Map<String, Object> getClaimsFromToken(ExternalOAuthCodeToken codeToken,
                                                      AbstractExternalOAuthIdentityProviderDefinition config) {
         String idToken = getTokenFromCode(codeToken, config);
+        codeToken.setIdToken(idToken);
         return getClaimsFromToken(idToken, config);
     }
 
@@ -821,7 +826,6 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         public String getUsername() {
             return username;
         }
-
 
         public List<? extends GrantedAuthority> getAuthorities() {
             return authorities;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -686,7 +686,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
     }
 
-    private String getTokenFromCode(ExternalOAuthCodeToken codeToken, AbstractExternalOAuthIdentityProviderDefinition config) {
+    protected String getTokenFromCode(ExternalOAuthCodeToken codeToken, AbstractExternalOAuthIdentityProviderDefinition config) {
         if (StringUtils.hasText(codeToken.getIdToken()) && "id_token".equals(getResponseType(config))) {
             logger.debug("ExternalOAuthCodeToken contains id_token, not exchanging code.");
             return codeToken.getIdToken();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
@@ -1,8 +1,6 @@
 package org.cloudfoundry.identity.uaa.provider.oauth;
 
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
-import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
-import org.cloudfoundry.identity.uaa.authentication.UaaLoginHint;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
@@ -72,11 +70,9 @@ public class ExternalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     sb.append("&client_id=");
     sb.append(oauthConfig.getRelyingPartyId());
 
-    if (authentication instanceof UaaAuthentication uaaAuthentication) {
-        if (uaaAuthentication.getIdpIdToken() != null) {
-            sb.append("&id_token_hint=");
-            sb.append(uaaAuthentication.getIdpIdToken());
-        }
+    if (authentication instanceof UaaAuthentication uaaAuthentication && uaaAuthentication.getIdpIdToken() != null) {
+        sb.append("&id_token_hint=");
+        sb.append(uaaAuthentication.getIdpIdToken());
     }
     return sb.toString();
   }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandler.java
@@ -1,6 +1,8 @@
 package org.cloudfoundry.identity.uaa.provider.oauth;
 
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
+import org.cloudfoundry.identity.uaa.authentication.UaaLoginHint;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
@@ -52,11 +54,12 @@ public class ExternalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
       return defaultUrl;
     }
 
-    return this.constructOAuthProviderLogoutUrl(request, logoutUrl, oauthConfig);
+    return this.constructOAuthProviderLogoutUrl(request, logoutUrl, oauthConfig, authentication);
   }
 
   public String constructOAuthProviderLogoutUrl(final HttpServletRequest request, final String logoutUrl,
-      final AbstractExternalOAuthIdentityProviderDefinition<OIDCIdentityProviderDefinition> oauthConfig) {
+      final AbstractExternalOAuthIdentityProviderDefinition<OIDCIdentityProviderDefinition> oauthConfig,
+      final Authentication authentication) {
     final StringBuilder oauthLogoutUriBuilder = new StringBuilder(request.getRequestURL());
     if (StringUtils.hasText(request.getQueryString())) {
       oauthLogoutUriBuilder.append("?");
@@ -68,6 +71,13 @@ public class ExternalOAuthLogoutHandler extends SimpleUrlLogoutSuccessHandler {
     sb.append(oauthLogoutUri);
     sb.append("&client_id=");
     sb.append(oauthConfig.getRelyingPartyId());
+
+    if (authentication instanceof UaaAuthentication uaaAuthentication) {
+        if (uaaAuthentication.getIdpIdToken() != null) {
+            sb.append("&id_token_hint=");
+            sb.append(uaaAuthentication.getIdpIdToken());
+        }
+    }
     return sb.toString();
   }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationSerializerDeserializerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/UaaAuthenticationSerializerDeserializerTest.java
@@ -21,6 +21,7 @@ public class UaaAuthenticationSerializerDeserializerTest {
         auth.setAuthContextClassRef(Collections.singleton("test:uri"));
         auth.setAuthenticatedTime(1485314434675L);
         auth.setLastLoginSuccessTime(1485305759366L);
+        auth.setIdpIdToken("idtoken");
 
         UaaAuthentication deserializedUaaAuthentication = JsonUtils.readValue(JsonUtils.writeValueAsString(auth), UaaAuthentication.class);
 
@@ -35,5 +36,6 @@ public class UaaAuthenticationSerializerDeserializerTest {
         assertEquals(auth.getAuthenticationMethods(), deserializedUaaAuthentication.getAuthenticationMethods());
         assertEquals(auth.getAuthContextClassRef(), deserializedUaaAuthentication.getAuthContextClassRef());
         assertEquals(auth.getLastLoginSuccessTime(), deserializedUaaAuthentication.getLastLoginSuccessTime());
+        assertEquals(auth.getIdpIdToken(), deserializedUaaAuthentication.getIdpIdToken());
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/ZoneAwareWhitelistLogoutHandlerTests.java
@@ -156,7 +156,7 @@ public class ZoneAwareWhitelistLogoutHandlerTests {
         configuration.getLinks().getLogout().setWhitelist(Collections.singletonList("http://somethingelse.com"));
         configuration.getLinks().getLogout().setDisableRedirectParameter(false);
         when(oAuthLogoutHandler.getLogoutUrl(null)).thenReturn("");
-        when(oAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, "", null)).thenReturn("/login");
+        when(oAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, "", null, null)).thenReturn("/login");
         request.setParameter("redirect", "http://testing.com");
         request.setParameter(CLIENT_ID, CLIENT_ID);
         assertEquals("/login", handler.determineTargetUrl(request, response));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -5,7 +5,6 @@ import com.nimbusds.jose.HeaderParameterNames;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
-
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.cache.StaleUrlCache;
@@ -17,7 +16,6 @@ import org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager.AuthenticationData;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupExternalMembershipManager;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.util.TimeServiceImpl;
@@ -460,15 +458,10 @@ public class ExternalOAuthAuthenticationManagerTest {
             entry(EXPIRY_IN_SECONDS, ((int) (System.currentTimeMillis()/1000L)) + 60),
             entry(SUB, "abc-def-asdf")
         );
-        Map<String, Object> externalGroupMapping = map(
-            entry(FAMILY_NAME_ATTRIBUTE_NAME, "external_family_name")
-        );
-        oidcConfig.setAttributeMappings(externalGroupMapping);
-        provider.setConfig(oidcConfig);
         IdentityZoneHolder.get().getConfig().getTokenPolicy().setKeys(Collections.singletonMap("uaa-key", uaaIdentityZoneTokenSigningKey));
         String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
         ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, origin, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
-        AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oidcAuthentication);
+        ExternalOAuthAuthenticationManager.AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oidcAuthentication);
         authManager.populateAuthenticationAttributes(authentication, oidcAuthentication, authenticationData);
         assertEquals(idTokenJwt, authentication.getIdpIdToken());
     }
@@ -490,9 +483,6 @@ public class ExternalOAuthAuthenticationManagerTest {
             entry(EXPIRY_IN_SECONDS, ((int) (System.currentTimeMillis()/1000L)) + 60),
             entry(SUB, "abc-def-asdf")
         );
-        Map<String, Object> externalGroupMapping = map(
-            entry(FAMILY_NAME_ATTRIBUTE_NAME, "external_family_name")
-        );
         String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
         ExternalOAuthCodeToken codeToken = new ExternalOAuthCodeToken("thecode", origin, "http://google.com", null, "accesstoken", "signedrequest");
 
@@ -502,7 +492,6 @@ public class ExternalOAuthAuthenticationManagerTest {
                 return idTokenJwt;
             }
         };
-
         authManager.getClaimsFromToken(codeToken, oidcConfig);
         assertEquals(idTokenJwt, codeToken.getIdToken());
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -5,6 +5,9 @@ import com.nimbusds.jose.HeaderParameterNames;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
+
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
+import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.cache.StaleUrlCache;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
@@ -14,6 +17,7 @@ import org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager.AuthenticationData;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupExternalMembershipManager;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.util.TimeServiceImpl;
@@ -436,5 +440,36 @@ public class ExternalOAuthAuthenticationManagerTest {
         expectedException.expectMessage("External token attribute external_family_name cannot be mapped to user attribute family_name");
         ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, origin, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
         authManager.getUser(oidcAuthentication, authManager.getExternalAuthenticationDetails(oidcAuthentication));
+    }
+
+    @Test
+    public void populateAuthenticationAttributes_setsIdpIdToken() {
+        UaaAuthentication authentication = new UaaAuthentication(new UaaPrincipal("user-guid", "marissa", "marissa@test.org", "uaa", "", ""), Collections.emptyList(), null);
+        Map<String, Object> header = map(
+            entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.RS256.getName()),
+            entry(HeaderParameterNames.KEY_ID, OIDC_PROVIDER_KEY)
+        );
+        JWSSigner signer = new KeyInfo("uaa-key", oidcProviderTokenSigningKey, DEFAULT_UAA_URL).getSigner();
+        Map<String, Object> entryMap = map(
+            entry("external_map_name", Arrays.asList("bar", "baz"))
+        );
+        Map<String, Object> claims = map(
+            entry("external_family_name", entryMap),
+            entry(ISS, oidcConfig.getIssuer()),
+            entry(AUD, "uaa-relying-party"),
+            entry(EXPIRY_IN_SECONDS, ((int) (System.currentTimeMillis()/1000L)) + 60),
+            entry(SUB, "abc-def-asdf")
+        );
+        Map<String, Object> externalGroupMapping = map(
+            entry(FAMILY_NAME_ATTRIBUTE_NAME, "external_family_name")
+        );
+        oidcConfig.setAttributeMappings(externalGroupMapping);
+        provider.setConfig(oidcConfig);
+        IdentityZoneHolder.get().getConfig().getTokenPolicy().setKeys(Collections.singletonMap("uaa-key", uaaIdentityZoneTokenSigningKey));
+        String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
+        ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, origin, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
+        AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oidcAuthentication);
+        authManager.populateAuthenticationAttributes(authentication, oidcAuthentication, authenticationData);
+        assertEquals(idTokenJwt, authentication.getIdpIdToken());
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandlerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthLogoutHandlerTest.java
@@ -95,6 +95,14 @@ class ExternalOAuthLogoutHandlerTest {
   }
 
   @Test
+  void determineTargetUrlWithIdTokenHint() {
+    request.setQueryString("parameter=value");
+    when(uaaAuthentication.getIdpIdToken()).thenReturn("token");
+    assertEquals("http://localhost:8080/uaa/logout.do?post_logout_redirect_uri=http%3A%2F%2Flocalhost%3Fparameter%3Dvalue&client_id=id&id_token_hint=token",
+        oAuthLogoutHandler.determineTargetUrl(request, response, uaaAuthentication));
+  }
+
+  @Test
   void determineDefaultTargetUrl() {
     oAuthIdentityProviderDefinition.setLogoutUrl(null);
     IdentityZoneHolder.get().setConfig(null);
@@ -104,7 +112,7 @@ class ExternalOAuthLogoutHandlerTest {
 
   @Test
   void constructOAuthProviderLogoutUrl() {
-    oAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, "", oAuthIdentityProviderDefinition);
+    oAuthLogoutHandler.constructOAuthProviderLogoutUrl(request, "", oAuthIdentityProviderDefinition, uaaAuthentication);
   }
 
   @Test


### PR DESCRIPTION
- populate the id_token from an external oidc login into the UAA authentication
- include the id_token in an external oidc logout via the id_token_hint parameter
- fixes #3037 