### PR TITLE
tests: in-memory ldap server runs on a random port

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LdapLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LdapLoginIT.java
@@ -68,7 +68,7 @@ public class LdapLoginIT {
 
     @BeforeClass
     public static void startLocalLdap() {
-        server = InMemoryLdapServer.startLdap(33389);
+        server = InMemoryLdapServer.startLdap();
     }
 
     @AfterClass
@@ -107,7 +107,7 @@ public class LdapLoginIT {
     @Test
     public void ldapLogin_with_StartTLS() throws Exception {
         Long beforeTest = System.currentTimeMillis();
-        performLdapLogin("testzone2", server.getLdapBaseUrl(), "marissa4", "ldap4");
+        performLdapLogin("testzone2", server.getUrl(), "marissa4", "ldap4");
         Long afterTest = System.currentTimeMillis();
         assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString("Where to?"));
         ScimUser user = IntegrationTestUtils.getUserByZone(zoneAdminToken, baseUrl, "testzone2", "marissa4");
@@ -117,7 +117,7 @@ public class LdapLoginIT {
 
     @Test
     public void ldap_login_using_utf8_characters() throws Exception {
-        performLdapLogin("testzone2", server.getLdapBaseUrl(), "\u7433\u8D3A", "koala");
+        performLdapLogin("testzone2", server.getUrl(), "\u7433\u8D3A", "koala");
         assertThat(webDriver.findElement(By.cssSelector("h1")).getText(), Matchers.containsString("Where to?"));
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/ldap/LdapCertificateMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/ldap/LdapCertificateMockMvcTests.java
@@ -32,11 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DefaultTestContext
 @ExtendWith(InMemoryLdapServer.LdapTrustStoreExtension.class)
 class LdapCertificateMockMvcTests {
-    private static final int LDAP_VALID_LDAP_PORT = 33390;
-    private static final int LDAP_EXPIRED_LDAP_PORT = LDAP_VALID_LDAP_PORT + 1;
-    private static final int LDAP_VALID_LDAPS_PORT = 33637;
-    private static final int LDAP_EXPIRED_LDAPS_PORT = LDAP_VALID_LDAPS_PORT + 1;
-
     private static File ldapRootDirectoryExpired;
     private static File ldapRootDirectoryValid;
     private static InMemoryLdapServer validLdapCertServer;
@@ -58,8 +53,8 @@ class LdapCertificateMockMvcTests {
         ldapRootDirectoryValid = new File(System.getProperty("java.io.tmpdir"), generator.generate());
         ldapRootDirectoryExpired = new File(System.getProperty("java.io.tmpdir"), generator.generate());
 
-        validLdapCertServer = InMemoryLdapServer.startLdapWithTls(LDAP_VALID_LDAP_PORT, LDAP_VALID_LDAPS_PORT, validKeystore);
-        expiredLdapCertServer = InMemoryLdapServer.startLdapWithTls(LDAP_EXPIRED_LDAP_PORT, LDAP_EXPIRED_LDAPS_PORT, expiredKeystore);
+        validLdapCertServer = InMemoryLdapServer.startLdapWithTls(validKeystore);
+        expiredLdapCertServer = InMemoryLdapServer.startLdapWithTls(expiredKeystore);
     }
 
     @AfterAll
@@ -81,7 +76,7 @@ class LdapCertificateMockMvcTests {
                 null, IdentityZoneHolder.getCurrentZoneId());
 
         LdapIdentityProviderDefinition definition = LdapIdentityProviderDefinition.searchAndBindMapGroupToScopes(
-                validLdapCertServer.getLdapSBaseUrl(),
+                validLdapCertServer.getUrl(),
                 "cn=admin,ou=Users,dc=test,dc=com",
                 "adminsecret",
                 "dc=test,dc=com",
@@ -103,7 +98,7 @@ class LdapCertificateMockMvcTests {
                 mockMvc,
                 webApplicationContext,
                 null, IdentityZoneHolder.getCurrentZoneId());
-        definition.setBaseUrl(expiredLdapCertServer.getLdapSBaseUrl());
+        definition.setBaseUrl(expiredLdapCertServer.getUrl());
         MockMvcUtils.createIdentityProvider(mockMvc, trustedButExpiredCertZone, OriginKeys.LDAP, definition);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/ldap/LdapSkipCertificateMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/ldap/LdapSkipCertificateMockMvcTests.java
@@ -32,11 +32,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DefaultTestContext
 @ExtendWith(InMemoryLdapServer.LdapTrustStoreExtension.class)
 class LdapSkipCertificateMockMvcTests {
-    private static final int LDAP_VALID_LDAP_PORT = 33390;
-    private static final int LDAP_EXPIRED_LDAP_PORT = LDAP_VALID_LDAP_PORT + 1;
-    private static final int LDAP_VALID_LDAPS_PORT = 33637;
-    private static final int LDAP_EXPIRED_LDAPS_PORT = LDAP_VALID_LDAPS_PORT + 1;
-
     private static File ldapRootDirectoryExpired;
     private static InMemoryLdapServer expiredLdapCertServer;
     private MockMvcUtils.IdentityZoneCreationResult trustedCertZone;
@@ -53,8 +48,7 @@ class LdapSkipCertificateMockMvcTests {
         File expiredKeystore = new File(classLoader.getResource("certs/expired-self-signed-ldap-cert.jks").getFile());
         RandomValueStringGenerator generator = new RandomValueStringGenerator();
         ldapRootDirectoryExpired = new File(System.getProperty("java.io.tmpdir"), generator.generate());
-
-        expiredLdapCertServer = InMemoryLdapServer.startLdapWithTls(LDAP_EXPIRED_LDAP_PORT, LDAP_EXPIRED_LDAPS_PORT, expiredKeystore);
+        expiredLdapCertServer = InMemoryLdapServer.startLdapWithTls(expiredKeystore);
     }
 
     @AfterAll
@@ -74,7 +68,7 @@ class LdapSkipCertificateMockMvcTests {
                 null, IdentityZoneHolder.getCurrentZoneId());
 
         LdapIdentityProviderDefinition definition = LdapIdentityProviderDefinition.searchAndBindMapGroupToScopes(
-                expiredLdapCertServer.getLdapSBaseUrl(),
+                expiredLdapCertServer.getUrl(),
                 "cn=admin,ou=Users,dc=test,dc=com",
                 "adminsecret",
                 "dc=test,dc=com",
@@ -97,7 +91,7 @@ class LdapSkipCertificateMockMvcTests {
                 mockMvc,
                 webApplicationContext,
                 null, IdentityZoneHolder.getCurrentZoneId());
-        definition.setBaseUrl(expiredLdapCertServer.getLdapSBaseUrl());
+        definition.setBaseUrl(expiredLdapCertServer.getUrl());
         MockMvcUtils.createIdentityProvider(mockMvc, trustedButExpiredCertZone, OriginKeys.LDAP, definition);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointDocs.java
@@ -159,8 +159,6 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
     private static final SnippetUtils.ConstrainableField VERSION = (SnippetUtils.ConstrainableField) fieldWithPath("version").type(NUMBER).description(VERSION_DESC);
     private static final Snippet commonRequestParams = requestParameters(parameterWithName("rawConfig").optional("false").type(BOOLEAN).description("<small><mark>UAA 3.4.0</mark></small> Flag indicating whether the response should use raw, unescaped JSON for the `config` field of the IDP, rather than the default behavior of encoding the JSON as a string."));
 
-    private static final int LDAP_PORT = 23389;
-
     private String adminToken;
     private IdentityProviderProvisioning identityProviderProvisioning;
 
@@ -241,7 +239,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
 
     @BeforeAll
     static void startLdapContainer() {
-        ldapContainer = InMemoryLdapServer.startLdap(LDAP_PORT);
+        ldapContainer = InMemoryLdapServer.startLdap();
     }
 
     private final FieldDescriptor ldapType = fieldWithPath("type").required().description("`ldap`");
@@ -792,7 +790,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
         LdapIdentityProviderDefinition providerDefinition = new LdapIdentityProviderDefinition();
         providerDefinition.setLdapProfileFile("ldap/ldap-simple-bind.xml");
         providerDefinition.setLdapGroupFile("ldap/ldap-groups-null.xml");
-        providerDefinition.setBaseUrl(ldapContainer.getLdapBaseUrl());
+        providerDefinition.setBaseUrl(ldapContainer.getUrl());
         providerDefinition.setUserDNPattern("cn={0},ou=Users,dc=test,dc=com");
         providerDefinition.setUserDNPatternDelimiter(";");
         providerDefinition.setMailAttributeName("mail");
@@ -812,7 +810,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
         LdapIdentityProviderDefinition providerDefinition = new LdapIdentityProviderDefinition();
         providerDefinition.setLdapProfileFile("ldap/ldap-search-and-bind.xml");
         providerDefinition.setLdapGroupFile("ldap/ldap-groups-map-to-scopes.xml");
-        providerDefinition.setBaseUrl(ldapContainer.getLdapBaseUrl());
+        providerDefinition.setBaseUrl(ldapContainer.getUrl());
         providerDefinition.setBindUserDn("cn=admin,ou=Users,dc=test,dc=com");
         providerDefinition.setBindPassword("adminsecret");
         providerDefinition.setUserSearchBase("dc=test,dc=com");
@@ -841,7 +839,7 @@ class IdentityProviderEndpointDocs extends EndpointDocs {
         LdapIdentityProviderDefinition providerDefinition = new LdapIdentityProviderDefinition();
         providerDefinition.setLdapProfileFile("ldap/ldap-search-and-compare.xml");
         providerDefinition.setLdapGroupFile("ldap/ldap-groups-as-scopes.xml");
-        providerDefinition.setBaseUrl(ldapContainer.getLdapBaseUrl());
+        providerDefinition.setBaseUrl(ldapContainer.getUrl());
         providerDefinition.setBindUserDn("cn=admin,ou=Users,dc=test,dc=com");
         providerDefinition.setBindPassword("adminsecret");
         providerDefinition.setUserSearchBase("dc=test,dc=com");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/providers/IdentityProviderEndpointsMockMvcTests.java
@@ -300,8 +300,8 @@ class IdentityProviderEndpointsMockMvcTests {
         providerDefinition.setGroupRoleAttribute("description");
 
         try (InMemoryLdapServer ldapServer =
-                InMemoryLdapServer.startLdap(33389)) {
-            providerDefinition.setBaseUrl(ldapServer.getLdapBaseUrl());
+                InMemoryLdapServer.startLdap()) {
+            providerDefinition.setBaseUrl(ldapServer.getUrl());
             newIdp.setConfig(providerDefinition);
 
             // Create an ldap identity provider


### PR DESCRIPTION
## Context

We want to run tests in parallel on local machines. But there are conflicts with some in-memory LDAP servers trying to bind to the same port.

This PR reworks `InMemoryLdapServer` so that it binds to a random port. To make the expected behavior clearer, the server now either listens on `ldap://` OR `ldaps://`, but not both.

### Notes

- Removed duplicate test `ableToConnectToLdapWithInvalidSsl_WithSkipValidation`
- Reworked the API of the in-memory LDAP server to be simpler: 
    - `InMemoryLdapServer#startLdap()`
    - `InMemoryLdapServer#startLdapWithTls(keystore)`
    - `server.getUrl()`