### PR TITLE
Add logs in case of SAML issues

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepository.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepository.java
@@ -51,7 +51,7 @@ public class ConfiguratorRelyingPartyRegistrationRepository extends BaseUaaRelyi
                 }
             }
         } catch (Exception e) {
-            // ignore
+            log.warn("Cannot retrieve SAML trusted party.", e);
         }
 
         return null;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -88,7 +88,7 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
             try {
                 relyingPartyRegistrations.add(RelyingPartyRegistrationBuilder.buildRelyingPartyRegistration(params));
             } catch (Saml2Exception e) {
-                // ignore
+                log.error("Error building relying party", e);
             }
         }
 


### PR DESCRIPTION
These issues should be ignored, because they were ignored before. Issue type:
1. Invalid IdP setup, e.g. invalid metadata. Write an error, but start the UAA
2. Invalid resolution of SAMl metadata during runtime. Add warning for such problems.