### PR TITLE
Prevent secret matches with more than 72 chars.

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrap.java
@@ -295,7 +295,7 @@ public class ClientAdminBootstrap implements
 
     private static void checkSecretLength(String secret) {
         if (ofNullable(secret).map(String::length).orElse(0) > 72) {
-            throw new InvalidClientDetailsException("Client must not have a secret with more than 72 characters");
+            throw new InvalidClientDetailsException("Client secret must be no more than 72 characters in length.");
         }
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrap.java
@@ -230,7 +230,10 @@ public class ClientAdminBootstrap implements
             try {
                 clientRegistrationService.addClientDetails(client, IdentityZone.getUaaZoneId());
                 if (secondSecret != null) {
+                    checkSecretLength(secondSecret);
                     clientRegistrationService.addClientSecret(clientId, secondSecret, IdentityZone.getUaaZoneId());
+                } else {
+                    checkSecretLength(client.getClientSecret());
                 }
             } catch (ClientAlreadyExistsException e) {
                 if (override) {
@@ -290,6 +293,12 @@ public class ClientAdminBootstrap implements
         return clientMetadata;
     }
 
+    private static void checkSecretLength(String secret) {
+        if (ofNullable(secret).map(String::length).orElse(0) > 72) {
+            throw new InvalidClientDetailsException("Client must not have a secret with more than 72 characters");
+        }
+    }
+
     private void updatePasswordsIfChanged(String clientId, String rawPassword1, String rawPassword2) {
         if (passwordEncoder != null) {
             ClientDetails existing = clientRegistrationService.loadClientByClientId(clientId, IdentityZone.getUaaZoneId());
@@ -298,6 +307,8 @@ public class ClientAdminBootstrap implements
             // check if both passwords are still up to date
             // 1st line: client already has 2 passwords: check if both are still correct
             // 2nd line: client has only 1 pasword: check if password is correct and second password is null
+            checkSecretLength(rawPassword1);
+            checkSecretLength(rawPassword2);
             if ((existingPasswordHash.length > 1 && rawPassword1 != null
                     && passwordEncoder.matches(rawPassword1, existingPasswordHash[0])
                     && rawPassword2 != null && passwordEncoder.matches(rawPassword2, existingPasswordHash[1]))

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoder.java
@@ -1,5 +1,7 @@
 package org.cloudfoundry.identity.uaa.util.beans;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -7,6 +9,7 @@ public class BackwardsCompatibleDelegatingPasswordEncoder implements PasswordEnc
 
     private static final String OPTIONAL_BCRYPT_PREFIX = "bcrypt";
     private final BCryptPasswordEncoder defaultPasswordEncoder;
+    private static final Logger slogger = LoggerFactory.getLogger(BackwardsCompatibleDelegatingPasswordEncoder.class);
 
     public BackwardsCompatibleDelegatingPasswordEncoder(final BCryptPasswordEncoder defaultPasswordEncoder) {
         this.defaultPasswordEncoder = defaultPasswordEncoder;
@@ -28,7 +31,8 @@ public class BackwardsCompatibleDelegatingPasswordEncoder implements PasswordEnc
         }
 
         if (rawPassword.length() > 72) {
-            throw new IllegalArgumentException("BCrypt password match cannot exceed 72 characters.");
+            slogger.error("BCrypt password match cannot exceed 72 characters.");
+            return false;
         }
 
         return defaultPasswordEncoder.matches(rawPassword, verifyPrefixAndExtractPassword(encodedPassword));

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoder.java
@@ -27,6 +27,10 @@ public class BackwardsCompatibleDelegatingPasswordEncoder implements PasswordEnc
             return false;
         }
 
+        if (rawPassword.length() > 72) {
+            throw new IllegalArgumentException("BCrypt password match cannot exceed 72 characters.");
+        }
+
         return defaultPasswordEncoder.matches(rawPassword, verifyPrefixAndExtractPassword(encodedPassword));
     }
 

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -309,7 +309,7 @@
 
     <bean id="globalClientSecretPolicy" class="org.cloudfoundry.identity.uaa.zone.ClientSecretPolicy">
         <constructor-arg name="minLength" value="${oauth.client.secret.policy.global.minLength:0}"/>
-        <constructor-arg name="maxLength" value="${oauth.client.secret.policy.global.maxLength:255}"/>
+        <constructor-arg name="maxLength" value="${oauth.client.secret.policy.global.maxLength:72}"/>
         <constructor-arg name="requireUpperCaseCharacter"
                               value="${oauth.client.secret.policy.global.requireUpperCaseCharacter:0}"/>
         <constructor-arg name="requireLowerCaseCharacter"

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/ForcedPasswordChangeIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/ForcedPasswordChangeIT.java
@@ -176,7 +176,7 @@ class ForcedPasswordChangeIT {
         webDriver.findElement(By.name("password_confirmation")).sendKeys(invalidNewPassword);
         webDriver.findElement(By.xpath("//input[@value='Create new password']")).click();
         assertThat(webDriver.getCurrentUrl()).isEqualTo(baseUrl + "/force_password_change");
-        assertThat(webDriver.findElement(By.cssSelector(".error-message")).getText()).contains("Password must be no more than 72 characters in length.");
+        assertThat(webDriver.findElement(By.cssSelector(".error-message")).getText()).contains("Password must be no more than 255 characters in length.");
     }
 
     private void navigateToForcePasswordChange() {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/ForcedPasswordChangeIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/ForcedPasswordChangeIT.java
@@ -176,7 +176,7 @@ class ForcedPasswordChangeIT {
         webDriver.findElement(By.name("password_confirmation")).sendKeys(invalidNewPassword);
         webDriver.findElement(By.xpath("//input[@value='Create new password']")).click();
         assertThat(webDriver.getCurrentUrl()).isEqualTo(baseUrl + "/force_password_change");
-        assertThat(webDriver.findElement(By.cssSelector(".error-message")).getText()).contains("Password must be no more than 255 characters in length.");
+        assertThat(webDriver.findElement(By.cssSelector(".error-message")).getText()).contains("Password must be no more than 72 characters in length.");
     }
 
     private void navigateToForcePasswordChange() {


### PR DESCRIPTION
Before:

uaac client add test --name test --authorized_grant_types client_credentials -s 'this-is-a-secret-which-is-not-longer-then-what-bcrypt-can-handle-matches'

uaac client client get test -s 'this-is-a-secret-which-is-not-longer-then-what-bcrypt-can-handle-matches'
works but also 
uaac client client get test -s 'this-is-a-secret-which-is-not-longer-then-what-bcrypt-can-handle-matchesXXXXXXXXXX'
uaac client client get test -s 'this-is-a-secret-which-is-not-longer-then-what-bcrypt-can-handle-matches-more-than-wanted'

After
uaac client add test --name test --authorized_grant_types client_credentials -s 'this-is-a-secret-which-is-not-longer-then-what-bcrypt-can-handle-matchesXXX'


```
{
  "error": "invalid_client",
  "error_description": "Client Secret must be no more than 72 characters in length."
}
```

Checks with secrets > 72 end always in bad credentials


more details
https://sendoh-daten.medium.com/using-bcrypt-as-password-encoder-can-be-problematic-when-passwords-are-non-ascii-characters-a5ac0478aeed