### PR TITLE
Remove retry for unit tests 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ buildscript {
         classpath(libraries.cargoGradlePlugin)
         classpath(libraries.springDependencyMangementGradlePlugin)
         classpath(libraries.springBootGradlePlugin)
-        classpath(libraries.testRetryPlugin)
         classpath(libraries.gradleJcocoPlugin)
         classpath(libraries.sonarqubePlugin)
     }
@@ -33,7 +32,6 @@ apply(plugin: "war")
 
 allprojects {
     apply(plugin: "io.spring.dependency-management")
-    apply(plugin: "org.gradle.test-retry")
     apply(plugin: "org.barfuin.gradle.jacocolog")
     apply(plugin: "org.sonarqube")
 
@@ -109,19 +107,6 @@ subprojects {
         failFast = false
         useJUnitPlatform()
         jvmArgs += ["-Xmx1024m", "-XX:+StartAttachListener", "-XX:+HeapDumpOnOutOfMemoryError", "-XX:HeapDumpPath=/var/log/uaa-tests.hprof"]
-
-        retry {
-            def failOnPassedAfterRetrySystemProperty = Boolean.parseBoolean(
-                    System.getProperty("failOnPassedAfterRetry", "false"));
-            if (!failOnPassedAfterRetrySystemProperty) {
-                logger.warn("retry: Flaky tests will not make the test run fail because failOnPassedAfterRetry is false.")
-            }
-
-            // Configure the retry extension
-            failOnPassedAfterRetry = failOnPassedAfterRetrySystemProperty
-            maxFailures = Integer.parseInt(System.getProperty("maxFailures", "3"))
-            maxRetries = Integer.parseInt(System.getProperty("maxRetries", "1"))
-        }
 
         testLogging {
             events("failed")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -137,7 +137,6 @@ libraries.apacheHttpClient = "org.apache.httpcomponents:httpclient:4.5.14"
 libraries.jacocoAgent = "org.jacoco:org.jacoco.agent:0.8.12"
 
 // gradle plugins
-libraries.testRetryPlugin = "org.gradle:test-retry-gradle-plugin:1.6.0"
 libraries.cargoGradlePlugin = "com.bmuschko:gradle-cargo-plugin:2.9.0"
 libraries.springBootGradlePlugin = "org.springframework.boot:spring-boot-gradle-plugin:${versions.springBootVersion}"
 libraries.springDependencyMangementGradlePlugin = "io.spring.gradle:dependency-management-plugin"


### PR DESCRIPTION
From #3229
We want unit tests to be as robust as possible.

Experiment: remove retries, and fix tests.
If it fails too often and is blocking, we can re-introduce retries at the test level with the junit-pioneer  @RetryingTest annotation.
