### PR TITLE
Potential fix for code scanning alert no. 43: Failure to use secure cookies

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -627,6 +627,7 @@ public class LoginInfoEndpoint {
         Cookie cookie = new Cookie("Saved-Account-%s".formatted(userId), "");
         cookie.setMaxAge(0);
         cookie.setPath(request.getContextPath() + "/login");
+        cookie.setSecure(true);
         response.addCookie(cookie);
         return "redirect:/login";
     }


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/uaa/security/code-scanning/43](https://github.com/cloudfoundry/uaa/security/code-scanning/43)

To fix the issue, the `secure` flag should be set on the cookie before adding it to the response. This can be achieved by calling `cookie.setSecure(true)` on the cookie object. This ensures that the cookie is only transmitted over HTTPS, even when it is being deleted. The change should be made in the `deleteSavedAccount` method, specifically before the `response.addCookie(cookie)` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
