### PR TITLE
fix(k8s): fix `JAVA_HOME`

### DIFF
--- a/k8s/templates/deployment.yml
+++ b/k8s/templates/deployment.yml
@@ -100,7 +100,7 @@ spec:
         - name: TRUSTSTORE_PASSWORD
           value: #@ truststore_password
         - name: JAVA_HOME
-          value: /layers/paketo-buildpacks_bellsoft-liberica/jre
+          value: /layers/tanzu-buildpacks_bellsoft-liberica/jre
         - name: OS_CERTS_DIR
           value: /etc/ssl/certs
         volumeMounts:


### PR DESCRIPTION
Updates the `JAVA_HOME` env var for the `build-uaa-truststore` init contianer to match the updated path used by the Paketo buildpack.

fixes: https://github.com/cloudfoundry/uaa/issues/2388

---

With this PR, the UAA k8s ytt template with [`local_testing.yml` addon](https://github.com/cloudfoundry/uaa/blob/d56b81711cc31f84be3a0e5e2105dd081f2e357a/k8s/addons/local_testing.yml) will deploy, but wont wont be "usable" as `jwt.policy.keys.FAKE_JWT_SIGNING_KEY_DO_NOT_USE` still needs to be patched with a valid private key to prevent UAA from rejecting its own tokens.

I did not include that patch here as I'm not sure if that "was used for anything else.