### PR TITLE
fix federated credential administration

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -132,7 +132,7 @@ libraries.nimbusJwt = "com.nimbusds:nimbus-jose-jwt:10.0.2"
 libraries.xmlSecurity = "org.apache.santuario:xmlsec:4.0.3"
 libraries.xmlUnit = "org.xmlunit:xmlunit-assertj:2.10.0"
 libraries.orgJson = "org.json:json:20250107"
-libraries.jodaTime = "joda-time:joda-time:2.13.1"
+libraries.jodaTime = "joda-time:joda-time:2.14.0"
 libraries.apacheHttpClient = "org.apache.httpcomponents:httpclient:4.5.14"
 libraries.jacocoAgent = "org.jacoco:org.jacoco.agent:0.8.12"
 

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtChangeRequest.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtChangeRequest.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static org.cloudfoundry.identity.uaa.oauth.client.ClientJwtChangeRequest.ChangeMode.ADD;
 import static org.cloudfoundry.identity.uaa.oauth.client.ClientJwtChangeRequest.ChangeMode.DELETE;
-import static org.cloudfoundry.identity.uaa.oauth.client.ClientJwtChangeRequest.ChangeMode.UPDATE;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -124,8 +123,8 @@ public class ClientJwtChangeRequest {
 
     @JsonIgnore
     public boolean isFederated() {
-        return ((changeMode == ADD || changeMode == UPDATE) && issuer != null && subject != null) ||
-                (changeMode == DELETE && (issuer != null && subject != null));
+        // is private_key_jwt according to RFC 7523. audience is addition supported, but optional
+        return (issuer != null && subject != null);
     }
 
     @JsonIgnore

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtChangeRequest.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtChangeRequest.java
@@ -123,8 +123,8 @@ public class ClientJwtChangeRequest {
 
     @JsonIgnore
     public boolean isFederated() {
-        // is private_key_jwt according to RFC 7523. audience is addition supported, but optional
-        return (issuer != null && subject != null);
+        // private_key_jwt according to RFC 7523. audience is addition supported, but optional
+        return issuer != null && subject != null;
     }
 
     @JsonIgnore

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtChangeRequest.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtChangeRequest.java
@@ -125,7 +125,7 @@ public class ClientJwtChangeRequest {
     @JsonIgnore
     public boolean isFederated() {
         return ((changeMode == ADD || changeMode == UPDATE) && issuer != null && subject != null) ||
-                (changeMode == DELETE && (issuer != null || subject != null));
+                (changeMode == DELETE && (issuer != null && subject != null));
     }
 
     @JsonIgnore

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredential.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredential.java
@@ -45,4 +45,21 @@ public class ClientJwtCredential {
         }
     }
 
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        ClientJwtCredential that = (ClientJwtCredential) object;
+        return subject.equals(that.subject) &&
+               issuer.equals(that.issuer) &&
+               (audience != null ? audience.equals(that.audience) : that.audience == null);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = subject.hashCode();
+        result = 31 * result + issuer.hashCode();
+        result = 31 * result + (audience != null ? audience.hashCode() : 0);
+        return result;
+    }
 }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredential.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredential.java
@@ -10,6 +10,7 @@ import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.springframework.util.StringUtils;
 
 import java.util.List;
+import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredential.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredential.java
@@ -52,7 +52,7 @@ public class ClientJwtCredential {
         ClientJwtCredential that = (ClientJwtCredential) object;
         return subject.equals(that.subject) &&
                issuer.equals(that.issuer) &&
-               (audience != null ? audience.equals(that.audience) : that.audience == null);
+               Objects.equals(audience, that.audience);
     }
 
     @Override

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredentialTest.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/ClientJwtCredentialTest.java
@@ -40,4 +40,16 @@ class ClientJwtCredentialTest {
         assertThatThrownBy(() -> ClientJwtCredential.parse("[\"iss\":\"issuer\"]"))
                 .isInstanceOf(IllegalArgumentException.class).hasMessage("Client jwt configuration cannot be parsed");
     }
+
+    @Test
+    void testHashCode() {
+        assertThat(new ClientJwtCredential("subject", "issuer", "audience")).hasSameHashCodeAs(new ClientJwtCredential("subject", "issuer", "audience"));
+        assertThat(new ClientJwtCredential("subject", "issuer", "audience")).doesNotHaveSameHashCodeAs(new ClientJwtCredential("subject", "issuer", null));
+    }
+
+    @Test
+    void testEquals() {
+        assertThat(new ClientJwtCredential("subject", "issuer", "audience")).isEqualTo(new ClientJwtCredential("subject", "issuer", "audience"));
+        assertThat(new ClientJwtCredential("subject", "issuer", "audience")).isNotEqualTo(new ClientJwtCredential("subject", "issuer", null));
+    }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
@@ -562,7 +562,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         ActionResult result;
         switch (change.getChangeMode()) {
             case ADD :
-                if (change.getChangeValue() != null) {
+                if (change.getChangeValue() != null && !change.isFederated()) {
                     clientRegistrationService.addClientJwtConfig(client_id, change.getChangeValue(), IdentityZoneHolder.get().getId(), false);
                     result = new ActionResult("ok", "Client jwt configuration is added");
                 } else {
@@ -577,7 +577,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
                 break;
 
             case DELETE :
-                if (ClientJwtConfiguration.readValue(uaaUaaClientDetails) != null && change.getChangeValue() != null) {
+                if (ClientJwtConfiguration.readValue(uaaUaaClientDetails) != null && change.getChangeValue() != null && !change.isFederated()) {
                     clientRegistrationService.deleteClientJwtConfig(client_id, change.getChangeValue(), IdentityZoneHolder.get().getId());
                     result = new ActionResult("ok", "Client jwt configuration is deleted");
                 } else {


### PR DESCRIPTION
fix administration of federated credentials, e.g. example client client_federated_jwt_trust

uaac client get client_federated_jwt_trust
 -> one entry
uaac client jwt add client_federated_jwt_trust --issuer http://localhost:8080/uaa/oauth/token --subject admin
uaac client jwt delete client_federated_jwt_trust --issuer http://localhost:8080/uaa/oauth/token --subject admin
uaac client get client_federated_jwt_trust
 -> one entry
