### PR TITLE
Add /healthz/ to support integration test

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -46,7 +46,7 @@ public class HealthzEndpoint {
         this.dataSource = dataSource;
     }
 
-    @GetMapping("/healthz")
+    @GetMapping({"/healthz", "/healthz/"})
     @ResponseBody
     public String getHealthz(HttpServletResponse response) {
         if (stopping) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -46,7 +46,7 @@ public class HealthzEndpoint {
         this.dataSource = dataSource;
     }
 
-    @GetMapping({"/healthz", "/healthz/"})
+    @GetMapping({"/healthz", "/healthz/**"})
     @ResponseBody
     public String getHealthz(HttpServletResponse response) {
         if (stopping) {


### PR DESCRIPTION
with spring 6 the test
https://github.com/cloudfoundry/uaa/blob/develop/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/HealthzEndpointIntegrationTests.java#L40

fails, so question is, either
[ ] fix test
[ ] allow more than only /healthz ?