### PR TITLE
Cargo: increase rate limitt for tests

### DIFF
--- a/scripts/cargo/uaa.yml
+++ b/scripts/cargo/uaa.yml
@@ -125,7 +125,7 @@ ratelimit:
         - "startsWith:/Users"
         - "startsWith:/Groups"
     - name: EverythingElse
-      global: 200r/s
+      global: 1000r/s
       pathSelectors:
         - "other"
 


### PR DESCRIPTION
On a recent machine (mac M1 pro), integration tests fail because of rate-limiting, the tests go too fast and there is more than 200 req/s.