### PR TITLE
Test-Fix of chromdriver129 issue

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/CreateAccountIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/CreateAccountIT.java
@@ -183,7 +183,7 @@ public class CreateAccountIT {
     public void testEmailDomainRegisteredWithIDPDoesNotAllowAccountCreation() throws Exception {
         String adminToken = IntegrationTestUtils.getClientCredentialsToken(baseUrl, "admin", "adminsecret");
         IdentityProvider<OIDCIdentityProviderDefinition> oidcProvider = new IdentityProvider().setName("oidc_provider").setActive(true).setType(OriginKeys.OIDC10).setOriginKey(OriginKeys.OIDC10).setConfig(new OIDCIdentityProviderDefinition());
-        oidcProvider.getConfig().setAuthUrl(new URL("https://example.com"));
+        oidcProvider.getConfig().setAuthUrl(new URL("http://example.com"));
         oidcProvider.getConfig().setShowLinkText(false);
         oidcProvider.getConfig().setTokenUrl(new URL("http://localhost:8080/uaa/idp_login"));
         oidcProvider.getConfig().setTokenKeyUrl(new URL("http://localhost:8080/uaa/idp_login"));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
@@ -15,9 +15,9 @@ package org.cloudfoundry.identity.uaa.integration.feature;
 import com.dumbster.smtp.SimpleSmtpServer;
 import org.cloudfoundry.identity.uaa.oauth.client.test.TestAccounts;
 import org.cloudfoundry.identity.uaa.test.UaaTestAccounts;
-import org.openqa.selenium.Dimension;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.CapabilityType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 @PropertySource("classpath:integration.test.properties")
 public class DefaultIntegrationTestConfig {
@@ -63,6 +63,7 @@ public class DefaultIntegrationTestConfig {
           "--verbose",
           "--headless=old",
           "--window-position=-2400,-2400",
+          "--window-size=1024,768",
           "--disable-web-security",
           "--ignore-certificate-errors",
           "--allow-running-insecure-content",
@@ -73,15 +74,12 @@ public class DefaultIntegrationTestConfig {
         );
 
         options.setAcceptInsecureCerts(true);
+        options.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
+        options.setImplicitWaitTimeout(Duration.ofSeconds(IMPLICIT_WAIT_TIME * timeoutMultiplier));
+        options.setPageLoadTimeout(Duration.ofSeconds(PAGE_LOAD_TIMEOUT * timeoutMultiplier));
+        options.setScriptTimeout(Duration.ofSeconds(SCRIPT_TIMEOUT * timeoutMultiplier));
 
-        ChromeDriver driver = new ChromeDriver(options);
-
-        driver.manage().timeouts()
-                .implicitlyWait(IMPLICIT_WAIT_TIME * timeoutMultiplier, TimeUnit.SECONDS)
-                .pageLoadTimeout(PAGE_LOAD_TIMEOUT * timeoutMultiplier, TimeUnit.SECONDS)
-                .setScriptTimeout(SCRIPT_TIMEOUT * timeoutMultiplier, TimeUnit.SECONDS);
-        driver.manage().window().setSize(new Dimension(1024, 768));
-        return driver;
+        return new ChromeDriver(options);
     }
 
     @Bean(destroyMethod = "stop")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
@@ -15,9 +15,9 @@ package org.cloudfoundry.identity.uaa.integration.feature;
 import com.dumbster.smtp.SimpleSmtpServer;
 import org.cloudfoundry.identity.uaa.oauth.client.test.TestAccounts;
 import org.cloudfoundry.identity.uaa.test.UaaTestAccounts;
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.CapabilityType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
@@ -27,7 +27,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 @PropertySource("classpath:integration.test.properties")
 public class DefaultIntegrationTestConfig {
@@ -74,12 +74,15 @@ public class DefaultIntegrationTestConfig {
         );
 
         options.setAcceptInsecureCerts(true);
-        options.setCapability(CapabilityType.ACCEPT_INSECURE_CERTS, true);
-        options.setImplicitWaitTimeout(Duration.ofSeconds(IMPLICIT_WAIT_TIME * timeoutMultiplier));
-        options.setPageLoadTimeout(Duration.ofSeconds(PAGE_LOAD_TIMEOUT * timeoutMultiplier));
-        options.setScriptTimeout(Duration.ofSeconds(SCRIPT_TIMEOUT * timeoutMultiplier));
 
-        return new ChromeDriver(options);
+        ChromeDriver driver = new ChromeDriver(options);
+
+        driver.manage().timeouts()
+                .implicitlyWait(IMPLICIT_WAIT_TIME * timeoutMultiplier, TimeUnit.SECONDS)
+                .pageLoadTimeout(PAGE_LOAD_TIMEOUT * timeoutMultiplier, TimeUnit.SECONDS)
+                .setScriptTimeout(SCRIPT_TIMEOUT * timeoutMultiplier, TimeUnit.SECONDS);
+        driver.manage().window().setSize(new Dimension(1024, 768));
+        return driver;
     }
 
     @Bean(destroyMethod = "stop")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
@@ -61,7 +61,8 @@ public class DefaultIntegrationTestConfig {
         ChromeOptions options = new ChromeOptions();
         options.addArguments(
           "--verbose",
-          "--headless",
+          "--headless=old",
+          "--window-position=-2400,-2400",
           "--disable-web-security",
           "--ignore-certificate-errors",
           "--allow-running-insecure-content",

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -18,6 +18,7 @@ import org.cloudfoundry.identity.uaa.ServerRunning;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.integration.endpoints.SamlLogoutAuthSourceEndpoint;
+import org.cloudfoundry.identity.uaa.integration.pageObjects.Page;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.integration.util.ScreenshotOnFail;
 import org.cloudfoundry.identity.uaa.oauth.client.test.TestAccounts;
@@ -486,9 +487,7 @@ public class OIDCLoginIT {
             webDriver.findElement(By.name("password")).sendKeys("saml6");
             webDriver.findElement(By.id("submit_button")).click();
 
-            if (!webDriver.getCurrentUrl().contains(zoneUrl)) {
-                Thread.sleep(5000);
-            }
+            Page.validateUrlStartsWithWait(webDriver, zoneUrl);
             assertThat(webDriver.getCurrentUrl(), containsString(zoneUrl));
             assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), containsString("Where to?"));
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -70,6 +70,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -475,6 +476,7 @@ public class OIDCLoginIT {
           This test creates an OIDC provider. That provider in turn has a SAML provider.
           The end user is authenticated using OIDC federating to SAML
          */
+            webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
             webDriver.get(zoneUrl + "/login");
             webDriver.findElement(By.linkText("My OIDC Provider")).click();
             Assert.assertThat(webDriver.getCurrentUrl(), containsString(baseUrl));
@@ -486,7 +488,7 @@ public class OIDCLoginIT {
             webDriver.findElement(By.name("password")).sendKeys("saml6");
             webDriver.findElement(By.id("submit_button")).click();
 
-            assertThat(webDriver.getCurrentUrl(), containsString(zoneUrl));
+
             assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), containsString("Where to?"));
 
             Cookie cookie = webDriver.manage().getCookieNamed("JSESSIONID");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -488,7 +488,7 @@ public class OIDCLoginIT {
             webDriver.findElement(By.name("password")).sendKeys("saml6");
             webDriver.findElement(By.id("submit_button")).click();
 
-
+            assertThat(webDriver.getCurrentUrl(), containsString(zoneUrl));
             assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), containsString("Where to?"));
 
             Cookie cookie = webDriver.manage().getCookieNamed("JSESSIONID");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -70,7 +70,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -476,7 +475,6 @@ public class OIDCLoginIT {
           This test creates an OIDC provider. That provider in turn has a SAML provider.
           The end user is authenticated using OIDC federating to SAML
          */
-            webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
             webDriver.get(zoneUrl + "/login");
             webDriver.findElement(By.linkText("My OIDC Provider")).click();
             Assert.assertThat(webDriver.getCurrentUrl(), containsString(baseUrl));
@@ -488,6 +486,9 @@ public class OIDCLoginIT {
             webDriver.findElement(By.name("password")).sendKeys("saml6");
             webDriver.findElement(By.id("submit_button")).click();
 
+            if (!webDriver.getCurrentUrl().contains(zoneUrl)) {
+                Thread.sleep(5000);
+            }
             assertThat(webDriver.getCurrentUrl(), containsString(zoneUrl));
             assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), containsString("Where to?"));
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/ResetPasswordIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/ResetPasswordIT.java
@@ -195,7 +195,7 @@ public class ResetPasswordIT {
         webDriver.findElement(By.name("password")).sendKeys("new_password");
         webDriver.findElement(By.xpath("//input[@value='Sign in']")).click();
 
-        assertThat(webDriver.getCurrentUrl(), startsWith("https://example.redirect.com/?code="));
+        assertThat(webDriver.getCurrentUrl(), startsWith("http://example.redirect.com/?code="));
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -637,7 +637,7 @@ public class SamlLoginIT {
     }
 
     @Test
-    public void test_RelayState_redirect_from_idp() {
+    public void test_RelayState_redirect_from_idp() throws InterruptedException {
         //ensure we are able to resolve DNS for hostname testzone1.localhost
         String zoneId = "testzone1";
 
@@ -694,6 +694,9 @@ public class SamlLoginIT {
         webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
         sendCredentials(testAccounts.getUserName(), "koala");
 
+        if (!webDriver.getCurrentUrl().startsWith("https://www.google.com")) {
+            Thread.sleep(5000);
+        }
         assertThat(webDriver.getCurrentUrl(), startsWith("https://www.google.com"));
         webDriver.get(baseUrl + "/logout.do");
         webDriver.get(zoneUrl + "/logout.do");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -690,6 +691,8 @@ public class SamlLoginIT {
         webDriver.get(samlUrl);
         //we should now be in the Simple SAML PHP site
         webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
+
+        webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
         sendCredentials(testAccounts.getUserName(), "koala");
 
         assertThat(webDriver.getCurrentUrl(), startsWith("https://www.google.com"));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -688,7 +687,6 @@ public class SamlLoginIT {
         String samlUrl = IntegrationTestUtils.SIMPLESAMLPHP_UAA_ACCEPTANCE + "/saml2/idp/SSOService.php?"+
             "spentityid=testzone1.cloudfoundry-saml-login&" +
             "RelayState=https://www.google.com";
-        webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
         webDriver.get(samlUrl);
         //we should now be in the Simple SAML PHP site
         webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -688,11 +688,10 @@ public class SamlLoginIT {
         String samlUrl = IntegrationTestUtils.SIMPLESAMLPHP_UAA_ACCEPTANCE + "/saml2/idp/SSOService.php?"+
             "spentityid=testzone1.cloudfoundry-saml-login&" +
             "RelayState=https://www.google.com";
+        webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
         webDriver.get(samlUrl);
         //we should now be in the Simple SAML PHP site
         webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
-
-        webDriver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
         sendCredentials(testAccounts.getUserName(), "koala");
 
         assertThat(webDriver.getCurrentUrl(), startsWith("https://www.google.com"));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -99,7 +99,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -692,10 +691,7 @@ public class SamlLoginIT {
         webDriver.findElement(By.xpath(SIMPLESAMLPHP_LOGIN_PROMPT_XPATH_EXPR));
         sendCredentials(testAccounts.getUserName(), "koala");
 
-        if (!webDriver.getCurrentUrl().startsWith("https://www.google.com")) {
-            Thread.sleep(5000);
-        }
-        assertThat(webDriver.getCurrentUrl(), startsWith("https://www.google.com"));
+        Page.validateUrlStartsWithWait(webDriver, "https://www.google.com");
         webDriver.get(baseUrl + "/logout.do");
         webDriver.get(zoneUrl + "/logout.do");
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.integration.pageObjects;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import org.hamcrest.Matcher;
 import org.openqa.selenium.By;
@@ -52,8 +53,8 @@ public class Page {
     }
 
     public static void validateUrlStartsWithWait(WebDriver driver, String currentUrlStart) throws InterruptedException {
-        if (!driver.getCurrentUrl().startsWith("https://www.google.com")) {
-            Thread.sleep(5000);
+        if (!driver.getCurrentUrl().startsWith(currentUrlStart)) {
+            TimeUnit.SECONDS.sleep(5);
         }
         assertThat(driver.getCurrentUrl(), startsWith(currentUrlStart));
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -6,6 +6,7 @@ import org.hamcrest.Matcher;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 
 public class Page {
@@ -48,5 +49,12 @@ public class Page {
 
     public void clearCookies() {
         driver.manage().deleteAllCookies();
+    }
+
+    public static void validateUrlStartsWithWait(WebDriver driver, String currentUrlStart) throws InterruptedException {
+        if (!driver.getCurrentUrl().startsWith("https://www.google.com")) {
+            Thread.sleep(5000);
+        }
+        assertThat(driver.getCurrentUrl(), startsWith(currentUrlStart));
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -13,7 +13,7 @@ public class Page {
 
     public Page(WebDriver driver) {
         this.driver = driver;
-        //driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
     }
 
     protected static void validateUrl(WebDriver driver, Matcher urlMatcher) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -13,7 +13,7 @@ public class Page {
 
     public Page(WebDriver driver) {
         this.driver = driver;
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+        //driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
     }
 
     protected static void validateUrl(WebDriver driver, Matcher urlMatcher) {


### PR DESCRIPTION
With Chrome 128 we had an issue already, solved with https://github.com/cloudfoundry/uaa/pull/3020
Now again , but another issue.

This option
--headless=old

uses old behavrior, therefore revert PR https://github.com/cloudfoundry/uaa/pull/3020 and set window-position.

With newer Chrome that might be refactored... but for now use these settings because of

- https://github.com/SeleniumHQ/selenium/issues/14514
- https://issues.chromium.org/issues/367755364
- https://stackoverflow.com/questions/78996364/chrome-129-headless-shows-blank-window
