### PR TITLE
fix: refer to JavaPluginConvention for g9 compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,8 +81,8 @@ subprojects {
 
     [compileJava, compileTestJava]*.options*.compilerArgs = ["-Xlint:none", "-nowarn"]
 
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+    java.sourceCompatibility = JavaVersion.VERSION_17
+    java.targetCompatibility = JavaVersion.VERSION_17
 
     test {
         maxParallelForks = 1


### PR DESCRIPTION
improves gradle 9 compatibility by referring to JavaPlugin properties on the convention rather than on the project directly, avoiding the below warning message:

```
Build file '~/IdeaProjects/uaa/build.gradle': line 84 The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.10.2/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_c5l1z2riwxqbf7m8y30n581oy$_run_closure2.doCall$original(~/IdeaProjects/uaa/build.gradle:84)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_c5l1z2riwxqbf7m8y30n581oy.run(~/IdeaProjects/uaa/build.gradle:55)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '~/IdeaProjects/uaa/build.gradle': line 85 The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.10.2/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_c5l1z2riwxqbf7m8y30n581oy$_run_closure2.doCall$original(~/IdeaProjects/uaa/build.gradle:85)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_c5l1z2riwxqbf7m8y30n581oy.run(~/IdeaProjects/uaa/build.gradle:55)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```