### PR TITLE
Move login-ui.xml to java configuration

### DIFF
--- a/scripts/cargo/uaa.yml
+++ b/scripts/cargo/uaa.yml
@@ -177,12 +177,14 @@ oauth:
     override: true
   clients:
     admin:
+      id: admin
       authorized-grant-types: client_credentials
       scope: uaa.none
       authorities: 'uaa.admin,clients.read,clients.write,clients.secret,clients.trust,scim.read,scim.write,clients.admin'
       secret: "adminsecret"
       jwks: '{"alg":"RS256","e":"AQAB","kid":"cUiuzP1rw1zm9MV8F0vtrws7BLc","kty":"RSA","n":"rWuIqrVV8kuqeorvRuLio1_pdQm_z7HZJKIcCD5SQqGO0AsKyf1xa5TPzHM0lqEh2GcPTer4u7MYQZzXAAvzOsSaTmgSlenLKDYCDZy2bwOjK0izVLbJwYqiiqyiMGhKeWsYokyDNoYaefjz8izDrp47XDHnwC2eeyJ43cE8GP0JJXRyxIPFecO8rfpe3AzTrHszJ9lPSX9E8QGppSFmcnUDUQYDRipNMzXXp2FHdR7T2MZkvxzjFhVSSMiaDTmAca-Wv_Uct2HpOfC3IuKSy1jpu8yr_GT6aBsDkt1XC1iARuFf9dE83R39oNgvVMICPjeWgNoyhK-ddQAUnRDeqw"}'
     cf:
+      id: cf
       secret: ''
       authorized-grant-types: 'implicit,password,refresh_token'
       scope: 'uaa.user,cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,cloud_controller.admin,scim.read,scim.write'
@@ -190,6 +192,7 @@ oauth:
       authorities: uaa.none
       autoapprove: 'true'
     app:
+      id: app
       secret: appclientsecret
       authorized-grant-types: password,implicit,authorization_code,client_credentials,refresh_token
       scope: cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,organizations.acme
@@ -200,6 +203,7 @@ oauth:
       change_email_redirect_url: http://localhost:8080/app/
       name: The Ultimate Oauth App
     appspecial:
+      id: appspecial
       secret: appclient|secret!
       authorized-grant-types: password,implicit,authorization_code,client_credentials,refresh_token
       scope: cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,organizations.acme
@@ -210,6 +214,7 @@ oauth:
       change_email_redirect_url: http://localhost:8080/app/
       name: The Ultimate Oauth App - Special
     login:
+      id: login
       secret: loginsecret
       scope: 'openid,oauth.approvals'
       authorized-grant-types: 'client_credentials,authorization_code'
@@ -218,16 +223,19 @@ oauth:
       autoapprove: 'true'
       allowpublic: 'true'
     dashboard:
+      id: dashboard
       secret: dashboardsecret
       scope: 'dashboard.user,openid'
       authorized-grant-types: authorization_code
       authorities: uaa.resource
       redirect-uri: 'http://localhost:8080/uaa/'
     notifications:
+      id: notifications
       secret: notificationssecret
       authorized-grant-types: client_credentials
       authorities: 'cloud_controller.admin,scim.read'
     identity:
+      id: identity
       secret: identitysecret
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password'
       scope: 'cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,zones.*.*,zones.*.*.*,zones.read,zones.write'
@@ -235,6 +243,7 @@ oauth:
       autoapprove: 'true'
       redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://oidcloginit.localhost:8080/uaa/**'
     oauth_showcase_authorization_code:
+      id: oauth_showcase_authorization_code
       secret: secret
       authorized-grant-types: authorization_code
       scope: openid
@@ -242,45 +251,54 @@ oauth:
       redirect-uri: http://localhost:8080/uaa/
       allowedproviders: [ uaa ]
     oauth_showcase_client_credentials:
+      id: oauth_showcase_client_credentials
       secret: secret
       authorized-grant-types: client_credentials
       scope: uaa.none
       authorities: 'uaa.resource,clients.read'
     oauth_showcase_password_grant:
+      id: oauth_showcase_password_grant
       secret: secret
       authorized-grant-types: password
       scope: openid
       authorities: uaa.resource
     oauth_showcase_implicit_grant:
+      id: oauth_showcase_implicit_grant
       authorized-grant-types: implicit
       scope: openid
       authorities: uaa.resource
       redirect-uri: 'http://localhost:8080/uaa/'
     oauth_showcase_user_token:
+      id: oauth_showcase_user_token
       authorized-grant-types: 'user_token,password,refresh_token'
       scope: 'openid,uaa.user'
       secret: secret
     oauth_showcase_user_token_public:
+      id: oauth_showcase_user_token_public
       secret: ''
       authorized-grant-types: 'user_token,password,authorization_code'
       scope: 'openid,uaa.user'
       redirect-uri: 'http://localhost:8080/uaa/'
       allowpublic: 'true'
     oauth_showcase_saml2_bearer:
+      id: oauth_showcase_saml2_bearer
       authorized-grant-types: 'password,urn:ietf:params:oauth:grant-type:saml2-bearer'
       scope: 'openid,uaa.user'
       secret: secret
     some_client_that_contains_redirect_uri_matching_request_param:
+      id: some_client_that_contains_redirect_uri_matching_request_param
       authorized-grant-types: 'uaa.admin,clients.read,clients.write,clients.secret,scim.read,scim.write,clients.admin'
       scope: openid
       authorities: uaa.resource
       redirect-uri: 'http://redirect.localhost'
     client_with_bcrypt_prefix:
+      id: client_with_bcrypt_prefix
       secret: password
       authorized-grant-types: client_credentials
       authorities: uaa.none
       use-bcrypt-prefix: 'true'
     jku_test:
+      id: jku_test
       secret: secret
       authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
       authorities: uaa.none
@@ -288,6 +306,7 @@ oauth:
       scope: 'openid,oauth.approvals,user_attributes'
       redirect-uri: 'http://localhost/**'
     jku_test_without_autoapprove:
+      id: jku_test_without_autoapprove
       secret: secret
       authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
       authorities: uaa.none
@@ -295,6 +314,7 @@ oauth:
       scope: 'openid,oauth.approvals,user_attributes'
       redirect-uri: 'http://localhost/**'
     client_without_openid:
+      id: client_without_openid
       secret: secret
       authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
       authorities: uaa.none
@@ -302,6 +322,7 @@ oauth:
       scope: password.write
       redirect-uri: 'http://localhost/**'
     client_with_jwks_trust:
+      id: client_with_jwks_trust
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password'
       scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
       authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
@@ -309,6 +330,7 @@ oauth:
       redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
       jwks: '{"kty":"RSA","e":"AQAB","use":"sig","kid":"key-id-1","alg":"RS256","n":"qMClJXznycV2bQ1pFbN8W-AWSYhpS2MVAGhkWNlmxv2Ix0_-n6zjivjdoxcq7RJR4kVycoVeD07DiWElYSnQLdeQPgKAcBiwilR30UyyDTKcqDQQ5rkCg2ONlwV0aMsg74KaXeXsV653ASs3FYEtuS1aD_Db5-FyXF8HkHo8xy19NUnqsDWQnh1Hhklynxu2tvW0fw2oDE1pwNl-WLEVPtlcpCtf4VSv-GawtBiI6xmYsGBMC9w29ESHFqPw0NSCRhlyJf6rDBNH_766mzK_vEzA4rzGTBEUqDxTg_8JpRhh9D3qljSsmqCtpQoloOAaUKCqSJb_hKPspe-7r9cYmw"}'
     client_with_allowpublic_and_jwks_uri_trust:
+      id: client_with_allowpublic_and_jwks_uri_trust
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password,urn:ietf:params:oauth:grant-type:jwt-bearer'
       scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
       authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
@@ -317,6 +339,7 @@ oauth:
       redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
       jwks_uri: 'http://localhost:8080/uaa/token_keys'
     client_federated_jwt_trust:
+      id: client_federated_jwt_trust
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password,urn:ietf:params:oauth:grant-type:jwt-bearer'
       scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
       authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfig.java
@@ -13,9 +13,13 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
 
+/**
+ * Configuration for application-wide beans, as well as "infrastructure" beans
+ * that help enable other beans (e.g. during the migration from XML config to Java config).
+ */
 @Configuration
 @EnableConfigurationProperties(UaaProperties.Uaa.class)
-public class UaaConfiguration {
+public class UaaConfig {
 
     /**
      * Represents the Spring Security Filter Chain bean we are using in the application.

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
@@ -1,0 +1,9 @@
+package org.cloudfoundry.identity.uaa;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(UaaProperties.class)
+class UaaConfiguration {
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
@@ -14,7 +14,7 @@ import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@EnableConfigurationProperties(UaaProperties.class)
+@EnableConfigurationProperties(UaaProperties.Uaa.class)
 public class UaaConfiguration {
 
     /**
@@ -23,8 +23,8 @@ public class UaaConfiguration {
     public static final String SPRING_SECURITY_FILTER_CHAIN_ID = "aggregateSpringSecurityFilterChain";
 
     @Bean
-    public KeyInfoService keyInfoService(UaaProperties uaaProperties) {
-        return new KeyInfoService(uaaProperties.getUrl());
+    public KeyInfoService keyInfoService(UaaProperties.Uaa uaaProperties) {
+        return new KeyInfoService(uaaProperties.url());
     }
 
     /**

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
@@ -1,9 +1,17 @@
 package org.cloudfoundry.identity.uaa;
 
+import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @EnableConfigurationProperties(UaaProperties.class)
 class UaaConfiguration {
+
+    @Bean
+    KeyInfoService keyInfoService(UaaProperties uaaProperties) {
+        return new KeyInfoService(uaaProperties.getUrl());
+    }
+
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaConfiguration.java
@@ -1,17 +1,65 @@
 package org.cloudfoundry.identity.uaa;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
+import org.cloudfoundry.identity.uaa.web.UaaFilterChain;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.web.FilterChainProxy;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableConfigurationProperties(UaaProperties.class)
-class UaaConfiguration {
+public class UaaConfiguration {
+
+    /**
+     * Represents the Spring Security Filter Chain bean we are using in the application.
+     */
+    public static final String SPRING_SECURITY_FILTER_CHAIN_ID = "aggregateSpringSecurityFilterChain";
 
     @Bean
-    KeyInfoService keyInfoService(UaaProperties uaaProperties) {
+    public KeyInfoService keyInfoService(UaaProperties uaaProperties) {
         return new KeyInfoService(uaaProperties.getUrl());
+    }
+
+    /**
+     * Creates an "aggregate" {@link FilterChainProxy} that contains filter chains registered both
+     * through XML config and Java config.
+     * <p>
+     * It is not possible to mix Java-based configuration and XML-based configuration for Spring
+     * Security out of the box. XML-based {@code <http>} elements are registered in a
+     * {@link FilterChainProxy} before any bean of type {@link SecurityFilterChain} are created.
+     * Any {@link Bean} of type SecurityFilterChain created in java configuration is, by default,
+     * not loaded in the Security configuration.
+     * <p>
+     * This method creates a {@link FilterChainProxy} bean that will be used instead of the default
+     * {@code springSecurityFilterChain} which only contains XML chains. By calling
+     * {@link WebSecurityConfiguration#springSecurityFilterChain()} explicitly inside a {@link Bean}
+     * method, we are catching both types of filter chains. By default, Java-based filter chains are
+     * registered before XML-based filter chains.
+     * <p>
+     * Java-based filter chains should be inserted last. We inject them as {@link UaaFilterChain}s,
+     * to tell them apart from XML, and reorder the default {@link FilterChainProxy} to put those
+     * in the last positions.
+     * <p>
+     * This filter chain is then registered as a filter, by name in {@code web.xml}.
+     *
+     * @see <a href="https://github.com/spring-projects/spring-security/issues/11108#issuecomment-1113608990">Spring Security #11108</a>
+     * @deprecated Remove this once there are no more XML-based filter chains.
+     */
+    @Bean(name = SPRING_SECURITY_FILTER_CHAIN_ID)
+    public FilterChainProxy aggregateSpringSecurityFilterChain(WebSecurityConfiguration webSecurityConfiguration, List<UaaFilterChain> javaFilterChains) throws Exception {
+        var xmlFilterChains = ((FilterChainProxy) webSecurityConfiguration.springSecurityFilterChain()).getFilterChains();
+        var securityFilterChains = new ArrayList<>(xmlFilterChains);
+        securityFilterChains.removeAll(javaFilterChains);
+        securityFilterChains.addAll(javaFilterChains);
+
+        return new FilterChainProxy(securityFilterChains);
     }
 
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaProperties.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaProperties.java
@@ -1,15 +1,21 @@
 package org.cloudfoundry.identity.uaa;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-@ConfigurationProperties(prefix = "uaa")
-@Getter
-@Setter
+/**
+ * Future replacement of {@link org.cloudfoundry.identity.uaa.impl.config.UaaConfiguration}
+ * for binding properties and validating them.
+ */
 public class UaaProperties {
 
-    private String url = UaaStringUtils.DEFAULT_UAA_URL;
-
+    @ConfigurationProperties(prefix = "uaa")
+    public record Uaa(String url) {
+        public Uaa {
+            if (url == null) {
+                url = UaaStringUtils.DEFAULT_UAA_URL;
+            }
+        }
+    }
 }
+

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/UaaProperties.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/UaaProperties.java
@@ -1,0 +1,15 @@
+package org.cloudfoundry.identity.uaa;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "uaa")
+@Getter
+@Setter
+public class UaaProperties {
+
+    private String url = UaaStringUtils.DEFAULT_UAA_URL;
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilter.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -15,6 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Component
 public class PasswordChangeUiRequiredFilter extends OncePerRequestFilter {
 
     private static final String MATCH_PATH = "/force_password_change";

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ReAuthenticationRequiredFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ReAuthenticationRequiredFilter.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.identity.uaa.authentication;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -13,6 +14,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+
 
 public class ReAuthenticationRequiredFilter extends OncePerRequestFilter {
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ReAuthenticationRequiredFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ReAuthenticationRequiredFilter.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 
+@Component
 public class ReAuthenticationRequiredFilter extends OncePerRequestFilter {
 
     private final String samlEntityID;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/home/BuildInfo.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/home/BuildInfo.java
@@ -1,10 +1,11 @@
 package org.cloudfoundry.identity.uaa.home;
 
+import org.cloudfoundry.identity.uaa.UaaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
+import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import java.io.IOException;
@@ -12,14 +13,18 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Properties;
 
+@Component
 public class BuildInfo implements InitializingBean {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    @Value("${uaa.url:#{T(org.cloudfoundry.identity.uaa.util.UaaStringUtils).DEFAULT_UAA_URL}}")
-    private String uaaUrl;
+    private final String uaaUrl;
     private String version;
     private String commitId;
     private String timestamp;
+
+    public BuildInfo(UaaProperties properties) {
+        this.uaaUrl = properties.getUrl();
+    }
 
     @Override
     public void afterPropertiesSet() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/home/BuildInfo.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/home/BuildInfo.java
@@ -22,8 +22,8 @@ public class BuildInfo implements InitializingBean {
     private String commitId;
     private String timestamp;
 
-    public BuildInfo(UaaProperties properties) {
-        this.uaaUrl = properties.getUrl();
+    public BuildInfo(UaaProperties.Uaa properties) {
+        this.uaaUrl = properties.url();
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -1,0 +1,8 @@
+package org.cloudfoundry.identity.uaa.login;
+
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+class LoginSecurityConfiguration {
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -48,7 +48,6 @@ class LoginSecurityConfiguration {
     UaaFilterChain uiSecurity(
             HttpSecurity http,
             @Qualifier("zoneAwareAuthzAuthenticationManager") AuthenticationManager authenticationManager,
-            HttpsHeaderFilter httpsHeaderFilter,
             ReAuthenticationRequiredFilter reAuthenticationRequiredFilter, // TODO: make @Component
             PasswordChangeUiRequiredFilter passwordChangeUiRequiredFilter, // TODO: make @Component
             LogoutFilter logoutFilter,
@@ -81,8 +80,7 @@ class LoginSecurityConfiguration {
                     login.failureHandler(loginFailureHandler);
                     login.authenticationDetailsSource(new UaaAuthenticationDetailsSource());
                 })
-                // TODO: is this required, with the double filter chain proxy?
-                .addFilterBefore(httpsHeaderFilter, DisableEncodeUrlFilter.class)
+                .addFilterBefore(new HttpsHeaderFilter(), DisableEncodeUrlFilter.class)
                 // TODO: Opt in to SecurityContextHolder filter instead of SecurityContextPersistenceFilter
                 // See: https://docs.spring.io/spring-security/reference/5.8/migration/servlet/session-management.html
                 .addFilterAfter(reAuthenticationRequiredFilter, SecurityContextPersistenceFilter.class)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -1,8 +1,17 @@
 package org.cloudfoundry.identity.uaa.login;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.support.ResourcePropertySource;
+
+import java.io.IOException;
 
 @Configuration
 class LoginSecurityConfiguration {
+
+    @Bean
+    ResourcePropertySource messagePropertiesSource() throws IOException {
+        return new ResourcePropertySource("messages.properties");
+    }
 
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -1,17 +1,101 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.support.ResourcePropertySource;
-
 import java.io.IOException;
 
+import org.cloudfoundry.identity.uaa.authentication.PasswordChangeUiRequiredFilter;
+import org.cloudfoundry.identity.uaa.authentication.ReAuthenticationRequiredFilter;
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetailsSource;
+import org.cloudfoundry.identity.uaa.security.CsrfAwareEntryPointAndDeniedHandler;
+import org.cloudfoundry.identity.uaa.security.web.CookieBasedCsrfTokenRepository;
+import org.cloudfoundry.identity.uaa.security.web.HttpsHeaderFilter;
+import org.cloudfoundry.identity.uaa.web.FilterChainOrder;
+import org.cloudfoundry.identity.uaa.web.UaaFilterChain;
+import org.cloudfoundry.identity.uaa.web.UaaSavedRequestCache;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.io.support.ResourcePropertySource;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.context.SecurityContextPersistenceFilter;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.session.DisableEncodeUrlFilter;
+import static org.cloudfoundry.identity.uaa.web.AuthorizationManagersUtils.anonymousOrFullyAuthenticated;
+
 @Configuration
+@EnableWebSecurity
 class LoginSecurityConfiguration {
 
     @Bean
     ResourcePropertySource messagePropertiesSource() throws IOException {
         return new ResourcePropertySource("messages.properties");
+    }
+
+    /**
+     * Handle the UI-related components, such as the login page, the home page, etc.
+     * <p>
+     * This is the catch-all "any-request" filter-chain that is executed last.
+     * <p>
+     * TODO: remove the dependence on the "uiSecurity" name (e.g. in SecurityFilterChainPostProcessor)
+     */
+    @Bean
+    @Order(FilterChainOrder.UI_SECURITY)
+    UaaFilterChain uiSecurity(
+            HttpSecurity http,
+            @Qualifier("zoneAwareAuthzAuthenticationManager") AuthenticationManager authenticationManager,
+            HttpsHeaderFilter httpsHeaderFilter,
+            ReAuthenticationRequiredFilter reAuthenticationRequiredFilter, // TODO: make @Component
+            PasswordChangeUiRequiredFilter passwordChangeUiRequiredFilter, // TODO: make @Component
+            LogoutFilter logoutFilter,
+            CookieBasedCsrfTokenRepository csrfTokenRepository,
+            UaaSavedRequestCache clientRedirectStateCache, // TODO: remove bean
+            AccountSavingAuthenticationSuccessHandler loginSuccessHandler,
+            UaaAuthenticationFailureHandler loginFailureHandler
+    ) throws Exception {
+
+        var originalChain = http
+                .csrf(csrf -> csrf.csrfTokenRepository(csrfTokenRepository))
+                .authenticationManager(authenticationManager)
+                .authorizeHttpRequests(auth -> {
+                    auth.requestMatchers("/force_password_change/**").fullyAuthenticated();
+                    auth.requestMatchers("/reset_password**").anonymous();
+                    auth.requestMatchers("/create_account*").anonymous();
+                    auth.requestMatchers("/login/idp_discovery/**").anonymous();
+                    auth.requestMatchers("/saml/metadata/**").anonymous();
+                    auth.requestMatchers("/origin-chooser").anonymous();
+                    auth.requestMatchers("/login**").access(anonymousOrFullyAuthenticated());
+                    auth.requestMatchers("/**").fullyAuthenticated();
+                })
+                .formLogin(login -> {
+                    login.loginPage("/login");
+                    login.usernameParameter("username");
+                    login.passwordParameter("password");
+                    login.loginProcessingUrl("/login.do");
+                    login.defaultSuccessUrl("/"); // TODO is this exactly the same?
+                    login.successHandler(loginSuccessHandler);
+                    login.failureHandler(loginFailureHandler);
+                    login.authenticationDetailsSource(new UaaAuthenticationDetailsSource());
+                })
+                // TODO: is this required, with the double filter chain proxy?
+                .addFilterBefore(httpsHeaderFilter, DisableEncodeUrlFilter.class)
+                // TODO: Opt in to SecurityContextHolder filter instead of SecurityContextPersistenceFilter
+                // See: https://docs.spring.io/spring-security/reference/5.8/migration/servlet/session-management.html
+                .addFilterAfter(reAuthenticationRequiredFilter, SecurityContextPersistenceFilter.class)
+                .addFilterBefore(clientRedirectStateCache, CsrfFilter.class)
+                .addFilterBefore(passwordChangeUiRequiredFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(logoutFilter, LogoutFilter.class)
+                .exceptionHandling(exception -> {
+                    // TODO: make common?
+                    exception.accessDeniedHandler(new CsrfAwareEntryPointAndDeniedHandler("/invalid_request", "/login?error=invalid_login_request"));
+                })
+                .requestCache(cache -> cache.requestCache(clientRedirectStateCache))
+                .build();
+        return new UaaFilterChain(originalChain);
     }
 
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -48,8 +48,8 @@ class LoginSecurityConfiguration {
     UaaFilterChain uiSecurity(
             HttpSecurity http,
             @Qualifier("zoneAwareAuthzAuthenticationManager") AuthenticationManager authenticationManager,
-            ReAuthenticationRequiredFilter reAuthenticationRequiredFilter, // TODO: make @Component
-            PasswordChangeUiRequiredFilter passwordChangeUiRequiredFilter, // TODO: make @Component
+            ReAuthenticationRequiredFilter reAuthenticationRequiredFilter,
+            PasswordChangeUiRequiredFilter passwordChangeUiRequiredFilter,
             LogoutFilter logoutFilter,
             CookieBasedCsrfTokenRepository csrfTokenRepository,
             UaaSavedRequestCache clientRedirectStateCache, // TODO: remove bean

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/MessagingConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/MessagingConfig.java
@@ -1,5 +1,6 @@
-package org.cloudfoundry.identity.uaa.impl.config;
+package org.cloudfoundry.identity.uaa.login;
 
+import org.cloudfoundry.identity.uaa.impl.config.SmtpProperties;
 import org.cloudfoundry.identity.uaa.message.EmailService;
 import org.cloudfoundry.identity.uaa.message.LocalUaaRestTemplate;
 import org.cloudfoundry.identity.uaa.message.MessageService;
@@ -35,7 +36,7 @@ import java.util.Properties;
 @Lazy
 @Configuration
 @EnableConfigurationProperties(SmtpProperties.class)
-public class LoginServerConfig {
+public class MessagingConfig {
 
     /**
      * Fallback bean for when there is no "notifications.url".

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/NotificationsProperties.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/NotificationsProperties.java
@@ -1,10 +1,10 @@
-package org.cloudfoundry.identity.uaa.impl.config;
+package org.cloudfoundry.identity.uaa.login;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
 @ConfigurationProperties(prefix = "notifications")
-record NotificationsProperties(
+public record NotificationsProperties(
         String url,
         @DefaultValue("true") boolean sendInDefaultZone
 ) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/message/LocalUaaRestTemplate.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/message/LocalUaaRestTemplate.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 
 import javax.net.ssl.SSLContext;
@@ -36,6 +37,7 @@ import java.util.stream.Collectors;
 
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_CLIENT_CREDENTIALS;
 
+@Component
 public class LocalUaaRestTemplate extends OAuth2RestTemplate {
     private final AuthorizationServerTokenServices authorizationServerTokenServices;
     private final String clientId;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/validate/UaaPasswordPolicyValidator.java
@@ -11,6 +11,7 @@ import org.passay.PasswordData;
 import org.passay.PropertiesMessageResolver;
 import org.passay.RuleResult;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -32,6 +33,7 @@ import static org.cloudfoundry.identity.uaa.util.PasswordValidatorUtil.validator
  * subcomponent's license, as noted in the LICENSE file.
  * *****************************************************************************
  */
+@Component
 public class UaaPasswordPolicyValidator implements PasswordValidator {
 
     private final IdentityProviderProvisioning provisioning;
@@ -41,8 +43,10 @@ public class UaaPasswordPolicyValidator implements PasswordValidator {
 
     private static final PropertiesMessageResolver messageResolver = messageResolver(DEFAULT_MESSAGE_PATH);
 
-    public UaaPasswordPolicyValidator(PasswordPolicy globalDefaultPolicy,
-            final @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning provisioning) {
+    public UaaPasswordPolicyValidator(
+            final @Qualifier("globalPasswordPolicy") PasswordPolicy globalDefaultPolicy,
+            final @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning provisioning
+    ) {
         this.globalDefaultPolicy = globalDefaultPolicy;
         this.provisioning = provisioning;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtils.java
@@ -1,0 +1,41 @@
+package org.cloudfoundry.identity.uaa.web;
+
+import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.Authentication;
+
+import java.util.function.Supplier;
+
+/**
+ * Utility class for creating {@link AuthorizationManager} instances.
+ */
+public class AuthorizationManagersUtils {
+
+    /**
+     * Grants access if the user either anonymous, or fully authenticated.
+     * <p>
+     * Java equivalent of the SpEL expression {@code isAnonymous() or isFullyAuthenticated()}.
+     */
+    public static <T> AuthorizationManager<T> anonymousOrFullyAuthenticated() {
+        return new AnoynmousOrFullyAuthenticated<T>();
+    }
+
+    private static class AnoynmousOrFullyAuthenticated<T> implements AuthorizationManager<T> {
+
+        private final AuthenticatedAuthorizationManager<Object> anonymous
+                = AuthenticatedAuthorizationManager.anonymous();
+        private final AuthenticatedAuthorizationManager<Object> fullyAuthenticated
+                = AuthenticatedAuthorizationManager.fullyAuthenticated();
+
+        @Override
+        public AuthorizationDecision check(Supplier<Authentication> authentication, T object) {
+            var isAnonymous = anonymous.check(authentication, object);
+            if (isAnonymous.isGranted()) { // NOSONAR
+                return isAnonymous;
+            }
+
+            return fullyAuthenticated.check(authentication, object);
+        }
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
@@ -1,0 +1,22 @@
+package org.cloudfoundry.identity.uaa.web;
+
+/**
+ * The order for all the filter chains in the UAA. The name references
+ * Spring Security's {@code FilterOrderRegistration}.
+ */
+public class FilterChainOrder {
+
+    // Order of filters in login-ui.xml
+    public static final int AUTOLOGIN = 1200;
+    public static final int INVITATIONS = 1201;
+    public static final int INVITE = 1202;
+    public static final int RESET_PASSWORD = 1203;
+    public static final int FORGOT_PASSWORD = 1204;
+    public static final int DELETE_SAVED_ACCOUNT = 1205;
+    public static final int VERIFY_EMAIL = 1206;
+    public static final int VERIFY_USER = 1207;
+    public static final int INVITATIONS_ACCEPT = 1208;
+    public static final int SAML_IDP_SSO = 1209;
+    public static final int UI_SECURITY = 1210;
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaFilterChain.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaFilterChain.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.web;
 
-import org.cloudfoundry.identity.uaa.UaaConfiguration;
+import org.cloudfoundry.identity.uaa.UaaConfig;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -12,7 +12,7 @@ import java.util.List;
  * Represents a Java-managed {@link SecurityFilterChain}. This allows mixing
  * XML-based configuration and Java-based configuration.
  * <p>
- * See {@link UaaConfiguration#aggregateSpringSecurityFilterChain(WebSecurityConfiguration, List)} for more information.
+ * See {@link UaaConfig#aggregateSpringSecurityFilterChain(WebSecurityConfiguration, List)} for more information.
  *
  * @deprecated Remove this once there are no more XML-based filter chains.
  */

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaFilterChain.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaFilterChain.java
@@ -1,0 +1,37 @@
+package org.cloudfoundry.identity.uaa.web;
+
+import org.cloudfoundry.identity.uaa.UaaConfiguration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.web.SecurityFilterChain;
+
+import javax.servlet.Filter;
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+
+/**
+ * Represents a Java-managed {@link SecurityFilterChain}. This allows mixing
+ * XML-based configuration and Java-based configuration.
+ * <p>
+ * See {@link UaaConfiguration#aggregateSpringSecurityFilterChain(WebSecurityConfiguration, List)} for more information.
+ *
+ * @deprecated Remove this once there are no more XML-based filter chains.
+ */
+@Deprecated
+public class UaaFilterChain implements SecurityFilterChain {
+
+    private final SecurityFilterChain chain;
+
+    public UaaFilterChain(SecurityFilterChain chain) {
+        this.chain = chain;
+    }
+
+    @Override
+    public List<Filter> getFilters() {
+        return this.chain.getFilters();
+    }
+
+    @Override
+    public boolean matches(HttpServletRequest request) {
+        return this.chain.matches(request);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/WebConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/WebConfig.java
@@ -1,0 +1,27 @@
+package org.cloudfoundry.identity.uaa.web;
+
+import java.util.List;
+
+import org.cloudfoundry.identity.uaa.authentication.manager.AutologinRequestConverter;
+
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Web stack configuration. It relies on Spring Boot's {@link WebMvcAutoConfiguration},
+ * with a few adjustments in a properties file to match the legacy behavior from UAA.
+ */
+@Configuration
+@EnableWebMvc
+@PropertySource("classpath:spring-mvc.properties")
+class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        converters.add(new AutologinRequestConverter());
+    }
+}

--- a/server/src/main/resources/spring-mvc.properties
+++ b/server/src/main/resources/spring-mvc.properties
@@ -1,0 +1,21 @@
+# -----------------------------------------------------------------------------
+# Spring Boot has some defaults that differ from non-Boot Spring. This file
+# configures Boot to match the behaviors from previous xml-based configuration.
+
+
+# -----------------------------------------------------------------------------
+# In a Spring @Controller, when you set values in the Model object and issue a
+# redirect with `return "redirect:foobar"`, Spring will append Model attributes
+# to the redirect URI by default. Spring Boot does not do this and needs to be
+# configured.
+#
+# See for example InvitationsController#processErrorReload
+# Permalink: https://github.com/cloudfoundry/uaa/blob/a7a98407d627857ffdf637f94c3b5763cd3017dc/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java#L300-L302
+spring.mvc.ignore-default-model-on-redirect=false
+
+
+# -----------------------------------------------------------------------------
+# In Spring, defaults from Jackson are used. Dates (e.g. "2025-02-06T11:04:12")
+# are serialized as timestamps, integers that look like 1339478482000000. In
+# Spring Boot, by default they are issued as raw strings.
+spring.jackson.serialization.write-dates-as-timestamps=true

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -352,8 +352,4 @@
     <mvc:resources mapping="/resources/**" location="/resources/"/>
     <mvc:default-servlet-handler/>
 
-    <bean id="uaaPasswordValidator" class="org.cloudfoundry.identity.uaa.scim.validate.UaaPasswordPolicyValidator">
-        <constructor-arg ref="globalPasswordPolicy"/>
-    </bean>
-
 </beans>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -206,40 +206,6 @@
         <csrf disabled="true"/>
     </http>
 
-    <http name="uiSecurity"
-                    use-expressions="true"
-                    authentication-manager-ref="zoneAwareAuthzAuthenticationManager"
-                    xmlns="http://www.springframework.org/schema/security">
-        <intercept-url pattern="/force_password_change/**" access="isFullyAuthenticated()"/>
-        <intercept-url pattern="/reset_password**" access="isAnonymous()"/>
-        <intercept-url pattern="/create_account*" access="isAnonymous()"/>
-        <intercept-url pattern="/login/idp_discovery/**" access="isAnonymous()"/>
-        <intercept-url pattern="/saml/metadata/**" access="isAnonymous()"/>
-        <intercept-url pattern="/origin-chooser" access="isAnonymous()"/>
-        <intercept-url pattern="/login**" access="isAnonymous() or isFullyAuthenticated()"/>
-        <intercept-url pattern="/**" access="isFullyAuthenticated()"/>
-        <!--        <security:custom-filter before="FIRST" ref="aggregateSpringSecurityFilterChain"/>-->
-        <security:custom-filter after="FIRST" ref="httpsHeaderFilter"/>
-        <!--        <security:custom-filter after="CHANNEL_FILTER" ref="samlFilter"/>-->
-        <security:custom-filter after="SECURITY_CONTEXT_FILTER" ref="reAuthenticationRequiredFilter"/>
-        <form-login login-page="/login"
-                              username-parameter="username"
-                              password-parameter="password"
-                              login-processing-url="/login.do"
-                              authentication-success-handler-ref="accountSavingAuthenticationSuccessHandler"
-                              authentication-failure-handler-ref="uaaAuthenticationFailureHandler"
-                              authentication-details-source-ref="authenticationDetailsSource"
-                              default-target-url="/"/>
-        <custom-filter ref="clientRedirectStateCache" before="CSRF_FILTER"/>
-        <custom-filter ref="passwordChangeUiRequiredFilter" before="FORM_LOGIN_FILTER"/>
-        <custom-filter ref="logoutFilter" after="LOGOUT_FILTER"/>
-        <!--        <custom-filter ref="samlLogoutFilter" before="LOGOUT_FILTER"/>-->
-        <csrf disabled="false"
-                              token-repository-ref="loginCookieCsrfRepository"/>
-        <access-denied-handler ref="loginEntryPoint"/>
-        <request-cache ref="clientRedirectStateCache"/>
-    </http>
-
     <bean id="errorMessageAuthenticationFailureHandler"
                     class="org.springframework.security.web.authentication.ExceptionMappingAuthenticationFailureHandler">
         <property name="exceptionMappings">

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -19,10 +19,6 @@
 
     <bean id="notificationsTemplate" class="org.cloudfoundry.identity.uaa.message.LocalUaaRestTemplate"/>
 
-    <bean id="notificationsUrl" class="java.lang.String">
-        <constructor-arg value="${notifications.url:}"/>
-    </bean>
-
     <!-- Pattern: /oauth/authorize parameters:{response_type=code,code=?} -->
     <http name="secFilterAutologinAuthorize" request-matcher-ref="autologinAuthorizeRequestMatcher"
                     entry-point-ref="loginEntryPoint"
@@ -301,8 +297,6 @@
 
     <!--<mvc:resources location="/" mapping="/**" />-->
 
-    <mvc:default-servlet-handler/>
-
     <bean id="links" class="java.util.HashMap">
         <constructor-arg value="#{@config['links']==null ? T(java.util.Collections).EMPTY_MAP : @config['links']}"/>
     </bean>
@@ -355,14 +349,10 @@
         </property>
     </bean>
 
-    <bean id="loginServerConfig" class="org.cloudfoundry.identity.uaa.impl.config.LoginServerConfig"/>
-
     <mvc:resources mapping="/resources/**" location="/resources/"/>
     <mvc:default-servlet-handler/>
 
     <bean id="buildInfo" class="org.cloudfoundry.identity.uaa.home.BuildInfo"/>
-
-    <bean id="thymeleafConfig" class="org.cloudfoundry.identity.uaa.login.ThymeleafConfig"/>
 
     <bean id="uaaPasswordValidator" class="org.cloudfoundry.identity.uaa.scim.validate.UaaPasswordPolicyValidator">
         <constructor-arg ref="globalPasswordPolicy"/>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -17,8 +17,6 @@
     <oauth:resource id="uaa" access-token-uri="${uaa.token.url:http://localhost:8080/uaa/oauth/token}"
                     client-id="login" client-secret="${LOGIN_SECRET:loginsecret}" type="client_credentials"/>
 
-    <bean id="notificationsTemplate" class="org.cloudfoundry.identity.uaa.message.LocalUaaRestTemplate"/>
-
     <!-- Pattern: /oauth/authorize parameters:{response_type=code,code=?} -->
     <http name="secFilterAutologinAuthorize" request-matcher-ref="autologinAuthorizeRequestMatcher"
                     entry-point-ref="loginEntryPoint"

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -45,9 +45,6 @@
         <csrf disabled="true"/>
     </http>
 
-    <bean id="backwardsCompatibleScopeParameter"
-                    class="org.cloudfoundry.identity.uaa.web.BackwardsCompatibleScopeParsingFilter"/>
-
     <bean id="acceptInvitationSecurityContextPersistenceFilter"
                     class="org.springframework.security.web.context.SecurityContextPersistenceFilter">
         <constructor-arg name="repo">

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -277,10 +277,6 @@
         <constructor-arg name="redirectNotLoggedIn" value="/login?error=invalid_login_request"/>
     </bean>
 
-    <bean id="keyInfoService" class="org.cloudfoundry.identity.uaa.oauth.KeyInfoService">
-        <constructor-arg name="uaaBaseURL" value="${uaa.url}"/>
-    </bean>
-
     <bean id="externalOAuthLogoutHandler"
                     class="org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthLogoutSuccessHandler">
         <constructor-arg name="providerProvisioning" ref="externalOAuthProviderConfigurator"/>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -291,10 +291,6 @@
 
     <!--<mvc:resources location="/" mapping="/**" />-->
 
-    <bean id="links" class="java.util.HashMap">
-        <constructor-arg value="#{@config['links']==null ? T(java.util.Collections).EMPTY_MAP : @config['links']}"/>
-    </bean>
-
     <!--apply the oauth client context -->
     <oauth:client id="oauth2ClientFilter"/>
 

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -276,7 +276,4 @@
         </property>
     </bean>
 
-    <mvc:resources mapping="/resources/**" location="/resources/"/>
-    <mvc:default-servlet-handler/>
-
 </beans>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -177,13 +177,6 @@
         <csrf disabled="true"/>
     </http>
 
-    <bean id="passwordChangeUiRequiredFilter"
-                    class="org.cloudfoundry.identity.uaa.authentication.PasswordChangeUiRequiredFilter"/>
-
-    <bean id="reAuthenticationRequiredFilter"
-                    class="org.cloudfoundry.identity.uaa.authentication.ReAuthenticationRequiredFilter">
-    </bean>
-
     <http name="idpSecurity"
                     use-expressions="true"
                     pattern="/saml/idp/SSO/**"

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -177,18 +177,6 @@
         <csrf disabled="true"/>
     </http>
 
-    <bean id="catchAllFilterChainProxy" class="org.springframework.security.web.FilterChainProxy">
-        <constructor-arg>
-            <util:list>
-                <security:filter-chain pattern="/**" filters="
-                    httpsHeaderFilter"/>
-                <!--                    httpsHeaderFilter,-->
-                <!--                    metadataGeneratorFilter,-->
-                <!--                    samlFilter"/>-->
-            </util:list>
-        </constructor-arg>
-    </bean>
-
     <bean id="passwordChangeUiRequiredFilter"
                     class="org.cloudfoundry.identity.uaa.authentication.PasswordChangeUiRequiredFilter"/>
 
@@ -230,8 +218,6 @@
         <constructor-arg name="delegate" ref="errorMessageAuthenticationFailureHandler"/>
         <constructor-arg name="currentUserCookieFactory" ref="currentUserCookieFactory"/>
     </bean>
-
-    <bean id="httpsHeaderFilter" class="org.cloudfoundry.identity.uaa.security.web.HttpsHeaderFilter"/>
 
     <bean id="loginEntryPoint" class="org.cloudfoundry.identity.uaa.security.CsrfAwareEntryPointAndDeniedHandler">
         <constructor-arg name="redirectCsrf" value="/invalid_request"/>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -352,8 +352,6 @@
     <mvc:resources mapping="/resources/**" location="/resources/"/>
     <mvc:default-servlet-handler/>
 
-    <bean id="buildInfo" class="org.cloudfoundry.identity.uaa.home.BuildInfo"/>
-
     <bean id="uaaPasswordValidator" class="org.cloudfoundry.identity.uaa.scim.validate.UaaPasswordPolicyValidator">
         <constructor-arg ref="globalPasswordPolicy"/>
     </bean>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -231,11 +231,6 @@
         <constructor-arg name="keyInfoService" ref="keyInfoService"/>
     </bean>
 
-    <!--<mvc:resources location="/" mapping="/**" />-->
-
-    <!--apply the oauth client context -->
-    <oauth:client id="oauth2ClientFilter"/>
-
     <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
         <mvc:message-converters>
             <bean class="org.cloudfoundry.identity.uaa.authentication.manager.AutologinRequestConverter"/>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -231,13 +231,6 @@
         <constructor-arg name="keyInfoService" ref="keyInfoService"/>
     </bean>
 
-    <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
-        <mvc:message-converters>
-            <bean class="org.cloudfoundry.identity.uaa.authentication.manager.AutologinRequestConverter"/>
-        </mvc:message-converters>
-        <mvc:path-matching registered-suffixes-only="true"/>
-    </mvc:annotation-driven>
-
     <bean id="autologinAuthenticationFilter"
                     class="org.cloudfoundry.identity.uaa.authentication.AuthzAuthenticationFilter">
         <constructor-arg ref="autologinAuthenticationManager"/>

--- a/server/src/main/resources/spring/login-ui.xml
+++ b/server/src/main/resources/spring/login-ui.xml
@@ -356,8 +356,4 @@
         <constructor-arg ref="globalPasswordPolicy"/>
     </bean>
 
-    <bean id="messagePropertiesSource" class="org.springframework.core.io.support.ResourcePropertySource">
-        <constructor-arg value="messages.properties"/>
-    </bean>
-
 </beans>

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerTest.java
@@ -24,6 +24,7 @@ import org.cloudfoundry.identity.uaa.user.UaaAuthority;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.BrandingInformation;
 import org.cloudfoundry.identity.uaa.zone.Consent;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
@@ -775,7 +776,7 @@ class InvitationsControllerTest {
 
         @Bean
         BuildInfo buildInfo() {
-            return new BuildInfo();
+            return new TestBuildInfo();
         }
 
         @Bean

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/AccountsControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/AccountsControllerTest.java
@@ -11,6 +11,7 @@ import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,7 +242,7 @@ class AccountsControllerTest {
 
         @Bean
         BuildInfo buildInfo() {
-            return new BuildInfo();
+            return new TestBuildInfo();
         }
 
         @Bean

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangeEmailControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangeEmailControllerTest.java
@@ -11,6 +11,7 @@ import org.cloudfoundry.identity.uaa.home.BuildInfo;
 import org.cloudfoundry.identity.uaa.user.UaaAuthority;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -381,7 +382,7 @@ class ChangeEmailControllerTest {
 
         @Bean
         BuildInfo buildInfo() {
-            return new BuildInfo();
+            return new TestBuildInfo();
         }
 
         @Bean

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.home.BuildInfo;
 import org.cloudfoundry.identity.uaa.home.HomeController;
 import org.cloudfoundry.identity.uaa.provider.saml.MetadataProviderNotFoundException;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.BrandingInformation;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -255,7 +256,7 @@ class HomeControllerViewTests extends TestClassNullifier {
 
         @Bean
         BuildInfo buildInfo() {
-            return new BuildInfo();
+            return new TestBuildInfo();
         }
 
         @Bean

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcTests.java
@@ -11,6 +11,7 @@ import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.home.BuildInfo;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientConstants;
 import org.cloudfoundry.identity.uaa.security.beans.SecurityContextAccessor;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
 import org.junit.jupiter.api.AfterEach;
@@ -78,7 +79,7 @@ class ProfileControllerMockMvcTests {
 
         @Bean
         BuildInfo buildInfo() {
-            return new BuildInfo();
+            return new TestBuildInfo();
         }
 
         @Bean

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
@@ -16,6 +16,7 @@ import org.cloudfoundry.identity.uaa.message.MessageType;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.util.TimeServiceImpl;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.BrandingInformation;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
@@ -344,7 +345,7 @@ class ResetPasswordControllerTest extends TestClassNullifier {
 
         @Bean
         BuildInfo buildInfo() {
-            return new BuildInfo();
+            return new TestBuildInfo();
         }
 
         @Bean

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/TestBuildInfo.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/TestBuildInfo.java
@@ -5,6 +5,6 @@ import org.cloudfoundry.identity.uaa.home.BuildInfo;
 
 public class TestBuildInfo extends BuildInfo {
     public TestBuildInfo() {
-        super(new UaaProperties());
+        super(new UaaProperties.Uaa(null));
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/TestBuildInfo.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/TestBuildInfo.java
@@ -1,0 +1,10 @@
+package org.cloudfoundry.identity.uaa.util.beans;
+
+import org.cloudfoundry.identity.uaa.UaaProperties;
+import org.cloudfoundry.identity.uaa.home.BuildInfo;
+
+public class TestBuildInfo extends BuildInfo {
+    public TestBuildInfo() {
+        super(new UaaProperties());
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtilsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtilsTests.java
@@ -1,0 +1,40 @@
+package org.cloudfoundry.identity.uaa.web;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.core.authority.AuthorityUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AuthorizationManagersUtilsTests {
+
+    @Nested
+    class AnonymousOrFullyAuthenticated {
+        private final AuthorizationManager<Object> matcher = AuthorizationManagersUtils.anonymousOrFullyAuthenticated();
+
+        @Test
+        void anonymous() {
+            var authentication = new AnonymousAuthenticationToken("ignored", "ignored", AuthorityUtils.createAuthorityList("ignored"));
+
+            assertThat(matcher.check(() -> authentication, null).isGranted()).isTrue();
+        }
+
+        @Test
+        void fullyAuthenticated() {
+            var authentication = UsernamePasswordAuthenticationToken.authenticated("ignored", null, AuthorityUtils.NO_AUTHORITIES);
+
+            assertThat(matcher.check(() -> authentication, null).isGranted()).isTrue();
+        }
+
+        @Test
+        void rememberMeAuthentication() {
+            var authentication = new RememberMeAuthenticationToken("ignored", "ignored", AuthorityUtils.createAuthorityList("ignored"));
+
+            assertThat(matcher.check(() -> authentication, null).isGranted()).isFalse();
+        }
+    }
+}

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -469,6 +469,10 @@
         <property name="allowOriginLoop" value="${login.allowOriginLoop:true}"/>
     </bean>
 
+    <bean id="links" class="java.util.HashMap">
+        <constructor-arg value="#{@config['links']==null ? T(java.util.Collections).EMPTY_MAP : @config['links']}"/>
+    </bean>
+
     <bean id="identityZoneConfigurationBootstrap"
                     class="org.cloudfoundry.identity.uaa.impl.config.IdentityZoneConfigurationBootstrap">
         <property name="validator" ref="identityZoneValidator"/>

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -14,7 +14,7 @@
     <context:annotation-config/>
     <context:component-scan base-package="org.cloudfoundry.identity.uaa"/>
 
-    <bean id="uaaConfig" class="org.cloudfoundry.identity.uaa.impl.config.YamlConfigurationValidator">
+    <bean id="uaaConfigValidation" class="org.cloudfoundry.identity.uaa.impl.config.YamlConfigurationValidator">
         <constructor-arg>
             <bean class="org.cloudfoundry.identity.uaa.impl.config.UaaConfiguration.UaaConfigConstructor"/>
         </constructor-arg>

--- a/uaa/src/main/webapp/WEB-INF/web.xml
+++ b/uaa/src/main/webapp/WEB-INF/web.xml
@@ -27,7 +27,7 @@
     </filter>
 
     <filter>
-        <!-- Filter name MUST match org.cloudfoundry.identity.uaa.UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID -->
+        <!-- Filter name MUST match org.cloudfoundry.identity.uaa.UaaConfig.SPRING_SECURITY_FILTER_CHAIN_ID -->
         <filter-name>aggregateSpringSecurityFilterChain</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
         <init-param>

--- a/uaa/src/main/webapp/WEB-INF/web.xml
+++ b/uaa/src/main/webapp/WEB-INF/web.xml
@@ -16,12 +16,6 @@
         </init-param>
     </filter>
 
-    <!--    <filter>-->
-    <!--        &lt;!&ndash; matches SamlConfiguration.AGGREGATE_SPRING_SECURITY_FILTER_CHAIN_ID &ndash;&gt;-->
-    <!--        <filter-name>aggregateSpringSecurityFilterChain</filter-name>-->
-    <!--        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>-->
-    <!--    </filter>-->
-
     <filter>
         <filter-name>springSessionRepositoryFilter</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
@@ -33,14 +27,15 @@
     </filter>
 
     <filter>
-        <filter-name>springSecurityFilterChain</filter-name>
+        <!-- Filter name MUST match org.cloudfoundry.identity.uaa.UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID -->
+        <filter-name>aggregateSpringSecurityFilterChain</filter-name>
         <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
         <init-param>
             <param-name>contextAttribute</param-name>
             <param-value>org.springframework.web.servlet.FrameworkServlet.CONTEXT.spring</param-value>
         </init-param>
     </filter>
-    
+
     <filter>
         <filter-name>backwardsCompatibleScopeParameter</filter-name>
         <filter-class>org.cloudfoundry.identity.uaa.web.BackwardsCompatibleScopeParsingFilter</filter-class>
@@ -90,7 +85,7 @@
     </filter-mapping>
 
     <filter-mapping>
-        <filter-name>springSecurityFilterChain</filter-name>
+        <filter-name>aggregateSpringSecurityFilterChain</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
@@ -99,13 +94,6 @@
         <filter-name>backwardsCompatibleScopeParameter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
-
-    <!--    <filter-mapping>-->
-    <!--        <filter-name>aggregateSpringSecurityFilterChain</filter-name>-->
-    <!--        <url-pattern>/saml/metadata/*</url-pattern>-->
-    <!--        <dispatcher>REQUEST</dispatcher>-->
-    <!--        <dispatcher>FORWARD</dispatcher>-->
-    <!--    </filter-mapping>-->
 
     <servlet>
         <servlet-name>spring</servlet-name>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/DefaultTestContext.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/DefaultTestContext.java
@@ -12,7 +12,6 @@ import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.PropertySource;
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -54,7 +53,7 @@ class TestClientAndMockMvcTestConfig {
     @Bean
     public MockMvc mockMvc(
             WebApplicationContext webApplicationContext,
-            @Qualifier(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID) FilterChainProxy securityFilterChain
+            @Qualifier(UaaConfig.SPRING_SECURITY_FILTER_CHAIN_ID) FilterChainProxy securityFilterChain
     ) {
         return MockMvcBuilders.webAppContextSetup(webApplicationContext)
                 .addFilter(securityFilterChain)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/DefaultTestContext.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/DefaultTestContext.java
@@ -4,12 +4,15 @@ import org.cloudfoundry.identity.uaa.db.beans.JdbcUrlCustomizer;
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.test.TestClient;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportResource;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -35,7 +38,8 @@ import java.lang.annotation.Target;
         // Conflicts with UaaJdbcSessionConfig
         SessionAutoConfiguration.class,
         // Conflicts with LdapSearchAndCompareConfig/LdapSearchAndBindConfig/LdapSimpleBindConfig
-        LdapAutoConfiguration.class
+        LdapAutoConfiguration.class,
+        SecurityAutoConfiguration.class
 })
 public @interface DefaultTestContext {
 }
@@ -50,10 +54,10 @@ class TestClientAndMockMvcTestConfig {
     @Bean
     public MockMvc mockMvc(
             WebApplicationContext webApplicationContext,
-            @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") FilterChainProxy springSecurityFilterChain
+            @Qualifier(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID) FilterChainProxy securityFilterChain
     ) {
         return MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(springSecurityFilterChain)
+                .addFilter(securityFilterChain)
                 .build();
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/YamlConfigurationValidationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/YamlConfigurationValidationTests.java
@@ -1,0 +1,93 @@
+package org.cloudfoundry.identity.uaa;
+
+import org.cloudfoundry.identity.uaa.impl.config.YamlConfigurationValidator;
+import org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.xml.ResourceEntityResolver;
+import org.springframework.beans.factory.xml.XmlBeanDefinitionReader;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+import org.springframework.mock.web.MockServletConfig;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.support.AbstractRefreshableWebApplicationContext;
+
+import javax.validation.ConstraintViolationException;
+import java.util.EventListener;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * This component-level test verifies that {@link YamlConfigurationValidator} is actually
+ * wired into the application context and does validate the configuration.
+ */
+class YamlConfigurationValidationTests {
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty("UAA_CONFIG_URL");
+    }
+
+    @Test
+    void validConfiguration() {
+        System.setProperty("UAA_CONFIG_URL", "classpath:integration_test_properties.yml");
+        var applicationContext = createApplicationContext();
+        assertThatNoException().isThrownBy(applicationContext::refresh);
+    }
+
+    @Test
+    void invalidConfiguration() {
+        System.setProperty("UAA_CONFIG_URL", "classpath:invalid_configuration.yml");
+        var applicationContext = createApplicationContext();
+        assertThatThrownBy(applicationContext::refresh)
+                .isInstanceOf(BeansException.class)
+                .getRootCause()
+                .isInstanceOf(ConstraintViolationException.class)
+                .hasMessageContaining("database.url: Database url is required");
+    }
+
+    private static TestApplicationContext createApplicationContext() {
+        var applicationContext = new TestApplicationContext();
+        var servletContext = new TestMockContext();
+        applicationContext.setServletContext(servletContext);
+        MockServletConfig servletConfig = new MockServletConfig(servletContext);
+        applicationContext.setServletConfig(servletConfig);
+
+        YamlServletProfileInitializer initializer = new YamlServletProfileInitializer();
+        initializer.initialize(applicationContext);
+        applicationContext.getEnvironment().setActiveProfiles("strict");
+        return applicationContext;
+    }
+
+
+    static class TestApplicationContext extends AbstractRefreshableWebApplicationContext {
+
+        @Override
+        protected void loadBeanDefinitions(@NonNull DefaultListableBeanFactory beanFactory) throws BeansException {
+            XmlBeanDefinitionReader beanDefinitionReader = new XmlBeanDefinitionReader(beanFactory);
+
+            // Configure the bean definition reader with this context's
+            // resource loading environment.
+            beanDefinitionReader.setEnvironment(this.getEnvironment());
+            beanDefinitionReader.setResourceLoader(this);
+            beanDefinitionReader.setEntityResolver(new ResourceEntityResolver(this));
+
+            beanDefinitionReader.loadBeanDefinitions("file:./src/main/webapp/WEB-INF/spring-servlet.xml");
+        }
+    }
+
+    ;
+
+    static class TestMockContext extends MockServletContext {
+        @Override
+        public <T extends EventListener> void addListener(@Nullable T t) {
+            //no op
+        }
+    }
+
+    ;
+
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcTests.java
@@ -397,6 +397,7 @@ class InvitationsEndpointMockMvcTests {
         branding.setCompanyName("Best Company");
         IdentityZoneConfiguration config = new IdentityZoneConfiguration();
         config.setBranding(branding);
+        config.setTokenPolicy(IdentityZoneHolder.getUaaZone().getConfig().getTokenPolicy());
         IdentityZone defaultZone = IdentityZoneHolder.getUaaZone();
         defaultZone.setConfig(config);
         identityZoneProvisioning.update(defaultZone);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -130,6 +130,7 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 import static org.springframework.http.HttpMethod.GET;
 import static org.springframework.http.HttpMethod.OPTIONS;
 import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.TEXT_HTML;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.securityContext;
@@ -2210,6 +2211,23 @@ public class LoginMockMvcTests {
                         .header("Authorization", "Basic " + new String(ENCODER.encode("admin:adminsecret".getBytes())))
                         .contentType(APPLICATION_JSON)
                         .content(JsonUtils.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/autologin")
+                        .param("code", "test" + generator.counter.get())
+                        .param("client_id", "admin"))
+                .andExpect(redirectedUrl("home"));
+    }
+
+    @Test
+    void autologin_with_validCode_and_formencoded_RedirectsToHome() throws Exception {
+        MockMvcUtils.PredictableGenerator generator = new MockMvcUtils.PredictableGenerator();
+        jdbcExpiringCodeStore.setGenerator(generator);
+
+        mockMvc.perform(post("/autologin")
+                        .header("Authorization", "Basic " + new String(ENCODER.encode("admin:adminsecret".getBytes())))
+                        .contentType(APPLICATION_FORM_URLENCODED)
+                        .content("username=marissa&password=koala"))
                 .andExpect(status().isOk());
 
         mockMvc.perform(get("/autologin")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -42,6 +42,7 @@ import org.cloudfoundry.identity.uaa.zone.InvalidIdentityZoneDetailsException;
 import org.cloudfoundry.identity.uaa.zone.JdbcIdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.Links;
 import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -734,6 +735,19 @@ public class LoginMockMvcTests {
         mockMvc.perform(get("/login")).andExpect(content().string(containsString("<a href=\"/privacy\">Privacy</a> &mdash; <a href=\"/terms.html\">Terms of Use</a>")));
     }
 
+
+    @Test
+    void buildInfoInFooter() throws Exception {
+        var footerTitleLocator = "//div[@class=\"copyright\"]/@title";
+        mockMvc.perform(get("/login"))
+                .andExpect(
+                        xpath(footerTitleLocator).string(Matchers.containsString("UAA: http://localhost:8080/uaa"))
+                )
+                .andExpect(
+                        xpath(footerTitleLocator).string(Matchers.containsString("Version: 0.0.0, Commit:"))
+                );
+    }
+
     @Test
     void forgotPasswordPageDoesNotHaveCsrf() throws Exception {
         mockMvc.perform(get("/forgot_password"))
@@ -1054,7 +1068,9 @@ public class LoginMockMvcTests {
 
     @Nested
     @DefaultTestContext
-    @TestPropertySource(properties = {"assetBaseUrl=//cdn.example.com/pivotal"})
+    @TestPropertySource(
+            properties = {"assetBaseUrl=//cdn.example.com/pivotal", "uaa.url=https://uaa.exmaple.com/uaa"}
+    )
     class Branding {
         @Autowired
         private MockMvc mockMvc;
@@ -1065,6 +1081,15 @@ public class LoginMockMvcTests {
                     .andExpect(xpath("//head/link[@rel='shortcut icon']/@href").string("//cdn.example.com/pivotal/images/square-logo.png"))
                     .andExpect(xpath("//head/link[@href='//cdn.example.com/pivotal/stylesheets/application.css']").exists())
                     .andExpect(xpath("//head/style[text()[contains(.,'//cdn.example.com/pivotal/images/product-logo.png')]]").exists());
+        }
+
+        @Test
+        void buildInfoInFooter() throws Exception {
+            mockMvc.perform(get("/login"))
+                    .andExpect(
+                            xpath("//div[@class=\"copyright\"]/@title")
+                                    .string(Matchers.containsString("UAA: https://uaa.exmaple.com/uaa"))
+                    );
         }
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/TokenEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/TokenEndpointDocs.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.login;
 
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
-import org.cloudfoundry.identity.uaa.UaaConfiguration;
+import org.cloudfoundry.identity.uaa.UaaConfig;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
@@ -154,7 +154,7 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
 
     private ScimUser user;
 
-    @Qualifier(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID)
+    @Qualifier(UaaConfig.SPRING_SECURITY_FILTER_CHAIN_ID)
     @Autowired
     FilterChainProxy securityFilterChain;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/TokenEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/TokenEndpointDocs.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.login;
 
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.cloudfoundry.identity.uaa.UaaConfiguration;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.opensaml.saml.saml2.core.NameID;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -152,8 +154,9 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
 
     private ScimUser user;
 
+    @Qualifier(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID)
     @Autowired
-    FilterChainProxy springSecurityFilterChain;
+    FilterChainProxy securityFilterChain;
 
     @BeforeAll
     static void beforeAll() {
@@ -170,7 +173,7 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
     @BeforeEach
     void setUpContext(ManualRestDocumentation manualRestDocumentation) {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(springSecurityFilterChain)
+                .addFilter(securityFilterChain)
                 .apply(documentationConfiguration(manualRestDocumentation)
                         .uris().withPort(80)
                         .and()

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/EndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/EndpointDocs.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.mock;
 
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
+import org.cloudfoundry.identity.uaa.UaaConfiguration;
 import org.cloudfoundry.identity.uaa.test.JUnitRestDocumentationExtension;
 import org.cloudfoundry.identity.uaa.test.TestClient;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
@@ -31,10 +32,10 @@ public class EndpointDocs {
 
     @BeforeEach
     void setupWebMvc(ManualRestDocumentation manualRestDocumentation) {
-        FilterChainProxy springSecurityFilterChain = webApplicationContext.getBean("springSecurityFilterChain", FilterChainProxy.class);
+        FilterChainProxy securityFilterChain = webApplicationContext.getBean(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID, FilterChainProxy.class);
 
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(springSecurityFilterChain)
+                .addFilter(securityFilterChain)
                 .apply(documentationConfiguration(manualRestDocumentation)
                         .uris().withPort(80)
                         .and()

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/EndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/EndpointDocs.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.mock;
 
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
-import org.cloudfoundry.identity.uaa.UaaConfiguration;
+import org.cloudfoundry.identity.uaa.UaaConfig;
 import org.cloudfoundry.identity.uaa.test.JUnitRestDocumentationExtension;
 import org.cloudfoundry.identity.uaa.test.TestClient;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
@@ -32,7 +32,7 @@ public class EndpointDocs {
 
     @BeforeEach
     void setupWebMvc(ManualRestDocumentation manualRestDocumentation) {
-        FilterChainProxy securityFilterChain = webApplicationContext.getBean(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID, FilterChainProxy.class);
+        FilterChainProxy securityFilterChain = webApplicationContext.getBean(UaaConfig.SPRING_SECURITY_FILTER_CHAIN_ID, FilterChainProxy.class);
 
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                 .addFilter(securityFilterChain)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -73,12 +73,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.codec.Utf8;
-import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.StringUtils;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -137,6 +135,7 @@ class AuditCheckMockMvcTests {
 
     @Autowired
     private ConfigurableApplicationContext configurableApplicationContext;
+    @Autowired
     private MockMvc mockMvc;
     private TestClient testClient;
     @Autowired
@@ -153,11 +152,7 @@ class AuditCheckMockMvcTests {
     JdbcScimUserProvisioning jdbcScimUserProvisioning;
 
     @BeforeEach
-    void setUp(@Autowired FilterChainProxy springSecurityFilterChain,
-               @Autowired WebApplicationContext webApplicationContext) throws Exception {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(springSecurityFilterChain)
-                .build();
+    void setUp() throws Exception {
         testClient = new TestClient(mockMvc);
 
         originalLoginClient = clientRegistrationService.loadClientByClientId("login");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantEndpointDocs.java
@@ -15,7 +15,7 @@
 
 package org.cloudfoundry.identity.uaa.mock.token;
 
-import org.cloudfoundry.identity.uaa.UaaConfiguration;
+import org.cloudfoundry.identity.uaa.UaaConfig;
 import org.cloudfoundry.identity.uaa.test.JUnitRestDocumentationExtension;
 import org.cloudfoundry.identity.uaa.test.TestClient;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
@@ -31,7 +31,9 @@ import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_JWT_BEARER;
-import static org.cloudfoundry.identity.uaa.test.SnippetUtils.*;
+import static org.cloudfoundry.identity.uaa.test.SnippetUtils.fieldWithPath;
+import static org.cloudfoundry.identity.uaa.test.SnippetUtils.headerWithName;
+import static org.cloudfoundry.identity.uaa.test.SnippetUtils.parameterWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -47,7 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(JUnitRestDocumentationExtension.class)
 class JwtBearerGrantEndpointDocs extends JwtBearerGrantMockMvcTests {
-    @Qualifier(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID)
+    @Qualifier(UaaConfig.SPRING_SECURITY_FILTER_CHAIN_ID)
     @Autowired
     FilterChainProxy securityFilterChain;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/JwtBearerGrantEndpointDocs.java
@@ -15,6 +15,7 @@
 
 package org.cloudfoundry.identity.uaa.mock.token;
 
+import org.cloudfoundry.identity.uaa.UaaConfiguration;
 import org.cloudfoundry.identity.uaa.test.JUnitRestDocumentationExtension;
 import org.cloudfoundry.identity.uaa.test.TestClient;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
@@ -22,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.restdocs.ManualRestDocumentation;
 import org.springframework.restdocs.headers.RequestHeadersSnippet;
 import org.springframework.restdocs.snippet.Snippet;
@@ -45,13 +47,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(JUnitRestDocumentationExtension.class)
 class JwtBearerGrantEndpointDocs extends JwtBearerGrantMockMvcTests {
+    @Qualifier(UaaConfiguration.SPRING_SECURITY_FILTER_CHAIN_ID)
     @Autowired
-    FilterChainProxy springSecurityFilterChain;
+    FilterChainProxy securityFilterChain;
 
     @BeforeEach
     void setUpContext(ManualRestDocumentation manualRestDocumentation) {
         mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(springSecurityFilterChain)
+                .addFilter(securityFilterChain)
                 .apply(documentationConfiguration(manualRestDocumentation)
                         .uris().withPort(80)
                         .and()

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/DisableInternalUserManagementFilterMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/DisableInternalUserManagementFilterMockMvcTests.java
@@ -7,9 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -21,17 +19,14 @@ class DisableInternalUserManagementFilterMockMvcTests {
 
     @Autowired
     WebApplicationContext webApplicationContext;
+    @Autowired
     private MockMvc mockMvc;
 
     @Value("${disableInternalUserManagement:false}")
     private boolean disableInternalUserManagement;
 
     @BeforeEach
-    void setUp(@Autowired FilterChainProxy springSecurityFilterChain) {
-        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
-                .addFilter(springSecurityFilterChain)
-                .build();
-
+    void setUp() {
         MockMvcUtils.setDisableInternalUserManagement(webApplicationContext, true);
     }
 

--- a/uaa/src/test/resources/integration_test_properties.yml
+++ b/uaa/src/test/resources/integration_test_properties.yml
@@ -1,5 +1,7 @@
 servlet:
   session-store: database
+  session-cookie:
+    encode-base64: true
 
 encryption:
   active_key_label: CHANGE-THIS-KEY
@@ -10,41 +12,45 @@ encryption:
 issuer:
   uri: http://localhost:8080/uaa
 
-# The secret that an external login server will use to authenticate to the uaa using the id `login`
+#The secret that an external login server will use to authenticate to the uaa using the id `login`
 LOGIN_SECRET: loginsecret
 
 jwt:
   token:
-    signing-alg: RS256
-    signing-key: |
-      -----BEGIN PRIVATE KEY-----
-      MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCowKUlfOfJxXZt
-      DWkVs3xb4BZJiGlLYxUAaGRY2WbG/YjHT/6frOOK+N2jFyrtElHiRXJyhV4PTsOJ
-      YSVhKdAt15A+AoBwGLCKVHfRTLINMpyoNBDmuQKDY42XBXRoyyDvgppd5exXrncB
-      KzcVgS25LVoP8Nvn4XJcXweQejzHLX01SeqwNZCeHUeGSXKfG7a29bR/DagMTWnA
-      2X5YsRU+2VykK1/hVK/4ZrC0GIjrGZiwYEwL3Db0RIcWo/DQ1IJGGXIl/qsME0f/
-      vrqbMr+8TMDivMZMERSoPFOD/wmlGGH0PeqWNKyaoK2lCiWg4BpQoKpIlv+Eo+yl
-      77uv1xibAgMBAAECggEADtC4jwJ/MDuZ6pGtvKSBEgKp7wzyJZa00ZzYo0sVSi1L
-      58FSDiW15Zqn84YSR2iY1l//eY0HVYCDC6aDC07W9cQoaArjLzQ6GslQqm6GOtqX
-      +CJ3q2Uc+RKkuL7XWgEfZDexb4+PwNQfb/OIOgCZCY1kP0sHm3BNEIDQheXD1gtq
-      8KTOBy/TtN7rV940LoudgQ8vzz+ShhmG7Dt5yws/QzaBpryLncGsGYZSDnvvEBYY
-      dlbYQEgfLmzdKSDKW3DNV+duaBDeArxZViD7EqPpQxIOawBvl5bs6Radz7OEGZ7k
-      hTr2fYU4JGn4WJl61yJg4Xm6pp9cJmi+BIgwLrvXNQKBgQDTPjZ6jCPXAfY6WRVD
-      +hTKgrdhMzNALuiZeyWNSKiiDKgtx1A8OhUAgGzY/PeqmDabiVWKtso+EazfMwa+
-      BrScf+HEZFUvNJ5tGxe6nEEFCx0n5ELUM/L4SWCtD6eFCNYcAY1XvzPD1F3KzewE
-      vw8FbT34fef+YayuIF3PPODtJwKBgQDMgcEnXARRzsIC7i1ggqSU8N0OUSu+rA/h
-      Md9Uh9HsY18p8JtNezAQ2vV4RL3R/CUPGXeDvCBYWhXlkNmjdCAsk24DZHs2Q18x
-      TeHZ15PUtmd2tH/tAxANDi6RTTjpQI3w2poXHl2ZVuT8M+XkTv0WzI0c8TNog2RA
-      SzHd5z5JbQKBgQCDlvim5E+bKzywYjfuDYYQFNeZNCTT8aSxn1XoKf/qWooVYlin
-      ++KDWnzzurmpSoKR5z4jV/SqL6aJr6aej1zJNJx2E65A5r1d6AejFp0mQCMca4P5
-      3paXdlZD2EGZjMSb05extojPj6YRpK9G0aHQ1plJB12SSFQicEUfyKOw9wKBgD09
-      ScLoih6ZRH2uJwZ0eKZlLj0AT5IsYiD0V0Uv2svnwfKEK21bSzxw5Prb0t/TmqFX
-      5fMb3a+3YkE5TALnXk8a4uG/MCpCqHnSMaSTKqCS8o6YZIpr1V2jdoxqTHWEsDyE
-      qYnsvOiTHcTsIZZplN5D6KnXDKbqWZXrLoadnYhNAoGACESLgCy552WcM7vNt4Fw
-      7lR/O3gEnwD41gIx5EGa/UoA08Q+i7sBt9PkL4oQrJ/MYCcVNnmg9KrJdlqF4AlE
-      HYeZSkMuQDYHcaO9xtYP3QdhD+nLXbNrCxaSSaSX8tS4BjdcSH1yMyLFg5OqiJYg
-      wYFiptyKFm5QqFhFTY+20aE=
-      -----END PRIVATE KEY-----
+    policy:
+      activeKeyId: key-id-1
+      keys:
+        key-id-1:
+          signingAlg: RS256
+          signingKey: |
+            -----BEGIN PRIVATE KEY-----
+            MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCowKUlfOfJxXZt
+            DWkVs3xb4BZJiGlLYxUAaGRY2WbG/YjHT/6frOOK+N2jFyrtElHiRXJyhV4PTsOJ
+            YSVhKdAt15A+AoBwGLCKVHfRTLINMpyoNBDmuQKDY42XBXRoyyDvgppd5exXrncB
+            KzcVgS25LVoP8Nvn4XJcXweQejzHLX01SeqwNZCeHUeGSXKfG7a29bR/DagMTWnA
+            2X5YsRU+2VykK1/hVK/4ZrC0GIjrGZiwYEwL3Db0RIcWo/DQ1IJGGXIl/qsME0f/
+            vrqbMr+8TMDivMZMERSoPFOD/wmlGGH0PeqWNKyaoK2lCiWg4BpQoKpIlv+Eo+yl
+            77uv1xibAgMBAAECggEADtC4jwJ/MDuZ6pGtvKSBEgKp7wzyJZa00ZzYo0sVSi1L
+            58FSDiW15Zqn84YSR2iY1l//eY0HVYCDC6aDC07W9cQoaArjLzQ6GslQqm6GOtqX
+            +CJ3q2Uc+RKkuL7XWgEfZDexb4+PwNQfb/OIOgCZCY1kP0sHm3BNEIDQheXD1gtq
+            8KTOBy/TtN7rV940LoudgQ8vzz+ShhmG7Dt5yws/QzaBpryLncGsGYZSDnvvEBYY
+            dlbYQEgfLmzdKSDKW3DNV+duaBDeArxZViD7EqPpQxIOawBvl5bs6Radz7OEGZ7k
+            hTr2fYU4JGn4WJl61yJg4Xm6pp9cJmi+BIgwLrvXNQKBgQDTPjZ6jCPXAfY6WRVD
+            +hTKgrdhMzNALuiZeyWNSKiiDKgtx1A8OhUAgGzY/PeqmDabiVWKtso+EazfMwa+
+            BrScf+HEZFUvNJ5tGxe6nEEFCx0n5ELUM/L4SWCtD6eFCNYcAY1XvzPD1F3KzewE
+            vw8FbT34fef+YayuIF3PPODtJwKBgQDMgcEnXARRzsIC7i1ggqSU8N0OUSu+rA/h
+            Md9Uh9HsY18p8JtNezAQ2vV4RL3R/CUPGXeDvCBYWhXlkNmjdCAsk24DZHs2Q18x
+            TeHZ15PUtmd2tH/tAxANDi6RTTjpQI3w2poXHl2ZVuT8M+XkTv0WzI0c8TNog2RA
+            SzHd5z5JbQKBgQCDlvim5E+bKzywYjfuDYYQFNeZNCTT8aSxn1XoKf/qWooVYlin
+            ++KDWnzzurmpSoKR5z4jV/SqL6aJr6aej1zJNJx2E65A5r1d6AejFp0mQCMca4P5
+            3paXdlZD2EGZjMSb05extojPj6YRpK9G0aHQ1plJB12SSFQicEUfyKOw9wKBgD09
+            ScLoih6ZRH2uJwZ0eKZlLj0AT5IsYiD0V0Uv2svnwfKEK21bSzxw5Prb0t/TmqFX
+            5fMb3a+3YkE5TALnXk8a4uG/MCpCqHnSMaSTKqCS8o6YZIpr1V2jdoxqTHWEsDyE
+            qYnsvOiTHcTsIZZplN5D6KnXDKbqWZXrLoadnYhNAoGACESLgCy552WcM7vNt4Fw
+            7lR/O3gEnwD41gIx5EGa/UoA08Q+i7sBt9PkL4oQrJ/MYCcVNnmg9KrJdlqF4AlE
+            HYeZSkMuQDYHcaO9xtYP3QdhD+nLXbNrCxaSSaSX8tS4BjdcSH1yMyLFg5OqiJYg
+            wYFiptyKFm5QqFhFTY+20aE=
+            -----END PRIVATE KEY-----
     revocable: false
     refresh:
       format: opaque
@@ -136,6 +142,40 @@ ldap:
     searchBase: 'dc=test,dc=com'
     searchFilter: 'cn={0}'
 
+ratelimit:
+  loggingOption: AllCalls
+  credentialID: 'JWT:Claims+"sub"\s*:\s*"(.*?)"'
+  limiterMappings:
+    - name: AuthToken
+      withCallerRemoteAddressID: 50r/s
+      pathSelectors:
+        - "equals:/oauth/token"
+    - name: AuthAuthorize
+      withCallerRemoteAddressID: 50r/s
+      pathSelectors:
+        - "equals:/oauth/authorize"
+    - name: LoginPage
+      withCallerRemoteAddressID: 50r/1s
+      pathSelectors:
+        - "equals:/login"
+    - name: LoginDo
+      withCallerRemoteAddressID: 50r/s
+      pathSelectors:
+        - "equals:/login.do"
+    - name: InfoLimit
+      withCallerRemoteAddressID: 20r/s
+      pathSelectors:
+        - "equals:/info"
+    - name: SCIM
+      withCallerCredentialsID: 500r/s
+      pathSelectors:
+        - "startsWith:/Users"
+        - "startsWith:/Groups"
+    - name: EverythingElse
+      global: 200r/s
+      pathSelectors:
+        - "other"
+
 scim:
   userids_enabled: true
   users:
@@ -183,12 +223,14 @@ oauth:
     override: true
   clients:
     admin:
+      id: admin
       authorized-grant-types: client_credentials
       scope: uaa.none
       authorities: 'uaa.admin,clients.read,clients.write,clients.secret,clients.trust,scim.read,scim.write,clients.admin'
       secret: "adminsecret"
       jwks: '{"alg":"RS256","e":"AQAB","kid":"cUiuzP1rw1zm9MV8F0vtrws7BLc","kty":"RSA","n":"rWuIqrVV8kuqeorvRuLio1_pdQm_z7HZJKIcCD5SQqGO0AsKyf1xa5TPzHM0lqEh2GcPTer4u7MYQZzXAAvzOsSaTmgSlenLKDYCDZy2bwOjK0izVLbJwYqiiqyiMGhKeWsYokyDNoYaefjz8izDrp47XDHnwC2eeyJ43cE8GP0JJXRyxIPFecO8rfpe3AzTrHszJ9lPSX9E8QGppSFmcnUDUQYDRipNMzXXp2FHdR7T2MZkvxzjFhVSSMiaDTmAca-Wv_Uct2HpOfC3IuKSy1jpu8yr_GT6aBsDkt1XC1iARuFf9dE83R39oNgvVMICPjeWgNoyhK-ddQAUnRDeqw"}'
     cf:
+      id: cf
       secret: ''
       authorized-grant-types: 'implicit,password,refresh_token'
       scope: 'uaa.user,cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,cloud_controller.admin,scim.read,scim.write'
@@ -196,6 +238,7 @@ oauth:
       authorities: uaa.none
       autoapprove: 'true'
     app:
+      id: app
       secret: appclientsecret
       authorized-grant-types: password,implicit,authorization_code,client_credentials,refresh_token
       scope: cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,organizations.acme
@@ -206,6 +249,7 @@ oauth:
       change_email_redirect_url: http://localhost:8080/app/
       name: The Ultimate Oauth App
     appspecial:
+      id: appspecial
       secret: appclient|secret!
       authorized-grant-types: password,implicit,authorization_code,client_credentials,refresh_token
       scope: cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,organizations.acme
@@ -216,6 +260,7 @@ oauth:
       change_email_redirect_url: http://localhost:8080/app/
       name: The Ultimate Oauth App - Special
     login:
+      id: login
       secret: loginsecret
       scope: 'openid,oauth.approvals'
       authorized-grant-types: 'client_credentials,authorization_code'
@@ -224,16 +269,19 @@ oauth:
       autoapprove: 'true'
       allowpublic: 'true'
     dashboard:
+      id: dashboard
       secret: dashboardsecret
       scope: 'dashboard.user,openid'
       authorized-grant-types: authorization_code
       authorities: uaa.resource
       redirect-uri: 'http://localhost:8080/uaa/'
     notifications:
+      id: notifications
       secret: notificationssecret
       authorized-grant-types: client_credentials
       authorities: 'cloud_controller.admin,scim.read'
     identity:
+      id: identity
       secret: identitysecret
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password'
       scope: 'cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,zones.*.*,zones.*.*.*,zones.read,zones.write'
@@ -241,6 +289,7 @@ oauth:
       autoapprove: 'true'
       redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://oidcloginit.localhost:8080/uaa/**'
     oauth_showcase_authorization_code:
+      id: oauth_showcase_authorization_code
       secret: secret
       authorized-grant-types: authorization_code
       scope: openid
@@ -248,45 +297,54 @@ oauth:
       redirect-uri: http://localhost:8080/uaa/
       allowedproviders: [ uaa ]
     oauth_showcase_client_credentials:
+      id: oauth_showcase_client_credentials
       secret: secret
       authorized-grant-types: client_credentials
       scope: uaa.none
       authorities: 'uaa.resource,clients.read'
     oauth_showcase_password_grant:
+      id: oauth_showcase_password_grant
       secret: secret
       authorized-grant-types: password
       scope: openid
       authorities: uaa.resource
     oauth_showcase_implicit_grant:
+      id: oauth_showcase_implicit_grant
       authorized-grant-types: implicit
       scope: openid
       authorities: uaa.resource
       redirect-uri: 'http://localhost:8080/uaa/'
     oauth_showcase_user_token:
+      id: oauth_showcase_user_token
       authorized-grant-types: 'user_token,password,refresh_token'
       scope: 'openid,uaa.user'
       secret: secret
     oauth_showcase_user_token_public:
+      id: oauth_showcase_user_token_public
       secret: ''
       authorized-grant-types: 'user_token,password,authorization_code'
       scope: 'openid,uaa.user'
       redirect-uri: 'http://localhost:8080/uaa/'
       allowpublic: 'true'
     oauth_showcase_saml2_bearer:
+      id: oauth_showcase_saml2_bearer
       authorized-grant-types: 'password,urn:ietf:params:oauth:grant-type:saml2-bearer'
       scope: 'openid,uaa.user'
       secret: secret
     some_client_that_contains_redirect_uri_matching_request_param:
+      id: some_client_that_contains_redirect_uri_matching_request_param
       authorized-grant-types: 'uaa.admin,clients.read,clients.write,clients.secret,scim.read,scim.write,clients.admin'
       scope: openid
       authorities: uaa.resource
       redirect-uri: 'http://redirect.localhost'
     client_with_bcrypt_prefix:
+      id: client_with_bcrypt_prefix
       secret: password
       authorized-grant-types: client_credentials
       authorities: uaa.none
       use-bcrypt-prefix: 'true'
     jku_test:
+      id: jku_test
       secret: secret
       authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
       authorities: uaa.none
@@ -294,6 +352,7 @@ oauth:
       scope: 'openid,oauth.approvals,user_attributes'
       redirect-uri: 'http://localhost/**'
     jku_test_without_autoapprove:
+      id: jku_test_without_autoapprove
       secret: secret
       authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
       authorities: uaa.none
@@ -301,6 +360,7 @@ oauth:
       scope: 'openid,oauth.approvals,user_attributes'
       redirect-uri: 'http://localhost/**'
     client_without_openid:
+      id: client_without_openid
       secret: secret
       authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
       authorities: uaa.none
@@ -308,6 +368,7 @@ oauth:
       scope: password.write
       redirect-uri: 'http://localhost/**'
     client_with_jwks_trust:
+      id: client_with_jwks_trust
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password'
       scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
       authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
@@ -315,6 +376,7 @@ oauth:
       redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
       jwks: '{"kty":"RSA","e":"AQAB","use":"sig","kid":"key-id-1","alg":"RS256","n":"qMClJXznycV2bQ1pFbN8W-AWSYhpS2MVAGhkWNlmxv2Ix0_-n6zjivjdoxcq7RJR4kVycoVeD07DiWElYSnQLdeQPgKAcBiwilR30UyyDTKcqDQQ5rkCg2ONlwV0aMsg74KaXeXsV653ASs3FYEtuS1aD_Db5-FyXF8HkHo8xy19NUnqsDWQnh1Hhklynxu2tvW0fw2oDE1pwNl-WLEVPtlcpCtf4VSv-GawtBiI6xmYsGBMC9w29ESHFqPw0NSCRhlyJf6rDBNH_766mzK_vEzA4rzGTBEUqDxTg_8JpRhh9D3qljSsmqCtpQoloOAaUKCqSJb_hKPspe-7r9cYmw"}'
     client_with_allowpublic_and_jwks_uri_trust:
+      id: client_with_allowpublic_and_jwks_uri_trust
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password,urn:ietf:params:oauth:grant-type:jwt-bearer'
       scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
       authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
@@ -323,6 +385,7 @@ oauth:
       redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
       jwks_uri: 'http://localhost:8080/uaa/token_keys'
     client_federated_jwt_trust:
+      id: client_federated_jwt_trust
       authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password,urn:ietf:params:oauth:grant-type:jwt-bearer'
       scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
       authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'

--- a/uaa/src/test/resources/invalid_configuration.yml
+++ b/uaa/src/test/resources/invalid_configuration.yml
@@ -1,0 +1,50 @@
+# a simple invalid configuration
+database: {}
+
+login:
+  url: http://localhost:8080/uaa
+  entityBaseURL: http://localhost:8080/uaa
+  entityID: integration-saml-entity-id
+  saml:
+    activeKeyId: key1
+    keys:
+      key1:
+        key: |
+          -----BEGIN PRIVATE KEY-----
+          MIICdwIBADANBgkqhkiG9w0BAQEFAASCAmEwggJdAgEAAoGBAMe0LmBRfEEqkSpl
+          MuQ28XA0ac0iSCA07A5BU1uk7RZUciK+KDkvf1apL27SGcD47swID8qWsBHhtdp5
+          VWHB9Q9gEoilppNYVBHlxNHVQVkkv84X28B+k7DOegProMMKdBWlsKO0NhZf7HqK
+          bGfwcJjGEyiXpmdNtKwVbpVmMUyNAgMBAAECgYBU6PZi+6KCLrAkP30A7Z+AXrix
+          gKb8EqRfd0UTDS/FM8iHnySJE/nnhe3mB6ztkKov1CmqsKFSKQ7iQn6cHxSrYC9p
+          kdukIRSZuKnToiWB0DjjSjSvQI+jWaA3Ea6WGJZE3jcuu7N+H2oo+GV6DZ2/IUZD
+          HLkaTopb+3whLjHivQJBAP91x4ED412Pdem5sd/Go3PgZM7Gd1z8BcCjA8amB7bO
+          mAhzt/nS3w4eEbpeGx8nTDJAQS+h0OFk9heQoGdc0fMCQQDIIDvq8DC7GoB3cw5u
+          GJ5ueIBTdKc9/a7h90vUQ6b3Z3IWzUnHLIuC78OyM+PHq1G2fhgBqXELOYAxcVJv
+          Wod/AkEAzerHfPSAYptQRa08dw/sE2yudYq/DoHLtULxuT99+lo/bJiylLrot71/
+          NsXCgPMxVVQ790QtVnIGeGpJEehdBwJBAJ4DZYvxLmjtWfX2sLQZWC7dkmVSvCJk
+          RUtB2Wu2JwU9doWufcx3zYgLDDeOZRFoodI36XiWcx1rv15Knc4yar0CQDSnv0G9
+          iwuyFQkme9uTvqkKNHbw8rh1XWBINQSpAwGrLjmm13AkuoskJ42hHQlRwM0hGE4K
+          4480Pulwy1fqEj8=
+          -----END PRIVATE KEY-----
+        passphrase: password
+        certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEO
+          MAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEO
+          MAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5h
+          cnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwx
+          CzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAM
+          BgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAb
+          BgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GN
+          ADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39W
+          qS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOw
+          znoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4Ha
+          MIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGc
+          gBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYD
+          VQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYD
+          VQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJh
+          QGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ
+          0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxC
+          KdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkK
+          RpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0=
+          -----END CERTIFICATE-----


### PR DESCRIPTION
## Context & goal

In the XML -> Java migration for UAA configuration, we are moving configuration out of `login-ui.xml`.

This PR addresses some of the challenges, and moves 25-30% of `login-ui.xml` to java configuration.

## Notable

### Spring Security incompatibilities

Spring Security does not support XML configuration + Java configuration in parallel, particularly declaring filter chains in both XML and Java.
The java filter chains beans are created after the full Spring Security XML configuration is registered, and are therefore never called.

There are workarounds introduced in 90d4a184, and they require creating another `FilterChainProxy` that has all the chains inside, and wiring that in `web.xml` instead of the usual `springSecurityFilterChain`. While it does introduce a bit of complexity, the upside is being able to move filter chains one by one and not have to do everything wholesale (there are 68 filter chains total).

Please take a look at this commit.

### Spring Boot vs non-Boot differences

There are some behavior differences in Boot vs non-Boot, around including `Model` data in redirect responses and jackson configuration for datetimes, covered in f4d5ca74.

### YamlConfigurationValidator

It was broken, see gh-3279 . I noticed because I created a bean called `uaaConfig` that conflicted with the validator.
I fixed the basics and introduced tests for it in 1a36b32c.

### Dead code

There were a few redundant `<mvc:...>` and `<oauth:...>` annotations.

There was also a `catchAllFilterChainProxy` that we determined with @fhanik was never actually used in production and only there for testing during development.

### Sonar & code coverage

Sonar is unhappy with code coverage because the majority of new code here is configuration classes and bean, and JaCoCo can't find coverage for it. Not going to block merging because of this.