### PR TITLE
fix AuditCheckMockMvcTests with `ldap` profile

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -101,6 +101,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
@@ -325,7 +326,8 @@ class AuditCheckMockMvcTests {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string("Location", "/login?error=login_failure"));
 
-        assertNumberOfAuditEventsReceived(3);
+        // When the profile is ldap, an extra event is emitted
+        assertNumberOfAuditEventsReceived(greaterThanOrEqualTo(3));
 
         IdentityProviderAuthenticationFailureEvent idpAuthFailEvent = (IdentityProviderAuthenticationFailureEvent) testListener.getEvents().get(0);
         assertEquals(testUser.getUserName(), idpAuthFailEvent.getUsername());
@@ -452,7 +454,8 @@ class AuditCheckMockMvcTests {
                 .andExpect(status().isUnauthorized())
                 .andExpect(content().string("{\"error\":\"authentication failed\"}"));
 
-        assertNumberOfAuditEventsReceived(3);
+        // When the profile is ldap, an extra event is emitted
+        assertNumberOfAuditEventsReceived(greaterThanOrEqualTo(3));
 
         IdentityProviderAuthenticationFailureEvent event1 = (IdentityProviderAuthenticationFailureEvent) testListener.getEvents().get(0);
         UserAuthenticationFailureEvent event2 = (UserAuthenticationFailureEvent) testListener.getEvents().get(1);
@@ -519,7 +522,8 @@ class AuditCheckMockMvcTests {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(header().string("Location", "/login?error=login_failure"));
 
-        assertNumberOfAuditEventsReceived(2);
+        // When the profile is ldap, an extra event is emitted
+        assertNumberOfAuditEventsReceived(greaterThanOrEqualTo(2));
 
         UserNotFoundEvent event1 = (UserNotFoundEvent) testListener.getEvents().get(0);
         assertTrue(event1.getAuditEvent().getOrigin().contains("sessionId=<SESSION>"));
@@ -1370,8 +1374,12 @@ class AuditCheckMockMvcTests {
     }
 
     private void assertNumberOfAuditEventsReceived(int expectedEventCount) {
-        assertEquals(expectedEventCount, testListener.getEventCount());
-        assertEquals(expectedEventCount, testLogger.getMessageCount());
+        assertNumberOfAuditEventsReceived(equalTo(expectedEventCount));
+    }
+
+    private void assertNumberOfAuditEventsReceived(org.hamcrest.Matcher<Integer> matcher) {
+        assertThat(testListener.getEventCount(), matcher);
+        assertThat(testLogger.getMessageCount(), matcher);
     }
 
     private void assertSingleAuditEventFiredWith(AuditEventType expectedEventType, String[] expectedScopes, String[] expectedAuthorities) {


### PR DESCRIPTION
The `AuditCheckMockMvcTests` started failing when running with the `ldap` + `default` profiles, after gh-3186. We can see the issue [in Concourse](https://bosh.ci.cloudfoundry.org/teams/uaa/pipelines/uaa-acceptance-gcp/jobs/ldap-unit-tests-postgresql/builds/392)

This is because:

1. We removed the unexpected behavior in `@DefaultTestContext` which set the profiles to `default` regardless of what profile was passed in from the command line. This means the failing tests had not run with the `ldap` profile for years.
2. We don't run tests with the `ldap` profile on Github actions, so we did not catch this early (We probably should).
3. There is an [old commit from 2019](https://github.com/cloudfoundry/uaa/commit/d4d087c8) that had reworked that test class, and lost some of the nuance - it used to be "at least 3 events", not "exactly 3 events". See for example the diff below. At the time the commit was made, the `default` profile was already active and so there was never an `ldap` provider here.

```diff
-        ArgumentCaptor<AbstractUaaEvent> captor = ArgumentCaptor.forClass(AbstractUaaEvent.class);
-        verify(listener, atLeast(3)).onApplicationEvent(captor.capture());
+        assertNumberOfAuditEventsReceived(3);
```

The failing tests verify that audit events are emitted when the user tries to log in with an incorrect password. Without LDAP `AuthzAuthenticationManager` (internal UAA userstore) emits an `IdentityProviderAuthenticationFailureEvent`, and then two technical events are emitted, for a total of three. When the `ldap` profile is turned on, the `DynamicLdapAuthenticationManager` also tries to authenticate the user, and also throws an `IdentityProviderAuthenticationFailureEvent`, bringing the total number of events to 4.

Same goes for `userNotFoundLoginUnsuccessfulTest` but the use-case is "user not found" and 2/3 events.

This fixes those failing tests, by ignoring the extra events that having an LDAP provider creates.