### PR TITLE
Support SAML keypair without a passphrase

### DIFF
--- a/scripts/cargo/uaa.yml
+++ b/scripts/cargo/uaa.yml
@@ -73,7 +73,6 @@ login:
           N+l4lnMda79eSp3OMmq9AkA0p79BvYsLshUJJnvbk76pCjR28PK4dV1gSDUEqQMB
           qy45ptdwJLqLJCeNoR0JUcDNIRhOCuOPND7pcMtX6hI/
           -----END RSA PRIVATE KEY-----
-        passphrase: password
         certificate: |
           -----BEGIN CERTIFICATE-----
           MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
@@ -98,7 +98,7 @@ public class GeneralIdentityZoneConfigurationValidator implements IdentityZoneCo
 
     private void failIfPartialCertKeyInfo(String samlSpCert, String samlSpKey, String samlSpkeyPassphrase) throws InvalidIdentityZoneConfigurationException {
         if ((samlSpCert == null && samlSpKey == null && samlSpkeyPassphrase == null) ||
-                (samlSpCert != null && samlSpKey != null && samlSpkeyPassphrase == null)) {
+                (samlSpCert != null && samlSpKey != null)) {
             return;
         }
         throw new InvalidIdentityZoneConfigurationException("Identity zone cannot be updated with partial Saml CertKey config.", null);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
@@ -98,9 +98,9 @@ public class GeneralIdentityZoneConfigurationValidator implements IdentityZoneCo
 
     private void failIfPartialCertKeyInfo(String samlSpCert, String samlSpKey, String samlSpkeyPassphrase) throws InvalidIdentityZoneConfigurationException {
         if ((samlSpCert == null && samlSpKey == null && samlSpkeyPassphrase == null) ||
-                (samlSpCert != null && samlSpKey != null && samlSpkeyPassphrase != null)) {
+                (samlSpCert != null && samlSpKey != null && samlSpkeyPassphrase == null)) {
             return;
         }
-        throw new InvalidIdentityZoneConfigurationException("Identity zone cannot be udpated with partial Saml CertKey config.", null);
+        throw new InvalidIdentityZoneConfigurationException("Identity zone cannot be updated with partial Saml CertKey config.", null);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -135,6 +135,22 @@ public class IdentityZoneConfigurationBootstrapTests {
     }
 
     @Test
+    void passphraseOnlyException() {
+        bootstrap.setSamlSpPrivateKey(key1());
+        bootstrap.setSamlSpCertificate(certificate1());
+        bootstrap.setSamlSpPrivateKeyPassphrase(passphrase1());
+        Map<String, Map<String, String>> keys = new HashMap<>();
+        Map<String, String> key1 = new HashMap<>();
+        key1.put("passphrase", passphrase1());
+        keys.put("key1", key1);
+        bootstrap.setActiveKeyId(null);
+        bootstrap.setSamlKeys(keys);
+        assertThatExceptionOfType(InvalidIdentityZoneDetailsException.class)
+                .isThrownBy(() -> bootstrap.afterPropertiesSet())
+                .withMessage("The zone configuration is invalid. Identity zone cannot be updated with partial Saml CertKey config.");
+    }
+
+    @Test
     void samlKeysAndSigningConfigs() throws Exception {
         bootstrap.setSamlSpPrivateKey(key1());
         bootstrap.setSamlSpCertificate(certificate1());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
@@ -781,7 +781,7 @@ class IdentityZoneEndpointsMockMvcTests {
         samlConfig.setPrivateKey(serviceProviderKey);
         samlConfig.setPrivateKeyPassword(null);
         samlConfig.setCertificate(serviceProviderCertificate);
-        updateZone(created, HttpStatus.UNPROCESSABLE_ENTITY, identityClientToken);
+        updateZone(created, HttpStatus.OK, identityClientToken);
 
         samlConfig = created.getConfig().getSamlConfig();
         samlConfig.setPrivateKey(null);


### PR DESCRIPTION
found during testings with various IdPs... we need a dummy entry, but this should not be the case