### PR TITLE
More waiting time for webdriver

### DIFF
--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/pageObjects/Page.java
@@ -20,7 +20,8 @@ public class Page {
 
     public Page(WebDriver driver) {
         this.driver = driver;
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(5));
+        // similar to https://github.com/cloudfoundry/uaa/blob/develop/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java#L35-L37
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30L));
     }
 
     public static AbstractStringAssert<?> assertThatUrlEventuallySatisfies(WebDriver driver, Consumer<AbstractStringAssert<?>> assertUrl) {


### PR DESCRIPTION
5 sec is not enough in some cases
In other scenarios we have about 30 sec.

https://github.com/cloudfoundry/uaa/blob/develop/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java#L35-L37