### PR TITLE
info endpoint providers

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -361,6 +361,21 @@ public class LoginInfoEndpoint {
             returnLoginPrompts = false;
         }
 
+        if (jsonResponse && request.getRequestURI().endsWith("/info")) {
+            List<Map<String, String>> infoIdentityProviders = new java.util.ArrayList<>();
+            providerProvisioning.retrieveAll(true, IdentityZoneHolder.get().getId())
+                    .forEach(provider -> {
+                        infoIdentityProviders.add(
+                                Map.of(
+                                        OriginKeys.ORIGIN, provider.getOriginKey(),
+                                        "name", provider.getName(),
+                                        "type", provider.getType()
+                                )
+                        );
+                    });
+            model.addAttribute("providers", infoIdentityProviders);
+        }
+
         // ldap or uaa not part of allowedIdentityProviderKeys
         if (allowedIdentityProviderKeys != null &&
                 !allowedIdentityProviderKeys.contains(OriginKeys.LDAP) &&

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointDocs.java
@@ -73,7 +73,11 @@ class LoginInfoEndpointDocs extends EndpointDocs {
                 fieldWithPath("prompts.password").type(ARRAY).description("Information about the password prompt."),
                 fieldWithPath("prompts.passcode").optional().type(ARRAY).description("If a SAML identity provider is configured, this prompt contains a URL to where the user can initiate the SAML authentication flow."),
                 fieldWithPath("zone_name").type(STRING).description("The name of the zone invoked"),
-                fieldWithPath("showLoginLinks").optional(false).type(BOOLEAN).description("Set to true if there are SAML or OAUTH/OIDC providers with a visible link on the login page.")
+                fieldWithPath("showLoginLinks").optional(false).type(BOOLEAN).description("Set to true if there are SAML or OAUTH/OIDC providers with a visible link on the login page."),
+                fieldWithPath("providers").optional().type(ARRAY).description("A list of identity providers that are active in this zone"),
+                fieldWithPath("providers[].name").optional().type(STRING).description("The human readable name of the identity provider"),
+                fieldWithPath("providers[].origin").optional().type(STRING).description("The origin key of the identity provider"),
+                fieldWithPath("providers[].type").optional().type(STRING).description("The type (SAML, LDAP, OIDC, OAUTH2, etc) of identity provider")
         );
 
         Snippet requestHeaders = requestHeaders(

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -2793,6 +2793,7 @@ public class LoginMockMvcTests {
 
     @Nested
     @DefaultTestContext
+    @DirtiesContext
     class ErrorAndSuccessMessages {
         @Test
         void hasValidError() throws Exception {
@@ -2820,6 +2821,118 @@ public class LoginMockMvcTests {
             mockMvc.perform(
                             get("/login?success=foobar&success=verify_success"))
                     .andExpect(content().string(containsString("Success!")));
+        }
+    }
+
+    @Nested
+    @DefaultTestContext
+    class IdentityProviderOnInfoEndpoint {
+        IdentityZone identityZone;
+        IdentityZoneCreationResult identityZoneCreationResult;
+        UaaClientDetails zoneAdminClient;
+        IdentityProvider samlProvider;
+        IdentityProvider ldapProvider;
+        IdentityProvider oidcProvider;
+        IdentityProvider inactiveOidcProvider;
+
+        @BeforeEach
+        void setupInfoProviders(@Autowired JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning) throws Exception {
+            zoneAdminClient = new UaaClientDetails("admin", null, null, "client_credentials", "clients.admin,scim.read,scim.write");
+            zoneAdminClient.setClientSecret("admin-secret");
+            identityZoneCreationResult = MockMvcUtils.createOtherIdentityZoneAndReturnResult("infoendpointIdp" + new RandomValueStringGenerator().generate(), mockMvc, webApplicationContext, zoneAdminClient, false, IdentityZoneHolder.getCurrentZoneId());
+            identityZone = identityZoneCreationResult.getIdentityZone();
+
+            String samlOrigin = "saml-" + new RandomValueStringGenerator().generate();
+            String samlMetadata = String.format(MockMvcUtils.IDP_META_DATA, new AlphanumericRandomValueStringGenerator().generate());
+            SamlIdentityProviderDefinition samlConfig = (SamlIdentityProviderDefinition) new SamlIdentityProviderDefinition()
+                    .setMetaDataLocation(samlMetadata)
+                    .setIdpEntityAlias(samlOrigin)
+                    .setLinkText("Active SAML Provider")
+                    .setZoneId(identityZone.getId())
+                    .setEmailDomain(Collections.singletonList("test.org"));
+
+            samlProvider = MultitenancyFixture.identityProvider(samlOrigin, identityZone.getId());
+            samlProvider.setType(SAML);
+            samlProvider.setConfig(samlConfig);
+            samlProvider = createIdentityProvider(jdbcIdentityProviderProvisioning, identityZone, samlProvider);
+
+            ldapProvider = MultitenancyFixture.identityProvider(LDAP, identityZone.getId());
+            ldapProvider.setType(LDAP);
+            ldapProvider.setConfig(new LdapIdentityProviderDefinition().setEmailDomain(Collections.singletonList("testLdap.org")));
+            ldapProvider = createIdentityProvider(jdbcIdentityProviderProvisioning, identityZone, ldapProvider);
+
+            AbstractExternalOAuthIdentityProviderDefinition oidcConfig = new OIDCIdentityProviderDefinition();
+            oidcConfig.setEmailDomain(singletonList("test.org"));
+            oidcConfig.setAuthUrl(new URL("http://myauthurl.com"));
+            oidcConfig.setTokenKey("key");
+            oidcConfig.setTokenUrl(new URL("http://mytokenurl.com"));
+            oidcConfig.setRelyingPartyId("id");
+            oidcConfig.setRelyingPartySecret("secret");
+            oidcConfig.setLinkText("my oidc provider");
+            oidcConfig.setResponseType("token id_token");
+
+            String inactiveOidcOrigin = "inactive-" + new RandomValueStringGenerator().generate();
+            inactiveOidcProvider =  MultitenancyFixture.identityProvider(inactiveOidcOrigin, identityZone.getId());
+            inactiveOidcProvider = MultitenancyFixture.identityProvider(inactiveOidcOrigin, identityZone.getId());
+            inactiveOidcProvider.setType(OIDC10);
+            inactiveOidcProvider.setActive(false);
+            inactiveOidcProvider.setConfig(oidcConfig);
+            inactiveOidcProvider = createIdentityProvider(jdbcIdentityProviderProvisioning, identityZone, inactiveOidcProvider);
+
+            String oidcOrigin = "oidc-" + new RandomValueStringGenerator().generate();
+            oidcProvider = MultitenancyFixture.identityProvider(oidcOrigin, identityZone.getId());
+            oidcProvider.setType(OIDC10);
+            oidcProvider.setConfig(oidcConfig);
+            oidcProvider = createIdentityProvider(jdbcIdentityProviderProvisioning, identityZone, oidcProvider);
+        }
+
+        @Test
+        void activeProvidersShowUpInInfoJSON () throws Exception {
+            String jsonData = mockMvc.perform(get("/info").accept(APPLICATION_JSON).with(new SetServerNameRequestPostProcessor(identityZone.getSubdomain() + ".localhost")))
+                    .andExpect(status().isOk())
+                    .andReturn()
+                    .getResponse().getContentAsString();
+            Map<String, Object> infoJson = JsonUtils.readValueAsMap(jsonData);
+            List<Map<String, Object>> identityProviders = (List<Map<String, Object>>) infoJson.get("providers");
+            org.junit.Assert.assertNotNull(identityProviders);
+            org.junit.Assert.assertEquals(4, identityProviders.size());
+            org.junit.Assert.assertThat(identityProviders, org.hamcrest.Matchers.hasItem(
+                    Map.of(
+                            "origin", UAA,
+                            "name", UAA,
+                            "type", UAA
+                    )
+            ));
+            org.junit.Assert.assertThat(identityProviders, org.hamcrest.Matchers.hasItem(
+                    Map.of(
+                            "origin", LDAP,
+                            "name", ldapProvider.getName(),
+                            "type", LDAP
+                    )
+            ));
+            org.junit.Assert.assertThat(identityProviders, org.hamcrest.Matchers.hasItem(
+                    Map.of(
+                            "origin", samlProvider.getOriginKey(),
+                            "name", samlProvider.getName(),
+                            "type", SAML
+                    )
+            ));
+            org.junit.Assert.assertThat(identityProviders, org.hamcrest.Matchers.hasItem(
+                    Map.of(
+                            "origin", oidcProvider.getOriginKey(),
+                            "name", oidcProvider.getName(),
+                            "type", OIDC10
+                    )
+            ));
+        }
+
+        @Test
+        void noProviderInfoOnLoginEndpoint() throws Exception {
+            mockMvc.perform(
+                            get("/login").accept(APPLICATION_JSON)
+                    )
+                    .andExpect(status().isOk())
+                    .andExpect(model().attributeDoesNotExist("provider"));
         }
     }
 


### PR DESCRIPTION
We'd like a bit more public visibility into the federation of providers in the /info endpoint. This PR displays an JSON object named `providers` with three attributes (name, origin, type) on the /info endpoint when JSON is requested.

You can today, go to the /login page, and extract origins for both SAML and OIDC providers, so we do believe it is ok to display this information.

To be discussed September 11, 2025 in UAA meeting