### PR TITLE
Move /userinfo endpoint to java config

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/UserInfoSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/UserInfoSecurityConfiguration.java
@@ -1,0 +1,60 @@
+package org.cloudfoundry.identity.uaa.account;
+
+import static org.cloudfoundry.identity.uaa.web.AuthorizationManagersUtils.anyOf;
+
+import org.cloudfoundry.identity.uaa.oauth.UaaTokenServices;
+import org.cloudfoundry.identity.uaa.oauth.provider.authentication.OAuth2AuthenticationManager;
+import org.cloudfoundry.identity.uaa.oauth.provider.authentication.OAuth2AuthenticationProcessingFilter;
+import org.cloudfoundry.identity.uaa.oauth.provider.error.OAuth2AccessDeniedHandler;
+import org.cloudfoundry.identity.uaa.oauth.provider.error.OAuth2AuthenticationEntryPoint;
+import org.cloudfoundry.identity.uaa.web.FilterChainOrder;
+import org.cloudfoundry.identity.uaa.web.UaaFilterChain;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
+import org.springframework.security.config.authentication.AuthenticationManagerBeanDefinitionParser;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
+@Configuration
+@EnableWebSecurity
+class UserInfoSecurityConfiguration {
+
+    @Bean
+    @Order(FilterChainOrder.USERINFO)
+    UaaFilterChain userinfo(
+            HttpSecurity http,
+            UaaTokenServices tokenServices,
+            @Qualifier("oauthAccessDeniedHandler") OAuth2AccessDeniedHandler oauthAccessDeniedHandler,
+            @Qualifier("oauthAuthenticationEntryPoint") OAuth2AuthenticationEntryPoint oauthAuthenticationEntryPoint
+    ) throws Exception {
+        var emptyAuthenticationManager = new ProviderManager(new AuthenticationManagerBeanDefinitionParser.NullAuthenticationProvider());
+
+        var oauth2AuthenticationManager = new OAuth2AuthenticationManager();
+        oauth2AuthenticationManager.setTokenServices(tokenServices);
+        oauth2AuthenticationManager.setResourceId("openid");
+        var oidcResourceAuthenticationFilter = new OAuth2AuthenticationProcessingFilter();
+        oidcResourceAuthenticationFilter.setAuthenticationManager(oauth2AuthenticationManager);
+        oidcResourceAuthenticationFilter.setAuthenticationEntryPoint(oauthAuthenticationEntryPoint);
+
+        var originalChain = http
+                .securityMatcher("/userinfo")
+                .authenticationManager(emptyAuthenticationManager) // TODO
+                .authorizeHttpRequests(auth -> auth.anyRequest().access(anyOf().hasScope("openid")))
+                .addFilterBefore(oidcResourceAuthenticationFilter, AbstractPreAuthenticatedProcessingFilter.class)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(CsrfConfigurer::disable) // TODO
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(oauthAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(oauthAccessDeniedHandler);
+                })
+                .build();
+        return new UaaFilterChain(originalChain, "userinfo");
+    }
+
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpoint.java
@@ -117,7 +117,7 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint implements Authen
     private OAuth2RequestValidator oauth2RequestValidator;
     private final AuthorizationCodeServices authorizationCodeServices;
     private final HybridTokenGranterForAuthorizationCode hybridTokenGranterForAuthCode;
-    private final OpenIdSessionStateCalculator openIdSessionStateCalculator;
+    private OpenIdSessionStateCalculator openIdSessionStateCalculator = new OpenIdSessionStateCalculator();
 
     private final SessionAttributeStore sessionAttributeStore;
     private final Object implicitLock;
@@ -132,7 +132,6 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint implements Authen
             final @Qualifier("oauth2RequestValidator") OAuth2RequestValidator oauth2RequestValidator,
             final @Qualifier("authorizationCodeServices") AuthorizationCodeServices authorizationCodeServices,
             final @Qualifier("hybridTokenGranterForAuthCodeGrant") HybridTokenGranterForAuthorizationCode hybridTokenGranterForAuthCode,
-            final @Qualifier("openIdSessionStateCalculator") OpenIdSessionStateCalculator openIdSessionStateCalculator,
             final @Qualifier("authorizationRequestManager") OAuth2RequestFactory oAuth2RequestFactory,
             final @Qualifier("jdbcClientDetailsService") MultitenantClientServices clientDetailsService,
             final @Qualifier("oauth2TokenGranter") TokenGranter tokenGranter,
@@ -142,7 +141,6 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint implements Authen
         this.oauth2RequestValidator = oauth2RequestValidator;
         this.authorizationCodeServices = authorizationCodeServices;
         this.hybridTokenGranterForAuthCode = hybridTokenGranterForAuthCode;
-        this.openIdSessionStateCalculator = openIdSessionStateCalculator;
         this.pkceValidationService = pkceValidationService;
 
         super.setOAuth2RequestFactory(oAuth2RequestFactory);
@@ -848,5 +846,9 @@ public class UaaAuthorizationEndpoint extends AbstractEndpoint implements Authen
 
     public void setUserApprovalHandler(UserApprovalHandler userApprovalHandler) {
         this.userApprovalHandler = userApprovalHandler;
+    }
+
+    public void setOpenIdSessionStateCalculator(OpenIdSessionStateCalculator openIdSessionStateCalculator) {
+        this.openIdSessionStateCalculator = openIdSessionStateCalculator;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
@@ -3,13 +3,34 @@ package org.cloudfoundry.identity.uaa.web;
 /**
  * The order for all the filter chains in the UAA. The name references
  * Spring Security's {@code FilterOrderRegistration}.
+ * <p>
+ * This class allows us to retain the implicit filter chain ordering that we had in
+ * {@code spring-servlet.xml}. The specific order is computed like so:
+ * {@code 100 * (position of file in spring-servlet) + (position of filter chain in file)}.
  */
 public class FilterChainOrder {
 
-    public static final int SCIM_PASSWORD = 400;
-    public static final int SCIM = 401;
+    // login-server-security.xml: 100
+
+    // oauth-endpoints.xml: 200
+
+    // scim-endpoints.xml: 300
+    public static final int SCIM_PASSWORD = 300;
+    public static final int SCIM = 301;
+
+    // multitenant-endpoints.xml: 400
+
+    // approval-endpoints.xml: 500
+
+    // client-admin-endpoints.xml: 600
+
+    // resource-endpoints.xml: 700
     public static final int RATE_LIMIT = 700;
+
+    // openid-endpoints.xml: 800
     public static final int USERINFO = 800;
+
+    // codestore-endpoints.xml: 900
     public static final int CODESTORE = 900;
 
     // login-ui.xml: 1200

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
@@ -6,14 +6,13 @@ package org.cloudfoundry.identity.uaa.web;
  */
 public class FilterChainOrder {
 
-    // Order of filters in login-ui.xml
     public static final int SCIM_PASSWORD = 400;
     public static final int SCIM = 401;
     public static final int RATE_LIMIT = 700;
+    public static final int USERINFO = 800;
     public static final int CODESTORE = 900;
 
-    // Order of filters handling user login features, formerly defined by
-    // ordering filter chains in login-ui.xml
+    // login-ui.xml: 1200
     public static final int AUTOLOGIN_CODE = 1200;
     public static final int AUTOLOGIN = 1201;
     public static final int INVITATIONS = 1202;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointParamaterizedTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointParamaterizedTest.java
@@ -65,11 +65,11 @@ public class UaaAuthorizationEndpointParamaterizedTest {
                 null,
                 null,
                 null,
-                calculator,
                 null,
                 clientDetailsService,
                 null,
                 null);
+        uaaAuthorizationEndpoint.setOpenIdSessionStateCalculator(calculator);
 
         request = new MockHttpServletRequest("GET", "/oauth/authorize");
         request.setParameter(OAuth2Utils.CLIENT_ID, client.getClientId());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointTest.java
@@ -75,11 +75,11 @@ class UaaAuthorizationEndpointTest {
                 null,
                 authorizationCodeServices,
                 null,
-                openIdSessionStateCalculator,
                 oAuth2RequestFactory,
                 null,
                 null,
                 pkceValidationService);
+        uaaAuthorizationEndpoint.setOpenIdSessionStateCalculator(openIdSessionStateCalculator);
         responseTypes = new HashSet<>();
 
         when(openIdSessionStateCalculator.calculate("userid", null, "http://example.com")).thenReturn("opbshash");

--- a/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -354,7 +354,6 @@
     <import resource="spring/approvals-endpoints.xml"/>
     <import resource="spring/client-admin-endpoints.xml"/>
     <import resource="spring/resource-endpoints.xml"/>
-    <import resource="spring/openid-endpoints.xml"/>
 
     <bean id="messageSource" class="org.springframework.context.support.ReloadableResourceBundleMessageSource">
         <property name="basenames">

--- a/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
@@ -5,19 +5,5 @@
         http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
         http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <http name="userInfoSecurity" pattern="/userinfo" create-session="stateless"
-                    authentication-manager-ref="emptyAuthenticationManager"
-                    entry-point-ref="oauthAuthenticationEntryPoint" access-decision-manager-ref="accessDecisionManager"
-                    use-expressions="false"
-                    xmlns="http://www.springframework.org/schema/security">
-        <intercept-url pattern="/**" access="scope=openid"/>
-        <custom-filter ref="openidResourceAuthenticationFilter" position="PRE_AUTH_FILTER"/>
-        <access-denied-handler ref="oauthAccessDeniedHandler"/>
-        <csrf disabled="true"/>
-    </http>
-
-    <oauth:resource-server id="openidResourceAuthenticationFilter" token-services-ref="tokenServices"
-                    resource-id="openid" entry-point-ref="oauthAuthenticationEntryPoint"/>
-
     <bean id="openIdSessionStateCalculator" class="org.cloudfoundry.identity.uaa.oauth.OpenIdSessionStateCalculator"/>
 </beans>

--- a/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
@@ -5,5 +5,4 @@
         http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
         http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-    <bean id="openIdSessionStateCalculator" class="org.cloudfoundry.identity.uaa.oauth.OpenIdSessionStateCalculator"/>
 </beans>

--- a/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
+++ b/uaa/src/main/webapp/WEB-INF/spring/openid-endpoints.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.springframework.org/schema/beans"
-          xmlns:oauth="http://www.springframework.org/schema/security/oauth2"
-          xsi:schemaLocation="http://www.springframework.org/schema/security/oauth2 https://www.springframework.org/schema/security/spring-security-oauth2-2.0.xsd
-        http://www.springframework.org/schema/security https://www.springframework.org/schema/security/spring-security.xsd
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
-
-</beans>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/oauth/AuthorizationPromptNoneEntryPointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/oauth/AuthorizationPromptNoneEntryPointMockMvcTests.java
@@ -105,13 +105,11 @@ class AuthorizationPromptNoneEntryPointMockMvcTests {
     }
 
     @Test
-    void silentAuthenticationIncludesSessionState(
-            @Autowired OpenIdSessionStateCalculator openIdSessionStateCalculator
-    ) throws Exception {
+    void silentAuthenticationIncludesSessionState() throws Exception {
         UaaAuthorizationEndpoint uaaAuthorizationEndpoint = (UaaAuthorizationEndpoint) webApplicationContext.getBean("uaaAuthorizationEndpoint");
         try {
             OpenIdSessionStateCalculator mockOpenIdSessionStateCalculator = mock(OpenIdSessionStateCalculator.class);
-            ReflectionTestUtils.setField(uaaAuthorizationEndpoint, "openIdSessionStateCalculator", mockOpenIdSessionStateCalculator);
+            uaaAuthorizationEndpoint.setOpenIdSessionStateCalculator(mockOpenIdSessionStateCalculator);
             when(mockOpenIdSessionStateCalculator.calculate(anyString(), anyString(), anyString())).thenReturn("sessionhash.saltvalue");
             String currentUserId = MockMvcUtils.getUserByUsername(mockMvc, "marissa", adminToken).getId();
 
@@ -140,18 +138,16 @@ class AuthorizationPromptNoneEntryPointMockMvcTests {
             // tab relying on uaa-singular aggressively polls /oauth/authorize?prompt=none
             assertThat(result.getResponse().getCookie("Current-User").getValue()).contains(currentUserId);
         } finally {
-            ReflectionTestUtils.setField(uaaAuthorizationEndpoint, "openIdSessionStateCalculator", openIdSessionStateCalculator);
+            uaaAuthorizationEndpoint.setOpenIdSessionStateCalculator(new OpenIdSessionStateCalculator());
         }
     }
 
     @Test
-    void silentAuthenticationRuntimeExceptionDisplaysErrorFragment(
-            @Autowired OpenIdSessionStateCalculator openIdSessionStateCalculator
-    ) throws Exception {
+    void silentAuthenticationRuntimeExceptionDisplaysErrorFragment() throws Exception {
         UaaAuthorizationEndpoint uaaAuthorizationEndpoint = (UaaAuthorizationEndpoint) webApplicationContext.getBean("uaaAuthorizationEndpoint");
         try {
             OpenIdSessionStateCalculator mockOpenIdSessionStateCalculator = mock(OpenIdSessionStateCalculator.class);
-            ReflectionTestUtils.setField(uaaAuthorizationEndpoint, "openIdSessionStateCalculator", mockOpenIdSessionStateCalculator);
+            uaaAuthorizationEndpoint.setOpenIdSessionStateCalculator(mockOpenIdSessionStateCalculator);
 
             when(mockOpenIdSessionStateCalculator.calculate(anyString(), anyString(), anyString())).thenThrow(RuntimeException.class);
 
@@ -165,7 +161,7 @@ class AuthorizationPromptNoneEntryPointMockMvcTests {
                     .andExpect(status().is3xxRedirection())
                     .andExpect(redirectedUrl("http://example.com/with/path.html#error=internal_server_error"));
         } finally {
-            ReflectionTestUtils.setField(uaaAuthorizationEndpoint, "openIdSessionStateCalculator", openIdSessionStateCalculator);
+            uaaAuthorizationEndpoint.setOpenIdSessionStateCalculator(new OpenIdSessionStateCalculator());
         }
     }
 


### PR DESCRIPTION
- Backfilled a test showing a `POST /userinfo` requests, explaining why CSRF protection must be disabled.
- Moved the OpenIdStateCalculator to a simple instance, not a bean.