### PR TITLE
Move `login-ui` Service classes to Javaconfig

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/EmailAccountCreationService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/EmailAccountCreationService.java
@@ -1,38 +1,45 @@
 package org.cloudfoundry.identity.uaa.account;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.cloudfoundry.identity.uaa.codestore.ExpiringCode;
 import org.cloudfoundry.identity.uaa.codestore.ExpiringCodeStore;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.error.UaaException;
 import org.cloudfoundry.identity.uaa.message.MessageService;
 import org.cloudfoundry.identity.uaa.message.MessageType;
+import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
+import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.scim.exception.ScimResourceAlreadyExistsException;
 import org.cloudfoundry.identity.uaa.scim.util.ScimUtils;
 import org.cloudfoundry.identity.uaa.scim.validate.PasswordValidator;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
-import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
-import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.MergedZoneBrandingInformation;
+import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
-import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
+import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static org.cloudfoundry.identity.uaa.codestore.ExpiringCodeType.REGISTRATION;
 import static org.cloudfoundry.identity.uaa.util.UaaUrlUtils.findMatchingRedirectUri;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
+@Service
 public class EmailAccountCreationService implements AccountCreationService {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -48,7 +55,7 @@ public class EmailAccountCreationService implements AccountCreationService {
     private final IdentityZoneManager identityZoneManager;
 
     public EmailAccountCreationService(
-            SpringTemplateEngine templateEngine,
+            @Qualifier("mailTemplateEngine") SpringTemplateEngine templateEngine,
             MessageService messageService,
             ExpiringCodeStore codeStore,
             ScimUserProvisioning scimUserProvisioning,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/EmailChangeEmailService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/EmailChangeEmailService.java
@@ -7,25 +7,32 @@ import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.error.UaaException;
 import org.cloudfoundry.identity.uaa.message.MessageService;
 import org.cloudfoundry.identity.uaa.message.MessageType;
+import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
+import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
 import org.cloudfoundry.identity.uaa.scim.ScimUser;
 import org.cloudfoundry.identity.uaa.scim.ScimUserProvisioning;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
-import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
 import org.cloudfoundry.identity.uaa.zone.MergedZoneBrandingInformation;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
-import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.thymeleaf.TemplateEngine;
 import org.thymeleaf.context.Context;
 
 import java.sql.Timestamp;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.cloudfoundry.identity.uaa.codestore.ExpiringCodeType.EMAIL;
 import static org.cloudfoundry.identity.uaa.util.UaaUrlUtils.findMatchingRedirectUri;
 
+@Service
 public class EmailChangeEmailService implements ChangeEmailService {
 
     static final String CHANGE_EMAIL_REDIRECT_URL = "change_email_redirect_url";
@@ -38,7 +45,8 @@ public class EmailChangeEmailService implements ChangeEmailService {
     private final MultitenantClientServices clientDetailsService;
     private final IdentityZoneManager identityZoneManager;
 
-    EmailChangeEmailService(final TemplateEngine templateEngine,
+    EmailChangeEmailService(
+            @Qualifier("mailTemplateEngine") final TemplateEngine templateEngine,
             final MessageService messageService,
             final ScimUserProvisioning scimUserProvisioning,
             final ExpiringCodeStore codeStore,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/UaaChangePasswordService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/UaaChangePasswordService.java
@@ -28,6 +28,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.List;
@@ -35,6 +36,7 @@ import java.util.List;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.UAA;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
+@Service
 public class UaaChangePasswordService implements ChangePasswordService, ApplicationEventPublisherAware {
 
     private final ScimUserProvisioning scimUserProvisioning;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/UaaResetPasswordService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/UaaResetPasswordService.java
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 
 import java.sql.Timestamp;
@@ -39,6 +40,7 @@ import static java.util.Collections.emptyList;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import static org.springframework.util.StringUtils.isEmpty;
 
+@Service("resetPasswordService")
 public class UaaResetPasswordService implements ResetPasswordService, ApplicationEventPublisherAware {
 
     public static final int PASSWORD_RESET_LIFETIME = 30 * 60 * 1000;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LoginServerConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LoginServerConfig.java
@@ -43,7 +43,7 @@ public class LoginServerConfig {
      *
      * @return -
      */
-    @Bean(name = "messageService")
+    @Bean
     public MessageService emailMessageService(
             // dgarnier: use DEFAULT_UAA_URL
             @Value("${login.url:http://localhost:8080/uaa}") String loginUrl,
@@ -100,7 +100,7 @@ public class LoginServerConfig {
          * @param notificationsProperties -
          * @return -
          */
-        @Bean(name = "messageService")
+        @Bean
         @Primary
         public MessageService notificationMessageService(
                 LocalUaaRestTemplate notificationsTemplate,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LoginServerConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/LoginServerConfig.java
@@ -1,21 +1,138 @@
 package org.cloudfoundry.identity.uaa.impl.config;
 
 import org.cloudfoundry.identity.uaa.message.EmailService;
+import org.cloudfoundry.identity.uaa.message.LocalUaaRestTemplate;
 import org.cloudfoundry.identity.uaa.message.MessageService;
+import org.cloudfoundry.identity.uaa.message.MessageType;
 import org.cloudfoundry.identity.uaa.message.NotificationsService;
+import org.cloudfoundry.identity.uaa.message.util.FakeJavaMailSender;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Configuration for sending e-mails or HTTP-based notifications, e.g. on account creation.
+ * <p>
+ * If a {@code notifications.url} property is defined, it uses HTTP-based notifications.
+ * Otherwise, if {@code smtp.*} properties are defined, it will send e-mails. If none of
+ * these properties are configured, it uses a {@link FakeJavaMailSender} mailer.
+ * <p>
+ * All beans are marked lazy except {@link NotificationConfiguration#notificationMessageService},
+ * as they are all "fallback" options and do not need to be created when {@code notifications.url}
+ * is defined.
+ */
+@Lazy
 @Configuration
+@EnableConfigurationProperties(SmtpProperties.class)
 public class LoginServerConfig {
 
-    @Bean
-    public MessageService messageService(EmailService emailService, NotificationsService notificationsService, Environment environment) {
-        if (environment.getProperty("notifications.url") != null && !"".equals(environment.getProperty("notifications.url"))) {
-            return notificationsService;
-        } else {
-            return emailService;
-        }
+    /**
+     * Fallback bean for when there is no "notifications.url".
+     * TODO: dgarnier annotate with @Fallback in Boot 3.4
+     *
+     * @return -
+     */
+    @Bean(name = "messageService")
+    public MessageService emailMessageService(
+            // dgarnier: use DEFAULT_UAA_URL
+            @Value("${login.url:http://localhost:8080/uaa}") String loginUrl,
+            JavaMailSender mailSender,
+            SmtpProperties smtpProperties,
+            IdentityZoneManager identityZoneManager) {
+        return new EmailService(
+                mailSender,
+                loginUrl,
+                smtpProperties.fromAddress(),
+                identityZoneManager
+        );
     }
+
+    /**
+     * Fallback for SMTP mail sender, when no real mail sender is used. This is mostly used in tests.
+     * TODO: dgarnier annotate with @Fallback in Boot 3.4
+     *
+     * @return -
+     */
+    @Bean
+    JavaMailSender fakeJavaMailSender() {
+        return new FakeJavaMailSender();
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(value = "smtp.host", matchIfMissing = false)
+    JavaMailSender smtpMailSender(SmtpProperties smtpProperties) {
+        var mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(smtpProperties.host());
+        mailSender.setPort(smtpProperties.port());
+        mailSender.setPassword(smtpProperties.password());
+        mailSender.setUsername(smtpProperties.user());
+
+        var javaMailProperties = new Properties();
+        javaMailProperties.put("mail.smtp.auth", smtpProperties.auth());
+        javaMailProperties.put("mail.smtp.starttls.enable", smtpProperties.starttls());
+        javaMailProperties.put("mail.smtp.ssl.protocols", smtpProperties.sslprotocols());
+        mailSender.setJavaMailProperties(javaMailProperties);
+        return mailSender;
+    }
+
+    @Configuration
+    @ConditionalOnProperty(value = "notifications.url", matchIfMissing = false)
+    @EnableConfigurationProperties(NotificationsProperties.class)
+    static class NotificationConfiguration {
+
+        /**
+         * HTTP-based {@link MessageService}. Takes precedence over any email-basedO
+         * configuration.
+         *
+         * @param notificationsTemplate   -
+         * @param notificationsProperties -
+         * @return -
+         */
+        @Bean(name = "messageService")
+        @Primary
+        public MessageService notificationMessageService(
+                LocalUaaRestTemplate notificationsTemplate,
+                NotificationsProperties notificationsProperties
+        ) {
+            return new NotificationsService(
+                    notificationsTemplate,
+                    notificationsProperties.url(),
+                    notifications(),
+                    notificationsProperties.sendInDefaultZone()
+            );
+        }
+
+        private static Map<MessageType, HashMap<String, Object>> notifications() {
+            return Map.of(
+                    MessageType.CREATE_ACCOUNT_CONFIRMATION, notification("Send activation code", "f7a85fdc-d920-41f0-b3a4-55db08e408ce"),
+                    MessageType.PASSWORD_RESET, notification("Reset Password", "141200f6-93bd-4761-a721-941ab511ba2c"),
+                    MessageType.CHANGE_EMAIL, notification("Change Email", "712de257-a7fa-44cb-b1ac-8a6588d1be23"),
+                    MessageType.INVITATION, notification("Invitation", "e6722687-3f0f-4e7a-9925-839a04712cea")
+            );
+        }
+
+        private static HashMap<String, Object> notification(String description, String id) {
+            return new HashMap<>(
+                    Map.of(
+                            "description", description,
+                            "id", id,
+                            "critical", true
+                    )
+            );
+        }
+
+    }
+
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/NotificationsProperties.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/NotificationsProperties.java
@@ -1,0 +1,11 @@
+package org.cloudfoundry.identity.uaa.impl.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "notifications")
+record NotificationsProperties(
+        String url,
+        @DefaultValue("true") boolean sendInDefaultZone
+) {
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/SmtpProperties.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/SmtpProperties.java
@@ -1,0 +1,17 @@
+package org.cloudfoundry.identity.uaa.impl.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "smtp")
+public record SmtpProperties(
+        @DefaultValue("localhost") String host,
+        @DefaultValue("25") int port,
+        @DefaultValue("") String user,
+        @DefaultValue("") String password,
+        @DefaultValue("false") boolean auth,
+        @DefaultValue("false") boolean starttls,
+        @DefaultValue("TLSv1.2") String sslprotocols,
+        @DefaultValue("") String fromAddress
+) {
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/ForcePasswordChangeController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/ForcePasswordChangeController.java
@@ -35,7 +35,7 @@ public class ForcePasswordChangeController {
 
     public ForcePasswordChangeController(
             final ResourcePropertySource resourcePropertySource,
-            final @Qualifier("resetPasswordService") ResetPasswordService resetPasswordService) {
+            ResetPasswordService resetPasswordService) {
         this.resourcePropertySource = resourcePropertySource;
         this.resetPasswordService = resetPasswordService;
     }

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -364,15 +364,6 @@
 
     <bean id="thymeleafConfig" class="org.cloudfoundry.identity.uaa.login.ThymeleafConfig"/>
 
-    <bean id="accountCreationService" class="org.cloudfoundry.identity.uaa.account.EmailAccountCreationService">
-        <constructor-arg ref="mailTemplateEngine"/>
-        <constructor-arg ref="messageService"/>
-        <constructor-arg ref="codeStore"/>
-        <constructor-arg ref="scimUserProvisioning"/>
-        <constructor-arg ref="jdbcClientDetailsService"/>
-        <constructor-arg ref="uaaPasswordValidator"/>
-    </bean>
-
     <bean id="uaaPasswordValidator" class="org.cloudfoundry.identity.uaa.scim.validate.UaaPasswordPolicyValidator">
         <constructor-arg ref="globalPasswordPolicy"/>
     </bean>
@@ -380,14 +371,6 @@
     <bean id="changePasswordService" class="org.cloudfoundry.identity.uaa.account.UaaChangePasswordService">
         <constructor-arg ref="scimUserProvisioning"/>
         <constructor-arg ref="uaaPasswordValidator"/>
-    </bean>
-
-    <bean id="changeEmailService" class="org.cloudfoundry.identity.uaa.account.EmailChangeEmailService">
-        <constructor-arg ref="mailTemplateEngine"/>
-        <constructor-arg ref="messageService"/>
-        <constructor-arg ref="jdbcClientDetailsService"/>
-        <constructor-arg ref="scimUserProvisioning"/>
-        <constructor-arg ref="codeStore"/>
     </bean>
 
     <bean id="messagePropertiesSource" class="org.springframework.core.io.support.ResourcePropertySource">

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -310,37 +310,6 @@
     <!--apply the oauth client context -->
     <oauth:client id="oauth2ClientFilter"/>
 
-    <util:map id="notifications" key-type="org.cloudfoundry.identity.uaa.message.MessageType">
-        <entry key="CREATE_ACCOUNT_CONFIRMATION">
-            <map>
-                <entry key="description" value="Send activation code"/>
-                <entry key="id" value="f7a85fdc-d920-41f0-b3a4-55db08e408ce"/>
-                <entry key="critical" value="true" value-type="java.lang.Boolean"/>
-            </map>
-        </entry>
-        <entry key="PASSWORD_RESET">
-            <map>
-                <entry key="description" value="Reset Password"/>
-                <entry key="id" value="141200f6-93bd-4761-a721-941ab511ba2c"/>
-                <entry key="critical" value="true" value-type="java.lang.Boolean"/>
-            </map>
-        </entry>
-        <entry key="CHANGE_EMAIL">
-            <map>
-                <entry key="description" value="Change Email"/>
-                <entry key="id" value="712de257-a7fa-44cb-b1ac-8a6588d1be23"/>
-                <entry key="critical" value="true" value-type="java.lang.Boolean"/>
-            </map>
-        </entry>
-        <entry key="INVITATION">
-            <map>
-                <entry key="description" value="Invitation"/>
-                <entry key="id" value="e6722687-3f0f-4e7a-9925-839a04712cea"/>
-                <entry key="critical" value="true" value-type="java.lang.Boolean"/>
-            </map>
-        </entry>
-    </util:map>
-
     <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
         <mvc:message-converters>
             <bean class="org.cloudfoundry.identity.uaa.authentication.manager.AutologinRequestConverter"/>
@@ -395,36 +364,6 @@
 
     <bean id="thymeleafConfig" class="org.cloudfoundry.identity.uaa.login.ThymeleafConfig"/>
 
-    <bean id="emailService" class="org.cloudfoundry.identity.uaa.message.EmailService">
-        <constructor-arg index="0"
-                              ref="#{T(org.springframework.util.StringUtils).hasText('${smtp.host:}') ? 'smtpJavaMailSender' : 'fakeJavaMailSender'}"/>
-        <constructor-arg index="1" value="${login.url:http://localhost:8080/uaa}"/>
-        <constructor-arg index="2" value="${smtp.from_address:}"/>
-    </bean>
-
-    <bean id="smtpJavaMailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
-        <property name="host" value="${smtp.host:localhost}"/>
-        <property name="port" value="${smtp.port:25}"/>
-        <property name="username" value="${smtp.user:}"/>
-        <property name="password" value="${smtp.password:}"/>
-        <property name="javaMailProperties">
-            <props>
-                <prop key="mail.smtp.auth">${smtp.auth:false}</prop>
-                <prop key="mail.smtp.starttls.enable">${smtp.starttls:false}</prop>
-                <prop key="mail.smtp.ssl.protocols">${smtp.sslprotocols:TLSv1.2}</prop>
-            </props>
-        </property>
-    </bean>
-
-    <bean id="fakeJavaMailSender" class="org.cloudfoundry.identity.uaa.message.util.FakeJavaMailSender"/>
-
-    <bean id="notificationsService" class="org.cloudfoundry.identity.uaa.message.NotificationsService">
-        <constructor-arg ref="notificationsTemplate"/>
-        <constructor-arg ref="notificationsUrl"/>
-        <constructor-arg ref="notifications"/>
-        <constructor-arg value="${notifications.send_in_default_zone:true}"/>
-    </bean>
-
     <bean id="accountCreationService" class="org.cloudfoundry.identity.uaa.account.EmailAccountCreationService">
         <constructor-arg ref="mailTemplateEngine"/>
         <constructor-arg ref="messageService"/>
@@ -443,6 +382,14 @@
         <constructor-arg ref="uaaPasswordValidator"/>
     </bean>
 
+    <bean id="changeEmailService" class="org.cloudfoundry.identity.uaa.account.EmailChangeEmailService">
+        <constructor-arg ref="mailTemplateEngine"/>
+        <constructor-arg ref="messageService"/>
+        <constructor-arg ref="jdbcClientDetailsService"/>
+        <constructor-arg ref="scimUserProvisioning"/>
+        <constructor-arg ref="codeStore"/>
+    </bean>
+
     <bean id="messagePropertiesSource" class="org.springframework.core.io.support.ResourcePropertySource">
         <constructor-arg value="messages.properties"/>
     </bean>
@@ -453,14 +400,6 @@
         <constructor-arg ref="uaaPasswordValidator"/>
         <constructor-arg ref="jdbcClientDetailsService"/>
         <constructor-arg ref="messagePropertiesSource"/>
-    </bean>
-
-    <bean id="changeEmailService" class="org.cloudfoundry.identity.uaa.account.EmailChangeEmailService">
-        <constructor-arg ref="mailTemplateEngine"/>
-        <constructor-arg ref="messageService"/>
-        <constructor-arg ref="jdbcClientDetailsService"/>
-        <constructor-arg ref="scimUserProvisioning"/>
-        <constructor-arg ref="codeStore"/>
     </bean>
 
 </beans>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -368,11 +368,6 @@
         <constructor-arg ref="globalPasswordPolicy"/>
     </bean>
 
-    <bean id="changePasswordService" class="org.cloudfoundry.identity.uaa.account.UaaChangePasswordService">
-        <constructor-arg ref="scimUserProvisioning"/>
-        <constructor-arg ref="uaaPasswordValidator"/>
-    </bean>
-
     <bean id="messagePropertiesSource" class="org.springframework.core.io.support.ResourcePropertySource">
         <constructor-arg value="messages.properties"/>
     </bean>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -372,12 +372,4 @@
         <constructor-arg value="messages.properties"/>
     </bean>
 
-    <bean id="resetPasswordService" class="org.cloudfoundry.identity.uaa.account.UaaResetPasswordService">
-        <constructor-arg ref="scimUserProvisioning"/>
-        <constructor-arg ref="codeStore"/>
-        <constructor-arg ref="uaaPasswordValidator"/>
-        <constructor-arg ref="jdbcClientDetailsService"/>
-        <constructor-arg ref="messagePropertiesSource"/>
-    </bean>
-
 </beans>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/AccountsControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/AccountsControllerMockMvcTests.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.identity.uaa.login;
 
+import java.util.Collections;
+
 import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.account.EmailAccountCreationService;
@@ -29,6 +31,7 @@ import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mock.env.MockPropertySource;
@@ -42,9 +45,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.context.support.StandardServletEnvironment;
-
-import java.util.Collections;
-
 import static org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils.CookieCsrfPostProcessor.cookieCsrf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -85,17 +85,17 @@ class AccountsControllerMockMvcTests {
     @Autowired
     private FakeJavaMailSender fakeJavaMailSender;
     private JavaMailSender originalEmailSender;
+    @Autowired
+    private EmailService emailService;
 
     @BeforeEach
     void setUp() {
         testClient = new TestClient(mockMvc);
 
-        EmailService emailService = webApplicationContext.getBean("emailService", EmailService.class);
         originalEmailSender = emailService.getMailSender();
         emailService.setMailSender(fakeJavaMailSender);
 
         userEmail = "user" + new AlphanumericRandomValueStringGenerator().generate() + "@example.com";
-        assertNotNull(webApplicationContext.getBean("messageService"));
         IdentityZoneHolder.setProvisioning(webApplicationContext.getBean(IdentityZoneProvisioning.class));
 
         mockMvcTestClient = new MockMvcTestClient(mockMvc);
@@ -111,7 +111,7 @@ class AccountsControllerMockMvcTests {
 
     @AfterEach
     void clearEmails() {
-        webApplicationContext.getBean("emailService", EmailService.class).setMailSender(originalEmailSender);
+        emailService.setMailSender(originalEmailSender);
         fakeJavaMailSender.clearMessage();
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/InvitationsServiceMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/InvitationsServiceMockMvcTests.java
@@ -78,7 +78,6 @@ public class InvitationsServiceMockMvcTests {
 
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     @Autowired
-    @Qualifier("emailService")
     EmailService emailService;
 
     public static final String REDIRECT_URI = "http://invitation.redirect.test";


### PR DESCRIPTION
  ## Context
  
  We are moving out of XML config and into java config.
  
  This moves `*Service` used by `login-ui` out of XML config, and can be used as a blueprint to move some config out of XML.
  
  Below are a few notable changes to the configuration.
  
  ### Configuration properties
  
  Example: `SmtpConfigurationProperties`.
  
Avoid `@Value`, prefer `@ConfigurationProperties` classes which allow for easily following where they are actually used. Default values can be provided. Validation can be applied.  Avoid SpEL expressions where possible, prefer Java code, either in constructors or in bean methodes.

For configuration properties, when possible, prefer immutable `record`s.
  
  ### Code-independent beans
  
  Examples: `EmailChangeEmailService`, `EmailAccountCreationService`, etc.
  
  Any bean that:
  1. Has a unique implementation
  1. Does not have conditions to decide whether it should be present or not
  1. Does not have configuration variants ("use this or that param, based on some  condition")
  
  can be provided with a stereotype annotation, such as `@Component` or `@Service`. When they are not used anywhere in XML config, they do not need to be named.
  
  ### Conditional and code-dependent beans
  
  Examples: `JavaMailSender`, `MessageService`.
  
  Some beans are configuration-dependent. They require some code to be correctly created, and may be conditional on some application properties ("only create a `NotificationsService` when there is a `notifications.url` property"). They are typically interfaces, that have multiple implementations.
  
  Those beans need to be provided in `@Bean` functions in `@Configuration` classes.
  
  Typically, one implementation is the default, and other is what happens when certain conditions are met. A way to achieve this in javaconfig is to annotation the configuration-dependent bean with `@Primary`, and it will override the default bean. Spring Framework 6.2 / Boot 3.4 will provide an [@Fallback](https://docs.spring.io/spring-framework/reference/core/beans/annotation-config/autowired-primary.html#page-title) annotation to achieve the same result.

Keep the code minimum in `@Bean` methods when possible, and rely on declarative configuration instead.
  
  ### Reference data
  
  With beans moved out of XML, reference data, such as `util:map id="notifications"`, needs to be moved to java (in this case, in a helper static method, `notifications()`). 

In this particular case we chose functions to avoid a nested `Map<String, Map<String, String>>`: it makes in XML or other text-based data representation, but less in Java.