### PR TITLE
Fix client authentication before spring security 6x

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/AbstractClientParametersAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/AbstractClientParametersAuthenticationFilter.java
@@ -114,7 +114,8 @@ public abstract class AbstractClientParametersAuthenticationFilter implements Fi
     }
 
     private Authentication performClientAuthentication(HttpServletRequest req, Map<String, String> loginInfo, String clientId) {
-        String clientSecret = loginInfo.get(CLIENT_SECRET);
+        // spring security 6.x requires a credential to be present
+        String clientSecret = Optional.ofNullable(loginInfo.get(CLIENT_SECRET)).orElse(UaaStringUtils.EMPTY_STRING);
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(clientId, clientSecret);
         authentication.setDetails(new UaaAuthenticationDetails(req, clientId));
         try {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ClientDetailsAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ClientDetailsAuthenticationProvider.java
@@ -65,7 +65,7 @@ public class ClientDetailsAuthenticationProvider extends DaoAuthenticationProvid
         for (String pwd : passwordList) {
             try {
                 UaaClient uaaClient = new UaaClient(userDetails, pwd);
-                if (authentication.getCredentials() == null) {
+                if (ObjectUtils.isEmpty(authentication.getCredentials())) {
                     if (isPublicGrantTypeUsageAllowed(authentication.getDetails()) && uaaClient.isAllowPublic()) {
                         // in case of grant_type=authorization_code and code_verifier passed (PKCE) we check if client has option allowpublic with true and continue even if no secret is in request
                         setAuthenticationMethod(authentication, CLIENT_AUTH_NONE);
@@ -76,10 +76,10 @@ public class ClientDetailsAuthenticationProvider extends DaoAuthenticationProvid
                             error = new BadCredentialsException("Bad client_assertion type");
                         }
                         break;
+                    } else {
+                        // set internally empty as client_auth_method e.g. cf client
+                        setAuthenticationMethod(authentication, CLIENT_AUTH_EMPTY);
                     }
-                } else if (ObjectUtils.isEmpty(authentication.getCredentials())) {
-                    // set internally empty as client_auth_method e.g. cf client
-                    setAuthenticationMethod(authentication, CLIENT_AUTH_EMPTY);
                 }
                 if (uaaClient.getPassword() == null) {
                     error = new BadCredentialsException("Missing credentials");


### PR DESCRIPTION
Credentials must not be null, thus refactor our client auth

https://sonarcloud.io/summary/new_code?id=cloudfoundry-identity-parent&pullRequest=3458