### PR TITLE
Refactor SAML authentication

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
@@ -19,16 +19,6 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 import lombok.extern.slf4j.Slf4j;
 import net.shibboleth.utilities.java.support.xml.ParserPool;
 import org.cloudfoundry.identity.uaa.authentication.BackwardsCompatibleTokenEndpointAuthenticationFilter;
-import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
-import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
-import org.cloudfoundry.identity.uaa.authentication.UaaSamlPrincipal;
-import org.cloudfoundry.identity.uaa.authentication.event.IdentityProviderAuthenticationSuccessEvent;
-import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
-import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
-import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.user.UaaUser;
-import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
-import org.cloudfoundry.identity.uaa.web.UaaSavedRequestAwareAuthenticationSuccessHandler;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
 import org.opensaml.core.config.ConfigurationService;
@@ -40,13 +30,10 @@ import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.impl.AssertionUnmarshaller;
 import org.opensaml.saml.saml2.core.impl.ResponseUnmarshaller;
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -55,7 +42,6 @@ import org.springframework.security.saml2.core.OpenSamlInitializationService;
 import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ResponseValidatorResult;
-import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
 import org.springframework.security.saml2.provider.service.authentication.DefaultSaml2AuthenticatedPrincipal;
 import org.springframework.security.saml2.provider.service.authentication.Saml2Authentication;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
@@ -64,10 +50,6 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
 import org.springframework.security.web.authentication.AuthenticationConverter;
 import org.springframework.util.Assert;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -76,15 +58,11 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 
-import static org.cloudfoundry.identity.uaa.constants.OriginKeys.NotANumber;
-import static org.cloudfoundry.identity.uaa.constants.OriginKeys.SAML;
 import static org.cloudfoundry.identity.uaa.provider.saml.OpenSaml4AuthenticationProvider.createDefaultAssertionValidatorWithParameters;
 
 /**
@@ -124,7 +102,6 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
 
     private final RelyingPartyRegistrationResolver relyingPartyRegistrationResolver;
     private final IdentityZoneManager identityZoneManager;
-    private final IdentityProviderProvisioning identityProviderProvisioning;
     private final SamlUaaAuthenticationUserManager userManager;
     private ApplicationEventPublisher eventPublisher;
 
@@ -133,14 +110,12 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
      */
     public Saml2BearerGrantAuthenticationConverter(RelyingPartyRegistrationResolver relyingPartyRegistrationResolver,
             IdentityZoneManager identityZoneManager,
-            IdentityProviderProvisioning identityProviderProvisioning,
             SamlUaaAuthenticationUserManager userManager,
             ApplicationEventPublisher eventPublisher) {
 
         Assert.notNull(relyingPartyRegistrationResolver, "relyingPartyRegistrationResolver cannot be null");
         this.relyingPartyRegistrationResolver = relyingPartyRegistrationResolver;
         this.identityZoneManager = identityZoneManager;
-        this.identityProviderProvisioning = identityProviderProvisioning;
         this.userManager = userManager;
         this.eventPublisher = eventPublisher;
     }
@@ -198,80 +173,21 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
 
         Assertion assertion = parseAssertion(assertionXml);
         RelyingPartyRegistration relyingPartyRegistration = relyingPartyRegistrationResolver.resolve(request, getIssuer(assertion));
-        IdentityProvider<SamlIdentityProviderDefinition> idp = retrieveSamlIdpSamlIdentityProvider(relyingPartyRegistration.getRegistrationId());
         Saml2AuthenticationToken authenticationToken = new Saml2AuthenticationToken(relyingPartyRegistration, assertionXml);
         process(authenticationToken, assertion);
 
-        String subjectName = assertion.getSubject().getNameID().getValue();
-        String alias = idp.getOriginKey();
         IdentityZone zone = identityZoneManager.getCurrentIdentityZone();
+        log.debug("Initiating SAML bearer authentication in zone '{}' domain '{}'",
+                zone.getId(), zone.getSubdomain());
 
-        UaaPrincipal initialPrincipal = new UaaPrincipal(NotANumber, subjectName, subjectName,
-                alias, subjectName, zone.getId());
-
-        SamlIdentityProviderDefinition samlConfig = idp.getConfig();
-        boolean addNew = samlConfig.isAddShadowUserOnLogin();
-
-        MultiValueMap<String, String> userAttributes = new LinkedMultiValueMap<>();
-
-        log.debug("Mapped SAML authentication to IDP with origin '{}' and username '{}'",
-                idp.getOriginKey(), initialPrincipal.getName());
-
-        UaaUser user = userManager.createIfMissing(initialPrincipal, addNew, List.of(), userAttributes);
-        UaaAuthentication authentication = new UaaAuthentication(
-                new UaaSamlPrincipal(user, null),
-                authenticationToken.getCredentials(),
-                user.getAuthorities(),
-                Set.of(),
-                userAttributes,
-                null,
-                true, System.currentTimeMillis(),
-                -1);
-        authentication.setAuthenticationMethods(Set.of("ext"));
-        setAuthContextClassRefs(assertion, authentication);
-
-        publish(new IdentityProviderAuthenticationSuccessEvent(user, authentication, SAML, identityZoneManager.getCurrentIdentityZoneId()));
-
-        AbstractSaml2AuthenticationRequest authenticationRequest = authenticationToken.getAuthenticationRequest();
-        if (authenticationRequest != null) {
-            String relayState = authenticationRequest.getRelayState();
-            configureRelayRedirect(relayState);
-        }
-
-        return authentication;
-    }
-
-    private static void setAuthContextClassRefs(Assertion assertion, UaaAuthentication authentication) {
-        Set<String> authContextClassRef = new HashSet<>();
-        assertion.getAuthnStatements().forEach(authnStatement -> {
-            if (authnStatement.getAuthnContext() != null) {
-                authContextClassRef.add(authnStatement.getAuthnContext().getAuthnContextClassRef().getURI());
-            }
-        });
-        authentication.setAuthContextClassRef(authContextClassRef);
-    }
-
-    public void configureRelayRedirect(String relayState) {
-        //configure relay state
-        if (UaaUrlUtils.isUrl(relayState)) {
-            RequestContextHolder.currentRequestAttributes()
-                    .setAttribute(
-                            UaaSavedRequestAwareAuthenticationSuccessHandler.URI_OVERRIDE_ATTRIBUTE,
-                            relayState,
-                            RequestAttributes.SCOPE_REQUEST
-                    );
-        }
+        String subjectName = assertion.getSubject().getNameID().getValue();
+        String alias = relyingPartyRegistration.getRegistrationId();
+        return userManager.getUaaAuthentication(subjectName, authenticationToken, alias, List.of(assertion), null);
     }
 
     @Override
     public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
         this.eventPublisher = applicationEventPublisher;
-    }
-
-    private void publish(ApplicationEvent event) {
-        if (eventPublisher != null) {
-            eventPublisher.publishEvent(event);
-        }
     }
 
     /**
@@ -359,19 +275,6 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
             throw OpenSaml4AuthenticationProvider.createAuthenticationException(first.getErrorCode(), first.getDescription(), null);
         } else {
             log.debug("Successfully processed SAML Assertion [{}]", assertion.getID());
-        }
-    }
-
-    private IdentityProvider<SamlIdentityProviderDefinition> retrieveSamlIdpSamlIdentityProvider(String origin) {
-        try {
-            IdentityProvider<SamlIdentityProviderDefinition> idp = identityProviderProvisioning.retrieveByOrigin(origin,
-                    identityZoneManager.getCurrentIdentityZoneId());
-            if (idp == null || !SAML.equals(idp.getType()) || !idp.isActive()) {
-                throw new ProviderNotFoundException("Identity Provider has been disabled by administrator for alias: " + origin);
-            }
-            return idp;
-        } catch (EmptyResultDataAccessException x) {
-            throw new ProviderNotFoundException("No SAML identity provider found in zone for alias: " + origin);
         }
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
@@ -30,8 +30,6 @@ import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.impl.AssertionUnmarshaller;
 import org.opensaml.saml.saml2.core.impl.ResponseUnmarshaller;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -71,8 +69,7 @@ import static org.cloudfoundry.identity.uaa.provider.saml.OpenSaml4Authenticatio
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7522">RFC 7522</a>
  */
 @Slf4j
-public final class Saml2BearerGrantAuthenticationConverter implements AuthenticationConverter,
-        ApplicationEventPublisherAware {
+public final class Saml2BearerGrantAuthenticationConverter implements AuthenticationConverter {
 
     static {
         OpenSamlInitializationService.initialize();
@@ -103,21 +100,18 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
     private final RelyingPartyRegistrationResolver relyingPartyRegistrationResolver;
     private final IdentityZoneManager identityZoneManager;
     private final SamlUaaAuthenticationUserManager userManager;
-    private ApplicationEventPublisher eventPublisher;
 
     /**
      * Creates an {@link Saml2BearerGrantAuthenticationConverter}
      */
     public Saml2BearerGrantAuthenticationConverter(RelyingPartyRegistrationResolver relyingPartyRegistrationResolver,
             IdentityZoneManager identityZoneManager,
-            SamlUaaAuthenticationUserManager userManager,
-            ApplicationEventPublisher eventPublisher) {
+            SamlUaaAuthenticationUserManager userManager) {
 
         Assert.notNull(relyingPartyRegistrationResolver, "relyingPartyRegistrationResolver cannot be null");
         this.relyingPartyRegistrationResolver = relyingPartyRegistrationResolver;
         this.identityZoneManager = identityZoneManager;
         this.userManager = userManager;
-        this.eventPublisher = eventPublisher;
     }
 
     /**
@@ -183,11 +177,6 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
         String subjectName = assertion.getSubject().getNameID().getValue();
         String alias = relyingPartyRegistration.getRegistrationId();
         return userManager.getUaaAuthentication(subjectName, authenticationToken, alias, List.of(assertion), null);
-    }
-
-    @Override
-    public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
-        this.eventPublisher = applicationEventPublisher;
     }
 
     /**

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
@@ -61,10 +61,17 @@ public class SamlAuthenticationFilterConfig {
     }
 
     @Bean
-    SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager(final UaaUserDatabase userDatabase,
+    SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager(IdentityZoneManager identityZoneManager,
+            final JdbcIdentityProviderProvisioning identityProviderProvisioning,
+            ScimGroupExternalMembershipManager externalMembershipManager,
+            final UaaUserDatabase userDatabase,
             ApplicationEventPublisher applicationEventPublisher) {
 
-        SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager = new SamlUaaAuthenticationUserManager(userDatabase);
+        SamlUaaAuthenticationAttributesConverter attributesConverter = new SamlUaaAuthenticationAttributesConverter();
+        SamlUaaAuthenticationAuthoritiesConverter authoritiesConverter = new SamlUaaAuthenticationAuthoritiesConverter(externalMembershipManager);
+        SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager =
+                new SamlUaaAuthenticationUserManager(identityZoneManager, identityProviderProvisioning, userDatabase,
+                        attributesConverter, authoritiesConverter);
         samlUaaAuthenticationUserManager.setApplicationEventPublisher(applicationEventPublisher);
 
         return samlUaaAuthenticationUserManager;
@@ -72,18 +79,12 @@ public class SamlAuthenticationFilterConfig {
 
     @Bean
     AuthenticationProvider samlAuthenticationProvider(IdentityZoneManager identityZoneManager,
-            final JdbcIdentityProviderProvisioning identityProviderProvisioning,
-            ScimGroupExternalMembershipManager externalMembershipManager,
             SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager,
             ApplicationEventPublisher applicationEventPublisher,
             SamlConfigProps samlConfigProps) {
 
-        SamlUaaAuthenticationAttributesConverter attributesConverter = new SamlUaaAuthenticationAttributesConverter();
-        SamlUaaAuthenticationAuthoritiesConverter authoritiesConverter = new SamlUaaAuthenticationAuthoritiesConverter(externalMembershipManager);
-
         SamlUaaResponseAuthenticationConverter samlResponseAuthenticationConverter =
-                new SamlUaaResponseAuthenticationConverter(identityZoneManager, identityProviderProvisioning,
-                        samlUaaAuthenticationUserManager, attributesConverter, authoritiesConverter);
+                new SamlUaaResponseAuthenticationConverter(identityZoneManager, samlUaaAuthenticationUserManager);
         samlResponseAuthenticationConverter.setApplicationEventPublisher(applicationEventPublisher);
 
         OpenSaml4AuthenticationProvider samlResponseAuthenticationProvider = new OpenSaml4AuthenticationProvider();
@@ -197,12 +198,11 @@ public class SamlAuthenticationFilterConfig {
      */
     @Bean
     Saml2BearerGrantAuthenticationConverter samlBearerGrantAuthenticationProvider(IdentityZoneManager identityZoneManager,
-            final JdbcIdentityProviderProvisioning identityProviderProvisioning,
             SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager,
             ApplicationEventPublisher applicationEventPublisher,
             UaaRelyingPartyRegistrationResolver relyingPartyRegistrationResolver) {
 
         return new Saml2BearerGrantAuthenticationConverter(relyingPartyRegistrationResolver, identityZoneManager,
-                identityProviderProvisioning, samlUaaAuthenticationUserManager, applicationEventPublisher);
+                samlUaaAuthenticationUserManager, applicationEventPublisher);
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
@@ -199,10 +199,9 @@ public class SamlAuthenticationFilterConfig {
     @Bean
     Saml2BearerGrantAuthenticationConverter samlBearerGrantAuthenticationProvider(IdentityZoneManager identityZoneManager,
             SamlUaaAuthenticationUserManager samlUaaAuthenticationUserManager,
-            ApplicationEventPublisher applicationEventPublisher,
             UaaRelyingPartyRegistrationResolver relyingPartyRegistrationResolver) {
 
         return new Saml2BearerGrantAuthenticationConverter(relyingPartyRegistrationResolver, identityZoneManager,
-                samlUaaAuthenticationUserManager, applicationEventPublisher);
+                samlUaaAuthenticationUserManager);
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAttributesConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAttributesConverter.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.USER_ATTRIBUTE_PREFIX;
-import static org.cloudfoundry.identity.uaa.provider.saml.SamlUaaResponseAuthenticationConverter.AUTHENTICATION_CONTEXT_CLASS_REFERENCE;
+import static org.cloudfoundry.identity.uaa.provider.saml.SamlUaaAuthenticationUserManager.AUTHENTICATION_CONTEXT_CLASS_REFERENCE;
 
 /**
  * Part of the AuthenticationConverter used during SAML login flow.

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAttributesConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAttributesConverter.java
@@ -6,7 +6,6 @@ import org.opensaml.core.xml.schema.XSURI;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AuthnContext;
 import org.opensaml.saml.saml2.core.AuthnStatement;
-import org.opensaml.saml.saml2.core.Response;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.ObjectUtils;
@@ -25,10 +24,9 @@ import static org.cloudfoundry.identity.uaa.provider.saml.SamlUaaResponseAuthent
 @Slf4j
 public class SamlUaaAuthenticationAttributesConverter {
 
-    public MultiValueMap<String, String> retrieveUserAttributes(SamlIdentityProviderDefinition definition, Response response) {
+    public MultiValueMap<String, String> retrieveUserAttributes(SamlIdentityProviderDefinition definition, List<Assertion> assertions) {
         log.debug("Retrieving SAML user attributes [zone:{}, origin:{}}]", definition.getZoneId(), definition.getIdpEntityAlias());
         MultiValueMap<String, String> userAttributes = new LinkedMultiValueMap<>();
-        List<Assertion> assertions = response.getAssertions();
         if (assertions.isEmpty()) {
             return userAttributes;
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAuthoritiesConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAuthoritiesConverter.java
@@ -6,6 +6,7 @@ import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupExternalMember;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupExternalMembershipManager;
 import org.opensaml.core.xml.XMLObject;
+import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.Response;
 import org.springframework.security.core.GrantedAuthority;
 
@@ -62,12 +63,12 @@ public class SamlUaaAuthenticationAuthoritiesConverter {
         return result;
     }
 
-    protected List<SamlUserAuthority> retrieveSamlAuthorities(SamlIdentityProviderDefinition definition, Response response) {
+    protected List<SamlUserAuthority> retrieveSamlAuthorities(SamlIdentityProviderDefinition definition, List<Assertion> assertions) {
         if (definition.getAttributeMappings().get(GROUP_ATTRIBUTE_NAME) != null) {
             List<String> groupAttributeNames = getGroupAttributeNames(definition);
 
             List<SamlUserAuthority> authorities = new ArrayList<>();
-            response.getAssertions().stream().flatMap(assertion -> assertion.getAttributeStatements().stream())
+            assertions.stream().flatMap(assertion -> assertion.getAttributeStatements().stream())
                     .flatMap(attributeStatement -> attributeStatement.getAttributes().stream())
                     .filter(attribute -> groupAttributeNames.contains(attribute.getName()) || groupAttributeNames.contains(attribute.getFriendlyName()))
                     .filter(attribute -> attribute.getAttributeValues() != null)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAuthoritiesConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationAuthoritiesConverter.java
@@ -7,7 +7,6 @@ import org.cloudfoundry.identity.uaa.scim.ScimGroupExternalMember;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupExternalMembershipManager;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.saml.saml2.core.Assertion;
-import org.opensaml.saml.saml2.core.Response;
 import org.springframework.security.core.GrantedAuthority;
 
 import java.util.ArrayList;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManager.java
@@ -51,7 +51,6 @@ import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDef
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.FAMILY_NAME_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.GIVEN_NAME_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.PHONE_NUMBER_ATTRIBUTE_NAME;
-import static org.cloudfoundry.identity.uaa.provider.saml.SamlUaaResponseAuthenticationConverter.AUTHENTICATION_CONTEXT_CLASS_REFERENCE;
 import static org.cloudfoundry.identity.uaa.util.UaaHttpRequestUtils.isAcceptedInvitationAuthentication;
 
 /**
@@ -60,6 +59,8 @@ import static org.cloudfoundry.identity.uaa.util.UaaHttpRequestUtils.isAcceptedI
  */
 @Slf4j
 public class SamlUaaAuthenticationUserManager implements ApplicationEventPublisherAware {
+
+    public static final String AUTHENTICATION_CONTEXT_CLASS_REFERENCE = "acr";
 
     ApplicationEventPublisher eventPublisher;
     private final IdentityZoneManager identityZoneManager;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManager.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.NotANumber;
+import static org.cloudfoundry.identity.uaa.constants.OriginKeys.SAML;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EMAIL_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EMAIL_VERIFIED_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.FAMILY_NAME_ATTRIBUTE_NAME;
@@ -203,12 +204,13 @@ public class SamlUaaAuthenticationUserManager implements ApplicationEventPublish
         IdentityProvider<SamlIdentityProviderDefinition> idp;
         SamlIdentityProviderDefinition samlConfig;
         try {
-            idp = identityProviderProvisioning.retrieveByOrigin(alias, identityZoneManager.getCurrentIdentityZoneId());
-            samlConfig = idp.getConfig();
-            addNew = samlConfig.isAddShadowUserOnLogin();
-            if (!idp.isActive()) {
+            IdentityProvider<?> idpConfig = identityProviderProvisioning.retrieveByOrigin(alias, identityZoneManager.getCurrentIdentityZoneId());
+            if (idpConfig == null || !SAML.equals(idpConfig.getType()) || !idpConfig.isActive()) {
                 throw new ProviderNotFoundException("Identity Provider has been disabled by administrator for alias:" + alias);
             }
+            samlConfig = (SamlIdentityProviderDefinition) idpConfig.getConfig();
+            idp = (IdentityProvider<SamlIdentityProviderDefinition>) idpConfig;
+            addNew = samlConfig.isAddShadowUserOnLogin();
         } catch (EmptyResultDataAccessException x) {
             throw new ProviderNotFoundException("No SAML identity provider found in zone for alias:" + alias);
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManager.java
@@ -2,23 +2,38 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
+import org.cloudfoundry.identity.uaa.authentication.UaaSamlPrincipal;
+import org.cloudfoundry.identity.uaa.authentication.event.IdentityProviderAuthenticationSuccessEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.ExternalGroupAuthorizationEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.InvitedUserAuthenticatedEvent;
 import org.cloudfoundry.identity.uaa.authentication.manager.NewUserAuthenticatedEvent;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.user.UaaUserPrototype;
 import org.cloudfoundry.identity.uaa.user.UserInfo;
+import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
+import org.cloudfoundry.identity.uaa.web.UaaSavedRequestAwareAuthenticationSuccessHandler;
+import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.opensaml.saml.saml2.core.Assertion;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.ProviderNotFoundException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
+import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationToken;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.request.RequestAttributes;
@@ -27,24 +42,41 @@ import org.springframework.web.context.request.RequestContextHolder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 
+import static org.cloudfoundry.identity.uaa.constants.OriginKeys.NotANumber;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EMAIL_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EMAIL_VERIFIED_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.FAMILY_NAME_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.GIVEN_NAME_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.PHONE_NUMBER_ATTRIBUTE_NAME;
+import static org.cloudfoundry.identity.uaa.provider.saml.SamlUaaResponseAuthenticationConverter.AUTHENTICATION_CONTEXT_CLASS_REFERENCE;
 import static org.cloudfoundry.identity.uaa.util.UaaHttpRequestUtils.isAcceptedInvitationAuthentication;
 
 /**
  * Part of the AuthenticationConverter used during SAML login flow.
  * This handles User creation and storage in the database.
  */
+@Slf4j
 public class SamlUaaAuthenticationUserManager implements ApplicationEventPublisherAware {
 
     ApplicationEventPublisher eventPublisher;
+    private final IdentityZoneManager identityZoneManager;
+    private final IdentityProviderProvisioning identityProviderProvisioning;
+    private final SamlUaaAuthenticationAttributesConverter attributesConverter;
+    private final SamlUaaAuthenticationAuthoritiesConverter authoritiesConverter;
 
-    public SamlUaaAuthenticationUserManager(UaaUserDatabase userDatabase) {
+    public SamlUaaAuthenticationUserManager(IdentityZoneManager identityZoneManager,
+                                            final JdbcIdentityProviderProvisioning identityProviderProvisioning,
+                                            UaaUserDatabase userDatabase,
+                                            SamlUaaAuthenticationAttributesConverter attributesConverter,
+                                            SamlUaaAuthenticationAuthoritiesConverter authoritiesConverter) {
         this.userDatabase = userDatabase;
+        this.identityZoneManager = identityZoneManager;
+        this.identityProviderProvisioning = identityProviderProvisioning;
+        this.attributesConverter = attributesConverter;
+        this.authoritiesConverter = authoritiesConverter;
     }
 
     private final UaaUserDatabase userDatabase;
@@ -158,6 +190,105 @@ public class SamlUaaAuthenticationUserManager implements ApplicationEventPublish
                 !StringUtils.equals(existingUser.getPhoneNumber(), user.getPhoneNumber()) ||
                 !StringUtils.equals(existingUser.getEmail(), user.getEmail()) ||
                 !StringUtils.equals(existingUser.getExternalId(), user.getExternalId());
+    }
+
+    protected UaaAuthentication getUaaAuthentication(String subjectName, Saml2AuthenticationToken authenticationToken, String alias, List<Assertion> assertions, List<String> sessionIndexess) {
+        UaaPrincipal initialPrincipal = new UaaPrincipal(NotANumber, subjectName, authenticationToken.getName(),
+                alias, authenticationToken.getName(), identityZoneManager.getCurrentIdentityZoneId());
+        log.debug("Mapped SAML authentication to IDP with origin '{}' and username '{}'",
+                alias, initialPrincipal.getName());
+
+        boolean addNew;
+        IdentityProvider<SamlIdentityProviderDefinition> idp;
+        SamlIdentityProviderDefinition samlConfig;
+        try {
+            idp = identityProviderProvisioning.retrieveByOrigin(alias, identityZoneManager.getCurrentIdentityZoneId());
+            samlConfig = idp.getConfig();
+            addNew = samlConfig.isAddShadowUserOnLogin();
+            if (!idp.isActive()) {
+                throw new ProviderNotFoundException("Identity Provider has been disabled by administrator for alias:" + alias);
+            }
+        } catch (EmptyResultDataAccessException x) {
+            throw new ProviderNotFoundException("No SAML identity provider found in zone for alias:" + alias);
+        }
+
+        MultiValueMap<String, String> userAttributes = attributesConverter.retrieveUserAttributes(samlConfig, assertions);
+        List<? extends GrantedAuthority> samlAuthorities = authoritiesConverter.retrieveSamlAuthorities(samlConfig, assertions);
+
+        log.debug("Mapped SAML authentication to IDP with origin '{}' and username '{}'",
+                idp.getOriginKey(), initialPrincipal.getName());
+
+        UaaUser user = createIfMissing(initialPrincipal, addNew, getMappedAuthorities(
+                idp, samlAuthorities), userAttributes);
+
+        UaaAuthentication authentication = new UaaAuthentication(
+                new UaaSamlPrincipal(user, sessionIndexess),
+                authenticationToken.getCredentials(),
+                user.getAuthorities(),
+                authoritiesConverter.filterSamlAuthorities(samlConfig, samlAuthorities),
+                attributesConverter.retrieveCustomUserAttributes(userAttributes),
+                null,
+                true, System.currentTimeMillis(),
+                -1);
+
+        authentication.setAuthenticationMethods(Set.of("ext"));
+        setAuthContextClassRef(userAttributes, authentication, samlConfig);
+
+        publish(new IdentityProviderAuthenticationSuccessEvent(user, authentication, OriginKeys.SAML, identityZoneManager.getCurrentIdentityZoneId()));
+
+        if (samlConfig.isStoreCustomAttributes()) {
+            storeCustomAttributesAndRoles(user, authentication);
+        }
+
+        AbstractSaml2AuthenticationRequest authenticationRequest = authenticationToken.getAuthenticationRequest();
+        if (authenticationRequest != null) {
+            String relayState = authenticationRequest.getRelayState();
+            configureRelayRedirect(relayState);
+        }
+
+        return authentication;
+    }
+
+    private static void setAuthContextClassRef(MultiValueMap<String, String> userAttributes,
+                                               UaaAuthentication authentication, SamlIdentityProviderDefinition samlConfig) {
+
+        List<String> acrValues = userAttributes.get(AUTHENTICATION_CONTEXT_CLASS_REFERENCE);
+        if (acrValues != null) {
+            authentication.setAuthContextClassRef(Set.copyOf(acrValues));
+        }
+
+        if (samlConfig.getAuthnContext() != null) {
+            assert acrValues != null;
+            if (Collections.disjoint(acrValues, samlConfig.getAuthnContext())) {
+                throw new BadCredentialsException(
+                        "Identity Provider did not authenticate with the requested AuthnContext.");
+            }
+        }
+    }
+
+    private Collection<? extends GrantedAuthority> getMappedAuthorities(
+            IdentityProvider<SamlIdentityProviderDefinition> idp,
+            List<? extends GrantedAuthority> samlAuthorities) {
+        Collection<? extends GrantedAuthority> authorities;
+        SamlIdentityProviderDefinition.ExternalGroupMappingMode groupMappingMode = idp.getConfig().getGroupMappingMode();
+        authorities = switch (groupMappingMode) {
+            case EXPLICITLY_MAPPED -> authoritiesConverter.mapAuthorities(idp.getOriginKey(),
+                    samlAuthorities, identityZoneManager.getCurrentIdentityZoneId());
+            case AS_SCOPES -> List.copyOf(samlAuthorities);
+        };
+        return authorities;
+    }
+
+    private void configureRelayRedirect(String relayState) {
+        //configure relay state
+        if (UaaUrlUtils.isUrl(relayState)) {
+            RequestContextHolder.currentRequestAttributes()
+                    .setAttribute(
+                            UaaSavedRequestAwareAuthenticationSuccessHandler.URI_OVERRIDE_ATTRIBUTE,
+                            relayState,
+                            RequestAttributes.SCOPE_REQUEST
+                    );
+        }
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaResponseAuthenticationConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaResponseAuthenticationConverter.java
@@ -29,8 +29,6 @@ public class SamlUaaResponseAuthenticationConverter
         implements Converter<OpenSaml4AuthenticationProvider.ResponseToken, UaaAuthentication>,
         ApplicationEventPublisherAware {
 
-    public static final String AUTHENTICATION_CONTEXT_CLASS_REFERENCE = "acr";
-
     private final IdentityZoneManager identityZoneManager;
 
     private ApplicationEventPublisher eventPublisher;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaResponseAuthenticationConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaResponseAuthenticationConverter.java
@@ -3,17 +3,6 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
-import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
-import org.cloudfoundry.identity.uaa.authentication.UaaSamlPrincipal;
-import org.cloudfoundry.identity.uaa.authentication.event.IdentityProviderAuthenticationSuccessEvent;
-import org.cloudfoundry.identity.uaa.constants.OriginKeys;
-import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
-import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
-import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
-import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
-import org.cloudfoundry.identity.uaa.user.UaaUser;
-import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
-import org.cloudfoundry.identity.uaa.web.UaaSavedRequestAwareAuthenticationSuccessHandler;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
 import org.opensaml.saml.saml2.core.Assertion;
@@ -23,24 +12,13 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.ProviderNotFoundException;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.saml2.provider.service.authentication.AbstractSaml2AuthenticationRequest;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationToken;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.context.request.RequestAttributes;
-import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.util.ObjectUtils;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-
-import static org.cloudfoundry.identity.uaa.constants.OriginKeys.NotANumber;
 
 /**
  * AuthenticationConverter used during SAML login flow to convert a SAML response token to a UaaAuthentication.
@@ -55,24 +33,14 @@ public class SamlUaaResponseAuthenticationConverter
 
     private final IdentityZoneManager identityZoneManager;
 
-    private final IdentityProviderProvisioning identityProviderProvisioning;
-
     private ApplicationEventPublisher eventPublisher;
 
     private final SamlUaaAuthenticationUserManager userManager;
-    private final SamlUaaAuthenticationAttributesConverter attributesConverter;
-    private final SamlUaaAuthenticationAuthoritiesConverter authoritiesConverter;
 
     public SamlUaaResponseAuthenticationConverter(IdentityZoneManager identityZoneManager,
-            final JdbcIdentityProviderProvisioning identityProviderProvisioning,
-            SamlUaaAuthenticationUserManager userManager,
-            SamlUaaAuthenticationAttributesConverter attributesConverter,
-            SamlUaaAuthenticationAuthoritiesConverter authoritiesConverter) {
+            SamlUaaAuthenticationUserManager userManager) {
         this.identityZoneManager = identityZoneManager;
-        this.identityProviderProvisioning = identityProviderProvisioning;
         this.userManager = userManager;
-        this.attributesConverter = attributesConverter;
-        this.authoritiesConverter = authoritiesConverter;
     }
 
     @Override
@@ -80,7 +48,10 @@ public class SamlUaaResponseAuthenticationConverter
         Saml2AuthenticationToken authenticationToken = responseToken.getToken();
         Response response = responseToken.getResponse();
         List<Assertion> assertions = response.getAssertions();
-        String subjectName = assertions.get(0).getSubject().getNameID().getValue();
+        List<String> subjectNameList = assertions.stream().filter(Objects::nonNull).map(assertion -> assertion.getSubject().getNameID().getValue()).toList();
+        if (ObjectUtils.isEmpty(subjectNameList) || subjectNameList.size() != 1) {
+            throw new BadCredentialsException("SAML response does not contain a subject name");
+        }
 
         IdentityZone zone = identityZoneManager.getCurrentIdentityZone();
         log.debug("Initiating SAML authentication in zone '{}' domain '{}'",
@@ -88,103 +59,8 @@ public class SamlUaaResponseAuthenticationConverter
 
         RelyingPartyRegistration relyingPartyRegistration = authenticationToken.getRelyingPartyRegistration();
         String alias = relyingPartyRegistration.getRegistrationId();
-        UaaPrincipal initialPrincipal = new UaaPrincipal(NotANumber, subjectName, authenticationToken.getName(),
-                alias, authenticationToken.getName(), zone.getId());
-        log.debug("Mapped SAML authentication to IDP with origin '{}' and username '{}'",
-                alias, initialPrincipal.getName());
-
-        boolean addNew;
-        IdentityProvider<SamlIdentityProviderDefinition> idp;
-        SamlIdentityProviderDefinition samlConfig;
-        try {
-            idp = identityProviderProvisioning.retrieveByOrigin(alias, zone.getId());
-            samlConfig = idp.getConfig();
-            addNew = samlConfig.isAddShadowUserOnLogin();
-            if (!idp.isActive()) {
-                throw new ProviderNotFoundException("Identity Provider has been disabled by administrator for alias:" + alias);
-            }
-        } catch (EmptyResultDataAccessException x) {
-            throw new ProviderNotFoundException("No SAML identity provider found in zone for alias:" + alias);
-        }
-
-        MultiValueMap<String, String> userAttributes = attributesConverter.retrieveUserAttributes(samlConfig, response);
-        List<? extends GrantedAuthority> samlAuthorities = authoritiesConverter.retrieveSamlAuthorities(samlConfig, response);
-
-        log.debug("Mapped SAML authentication to IDP with origin '{}' and username '{}'",
-                idp.getOriginKey(), initialPrincipal.getName());
-
-        UaaUser user = userManager.createIfMissing(initialPrincipal, addNew, getMappedAuthorities(
-                idp, samlAuthorities), userAttributes);
-
         List<String> sessionIndexes = assertions.stream().flatMap(assertion -> assertion.getAuthnStatements().stream().filter(Objects::nonNull).map(AuthnStatement::getSessionIndex).filter(Objects::nonNull)).toList();
-        UaaAuthentication authentication = new UaaAuthentication(
-                new UaaSamlPrincipal(user, sessionIndexes),
-                authenticationToken.getCredentials(),
-                user.getAuthorities(),
-                authoritiesConverter.filterSamlAuthorities(samlConfig, samlAuthorities),
-                attributesConverter.retrieveCustomUserAttributes(userAttributes),
-                null,
-                true, System.currentTimeMillis(),
-                -1);
-
-        authentication.setAuthenticationMethods(Set.of("ext"));
-        setAuthContextClassRef(userAttributes, authentication, samlConfig);
-
-        publish(new IdentityProviderAuthenticationSuccessEvent(user, authentication, OriginKeys.SAML, identityZoneManager.getCurrentIdentityZoneId()));
-
-        if (samlConfig.isStoreCustomAttributes()) {
-            userManager.storeCustomAttributesAndRoles(user, authentication);
-        }
-
-        AbstractSaml2AuthenticationRequest authenticationRequest = authenticationToken.getAuthenticationRequest();
-        if (authenticationRequest != null) {
-            String relayState = authenticationRequest.getRelayState();
-            configureRelayRedirect(relayState);
-        }
-
-        return authentication;
-    }
-
-    private static void setAuthContextClassRef(MultiValueMap<String, String> userAttributes,
-            UaaAuthentication authentication, SamlIdentityProviderDefinition samlConfig) {
-
-        List<String> acrValues = userAttributes.get(AUTHENTICATION_CONTEXT_CLASS_REFERENCE);
-        if (acrValues != null) {
-            authentication.setAuthContextClassRef(Set.copyOf(acrValues));
-        }
-
-        if (samlConfig.getAuthnContext() != null) {
-            assert acrValues != null;
-            if (Collections.disjoint(acrValues, samlConfig.getAuthnContext())) {
-                throw new BadCredentialsException(
-                        "Identity Provider did not authenticate with the requested AuthnContext.");
-            }
-        }
-    }
-
-    private Collection<? extends GrantedAuthority> getMappedAuthorities(
-            IdentityProvider<SamlIdentityProviderDefinition> idp,
-            List<? extends GrantedAuthority> samlAuthorities) {
-        Collection<? extends GrantedAuthority> authorities;
-        SamlIdentityProviderDefinition.ExternalGroupMappingMode groupMappingMode = idp.getConfig().getGroupMappingMode();
-        authorities = switch (groupMappingMode) {
-            case EXPLICITLY_MAPPED -> authoritiesConverter.mapAuthorities(idp.getOriginKey(),
-                    samlAuthorities, identityZoneManager.getCurrentIdentityZoneId());
-            case AS_SCOPES -> List.copyOf(samlAuthorities);
-        };
-        return authorities;
-    }
-
-    public void configureRelayRedirect(String relayState) {
-        //configure relay state
-        if (UaaUrlUtils.isUrl(relayState)) {
-            RequestContextHolder.currentRequestAttributes()
-                    .setAttribute(
-                            UaaSavedRequestAwareAuthenticationSuccessHandler.URI_OVERRIDE_ATTRIBUTE,
-                            relayState,
-                            RequestAttributes.SCOPE_REQUEST
-                    );
-        }
+        return userManager.getUaaAuthentication(subjectNameList.get(0), authenticationToken, alias, assertions, sessionIndexes);
     }
 
     @Override

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUaaTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUaaTests.java
@@ -255,9 +255,9 @@ class OpenSaml4AuthenticationProviderUaaTests {
         publisher = new CreateUserPublisher(bootstrap);
 
         samlAuthenticationFilterConfig = new SamlAuthenticationFilterConfig();
-        samlUaaAuthenticationUserManager = samlAuthenticationFilterConfig.samlUaaAuthenticationUserManager(userDatabase, publisher);
+        samlUaaAuthenticationUserManager = samlAuthenticationFilterConfig.samlUaaAuthenticationUserManager(identityZoneManager, providerProvisioning, externalManager, userDatabase, publisher);
         authprovider = samlAuthenticationFilterConfig.samlAuthenticationProvider(
-                identityZoneManager, providerProvisioning, externalManager, samlUaaAuthenticationUserManager, publisher, new SamlConfigProps());
+                identityZoneManager, samlUaaAuthenticationUserManager, publisher, new SamlConfigProps());
 
         providerDefinition = new SamlIdentityProviderDefinition();
         providerDefinition.setMetaDataLocation(IDP_META_DATA.formatted(OriginKeys.SAML));
@@ -825,7 +825,7 @@ class OpenSaml4AuthenticationProviderUaaTests {
         SamlConfigProps samlConfigProps = new SamlConfigProps();
         samlConfigProps.setDisableInResponseToCheck(true);
         authprovider = samlAuthenticationFilterConfig.samlAuthenticationProvider(
-                identityZoneManager, providerProvisioning, externalManager, samlUaaAuthenticationUserManager, publisher, samlConfigProps);
+                identityZoneManager, samlUaaAuthenticationUserManager, publisher, samlConfigProps);
 
         Response response = responseWithAssertions();
         response.setInResponseTo("incorrect");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverterTest.java
@@ -95,7 +95,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         RelyingPartyRegistrationResolver relyingPartyRegistrationResolver = samlRelyingPartyRegistrationRepositoryConfig.relyingPartyRegistrationResolver(relyingPartyRegistrationRepository, null);
 
         provider = new Saml2BearerGrantAuthenticationConverter(relyingPartyRegistrationResolver, identityZoneManager,
-                null, null);
+               null);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverterTest.java
@@ -95,7 +95,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         RelyingPartyRegistrationResolver relyingPartyRegistrationResolver = samlRelyingPartyRegistrationRepositoryConfig.relyingPartyRegistrationResolver(relyingPartyRegistrationRepository, null);
 
         provider = new Saml2BearerGrantAuthenticationConverter(relyingPartyRegistrationResolver, identityZoneManager,
-                providerProvisioning, null, null);
+                null, null);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlUaaAuthenticationUserManagerTest.java
@@ -66,7 +66,7 @@ class SamlUaaAuthenticationUserManagerTest {
 
     @Test
     void getUserByDefaultUsesTheAvailableData() {
-        SamlUaaAuthenticationUserManager userManager = new SamlUaaAuthenticationUserManager(null);
+        SamlUaaAuthenticationUserManager userManager = new SamlUaaAuthenticationUserManager(null, null,null, null, null);
 
         UaaPrincipal principal = new UaaPrincipal(
                 UUID.randomUUID().toString(),
@@ -100,7 +100,7 @@ class SamlUaaAuthenticationUserManagerTest {
 
     @Test
     void getUserWithoutVerifiedDefaultsToFalse() {
-        SamlUaaAuthenticationUserManager userManager = new SamlUaaAuthenticationUserManager(null);
+        SamlUaaAuthenticationUserManager userManager = new SamlUaaAuthenticationUserManager(null, null, null, null, null);
 
         UaaPrincipal principal = new UaaPrincipal(
                 UUID.randomUUID().toString(),
@@ -118,7 +118,7 @@ class SamlUaaAuthenticationUserManagerTest {
 
     @Test
     void throwsIfPrincipalUserNameAndUserAttributesEmailIsMissing() {
-        SamlUaaAuthenticationUserManager userManager = new SamlUaaAuthenticationUserManager(null);
+        SamlUaaAuthenticationUserManager userManager = new SamlUaaAuthenticationUserManager(null, null, null, null, null);
 
         UaaPrincipal principal = new UaaPrincipal(
                 UUID.randomUUID().toString(),


### PR DESCRIPTION
SAML Response to UAA user and SAML Bearer Assertion to Uaa user was implemented twice with some different logic.

SAML Response SSO has all we need, but SAML Bearer has no attribute processing and no user attribute store. With the refactoring this should be fixed and should be less code now

Sonar
https://sonarcloud.io/summary/new_code?id=cloudfoundry-identity-parent&pullRequest=3439

Main refacotoring is: getUaaAuthentication in SamlUaaAuthenticationUserManager.java now, instead of Saml2BearerGrantAuthenticationConverter.java and SamlUaaResponseAuthenticationConverter.java