### PR TITLE
Deprecate SAML `assertionConsumerIndex` config property

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -1344,7 +1344,7 @@ Fields            *Available Fields* ::
                     zoneId                   String                  Required Must match ``identityZoneId`` in the provider definition
                     metaDataLocation         String                  Required SAML Metadata - either an XML string or a URL that will deliver XML content
                     nameID                   String                  Optional The name ID to use for the username, default is "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified". Currently the UAA expects the username to be a valid email address.
-                    assertionConsumerIndex   int                     Optional SAML assertion consumer index, default is 0
+                    assertionConsumerIndex   int                     Optional SAML assertion consumer index, default is 0. (Deprecated. Does not work if set to anything but 0.)
                     metadataTrustCheck       boolean                 Optional Should metadata be validated, defaults to false
                     showSamlLink             boolean                 Optional Should the SAML login link be displayed on the login page, defaults to false
                     linkText                 String                  Optional Required if the ``showSamlLink`` is set to true.


### PR DESCRIPTION
- It only works if set to `0`, which is the default value for the optional parameter.

When the property was set to 1, UAA tried to use URI binding as expected per the SAML SP metadata. However, it failed with exception as URI binding is not supported by the saml library, as follows:
```
ERROR --- SecurityFilterChainPostProcessor$HttpsEnforcementFilter: Uncaught Exception:
javax.servlet.ServletException: org.opensaml.saml2.metadata.provider.MetadataProviderException: Endpoint designated by the value in the WebSSOProfileOptions is not supported by this profile
        at org.cloudfoundry.identity.uaa.provider.saml.LoginSamlEntryPoint.commence(LoginSamlEntryPoint.java:70) ~[cloudfoundry-identity-server-0.0.0.jar:?]
...
Caused by: org.opensaml.saml2.metadata.provider.MetadataProviderException: Endpoint designated by the value in the WebSSOProfileOptions is not supported by this profile
        at org.springframework.security.saml.websso.WebSSOProfileImpl.getAssertionConsumerService(WebSSOProfileImpl.java:180) ~[spring-security-saml2-core-1.0.10.RELEASE.jar:1.0.10.RELEASE]
        at org.springframework.security.saml.websso.WebSSOProfileImpl.sendAuthenticationRequest(WebSSOProfileImpl.java:90) ~[spring-security-saml2-core-1.0.10.RELEASE.jar:1.0.10.RELEASE]
        at org.springframework.security.saml.SAMLEntryPoint.initializeSSO(SAMLEntryPoint.java:225) ~[spring-security-saml2-core-1.0.10.RELEASE.jar:1.0.10.RELEASE]
        at org.cloudfoundry.identity.uaa.provider.saml.LoginSamlEntryPoint.commence(LoginSamlEntryPoint.java:61) ~[cloudfoundry-identity-server-0.0.0.jar:?]
        ... 102 more
```