### PR TITLE
fix: default values of custom zone's saml entityID and saml alias (wh…

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BaseUaaRelyingPartyRegistrationRepository.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BaseUaaRelyingPartyRegistrationRepository.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.provider.saml;
 
 import lombok.extern.slf4j.Slf4j;
+import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.SamlConfig;
@@ -36,8 +37,18 @@ public abstract class BaseUaaRelyingPartyRegistrationRepository implements Relyi
         return Optional.ofNullable(currentZone.getConfig())
                 .map(IdentityZoneConfiguration::getSamlConfig)
                 .map(SamlConfig::getEntityID)
-                // otherwise use the zone subdomain + default entityID
-                .orElseGet(() -> "%s.%s".formatted(currentZone.getSubdomain(), uaaWideSamlEntityID));
+                // otherwise, construct a default value using the zone subdomain & uaa wide entityID
+                .orElseGet(
+                        () -> getDefaultZoneEntityId(currentZone.getSubdomain(), uaaWideSamlEntityID)
+                );
+    }
+
+    private String getDefaultZoneEntityId(String zoneSubdomain, String uaaWideSamlEntityID) {
+        if (UaaUrlUtils.isUrl(uaaWideSamlEntityID)) {
+            return UaaUrlUtils.addSubdomainToUrl(uaaWideSamlEntityID, zoneSubdomain);
+        } else {
+            return "%s.%s".formatted(zoneSubdomain, uaaWideSamlEntityID);
+        }
     }
 
     String getZoneEntityIdAlias(IdentityZone currentZone) {
@@ -48,7 +59,11 @@ public abstract class BaseUaaRelyingPartyRegistrationRepository implements Relyi
         if (currentZone.isUaa()) {
             return alias;
         }
-        // for non-default zone, use the "zone subdomain+.+alias"
-        return "%s.%s".formatted(currentZone.getSubdomain(), alias);
+        // for non-default zone, construct a value using the zone subdomain & alias
+        if (UaaUrlUtils.isUrl(alias)) {
+            return UaaUrlUtils.getHostForURI(UaaUrlUtils.addSubdomainToUrl(alias, currentZone.getSubdomain()));
+        } else {
+            return "%s.%s".formatted(currentZone.getSubdomain(), alias);
+        }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/DefaultRelyingPartyRegistrationRepositoryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/DefaultRelyingPartyRegistrationRepositoryTest.java
@@ -126,6 +126,26 @@ class DefaultRelyingPartyRegistrationRepositoryTest {
     }
 
     @Test
+    void findByRegistrationIdForZoneWithoutConfig_WhenUaaWideSamlEntityIdIsInUrlFormat() {
+        String uaaWideEntityIDInUrlFormat = "https://login.foo.cf-app.com";
+        repository = spy(new DefaultRelyingPartyRegistrationRepository(uaaWideEntityIDInUrlFormat, uaaWideEntityIDInUrlFormat, List.of(), NAME_ID_FORMAT));
+
+        when(repository.retrieveZone()).thenReturn(identityZone);
+        when(identityZone.isUaa()).thenReturn(false);
+        when(identityZone.getSubdomain()).thenReturn(ZONE_SUBDOMAIN);
+
+        RelyingPartyRegistration registration = repository.findByRegistrationId(REGISTRATION_ID_2);
+        assertThat(registration)
+                // from definition
+                .returns(REGISTRATION_ID_2, RelyingPartyRegistration::getRegistrationId)
+                .returns("https://%s.login.foo.cf-app.com".formatted(ZONE_SUBDOMAIN), RelyingPartyRegistration::getEntityId)
+                .returns(NAME_ID_FORMAT, RelyingPartyRegistration::getNameIdFormat)
+                // from functions
+                .returns("{baseUrl}/saml/SSO/alias/%s.login.foo.cf-app.com".formatted(ZONE_SUBDOMAIN), RelyingPartyRegistration::getAssertionConsumerServiceLocation)
+                .returns("{baseUrl}/saml/SingleLogout/alias/%s.login.foo.cf-app.com".formatted(ZONE_SUBDOMAIN), RelyingPartyRegistration::getSingleLogoutServiceResponseLocation);
+    }
+
+    @Test
     void findByRegistrationId_NoAliasFailsOverToEntityId() {
         repository = spy(new DefaultRelyingPartyRegistrationRepository(ENTITY_ID, null, List.of(), NAME_ID_FORMAT));
         when(repository.retrieveZone()).thenReturn(identityZone);


### PR DESCRIPTION
…en the configured entityID is a URL)

- maintain the existing behavior where a custom identity zone's saml entityID is defaulted to either 1) `zoneSubdomain.uaaWideSamlEntityID` if `uaaWideSamlEntityID` is not a URL, or 2) if `uaaWideSamlEntityID` is a URL, integration the zoneSubdomain into the URL (see tests for example).

- similar logic for saml entity alias (which is used in various saml sp urls, such as `AssertionConsumerService`) except that the alias should not include url scheme (aka without `https://`), so that the resulting saml sp urls are valid urls (e.g.: `https://zone1.uaa.com/saml/SSO/alias/[saml entity alias]`, see tests for examples).

- reference on develop branch (old saml code):
  - doc: https://github.com/cloudfoundry/uaa/blob/65952b1b53b8d01cf93e68493a3f6ac85ad8a825/docs/login/Okta-README.md?plain=1#L73-L75
  - code: https://github.com/cloudfoundry/uaa/blob/cc5f76fba495e5d1b3fd755ac3a6ff137fc91878/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ZoneAwareMetadataGenerator.java#L53-L54

# problem statement
without this commit, when
* a custom zone is created without a `zone.config.samlConfig.entityID` specified
* the default zone's `login.entityID` is configured to a URL, such as `https://uaa.com`
* the default zone's `login.saml.entityIDAlias` is not set, aka default to `login.entityID` Then the resulting custom zone sp metadata has some discrepancies with the old saml code's metadata:

## For `AssertionConsumerService`:
- old (correct) value is: https://test-zone-before.uaa.com/saml/SSO/alias/test-zone-before.uaa.com
- new value is: https://test-zone.uaa.com/saml/SSO/alias/test-zone.http:/uaa.com 
## For `entityID`:
- old (correct) value is: http://test-zone-before.uaa.com
- new value is: test-zone.http://uaa.com

This results in the external SAML login for this zone not working.