### PR TITLE
Fix the client_auth_method check

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenConstants.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenConstants.java
@@ -65,6 +65,7 @@ public class TokenConstants {
 
     public static final String CLIENT_AUTH_NONE = ClientAuthentication.NONE;
     public static final String CLIENT_AUTH_EMPTY = "empty";
+    public static final String CLIENT_AUTH_SECRET = "secret";
     public static final String CLIENT_AUTH_PRIVATE_KEY_JWT = ClientAuthentication.PRIVATE_KEY_JWT;
 
     public static final String ID_TOKEN_HINT_PROMPT = "prompt";

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/client/ClientCredentialsTokenGranter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/client/ClientCredentialsTokenGranter.java
@@ -8,6 +8,10 @@ import org.cloudfoundry.identity.uaa.oauth.provider.token.AbstractTokenGranter;
 import org.cloudfoundry.identity.uaa.oauth.provider.token.AuthorizationServerTokenServices;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetailsService;
 
+import java.util.List;
+
+import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.CLIENT_AUTH_PRIVATE_KEY_JWT;
+import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.CLIENT_AUTH_SECRET;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_CLIENT_CREDENTIALS;
 
 /**
@@ -19,6 +23,8 @@ import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYP
  * Scope: OAuth2 server
  */
 public class ClientCredentialsTokenGranter extends AbstractTokenGranter {
+
+    private static final List<String> ALLOWED_AUTH_METHODS = List.of(CLIENT_AUTH_SECRET, CLIENT_AUTH_PRIVATE_KEY_JWT);
 
     public ClientCredentialsTokenGranter(AuthorizationServerTokenServices tokenServices,
             ClientDetailsService clientDetailsService, OAuth2RequestFactory requestFactory) {
@@ -33,7 +39,7 @@ public class ClientCredentialsTokenGranter extends AbstractTokenGranter {
     @Override
     public OAuth2AccessToken grant(String grantType, TokenRequest tokenRequest) {
         OAuth2AccessToken token = super.grant(grantType, tokenRequest);
-        if (token != null) {
+        if (token != null && isValidClientAuthentication(ALLOWED_AUTH_METHODS)) {
             DefaultOAuth2AccessToken norefresh = new DefaultOAuth2AccessToken(token);
             // The spec says that client credentials should not be allowed to get a refresh token
             norefresh.setRefreshToken(null);
@@ -41,5 +47,4 @@ public class ClientCredentialsTokenGranter extends AbstractTokenGranter {
         }
         return token;
     }
-
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/provider/client/ClientCredentialsTokenGranterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/provider/client/ClientCredentialsTokenGranterTests.java
@@ -1,6 +1,9 @@
 package org.cloudfoundry.identity.uaa.oauth.provider.client;
 
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
+import org.cloudfoundry.identity.uaa.oauth.common.DefaultOAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
+import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidRequestException;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetailsService;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Request;
@@ -8,12 +11,16 @@ import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2RequestFactory;
 import org.cloudfoundry.identity.uaa.oauth.provider.TokenRequest;
 import org.cloudfoundry.identity.uaa.oauth.provider.token.AuthorizationServerTokenServices;
 import org.cloudfoundry.identity.uaa.oauth.token.TokenConstants;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -35,6 +42,11 @@ class ClientCredentialsTokenGranterTests {
         clientCredentialsTokenGranter = new ClientCredentialsTokenGranter(tokenServices, clientDetailsService, requestFactory);
     }
 
+    @AfterEach
+    void cleanUp() {
+        SecurityContextHolder.clearContext();
+    }
+
     @Test
     void grant() {
         OAuth2Request oAuth2Request = mock(OAuth2Request.class);
@@ -53,5 +65,23 @@ class ClientCredentialsTokenGranterTests {
         when(tokenServices.createAccessToken(any())).thenReturn(null);
         when(oAuth2Request.getAuthorities()).thenReturn(Collections.emptyList());
         assertThat(clientCredentialsTokenGranter.grant(TokenConstants.GRANT_TYPE_CLIENT_CREDENTIALS, tokenRequest)).isNull();
+    }
+
+    @Test
+    void grantNoSecretFails() {
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken("username", null, null);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        UaaAuthenticationDetails uaaAuthenticationDetails = mock(UaaAuthenticationDetails.class);
+        authentication.setDetails(uaaAuthenticationDetails);
+        when(clientDetailsService.loadClientByClientId(any())).thenReturn(mock(ClientDetails.class));
+        when(requestFactory.createOAuth2Request(any(), any())).thenReturn(oAuth2Request);
+        when(tokenServices.createAccessToken(any())).thenReturn(new DefaultOAuth2AccessToken("eyJx"));
+        when(oAuth2Request.getAuthorities()).thenReturn(Collections.emptyList());
+        when(uaaAuthenticationDetails.getAuthenticationMethod()).thenReturn("none");
+        assertThatThrownBy(() -> clientCredentialsTokenGranter
+                .grant(TokenConstants.GRANT_TYPE_CLIENT_CREDENTIALS, tokenRequest))
+                .isInstanceOf(InvalidRequestException.class)
+                .hasMessage("Client credentials required");
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/security/UaaUsingDelegatingPasswordEncoderMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/security/UaaUsingDelegatingPasswordEncoderMockMvcTest.java
@@ -56,14 +56,14 @@ class UaaUsingDelegatingPasswordEncoderMockMvcTest {
     @ValueSource(strings = {
             "client_id_with_empty_password"
     })
-    void tryToGetTokenWithEmtpyPasswordSucceeds(String clientId) throws Exception {
+    void tryToGetTokenWithEmtpyPasswordMustFail(String clientId) throws Exception {
         mockMvc.perform(post("/oauth/token")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .accept(MediaType.APPLICATION_JSON)
                 .param("client_id", clientId)
                 .param("client_secret", "")
                 .param("grant_type", "client_credentials"))
-                .andExpect(status().isOk());
+                .andExpect(status().isBadRequest());
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Ensure for client_credentials that either secret or private_key_jwt is used
If value from claim client_auth_method is none or empty we have to reject token requests

Prevent

```
uaac client update cf --authorized_grant_types "client_credentials"
uaac token client get cf -t -s ""
```