### PR TITLE
Do not add whitespaces in XML signature of /saml/metadata

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/IdentityZoneConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/IdentityZoneConfig.java
@@ -26,6 +26,7 @@ public class IdentityZoneConfig {
             log.info("New securerandom.strongAlgorithms: {}", newStrongAlgorithm);
             Security.setProperty("securerandom.strongAlgorithms", newStrongAlgorithm);
         }
+        System.setProperty("org.apache.xml.security.ignoreLineBreaks", "true");
         BouncyCastleFipsProvider provider = new BouncyCastleFipsProvider();
         Security.addProvider(provider);
         return provider;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -229,6 +229,8 @@ public class SamlLoginIT {
         ResponseEntity<String> response = request.getForEntity("%s/saml/metadata".formatted(baseUrl), String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         String metadataXml = response.getBody();
+        // CR carriage return must not be in output
+        assertThat(metadataXml).doesNotContain("&#13;", "\r\n");
         XmlAssert xmlAssert = XmlAssert.assertThat(metadataXml).withNamespaceContext(xmlNamespaces());
 
         // The SAML SP metadata should match the following UAA configs:
@@ -245,6 +247,8 @@ public class SamlLoginIT {
         xmlAssert.valueByXPath("/md:EntityDescriptor/ds:Signature/ds:SignedInfo/ds:SignatureMethod/@Algorithm").isEqualTo(ALGO_ID_SIGNATURE_RSA_SHA256);
         xmlAssert.valueByXPath("/md:EntityDescriptor/ds:Signature/ds:SignedInfo/ds:Reference/ds:DigestMethod/@Algorithm").isEqualTo(ALGO_ID_DIGEST_SHA256);
         xmlAssert.nodesByXPath("/md:EntityDescriptor/ds:Signature/ds:SignatureValue").exist();
+        // CR carriage return is not visible in XML Assert anymore, but stay we check even here
+        xmlAssert.nodesByXPath("/md:EntityDescriptor/ds:Signature/ds:SignatureValue").asString().doesNotContain("&#13;", "\r\n");
         xmlAssert.nodesByXPath("/md:EntityDescriptor/ds:Signature/ds:SignedInfo/ds:Reference/ds:DigestValue").exist();
         // login.saml.nameID
         xmlAssert.nodesByXPath("/md:EntityDescriptor/md:SPSSODescriptor/md:NameIDFormat")
@@ -280,6 +284,8 @@ public class SamlLoginIT {
         ResponseEntity<String> response = request.getForEntity("%s/saml/metadata".formatted(zoneUrl), String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         String metadataXml = response.getBody();
+        // CR carriage return must not be in output
+        assertThat(metadataXml).doesNotContain("&#13;", "\r\n");
         XmlAssert xmlAssert = XmlAssert.assertThat(metadataXml).withNamespaceContext(xmlNamespaces());
 
         // The SAML SP metadata should match the following UAA configs:
@@ -296,6 +302,8 @@ public class SamlLoginIT {
                 .contains("testzone1.localhost")
                 .contains("/saml/SSO/alias/testzone1.cloudfoundry-saml-login");
         xmlAssert.nodesByXPath("//md:EntityDescriptor/ds:Signature/ds:SignatureValue").exist();
+        // CR carriage return is not visible in XML Assert anymore, but stay we check even here
+        xmlAssert.nodesByXPath("/md:EntityDescriptor/ds:Signature/ds:SignatureValue").asString().doesNotContain("&#13;", "\r\n");
         xmlAssert.nodesByXPath("//md:EntityDescriptor/ds:Signature/ds:SignedInfo/ds:Reference/ds:DigestValue").exist();
 
         assertThat(response.getHeaders().getContentDisposition().getFilename()).isEqualTo("saml-testzone1-sp.xml");


### PR DESCRIPTION
Add property, e.g. https://stackoverflow.com/questions/4728300/how-to-produce-xml-signature-with-no-whitespaces-and-line-breaks-in-java

Signature value ONLY of endpoint /saml/metadata contain the line breaks, other signatures dont show such chars

