### PR TITLE
fix missing default-profile on CI oidc10 app

### DIFF
--- a/scripts/saml/saml-legacy-uaa.yml
+++ b/scripts/saml/saml-legacy-uaa.yml
@@ -137,3 +137,172 @@ ratelimit:
       global: 200r/s
       pathSelectors:
         - "other"
+
+scim:
+  userids_enabled: true
+  users:
+    - marissa|koala|marissa@test.org|Marissa|Bloggs|uaa.user
+    - testbootuser|password|testbootuser@test.org|Test|Bootstrap|uaa.user,scim.read
+    - admin|admin|admin|||foo.bar,uaa.admin|uaa
+  external_groups:
+    - organizations.acme|cn=test_org,ou=people,o=springsource,o=org
+    - internal.read|cn=developers,ou=scopes,dc=test,dc=com
+    - internal.write|cn=operators,ou=scopes,dc=test,dc=com
+    - internal.everything|cn=superusers,ou=scopes,dc=test,dc=com
+    - internal.superuser|cn=superusers,ou=scopes,dc=test,dc=com
+
+oauth:
+  client:
+    autoapprove:
+      - cf
+      - my
+      - support
+    override: true
+  clients:
+    admin:
+      authorized-grant-types: client_credentials
+      scope: uaa.none
+      authorities: 'uaa.admin,clients.read,clients.write,clients.secret,clients.trust,scim.read,scim.write,clients.admin'
+      secret: "adminsecret"
+      jwks: '{"alg":"RS256","e":"AQAB","kid":"cUiuzP1rw1zm9MV8F0vtrws7BLc","kty":"RSA","n":"rWuIqrVV8kuqeorvRuLio1_pdQm_z7HZJKIcCD5SQqGO0AsKyf1xa5TPzHM0lqEh2GcPTer4u7MYQZzXAAvzOsSaTmgSlenLKDYCDZy2bwOjK0izVLbJwYqiiqyiMGhKeWsYokyDNoYaefjz8izDrp47XDHnwC2eeyJ43cE8GP0JJXRyxIPFecO8rfpe3AzTrHszJ9lPSX9E8QGppSFmcnUDUQYDRipNMzXXp2FHdR7T2MZkvxzjFhVSSMiaDTmAca-Wv_Uct2HpOfC3IuKSy1jpu8yr_GT6aBsDkt1XC1iARuFf9dE83R39oNgvVMICPjeWgNoyhK-ddQAUnRDeqw"}'
+    cf:
+      secret: ''
+      authorized-grant-types: 'implicit,password,refresh_token'
+      scope: 'uaa.user,cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,cloud_controller.admin,scim.read,scim.write'
+      redirect-uri: 'http://localhost:8080/**,http://localhost:7000/**'
+      authorities: uaa.none
+      autoapprove: 'true'
+    app:
+      secret: appclientsecret
+      authorized-grant-types: password,implicit,authorization_code,client_credentials,refresh_token
+      scope: cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,organizations.acme
+      authorities: uaa.resource
+      autoapprove: [ openid ]
+      redirect-uri: http://localhost:8080/**,http://localhost:7000/**
+      signup_redirect_url: http://localhost:8080/app/
+      change_email_redirect_url: http://localhost:8080/app/
+      name: The Ultimate Oauth App
+    appspecial:
+      secret: appclient|secret!
+      authorized-grant-types: password,implicit,authorization_code,client_credentials,refresh_token
+      scope: cloud_controller.read,cloud_controller.write,openid,password.write,scim.userids,organizations.acme
+      authorities: uaa.resource
+      autoapprove: [ openid ]
+      redirect-uri: http://localhost:8080/**,http://localhost:7000/**
+      signup_redirect_url: http://localhost:8080/app/
+      change_email_redirect_url: http://localhost:8080/app/
+      name: The Ultimate Oauth App - Special
+    login:
+      secret: loginsecret
+      scope: 'openid,oauth.approvals'
+      authorized-grant-types: 'client_credentials,authorization_code'
+      redirect-uri: 'http://localhost/**'
+      authorities: 'oauth.login,scim.write,clients.read,notifications.write,critical_notifications.write,emails.write,scim.userids,password.write,idps.write'
+      autoapprove: 'true'
+      allowpublic: 'true'
+    dashboard:
+      secret: dashboardsecret
+      scope: 'dashboard.user,openid'
+      authorized-grant-types: authorization_code
+      authorities: uaa.resource
+      redirect-uri: 'http://localhost:8080/uaa/'
+    notifications:
+      secret: notificationssecret
+      authorized-grant-types: client_credentials
+      authorities: 'cloud_controller.admin,scim.read'
+    identity:
+      secret: identitysecret
+      authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password'
+      scope: 'cloud_controller.admin,cloud_controller.read,cloud_controller.write,openid,zones.*.*,zones.*.*.*,zones.read,zones.write'
+      authorities: 'scim.zones,zones.read,cloud_controller.read,uaa.resource,zones.write'
+      autoapprove: 'true'
+      redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://oidcloginit.localhost:8080/uaa/**'
+    oauth_showcase_authorization_code:
+      secret: secret
+      authorized-grant-types: authorization_code
+      scope: openid
+      authorities: uaa.resource
+      redirect-uri: http://localhost:8080/uaa/
+      allowedproviders: [ uaa ]
+    oauth_showcase_client_credentials:
+      secret: secret
+      authorized-grant-types: client_credentials
+      scope: uaa.none
+      authorities: 'uaa.resource,clients.read'
+    oauth_showcase_password_grant:
+      secret: secret
+      authorized-grant-types: password
+      scope: openid
+      authorities: uaa.resource
+    oauth_showcase_implicit_grant:
+      authorized-grant-types: implicit
+      scope: openid
+      authorities: uaa.resource
+      redirect-uri: 'http://localhost:8080/uaa/'
+    oauth_showcase_user_token:
+      authorized-grant-types: 'user_token,password,refresh_token'
+      scope: 'openid,uaa.user'
+      secret: secret
+    oauth_showcase_user_token_public:
+      secret: ''
+      authorized-grant-types: 'user_token,password,authorization_code'
+      scope: 'openid,uaa.user'
+      redirect-uri: 'http://localhost:8080/uaa/'
+      allowpublic: 'true'
+    oauth_showcase_saml2_bearer:
+      authorized-grant-types: 'password,urn:ietf:params:oauth:grant-type:saml2-bearer'
+      scope: 'openid,uaa.user'
+      secret: secret
+    some_client_that_contains_redirect_uri_matching_request_param:
+      authorized-grant-types: 'uaa.admin,clients.read,clients.write,clients.secret,scim.read,scim.write,clients.admin'
+      scope: openid
+      authorities: uaa.resource
+      redirect-uri: 'http://redirect.localhost'
+    client_with_bcrypt_prefix:
+      secret: password
+      authorized-grant-types: client_credentials
+      authorities: uaa.none
+      use-bcrypt-prefix: 'true'
+    jku_test:
+      secret: secret
+      authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
+      authorities: uaa.none
+      autoapprove: 'true'
+      scope: 'openid,oauth.approvals,user_attributes'
+      redirect-uri: 'http://localhost/**'
+    jku_test_without_autoapprove:
+      secret: secret
+      authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
+      authorities: uaa.none
+      autoapprove: 'false'
+      scope: 'openid,oauth.approvals,user_attributes'
+      redirect-uri: 'http://localhost/**'
+    client_without_openid:
+      secret: secret
+      authorized-grant-types: 'password,client_credentials,refresh_token,authorization_code'
+      authorities: uaa.none
+      autoapprove: 'true'
+      scope: password.write
+      redirect-uri: 'http://localhost/**'
+    client_with_jwks_trust:
+      authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password'
+      scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
+      authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
+      autoapprove: 'true'
+      redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
+      jwks: '{"kty":"RSA","e":"AQAB","use":"sig","kid":"key-id-1","alg":"RS256","n":"qMClJXznycV2bQ1pFbN8W-AWSYhpS2MVAGhkWNlmxv2Ix0_-n6zjivjdoxcq7RJR4kVycoVeD07DiWElYSnQLdeQPgKAcBiwilR30UyyDTKcqDQQ5rkCg2ONlwV0aMsg74KaXeXsV653ASs3FYEtuS1aD_Db5-FyXF8HkHo8xy19NUnqsDWQnh1Hhklynxu2tvW0fw2oDE1pwNl-WLEVPtlcpCtf4VSv-GawtBiI6xmYsGBMC9w29ESHFqPw0NSCRhlyJf6rDBNH_766mzK_vEzA4rzGTBEUqDxTg_8JpRhh9D3qljSsmqCtpQoloOAaUKCqSJb_hKPspe-7r9cYmw"}'
+    client_with_allowpublic_and_jwks_uri_trust:
+      authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password,urn:ietf:params:oauth:grant-type:jwt-bearer'
+      scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
+      authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
+      autoapprove: 'true'
+      allowpublic: 'true'
+      redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
+      jwks_uri: 'http://localhost:8080/uaa/token_keys'
+    client_federated_jwt_trust:
+      authorized-grant-types: 'authorization_code,client_credentials,refresh_token,password,urn:ietf:params:oauth:grant-type:jwt-bearer'
+      scope: 'openid,password.write,scim.userids,cloud_controller.read,cloud_controller.write'
+      authorities: 'password.write,scim.userids,cloud_controller.read,cloud_controller.write,uaa.resource'
+      autoapprove: 'true'
+      redirect-uri: 'http://localhost/*,http://localhost:8080/**,http://localhost:7000/**'
+      jwt_creds: '[{"iss":"http://localhost:8080/uaa/oauth/token","sub":"client_with_jwks_trust","aud":"client_with_jwks_trust"}]'


### PR DESCRIPTION
- gh-3253 removed the default profile, and reintroduced the default users and clients in cargo/uaa.yml
- However, the [oidc10](https://oidc10.uaa-acceptance.cf-app.com/) app, which is a UAA deployed for integration tests that need an upstream OIDC provider, used the default profile.
- OIDC10 is deployed through [uaa-ci](https://github.com/cloudfoundry/uaa-ci/blob/main/concourse/uaa-acceptance-gcp/tasks/push-oidc10/manifest-oidc10.yml), and so values need to be added to its own config file.