### PR TITLE
tests: fix missing BCFIPS provider in DefaultRelyingPartyRegistrationRepositoryTest

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/DefaultRelyingPartyRegistrationRepositoryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/DefaultRelyingPartyRegistrationRepositoryTest.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.provider.saml;
 
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
@@ -13,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 
+import java.security.Security;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +55,7 @@ class DefaultRelyingPartyRegistrationRepositoryTest {
 
     @BeforeAll
     public static void beforeAll() {
+        Security.addProvider(new BouncyCastleFipsProvider());
         new IdentityZoneHolder.Initializer(null, new SamlKeyManagerFactory(samlConfigProps));
     }
 


### PR DESCRIPTION
There is an issue with `DefaultRelyingPartyRegistrationRepositoryTest`. Running:

```
$ ./gradlew cloudfoundry-identity-server:test \
  --tests "DefaultRelyingPartyRegistrationRepositoryTest"
```

will fail because of a missing Security provider. Depending on the order of the tests of the whole suite, this _may_ not happen because some other test registers the provider.