### PR TITLE
Spring 6 refactorings because of CSRF cookie

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -513,16 +513,20 @@ class LoginSecurityConfiguration {
         var clientRedirectStateCache = new UaaSavedRequestCache();
         clientRedirectStateCache.setRequestMatcher(new AntPathRequestMatcher("/oauth/authorize**"));
 
+        // See: https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#migrating-to-spring-security-6
+        var csrfRequestHandler = new CsrfTokenRequestAttributeHandler();
+        csrfRequestHandler.setCsrfRequestAttributeName(null);
         var originalChain = http
                 .csrf(csrf -> {
                     csrf.csrfTokenRepository(csrfTokenRepository);
-                    csrf.csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler());
+                    csrf.csrfTokenRequestHandler(csrfRequestHandler);
                 })
                 .authenticationManager(authenticationManager)
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers("/force_password_change/**").fullyAuthenticated();
                     auth.requestMatchers("/reset_password**").anonymous();
                     auth.requestMatchers("/create_account*").anonymous();
+                    auth.requestMatchers("/login/idp_discovery").anonymous();
                     auth.requestMatchers("/login/idp_discovery/**").anonymous();
                     auth.requestMatchers("/saml/metadata/**").anonymous();
                     auth.requestMatchers("/origin-chooser").anonymous();


### PR DESCRIPTION
In some deployments, we see that X-Uaa-Csrf cookie is sent only in first request but then the value stays. The value in the Thymeleaf generated HTML forms get changed with each request.

This ends in /login?error=invalid_login_request

Change csrfTokenRequestHandler because of
https://stackoverflow.com/questions/74811673/spring-security-not-sending-csrf-token-in-rest-application https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#migrating-to-spring-security-6