### PR TITLE
Fix cargo local with Tomcat 9.0.100

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -191,6 +191,7 @@ cargo {
         jvmArgs = String.format("%s -DCLOUDFOUNDRY_CONFIG_PATH='%s'", jvmArgs, file("scripts/cargo").getAbsolutePath())
         jvmArgs = String.format("%s -Dlogging.config='%s'", jvmArgs, file("scripts/cargo/log4j2.properties").getAbsolutePath())
         jvmArgs = String.format("%s -Dstatsd.enabled=true", jvmArgs)
+        jvmArgs = String.format("%s --add-opens=java.base/java.io=ALL-UNNAMED", jvmArgs)
 
         String activeSpringProfiles = System.getProperty("spring.profiles.active", "").split(',');
         if (activeSpringProfiles.contains("debugs") || Boolean.valueOf(System.getProperty("xdebugs"))) {


### PR DESCRIPTION
- Fixes a regression in the dev environment introduced in 4d292c28c07f7a9996324b7cce57b1e0be3eb3c2
- This is similar to a Boot issue here: https://github.com/spring-projects/spring-boot/issues/44342 ; since this is Tomcat-version related issue, and only happens in cargo, we're using the simplest fix. We chose not to invest in this, because when the Boot migration is complete we will be getting rid of Cargo entirely.