### PR TITLE
Fix regression with OIDC discovery url but no tokenUrl

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManager.java
@@ -161,6 +161,10 @@ public class PasswordGrantAuthenticationManager implements AuthenticationManager
         if (clientSecret == null && config.getJwtClientAuthentication() == null && config.getAuthMethod() == null) {
             throw new ProviderConfigurationException("External OpenID Connect provider configuration is missing relyingPartySecret, jwtClientAuthentication or authMethod.");
         }
+        if (tokenUrl == null) {
+            externalOAuthAuthenticationManager.fetchMetadataAndUpdateDefinition(config);
+            tokenUrl = Optional.ofNullable(config.getTokenUrl()).orElseThrow(() -> new ProviderConfigurationException("External OpenID Connect metadata is missing after discovery update."));
+        }
         String calcAuthMethod = ClientAuthentication.getCalculatedMethod(config.getAuthMethod(), clientSecret != null, config.getJwtClientAuthentication() != null);
         String userName = authentication.getPrincipal() instanceof String pStr ? pStr : null;
         if (userName == null || authentication.getCredentials() == null || !(authentication.getCredentials() instanceof String)) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -808,6 +808,14 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         return keyInfoService;
     }
 
+    public void fetchMetadataAndUpdateDefinition(OIDCIdentityProviderDefinition definition) {
+        try {
+            oidcMetadataFetcher.fetchMetadataAndUpdateDefinition(definition);
+        } catch (OidcMetadataFetchingException e) {
+            logger.warn("OidcMetadataFetchingException", e);
+        }
+    }
+
     protected static class AuthenticationData {
 
         private Map<String, Object> claims;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManagerTest.java
@@ -418,14 +418,14 @@ class PasswordGrantAuthenticationManagerTest {
     @Test
     void oidcPasswordGrantProviderFailedInOidcMetadataUpdate() {
         IdentityProvider localIdp = mock(IdentityProvider.class);
-        OIDCIdentityProviderDefinition idpConfig = mock(OIDCIdentityProviderDefinition.class);
+        OIDCIdentityProviderDefinition localIdpConfig = mock(OIDCIdentityProviderDefinition.class);
         when(localIdp.getOriginKey()).thenReturn("oidcprovider");
-        when(localIdp.getConfig()).thenReturn(idpConfig);
         when(localIdp.getType()).thenReturn(OriginKeys.OIDC10);
         when(localIdp.isActive()).thenReturn(true);
-        when(idpConfig.isPasswordGrantEnabled()).thenReturn(true);
-        when(idpConfig.getRelyingPartyId()).thenReturn("oidcprovider");
-        when(idpConfig.getRelyingPartySecret()).thenReturn("");
+        when(localIdp.getConfig()).thenReturn(localIdpConfig);
+        when(localIdpConfig.isPasswordGrantEnabled()).thenReturn(true);
+        when(localIdpConfig.getRelyingPartyId()).thenReturn("oidcprovider");
+        when(localIdpConfig.getRelyingPartySecret()).thenReturn("");
 
         when(identityProviderProvisioning.retrieveActive("uaa")).thenReturn(Arrays.asList(uaaProvider, ldapProvider, localIdp));
         when(identityProviderProvisioning.retrieveByOrigin("oidcprovider", "uaa")).thenReturn(localIdp);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/manager/PasswordGrantAuthenticationManagerTest.java
@@ -416,6 +416,33 @@ class PasswordGrantAuthenticationManagerTest {
     }
 
     @Test
+    void oidcPasswordGrantProviderFailedInOidcMetadataUpdate() {
+        IdentityProvider localIdp = mock(IdentityProvider.class);
+        OIDCIdentityProviderDefinition idpConfig = mock(OIDCIdentityProviderDefinition.class);
+        when(localIdp.getOriginKey()).thenReturn("oidcprovider");
+        when(localIdp.getConfig()).thenReturn(idpConfig);
+        when(localIdp.getType()).thenReturn(OriginKeys.OIDC10);
+        when(localIdp.isActive()).thenReturn(true);
+        when(idpConfig.isPasswordGrantEnabled()).thenReturn(true);
+        when(idpConfig.getRelyingPartyId()).thenReturn("oidcprovider");
+        when(idpConfig.getRelyingPartySecret()).thenReturn("");
+
+        when(identityProviderProvisioning.retrieveActive("uaa")).thenReturn(Arrays.asList(uaaProvider, ldapProvider, localIdp));
+        when(identityProviderProvisioning.retrieveByOrigin("oidcprovider", "uaa")).thenReturn(localIdp);
+        UaaLoginHint loginHint = mock(UaaLoginHint.class);
+        when(loginHint.getOrigin()).thenReturn("oidcprovider");
+        Authentication auth = mock(Authentication.class);
+        when(zoneAwareAuthzAuthenticationManager.extractLoginHint(auth)).thenReturn(loginHint);
+
+        try {
+            instance.authenticate(auth);
+            fail("");
+        } catch (ProviderConfigurationException e) {
+            assertThat(e.getMessage()).isEqualTo("External OpenID Connect metadata is missing after discovery update.");
+        }
+    }
+
+    @Test
     void oidcPasswordGrantProviderJwtClientCredentials() throws ParseException, JOSEException {
         // Given
         mockKeyInfoService();
@@ -450,10 +477,11 @@ class PasswordGrantAuthenticationManagerTest {
     }
 
     @Test
-    void oidcPasswordGrantNoUserCredentials() {
+    void oidcPasswordGrantNoUserCredentials() throws MalformedURLException {
         UaaLoginHint loginHint = mock(UaaLoginHint.class);
         when(loginHint.getOrigin()).thenReturn("oidcprovider");
         Authentication auth = mock(Authentication.class);
+        when(idpConfig.getTokenUrl()).thenReturn(null).thenReturn(new URL("http://localhost:8080/uaa/oauth/token"));
         when(zoneAwareAuthzAuthenticationManager.extractLoginHint(auth)).thenReturn(loginHint);
 
         try {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -52,6 +52,7 @@ import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDef
 import static org.cloudfoundry.identity.uaa.util.UaaMapUtils.entry;
 import static org.cloudfoundry.identity.uaa.util.UaaMapUtils.map;
 import static org.cloudfoundry.identity.uaa.util.UaaStringUtils.DEFAULT_UAA_URL;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -481,5 +482,14 @@ class ExternalOAuthAuthenticationManagerTest {
 
         authManager.getClaimsFromToken(codeToken, idp);
         assertThat(codeToken.getIdToken()).isEqualTo(idTokenJwt);
+    }
+
+    @Test
+    void fetchOidcMetadata() throws OidcMetadataFetchingException {
+        OIDCIdentityProviderDefinition mockedProviderDefinition = mock(OIDCIdentityProviderDefinition.class);
+        OidcMetadataFetcher mockedOidcMetadataFetcher = mock(OidcMetadataFetcher.class);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(uaaIssuerBaseUrl), mockedOidcMetadataFetcher);
+        doThrow(new OidcMetadataFetchingException("error")).when(mockedOidcMetadataFetcher).fetchMetadataAndUpdateDefinition(mockedProviderDefinition);
+        assertThatNoException().isThrownBy(() -> authManager.fetchMetadataAndUpdateDefinition(mockedProviderDefinition));
     }
 }


### PR DESCRIPTION
Causing Issue #3271

Withe the change from https://github.com/cloudfoundry/uaa/pull/3165 we improved performance because the loop of OIDC providers in /login endpoint should not request always all OIDC idps. 
But now if you want use a concrete OIDC idp for password grant there could be the situation, that no tokenUrl is available

This PR checks if tokenUrl is null ( which is allowed from configuration ) and then fetch OIDC metadata. If the tokenUrl still is null, then exit with an error, but not run ino NPE.