### PR TITLE
fix SAML IdP initiated SSO

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.cloudfoundry.identity.uaa.provider.saml.SamlMetadataEndpoint.DEFAULT_REGISTRATION_ID;
 
@@ -108,6 +109,6 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
     @Bean
     UaaRelyingPartyRegistrationResolver relyingPartyRegistrationResolver(RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
             @Qualifier("samlEntityID") String samlEntityID) {
-        return new UaaRelyingPartyRegistrationResolver(relyingPartyRegistrationRepository, samlEntityID);
+        return new UaaRelyingPartyRegistrationResolver(relyingPartyRegistrationRepository, Optional.ofNullable(samlConfigProps.getEntityIDAlias()).orElse(samlEntityID));
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolver.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolver.java
@@ -43,15 +43,15 @@ import java.util.function.Function;
 @Slf4j
 public final class UaaRelyingPartyRegistrationResolver implements Converter<HttpServletRequest, RelyingPartyRegistration>, RelyingPartyRegistrationResolver {
 
-    private final String samlEntityID;
+    private final String uaaWideSamlEntityIDAlias;
     private final RelyingPartyRegistrationRepository relyingPartyRegistrationRepository;
     private final RequestMatcher registrationRequestMatcher = new AntPathRequestMatcher("/**/{registrationId}");
 
     public UaaRelyingPartyRegistrationResolver(RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
-            String samlEntityID) {
+            String uaaWideSamlEntityIDAlias) {
         Assert.notNull(relyingPartyRegistrationRepository, "relyingPartyRegistrationRepository cannot be null");
         this.relyingPartyRegistrationRepository = relyingPartyRegistrationRepository;
-        this.samlEntityID = samlEntityID;
+        this.uaaWideSamlEntityIDAlias = uaaWideSamlEntityIDAlias;
     }
 
     public RelyingPartyRegistration convert(HttpServletRequest request) {
@@ -95,7 +95,7 @@ public final class UaaRelyingPartyRegistrationResolver implements Converter<Http
 
     private String resolveFromRequest(HttpServletRequest request, String resolvedEntityId, String samlResponseParameter) {
         String relyingPartyRegistrationId = null;
-        if (samlEntityID != null && samlEntityID.equals(resolvedEntityId) && samlResponseParameter != null) {
+        if (uaaWideSamlEntityIDAlias != null && uaaWideSamlEntityIDAlias.equals(resolvedEntityId) && samlResponseParameter != null) {
             if (log.isTraceEnabled()) {
                 log.trace("Attempting to resolve from SAMLResponse parameter");
             }


### PR DESCRIPTION
Use both entityIdAlias and/or entityID, similar to bean creation relyingPartyRegistrationRepository, -> https://github.com/cloudfoundry/uaa/blob/develop/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java#L53