### PR TITLE
Introduce optional Cache for Login Info IdPs

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingExternalOAuthProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingExternalOAuthProviderConfigurator.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.login;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthProviderConfigurator;
@@ -19,9 +20,9 @@ import static java.util.stream.Collectors.toSet;
 
 /**
  * Extension for {@link ExternalOAuthProviderConfigurator} that caches the IdPs returned by
- * {@link ExternalOAuthProviderConfigurator#retrieveActiveByTypes(String, String...)}.
- * The cache is neither synchronized across app instances nor invalidated after the set of IdPs changes (e.g., when an
- * IdP is deleted). Therefore, an inconsistent set of IdPs might be returned until the cache expires.
+ * {@link ExternalOAuthProviderConfigurator#retrieveActiveByTypes(String, String...)}. The cache is neither synchronized
+ * across app instances nor invalidated after the set of IdPs changes (e.g., when an IdP is deleted). Therefore, an
+ * inconsistent set of IdPs might be returned until the cache expires.
  */
 public class CachingExternalOAuthProviderConfigurator extends ExternalOAuthProviderConfigurator {
 
@@ -35,10 +36,25 @@ public class CachingExternalOAuthProviderConfigurator extends ExternalOAuthProvi
             final IdentityZoneManager identityZoneManager,
             final long cacheDurationInMs
     ) {
+        this(providerProvisioning, oidcMetadataFetcher, uaaRandomStringUtil, identityZoneProvisioning,
+                identityZoneManager, cacheDurationInMs, Ticker.systemTicker());
+    }
+
+    /** Constructor for testing; allows injecting ticker to advance time. */
+    CachingExternalOAuthProviderConfigurator(
+            final IdentityProviderProvisioning providerProvisioning,
+            final OidcMetadataFetcher oidcMetadataFetcher,
+            final UaaRandomStringUtil uaaRandomStringUtil,
+            final IdentityZoneProvisioning identityZoneProvisioning,
+            final IdentityZoneManager identityZoneManager,
+            final long cacheDurationInMs,
+            final Ticker ticker
+    ) {
         super(providerProvisioning, oidcMetadataFetcher, uaaRandomStringUtil, identityZoneProvisioning,
                 identityZoneManager);
 
         this.cache = Caffeine.newBuilder()
+                .ticker(ticker)
                 .expireAfterWrite(cacheDurationInMs, MILLISECONDS)
                 .build(cacheKey ->
                         super.retrieveActiveByTypes(cacheKey.zoneId(), cacheKey.types().toArray(new String[0]))

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingExternalOAuthProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingExternalOAuthProviderConfigurator.java
@@ -1,0 +1,57 @@
+package org.cloudfoundry.identity.uaa.login;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthProviderConfigurator;
+import org.cloudfoundry.identity.uaa.provider.oauth.OidcMetadataFetcher;
+import org.cloudfoundry.identity.uaa.util.UaaRandomStringUtil;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toSet;
+
+/**
+ * Extension for {@link ExternalOAuthProviderConfigurator} that caches the IdPs returned by
+ * {@link ExternalOAuthProviderConfigurator#retrieveActiveByTypes(String, String...)}.
+ * The cache is neither synchronized across app instances nor invalidated after the set of IdPs changes (e.g., when an
+ * IdP is deleted). Therefore, an inconsistent set of IdPs might be returned until the cache expires.
+ */
+public class CachingExternalOAuthProviderConfigurator extends ExternalOAuthProviderConfigurator {
+
+    private final LoadingCache<CacheKey, List<IdentityProvider>> cache;
+
+    public CachingExternalOAuthProviderConfigurator(
+            final IdentityProviderProvisioning providerProvisioning,
+            final OidcMetadataFetcher oidcMetadataFetcher,
+            final UaaRandomStringUtil uaaRandomStringUtil,
+            final IdentityZoneProvisioning identityZoneProvisioning,
+            final IdentityZoneManager identityZoneManager,
+            final long cacheDurationInMs
+    ) {
+        super(providerProvisioning, oidcMetadataFetcher, uaaRandomStringUtil, identityZoneProvisioning,
+                identityZoneManager);
+
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(cacheDurationInMs, MILLISECONDS)
+                .build(cacheKey ->
+                        super.retrieveActiveByTypes(cacheKey.zoneId(), cacheKey.types().toArray(new String[0]))
+                );
+    }
+
+    private record CacheKey(String zoneId, Set<String> types) {
+    }
+
+    @Override
+    public List<IdentityProvider> retrieveActiveByTypes(final String zoneId, final String... types) {
+        final Set<String> typesAsSet = Stream.of(types).collect(toSet());
+        final CacheKey cacheKey = new CacheKey(zoneId, typesAsSet);
+        return cache.get(cacheKey);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingSamlProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingSamlProviderConfigurator.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.login;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.saml.FixedHttpMetaDataProvider;
@@ -35,10 +36,23 @@ public class CachingSamlProviderConfigurator extends SamlIdentityProviderConfigu
             final FixedHttpMetaDataProvider fixedHttpMetaDataProvider,
             final long cacheDurationInMs
     ) {
+        this(providerProvisioning, identityZoneManager, fixedHttpMetaDataProvider, cacheDurationInMs,
+                Ticker.systemTicker());
+    }
+
+    /** Constructor for testing; allows injecting ticker to advance time. */
+    CachingSamlProviderConfigurator(
+            final IdentityProviderProvisioning providerProvisioning,
+            final IdentityZoneManager identityZoneManager,
+            final FixedHttpMetaDataProvider fixedHttpMetaDataProvider,
+            final long cacheDurationInMs,
+            final Ticker ticker
+    ) {
         super(providerProvisioning, identityZoneManager, fixedHttpMetaDataProvider);
 
         this.cache = Caffeine.newBuilder()
                 .expireAfterWrite(cacheDurationInMs, MILLISECONDS)
+                .ticker(ticker)
                 .build(cacheKey -> {
                     final List<String> allowedIdps = Optional.ofNullable(cacheKey.allowedIdps())
                             .map(ArrayList::new)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingSamlProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/CachingSamlProviderConfigurator.java
@@ -1,0 +1,64 @@
+package org.cloudfoundry.identity.uaa.login;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.saml.FixedHttpMetaDataProvider;
+import org.cloudfoundry.identity.uaa.provider.saml.SamlIdentityProviderConfigurator;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * Extension for {@link SamlIdentityProviderConfigurator} that caches the IdPs returned by
+ * {@link SamlIdentityProviderConfigurator#getIdentityProviderDefinitions(List, IdentityZone)}. The cache is neither
+ * synchronized across app instances nor invalidated after the set of IdPs changes (e.g., when an IdP is deleted).
+ * Therefore, an inconsistent set of IdPs might be returned until the cache expires.
+ */
+public class CachingSamlProviderConfigurator extends SamlIdentityProviderConfigurator {
+
+    private final LoadingCache<CacheKey, List<SamlIdentityProviderDefinition>> cache;
+
+    public CachingSamlProviderConfigurator(
+            final IdentityProviderProvisioning providerProvisioning,
+            final IdentityZoneManager identityZoneManager,
+            final FixedHttpMetaDataProvider fixedHttpMetaDataProvider,
+            final long cacheDurationInMs
+    ) {
+        super(providerProvisioning, identityZoneManager, fixedHttpMetaDataProvider);
+
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(cacheDurationInMs, MILLISECONDS)
+                .build(cacheKey -> {
+                    final List<String> allowedIdps = Optional.ofNullable(cacheKey.allowedIdps())
+                            .map(ArrayList::new)
+                            .orElse(null); // all IdPs are allowed
+                    return super.getIdentityProviderDefinitions(allowedIdps, cacheKey.zone());
+                });
+    }
+
+    private record CacheKey(IdentityZone zone, Set<String> allowedIdps) {
+    }
+
+    @Override
+    public List<SamlIdentityProviderDefinition> getIdentityProviderDefinitions(
+            @Nullable final List<String> allowedIdps,
+            @Nonnull final IdentityZone zone
+    ) {
+        final Set<String> allowedIdpsAsSet = Optional.ofNullable(allowedIdps)
+                .map(HashSet::new)
+                .orElse(null); // all IdPs are allowed
+        final CacheKey cacheKey = new CacheKey(zone, allowedIdpsAsSet);
+        return cache.get(cacheKey);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoConfiguration.java
@@ -1,0 +1,79 @@
+package org.cloudfoundry.identity.uaa.login;
+
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthProviderConfigurator;
+import org.cloudfoundry.identity.uaa.provider.oauth.OidcMetadataFetcher;
+import org.cloudfoundry.identity.uaa.provider.saml.FixedHttpMetaDataProvider;
+import org.cloudfoundry.identity.uaa.provider.saml.SamlIdentityProviderConfigurator;
+import org.cloudfoundry.identity.uaa.util.UaaRandomStringUtil;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LoginInfoConfiguration {
+
+    @Bean("loginInfoIdpCacheEnabled")
+    public boolean loginInfoIdpCacheEnabled(
+            final @Value("${login.loginInfoIdpCache.enabled:false}") boolean enabled
+    ) {
+        return enabled;
+    }
+
+    @Bean("loginInfoIdpCacheDurationInMs")
+    public long loginInfoIdpCacheDurationInMs(
+            final @Value("${login.loginInfoIdpCache.durationInMs:30000}") long durationInMs
+    ) {
+        return Math.max(durationInMs, 0); // must be positive
+    }
+
+    @Bean("loginInfoExternalOAuthProviderConfigurator")
+    public ExternalOAuthProviderConfigurator loginInfoExternalOAuthProviderConfigurator(
+            final @Qualifier("loginInfoIdpCacheEnabled") boolean idpCacheEnabled,
+            final @Qualifier("loginInfoIdpCacheDurationInMs") long cacheDurationInMs,
+            final @Qualifier("externalOAuthProviderConfigurator") ExternalOAuthProviderConfigurator nonCachingConfigurator,
+            final @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning providerProvisioning,
+            final OidcMetadataFetcher oidcMetadataFetcher,
+            final UaaRandomStringUtil uaaRandomStringUtil,
+            final @Qualifier("identityZoneProvisioning") IdentityZoneProvisioning identityZoneProvisioning,
+            final IdentityZoneManager identityZoneManager
+    ) {
+        if (!idpCacheEnabled) {
+            return nonCachingConfigurator;
+        }
+
+        return new CachingExternalOAuthProviderConfigurator(
+                providerProvisioning,
+                oidcMetadataFetcher,
+                uaaRandomStringUtil,
+                identityZoneProvisioning,
+                identityZoneManager,
+                cacheDurationInMs
+        );
+    }
+
+    @Bean("loginInfoSamlProviderConfigurator")
+    public SamlIdentityProviderConfigurator loginInfoSamlProviderConfigurator(
+            final @Qualifier("loginInfoIdpCacheEnabled") boolean idpCacheEnabled,
+            final @Qualifier("loginInfoIdpCacheDurationInMs") long cacheDurationInMs,
+            final @Qualifier("metaDataProviders") SamlIdentityProviderConfigurator nonCachingConfigurator,
+            final @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning providerProvisioning,
+            final @Qualifier("identityZoneManager") IdentityZoneManager identityZoneManager,
+            final @Qualifier("fixedHttpMetaDataProvider") FixedHttpMetaDataProvider fixedHttpMetaDataProvider
+    ) {
+        if (!idpCacheEnabled) {
+            return nonCachingConfigurator;
+        }
+
+        return new CachingSamlProviderConfigurator(
+                providerProvisioning,
+                identityZoneManager,
+                fixedHttpMetaDataProvider,
+                cacheDurationInMs
+        );
+    }
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -154,12 +154,13 @@ public class LoginInfoEndpoint {
             final @Qualifier("codeStore") ExpiringCodeStore expiringCodeStore,
             final @Value("${login.url:''}") String externalLoginUrl,
             final @Qualifier("uaaUrl") String baseUrl,
-            final @Qualifier("externalOAuthProviderConfigurator") ExternalOAuthProviderConfigurator externalOAuthProviderConfigurator,
+            final @Qualifier("loginInfoExternalOAuthProviderConfigurator") ExternalOAuthProviderConfigurator externalOAuthProviderConfigurator,
             final @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning providerProvisioning,
             final @Qualifier("samlEntityID") String entityID,
             final @Qualifier("globalLinks") Links globalLinks,
             final @Qualifier("jdbcClientDetailsService") MultitenantClientServices clientDetailsService,
-            final @Qualifier("metaDataProviders") SamlIdentityProviderConfigurator idpDefinitions) {
+            final @Qualifier("loginInfoSamlProviderConfigurator") SamlIdentityProviderConfigurator idpDefinitions
+    ) {
         this.authenticationManager = authenticationManager;
         this.expiringCodeStore = expiringCodeStore;
         this.externalLoginUrl = externalLoginUrl;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfigurator.java
@@ -10,6 +10,7 @@ import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Primary;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrations;
@@ -23,6 +24,7 @@ import java.util.List;
 import static org.springframework.util.StringUtils.hasText;
 
 @Component("metaDataProviders")
+@Primary
 public class SamlIdentityProviderConfigurator {
     private final IdentityProviderProvisioning providerProvisioning;
     private final IdentityZoneManager identityZoneManager;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/CachingExternalOAuthProviderConfiguratorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/CachingExternalOAuthProviderConfiguratorTest.java
@@ -1,0 +1,181 @@
+package org.cloudfoundry.identity.uaa.login;
+
+import com.google.common.testing.FakeTicker;
+import org.cloudfoundry.identity.uaa.provider.AbstractIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.oauth.OidcMetadataFetcher;
+import org.cloudfoundry.identity.uaa.util.UaaRandomStringUtil;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OAUTH20;
+import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OIDC10;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CachingExternalOAuthProviderConfiguratorTest {
+
+    private static final long CACHE_DURATION_IN_MS = 50_000;
+
+    private final FakeTicker fakeTicker = new FakeTicker();
+    private final String zoneId = UUID.randomUUID().toString();
+
+    @Mock
+    private IdentityProviderProvisioning identityProviderProvisioning;
+
+    @Mock
+    private OidcMetadataFetcher oidcMetadataFetcher;
+
+    @Mock
+    private UaaRandomStringUtil uaaRandomStringUtil;
+
+    @Mock
+    private IdentityZoneProvisioning identityZoneProvisioning;
+
+    @Mock
+    private IdentityZoneManager identityZoneManager;
+
+    private CachingExternalOAuthProviderConfigurator configurator;
+
+    @BeforeEach
+    void setUp() {
+        configurator = new CachingExternalOAuthProviderConfigurator(
+                identityProviderProvisioning,
+                oidcMetadataFetcher,
+                uaaRandomStringUtil,
+                identityZoneProvisioning,
+                identityZoneManager,
+                CACHE_DURATION_IN_MS,
+                fakeTicker::read
+        );
+    }
+
+    @Test
+    void shouldUseCache_WhenAlreadyCalledEarlierAndNotExpired() {
+        // arrange real result 1
+        final List<IdentityProvider> idps1 = List.of(buildMockIdp(OIDC10), buildMockIdp(OAUTH20));
+        arrangeIdpsForZone(idps1, zoneId, OIDC10, OAUTH20);
+
+        final List<IdentityProvider> resultAfter1stCall = configurator.retrieveActiveByTypes(zoneId, OIDC10, OAUTH20);
+        assertRealMethodIsCalled(zoneId, OIDC10, OAUTH20);
+        assertThat(resultAfter1stCall).isEqualTo(idps1);
+
+        // advance time but stay within cache duration
+        fakeTicker.advance(10, MILLISECONDS);
+
+        // arrange real result 2
+        final List<IdentityProvider> idps2 = List.of(buildMockIdp(OIDC10), buildMockIdp(OAUTH20), buildMockIdp(OIDC10));
+        arrangeIdpsForZone(idps2, zoneId, OIDC10, OAUTH20);
+
+        final List<IdentityProvider> resultAfter2ndCall = configurator.retrieveActiveByTypes(zoneId, OIDC10, OAUTH20);
+        assertCacheIsUsed(zoneId, OIDC10, OAUTH20);
+        assertThat(resultAfter2ndCall).isEqualTo(idps1); // should still return first result (from cache)
+
+        // advance time such that cache duration is expired
+        fakeTicker.advance(CACHE_DURATION_IN_MS, MILLISECONDS);
+
+        final List<IdentityProvider> resultAfter3rdCall = configurator.retrieveActiveByTypes(zoneId, OIDC10, OAUTH20);
+        assertRealMethodIsCalled(zoneId, OIDC10, OAUTH20);
+        assertThat(resultAfter3rdCall).isEqualTo(idps2); // should now return new result
+    }
+
+    @Test
+    void shouldUseCache_WhenAlreadyCalledEarlierAndNotExpired_ShouldIgnoreOrder() {
+        // arrange real result 1
+        final List<IdentityProvider> idps1 = List.of(buildMockIdp(OIDC10), buildMockIdp(OAUTH20));
+        arrangeIdpsForZone(idps1, zoneId, OIDC10, OAUTH20);
+
+        final List<IdentityProvider> resultAfter1stCall = configurator.retrieveActiveByTypes(zoneId, OIDC10, OAUTH20);
+        assertRealMethodIsCalled(zoneId, OIDC10, OAUTH20);
+        assertThat(resultAfter1stCall).isEqualTo(idps1);
+
+        // advance time but stay within cache duration
+        fakeTicker.advance(10, MILLISECONDS);
+
+        final List<IdentityProvider> resultAfter2ndCall = configurator.retrieveActiveByTypes(
+                zoneId,
+                OAUTH20, OIDC10 // same types, but in different order
+        );
+        assertCacheIsUsed(zoneId, OIDC10, OAUTH20);
+        assertThat(resultAfter2ndCall).isEqualTo(idps1); // should still return first result (from cache)
+    }
+
+    @Test
+    void shouldUseDifferentCacheKeysWhenDifferentArgumentsAreUsed() {
+        final String otherZoneId = UUID.randomUUID().toString();
+
+        configurator.retrieveActiveByTypes(zoneId, OAUTH20);
+        assertRealMethodIsCalled(zoneId, OAUTH20);
+
+        configurator.retrieveActiveByTypes(otherZoneId, OIDC10);
+        assertRealMethodIsCalled(otherZoneId, OIDC10);
+
+        configurator.retrieveActiveByTypes(zoneId, OIDC10);
+        assertRealMethodIsCalled(zoneId, OIDC10);
+
+        configurator.retrieveActiveByTypes(otherZoneId, OAUTH20);
+        assertRealMethodIsCalled(otherZoneId, OAUTH20);
+
+        configurator.retrieveActiveByTypes(otherZoneId, OIDC10);
+        assertCacheIsUsed(otherZoneId, OIDC10);
+
+        configurator.retrieveActiveByTypes(zoneId, OAUTH20);
+        assertCacheIsUsed(zoneId, OAUTH20);
+
+        configurator.retrieveActiveByTypes(zoneId, OIDC10);
+        assertCacheIsUsed(zoneId, OIDC10);
+
+        configurator.retrieveActiveByTypes(otherZoneId, OAUTH20);
+        assertCacheIsUsed(otherZoneId, OAUTH20);
+    }
+
+    private void arrangeIdpsForZone(final List<IdentityProvider> idps, final String zoneId, final String... types) {
+        when(identityProviderProvisioning.retrieveActiveByTypes(zoneId, types)).thenReturn(idps);
+    }
+
+    private void assertRealMethodIsCalled(final String zoneId, final String type) {
+        verify(identityProviderProvisioning, times(1)).retrieveActiveByTypes(eq(zoneId), eq(type));
+        clearInvocations(identityProviderProvisioning);
+    }
+
+    private void assertRealMethodIsCalled(final String zoneId, final String type1, final String type2) {
+        verify(identityProviderProvisioning, times(1)).retrieveActiveByTypes(eq(zoneId), eq(type1), eq(type2));
+        clearInvocations(identityProviderProvisioning);
+    }
+
+    private void assertCacheIsUsed(final String zoneId, final String type) {
+        verify(identityProviderProvisioning, never()).retrieveActiveByTypes(eq(zoneId), eq(type));
+        clearInvocations(identityProviderProvisioning);
+    }
+
+    private void assertCacheIsUsed(final String zoneId, final String type1, final String type2) {
+        // no call with any order of the types should occur
+        verify(identityProviderProvisioning, never()).retrieveActiveByTypes(eq(zoneId), eq(type1), eq(type2));
+        verify(identityProviderProvisioning, never()).retrieveActiveByTypes(eq(zoneId), eq(type2), eq(type1));
+
+        clearInvocations(identityProviderProvisioning);
+    }
+
+    private static IdentityProvider buildMockIdp(final String type) {
+        final IdentityProvider<AbstractIdentityProviderDefinition> idp = new IdentityProvider<>();
+        idp.setId(UUID.randomUUID().toString());
+        idp.setType(type);
+        return idp;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/CachingSamlProviderConfiguratorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/CachingSamlProviderConfiguratorTest.java
@@ -1,0 +1,216 @@
+package org.cloudfoundry.identity.uaa.login;
+
+import com.google.common.testing.FakeTicker;
+import org.cloudfoundry.identity.uaa.provider.AbstractIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.saml.FixedHttpMetaDataProvider;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.cloudfoundry.identity.uaa.constants.OriginKeys.SAML;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CachingSamlProviderConfiguratorTest {
+    private static final long CACHE_DURATION_IN_MS = 50_000;
+
+    private final FakeTicker fakeTicker = new FakeTicker();
+    private final IdentityZone zone;
+
+    @Mock
+    private IdentityProviderProvisioning providerProvisioning;
+
+    @Mock
+    private IdentityZoneManager identityZoneManager;
+
+    @Mock
+    private FixedHttpMetaDataProvider fixedHttpMetaDataProvider;
+
+    private CachingSamlProviderConfigurator configurator;
+
+    public CachingSamlProviderConfiguratorTest() {
+        final String zoneId = UUID.randomUUID().toString();
+        zone = new IdentityZone();
+        zone.setId(zoneId);
+    }
+
+    @BeforeEach
+    void setUp() {
+        configurator = new CachingSamlProviderConfigurator(
+                providerProvisioning,
+                identityZoneManager,
+                fixedHttpMetaDataProvider,
+                CACHE_DURATION_IN_MS,
+                fakeTicker::read
+        );
+    }
+
+    @Test
+    void shouldUseCache_WhenAlreadyCalledEarlierAndNotExpired() {
+        // arrange real result 1
+        final List<IdentityProvider> idps1 = List.of(
+                buildMockSamlIdp("origin1"),
+                buildMockSamlIdp("origin2"),
+                buildMockSamlIdp("origin3")
+        );
+        arrangeIdpsForZone(idps1, zone);
+
+        final List<String> allowedIdps = List.of("origin1", "origin2", "origin4");
+
+        final List<SamlIdentityProviderDefinition> resultAfter1stCall = configurator.getIdentityProviderDefinitions(
+                allowedIdps,
+                zone
+        );
+        assertRealMethodIsCalled(zone);
+        final List<AbstractIdentityProviderDefinition> filteredIdps1 = idps1.stream()
+                .filter(it -> !Objects.equals("origin3", it.getOriginKey()))
+                .map(IdentityProvider::getConfig)
+                .toList();
+        assertThat(resultAfter1stCall).isEqualTo(filteredIdps1);
+
+        // advance time but stay within cache duration
+        fakeTicker.advance(10, MILLISECONDS);
+
+        // arrange real result 2
+        final List<IdentityProvider> idps2 = List.of(
+                buildMockSamlIdp("origin1"),
+                buildMockSamlIdp("origin2"),
+                buildMockSamlIdp("origin3"),
+                buildMockSamlIdp("origin4")
+        );
+        arrangeIdpsForZone(idps2, zone);
+
+        final List<SamlIdentityProviderDefinition> resultAfter2ndCall = configurator.getIdentityProviderDefinitions(
+                allowedIdps,
+                zone
+        );
+        assertCacheIsUsed(zone);
+        assertThat(resultAfter2ndCall).isEqualTo(filteredIdps1); // should still return first result (from cache)
+
+        // advance time such that cache duration is expired
+        fakeTicker.advance(CACHE_DURATION_IN_MS, MILLISECONDS);
+
+        final List<SamlIdentityProviderDefinition> resultAfter3rdCall = configurator.getIdentityProviderDefinitions(
+                allowedIdps,
+                zone
+        );
+        assertRealMethodIsCalled(zone);
+        assertThat(resultAfter3rdCall).isEqualTo(
+                // should now return new result
+                idps2.stream()
+                        .filter(it -> !Objects.equals("origin3", it.getOriginKey()))
+                        .map(IdentityProvider::getConfig)
+                        .toList()
+        );
+    }
+
+    @Test
+    void shouldUseCache_WhenAlreadyCalledEarlierAndNotExpired_ShouldIgnoreDuplicates() {
+        // arrange real result 1
+        final List<IdentityProvider> idps1 = List.of(
+                buildMockSamlIdp("origin1"),
+                buildMockSamlIdp("origin2")
+        );
+        arrangeIdpsForZone(idps1, zone);
+
+        final List<String> allowedIdps1 = List.of("origin1", "origin2");
+
+        final List<SamlIdentityProviderDefinition> resultAfter1stCall = configurator.getIdentityProviderDefinitions(
+                allowedIdps1,
+                zone
+        );
+        assertRealMethodIsCalled(zone);
+        assertThat(resultAfter1stCall).isEqualTo(idps1.stream().map(IdentityProvider::getConfig).toList());
+
+        // advance time but stay within cache duration
+        fakeTicker.advance(10, MILLISECONDS);
+
+        final List<String> allowedIdps2 = List.of(
+                "origin1", "origin2",
+                "origin2" /* duplicate */
+        );
+
+        final List<SamlIdentityProviderDefinition> resultAfter2ndCall = configurator.getIdentityProviderDefinitions(
+                allowedIdps2, // same values, one of them duplicated
+                zone
+        );
+        assertCacheIsUsed(zone);
+        // should still return first result (from cache)
+        assertThat(resultAfter2ndCall).isEqualTo(idps1.stream().map(IdentityProvider::getConfig).toList());
+    }
+
+    @Test
+    void shouldUseDifferentCacheKeysWhenDifferentArgumentsAreUsed() {
+        final IdentityZone otherZone = new IdentityZone();
+        otherZone.setId(UUID.randomUUID().toString());
+
+        final List<String> allowedIdps1 = List.of("origin1", "origin2");
+        final List<String> allowedIdps2 = List.of("origin3", "origin4");
+
+        configurator.getIdentityProviderDefinitions(allowedIdps1, zone);
+        assertRealMethodIsCalled(zone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps2, otherZone);
+        assertRealMethodIsCalled(otherZone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps2, zone);
+        assertRealMethodIsCalled(zone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps1, otherZone);
+        assertRealMethodIsCalled(otherZone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps2, otherZone);
+        assertCacheIsUsed(otherZone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps1, zone);
+        assertCacheIsUsed(zone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps2, zone);
+        assertCacheIsUsed(zone);
+
+        configurator.getIdentityProviderDefinitions(allowedIdps1, otherZone);
+        assertCacheIsUsed(otherZone);
+    }
+
+    private void arrangeIdpsForZone(final List<IdentityProvider> idps, final IdentityZone zone) {
+        when(providerProvisioning.retrieveActiveByTypes(zone.getId(), SAML)).thenReturn(idps);
+    }
+
+    private void assertRealMethodIsCalled(final IdentityZone zone) {
+        verify(providerProvisioning, times(1)).retrieveActiveByTypes(zone.getId(), SAML);
+        clearInvocations(providerProvisioning);
+    }
+
+    private void assertCacheIsUsed(final IdentityZone zone) {
+        verify(providerProvisioning, never()).retrieveActiveByTypes(zone.getId(), SAML);
+        clearInvocations(providerProvisioning);
+    }
+
+    private static IdentityProvider buildMockSamlIdp(final String originKey) {
+        final IdentityProvider<AbstractIdentityProviderDefinition> idp = new IdentityProvider<>();
+        idp.setId(UUID.randomUUID().toString());
+        idp.setType(SAML);
+        idp.setOriginKey(originKey);
+        final SamlIdentityProviderDefinition config = new SamlIdentityProviderDefinition();
+        config.setIdpEntityId(idp.getId());
+        idp.setConfig(config);
+        return idp;
+    }
+}

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -377,6 +377,9 @@ login:
 #  idpDiscoveryEnabled: true
 #  accountChooserEnabled: true
 #  aliasEntitiesEnabled: true
+#  loginInfoIdpCache:
+#    enabled: true
+#    durationInMs: 3000
 
   # SAML Key Configuration
   # The location and credentials of the certificate for this SP


### PR DESCRIPTION
Introduce a cache for the SAML or OAuth identity providers returned in the login info endpoint. By default, the cache is disabled.

If enabled, the cached IdPs are neither synchronized between the different UAA instances and are not invalidated whenever an IdP is created, updated or deleted. Therefore, during a cache period, the returned set might be inconsistent.