### PR TITLE
fix: concurrent group membership race conditions

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrap.java
@@ -25,6 +25,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.util.StringUtils;
 
@@ -254,7 +255,11 @@ public class ScimUserBootstrap implements
                     }
                 }
                 for (ScimGroup group : groupsMap.values()) {
-                    membershipManager.removeMemberById(group.getId(), exEvent.getUser().getId(), group.getZoneId());
+                    try {
+                        membershipManager.removeMemberById(group.getId(), exEvent.getUser().getId(), group.getZoneId());
+                    } catch (MemberNotFoundException ex) {
+                        // do nothing
+                    }
                 }
             }
             //update the user itself
@@ -294,6 +299,8 @@ public class ScimUserBootstrap implements
             groupMember.setOrigin(ofNullable(origin).orElse(OriginKeys.UAA));
             membershipManager.addMember(group.getId(), groupMember, IdentityZoneHolder.get().getId());
         } catch (MemberAlreadyExistsException ex) {
+            // do nothing
+        } catch (DuplicateKeyException ex) {
             // do nothing
         }
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/bootstrap/ScimUserBootstrapTests.java
@@ -805,8 +805,6 @@ class ScimUserBootstrapTests {
             jdbcScimGroupMembershipManager.addMember(gid, member, IdentityZone.getUaaZoneId());
         }
 
-        bootstrap.onApplicationEvent(new ExternalGroupAuthorizationEvent(user, true, getAuthorities(externalAuthorities), true));
-
         ExternalGroupAuthorizationEvent externalGroupAuthorizationEvent = new ExternalGroupAuthorizationEvent(user, false, getAuthorities(externalAuthorities), true);
 
         Thread[] threads = new Thread[numthreads];


### PR DESCRIPTION
- catch the DuplicateKeyException when adding a member to a group. Needed due to https://github.com/cloudfoundry/uaa/commit/f8188564facddee35600a23580eb845194337753

- catch MemberNotFoundException when attempting to remove member from a group.
