### PR TITLE
Remove spring-ldap-core-tiger

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -101,7 +101,6 @@ libraries.springContext = "org.springframework:spring-context:${versions.springF
 libraries.springContextSupport = "org.springframework:spring-context-support:${versions.springFrameworkVersion}"
 libraries.springJdbc = "org.springframework:spring-jdbc:${versions.springFrameworkVersion}"
 libraries.springLdapCore = "org.springframework.ldap:spring-ldap-core"
-libraries.springLdapCoreTiger = "org.springframework.ldap:spring-ldap-core-tiger"
 libraries.springRestdocs = "org.springframework.restdocs:spring-restdocs-mockmvc"
 libraries.springRetry = "org.springframework.retry:spring-retry"
 libraries.springSecurityConfig = "org.springframework.security:spring-security-config:${versions.springSecurityVersion}"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -70,7 +70,6 @@ dependencies {
     implementation(libraries.springWebMvc)
     implementation(libraries.springSecurityLdap)
     implementation(libraries.springLdapCore)
-    implementation(libraries.springLdapCoreTiger)
     implementation(libraries.apacheLdapApi) {
         exclude(module: "slf4j-api")
         exclude(module: "mina-core")


### PR DESCRIPTION
It seems there are no direct imports from `org.springframework.ldap.core.simple.*` and also there are no dependencies that bring `spring-ldap-core-tiger` transitively.