### PR TITLE
fix: accept application/jwk-set+json when fetching JWKs

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
@@ -86,7 +86,7 @@ public class OidcMetadataFetcher {
         if (authorizationValue != null) {
             headers.add("Authorization", authorizationValue);
         }
-        headers.add("Accept", "application/json");
+        headers.add("Accept", "application/json,application/jwk-set+json");
         HttpEntity<Object> tokenKeyRequest = new HttpEntity<>(null, headers);
         if (isCached) {
             return getCachedResponse(uri, isSkipSslValidation, HttpMethod.GET, tokenKeyRequest);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -950,7 +950,7 @@ class ExternalOAuthAuthenticationManagerIT {
         mockToken();
         mockUaaServer.expect(requestTo("http://localhost/token_key"))
                 .andExpect(header("Authorization", "Basic " + new String(Base64.encodeBase64("identity:identitysecret".getBytes()))))
-                .andExpect(header("Accept", "application/json"))
+                .andExpect(header("Accept", "application/json,application/jwk-set+json"))
                 .andRespond(withStatus(OK).contentType(APPLICATION_JSON).body(response));
 
         mockToken();
@@ -1265,7 +1265,7 @@ class ExternalOAuthAuthenticationManagerIT {
         mockToken();
         mockUaaServer.expect(requestTo(keyUrl))
                 .andExpect(header("Authorization", "Basic " + new String(Base64.encodeBase64("identity:identitysecret".getBytes()))))
-                .andExpect(header("Accept", "application/json"))
+                .andExpect(header("Accept", "application/json,application/jwk-set+json"))
                 .andRespond(withStatus(OK).contentType(APPLICATION_JSON).body(response));
     }
 


### PR DESCRIPTION
Needed this to setup federated JWT client authentication with a Kubernetes cluster. Without this, the Kubernetes API returns a 406 http status code when UAA attempts to fetch the JWK set.