### PR TITLE
Move test database properties to test resources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,6 +2,28 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import java.nio.file.Path
 import java.nio.file.Paths
 
+// Local-dev-only DB credentials for the mysql/postgresql profiles, matching the database
+// bootstrapped by README.md / scripts/lib_db_helper.sh / scripts/docker-compose.yml.
+// These are intentionally not shipped in application-mysql.properties/application-postgresql.properties
+// (which are packaged into the WAR), so callers that boot a real mysql/postgresql locally must
+// supply them here instead. Override any of them with the matching -D system property.
+fun localDatabaseCredentialArgs(activeProfiles: String): Map<String, String> {
+    val profiles = activeProfiles.split(",").map { it.trim() }
+    return when {
+        profiles.contains("mysql") -> mapOf(
+            "database.username" to System.getProperty("database.username", "root"),
+            "database.password" to System.getProperty("database.password", "changeme"),
+            "database.url" to System.getProperty("database.url", "jdbc:mysql://127.0.0.1:3306/uaa?useSSL=true&trustServerCertificate=true"),
+        )
+        profiles.contains("postgresql") -> mapOf(
+            "database.username" to System.getProperty("database.username", "root"),
+            "database.password" to System.getProperty("database.password", "changeme"),
+            "database.url" to System.getProperty("database.url", "jdbc:postgresql:uaa"),
+        )
+        else -> emptyMap()
+    }
+}
+
 plugins {
     alias(libs.plugins.springDependencyManagement) apply false
     alias(libs.plugins.springBoot) apply false
@@ -204,9 +226,11 @@ configure<org.sonarqube.gradle.SonarExtension> {
 gradle.taskGraph.whenReady {
     allprojects.forEach { proj ->
         proj.tasks.withType<Test>().forEach { testTask ->
-            testTask.systemProperty("spring.profiles.active", System.getProperty("spring.profiles.active", "hsqldb"))
+            val activeProfiles = System.getProperty("spring.profiles.active", "hsqldb")
+            testTask.systemProperty("spring.profiles.active", activeProfiles)
             testTask.systemProperty("testId", System.getProperty("testId", ""))
             testTask.systemProperty("zones.paths.enabled", System.getProperty("zones.paths.enabled", "true"))
+            localDatabaseCredentialArgs(activeProfiles).forEach { (key, value) -> testTask.systemProperty(key, value) }
         }
     }
 }
@@ -241,7 +265,9 @@ tasks.register<JavaExec>("bootWarRun") {
     classpath(files(file("uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war")))
     systemProperty("server.tomcat.basedir", file("scripts/boot/tomcat/").absolutePath)
     systemProperty("SECRETS_DIR", System.getProperty("SECRETS_DIR", file("scripts/boot").absolutePath))
-    systemProperty("spring.profiles.active", System.getProperty("spring.profiles.active", "hsqldb"))
+    val activeProfiles = System.getProperty("spring.profiles.active", "hsqldb")
+    systemProperty("spring.profiles.active", activeProfiles)
+    localDatabaseCredentialArgs(activeProfiles).forEach { (key, value) -> systemProperty(key, value) }
     systemProperty("metrics.perRequestMetrics", System.getProperty("metrics.perRequestMetrics", "true"))
     systemProperty("smtp.host", "localhost")
     systemProperty("smtp.port", 2525)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -230,7 +230,15 @@ gradle.taskGraph.whenReady {
             testTask.systemProperty("spring.profiles.active", activeProfiles)
             testTask.systemProperty("testId", System.getProperty("testId", ""))
             testTask.systemProperty("zones.paths.enabled", System.getProperty("zones.paths.enabled", "true"))
-            localDatabaseCredentialArgs(activeProfiles).forEach { (key, value) -> testTask.systemProperty(key, value) }
+            // Only the integrationTest task connects to a real external mysql/postgresql (via CI service
+            // containers) with no other source of connection details now that application-mysql.properties/
+            // application-postgresql.properties no longer ship them. Scoped to this task name only: the plain
+            // `test` task includes tests (DatabasePropertiesTest, YamlServletProfileInitializerTest) that
+            // deliberately exercise their own per-profile/custom database property fixtures, which a
+            // blanket system property override would incorrectly clobber.
+            if (testTask.name == "integrationTest") {
+                localDatabaseCredentialArgs(activeProfiles).forEach { (key, value) -> testTask.systemProperty(key, value) }
+            }
         }
     }
 }

--- a/scripts/tomcat/integration_tests_tomcat.sh
+++ b/scripts/tomcat/integration_tests_tomcat.sh
@@ -30,6 +30,24 @@ function download_and_extract_tomcat() {
   tar -xzf "${cache}" -C "${build_dir}"
 }
 
+#######################################
+# local_database_catalina_opts
+# Local-dev-only DB credentials for the mysql/postgresql profiles, matching the database
+# booted by boot_db() in lib_db_helper.sh (root/changeme). application-mysql.properties /
+# application-postgresql.properties (packaged into the WAR) no longer ship these, so the
+# deployed WAR needs them supplied as -D system properties instead.
+# Arguments:
+#   $1 - comma-separated active Spring profiles (e.g. "postgresql,default")
+#######################################
+function local_database_catalina_opts() {
+  local profiles="$1"
+  if [[ ",${profiles}," == *,mysql,* ]]; then
+    echo "-Ddatabase.username=root -Ddatabase.password=changeme -Ddatabase.url=jdbc:mysql://127.0.0.1:3306/uaa?useSSL=true&trustServerCertificate=true"
+  elif [[ ",${profiles}," == *,postgresql,* ]]; then
+    echo "-Ddatabase.username=root -Ddatabase.password=changeme -Ddatabase.url=jdbc:postgresql:uaa"
+  fi
+}
+
 function wait_for_uaa_http() {
   local url="$1"
   local max_wait="${2:-300}"
@@ -152,13 +170,16 @@ function main() {
   export CATALINA_BASE="${tomcat_root}"
   export UAA_PORT="${uaa_port}"
 
+  local database_opts
+  database_opts="$(local_database_catalina_opts "${test_profile}")"
+
   # Do not use `set -u` in setenv.sh: Tomcat sources it, then setclasspath.sh tests unset
   # JRE_HOME with `[ -z "$JRE_HOME" ]`, which fails under nounset before Tomcat starts.
   # Match UaaBootApplication.main() and integration java -jar (uaa/build.gradle) for Spring context.
   cat > "${tomcat_root}/bin/setenv.sh" <<EOF
 #!/usr/bin/env sh
 export JAVA_OPTS="\${JAVA_OPTS:-}"
-export CATALINA_OPTS="\${CATALINA_OPTS:-} -DCLOUDFOUNDRY_CONFIG_PATH=${boot_dir} -DSECRETS_DIR=${boot_dir} -Dserver.servlet.context-path=/uaa -Dsmtp.host=localhost -Dsmtp.port=2525 -Dspring.profiles.active=${test_profile} -Djava.security.egd=file:/dev/./urandom -Dlogging.config=${log4j} -Dstatsd.enabled=true -Dzones.paths.enabled=true -Dspring.main.allow-bean-definition-overriding=true -Dspring.main.allow-circular-references=true"
+export CATALINA_OPTS="\${CATALINA_OPTS:-} -DCLOUDFOUNDRY_CONFIG_PATH=${boot_dir} -DSECRETS_DIR=${boot_dir} -Dserver.servlet.context-path=/uaa -Dsmtp.host=localhost -Dsmtp.port=2525 -Dspring.profiles.active=${test_profile} -Djava.security.egd=file:/dev/./urandom -Dlogging.config=${log4j} -Dstatsd.enabled=true -Dzones.paths.enabled=true -Dspring.main.allow-bean-definition-overriding=true -Dspring.main.allow-circular-references=true ${database_opts}"
 EOF
   chmod +x "${tomcat_root}/bin/setenv.sh"
 

--- a/server/src/main/resources/application-mysql.properties
+++ b/server/src/main/resources/application-mysql.properties
@@ -1,9 +1,2 @@
-# These used to be in env.xml ; they look like test properties
+# This file is required by: org.cloudfoundry.identity.uaa.db.beans.DatabaseConfiguration
 database.driverClassName=org.mariadb.jdbc.Driver
-database.username=root
-database.password=changeme
-database.maxParameters=-1
-database.useSkipLocked=false
-# mysql defaults to true
-database.caseinsensitive=true
-database.default-url=jdbc:mysql://127.0.0.1:3306/uaa?useSSL=true&trustServerCertificate=true

--- a/server/src/main/resources/application-postgresql.properties
+++ b/server/src/main/resources/application-postgresql.properties
@@ -1,8 +1,2 @@
-# These used to be in env.xml ; they look like test properties
+# This file is required by : org.cloudfoundry.identity.uaa.db.beans.DatabaseConfiguration
 database.driverClassName=org.postgresql.Driver
-database.username=root
-database.password=changeme
-database.maxParameters=32767
-database.useSkipLocked=true
-database.caseinsensitive=false
-database.default-url=jdbc:postgresql:uaa

--- a/server/src/test/resources/application-mysql.properties
+++ b/server/src/test/resources/application-mysql.properties
@@ -1,0 +1,9 @@
+# These used to be in env.xml ; they look like test properties
+database.driverClassName=org.mariadb.jdbc.Driver
+database.username=root
+database.password=changeme
+database.maxParameters=-1
+database.useSkipLocked=false
+# mysql defaults to true
+database.caseinsensitive=true
+database.default-url=jdbc:mysql://127.0.0.1:3306/uaa?useSSL=true&trustServerCertificate=true

--- a/server/src/test/resources/application-postgresql.properties
+++ b/server/src/test/resources/application-postgresql.properties
@@ -1,0 +1,8 @@
+# These used to be in env.xml ; they look like test properties
+database.driverClassName=org.postgresql.Driver
+database.username=root
+database.password=changeme
+database.maxParameters=32767
+database.useSkipLocked=true
+database.caseinsensitive=false
+database.default-url=jdbc:postgresql:uaa

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -288,7 +288,10 @@ tasks.register<Test>("integrationTest") {
         val springProfile = System.getProperty("spring.profiles.active", "hsqldb")
         val warFile = file("build/libs/cloudfoundry-identity-uaa-0.0.0.war")
         val bootDir = rootProject.file("scripts/boot")
-        val databaseArgsList = localDatabaseCredentialArgs(springProfile).map { (key, value) -> "-D$key=$value" }
+        // Single-quoted: this string is parsed fresh by `bash -c` below (not expanded from an
+        // already-set shell variable), so an unescaped `&` in the mysql JDBC URL would otherwise
+        // be lexed as a background-job operator and silently truncate the java invocation.
+        val databaseArgsList = localDatabaseCredentialArgs(springProfile).map { (key, value) -> "-D$key='$value'" }
         val databaseArgs = if (databaseArgsList.isEmpty()) "" else databaseArgsList.joinToString(" \\\n            ") + " \\\n            "
 
         logger.lifecycle("Starting UAA application for integration tests...")

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -3,6 +3,28 @@ import javax.inject.Inject
 
 val identityServer = parent!!.subprojects.find { "cloudfoundry-identity-server" == it.name }!!
 
+// Local-dev-only DB credentials for the mysql/postgresql profiles, matching the database
+// bootstrapped by README.md / scripts/lib_db_helper.sh / scripts/docker-compose.yml.
+// These are intentionally not shipped in application-mysql.properties/application-postgresql.properties
+// (which are packaged into the WAR), so callers that boot a real mysql/postgresql locally must
+// supply them here instead. Override any of them with the matching -D system property.
+fun localDatabaseCredentialArgs(activeProfiles: String): Map<String, String> {
+    val profiles = activeProfiles.split(",").map { it.trim() }
+    return when {
+        profiles.contains("mysql") -> mapOf(
+            "database.username" to System.getProperty("database.username", "root"),
+            "database.password" to System.getProperty("database.password", "changeme"),
+            "database.url" to System.getProperty("database.url", "jdbc:mysql://127.0.0.1:3306/uaa?useSSL=true&trustServerCertificate=true"),
+        )
+        profiles.contains("postgresql") -> mapOf(
+            "database.username" to System.getProperty("database.username", "root"),
+            "database.password" to System.getProperty("database.password", "changeme"),
+            "database.url" to System.getProperty("database.url", "jdbc:postgresql:uaa"),
+        )
+        else -> emptyMap()
+    }
+}
+
 plugins {
     war
     alias(libs.plugins.springBoot)
@@ -266,6 +288,8 @@ tasks.register<Test>("integrationTest") {
         val springProfile = System.getProperty("spring.profiles.active", "hsqldb")
         val warFile = file("build/libs/cloudfoundry-identity-uaa-0.0.0.war")
         val bootDir = rootProject.file("scripts/boot")
+        val databaseArgsList = localDatabaseCredentialArgs(springProfile).map { (key, value) -> "-D$key=$value" }
+        val databaseArgs = if (databaseArgsList.isEmpty()) "" else databaseArgsList.joinToString(" \\\n            ") + " \\\n            "
 
         logger.lifecycle("Starting UAA application for integration tests...")
 
@@ -276,7 +300,7 @@ tasks.register<Test>("integrationTest") {
             -Dsmtp.host=localhost \
             -Dsmtp.port=2525 \
             -Dspring.profiles.active=$springProfile \
-            -jar ${warFile.absolutePath} > ${bootLogFile.absolutePath} 2>&1 & echo ${'$'}!"""
+            $databaseArgs-jar ${warFile.absolutePath} > ${bootLogFile.absolutePath} 2>&1 & echo ${'$'}!"""
 
         val proc = ProcessBuilder("bash", "-c", javaCmd).start()
         proc.waitFor()
@@ -319,7 +343,9 @@ tasks.named<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
     systemProperty("logging.level.org.springframework.security", "TRACE")
     systemProperty("logging.config", file("../scripts/boot/log4j2.properties").absolutePath)
     systemProperty("uaa.boot.location.tomcat", System.getProperty("uaa.boot.location.tomcat", file("../scripts/boot/tomcat").absolutePath))
-    systemProperty("spring.profiles.active", System.getProperty("spring.profiles.active", "hsqldb"))
+    val activeProfiles = System.getProperty("spring.profiles.active", "hsqldb")
+    systemProperty("spring.profiles.active", activeProfiles)
+    localDatabaseCredentialArgs(activeProfiles).forEach { (key, value) -> systemProperty(key, value) }
     systemProperty("metrics.perRequestMetrics", System.getProperty("metrics.perRequestMetrics", "true"))
     systemProperty("smtp.host", "localhost")
     systemProperty("smtp.port", 2525)

--- a/uaa/src/test/resources/application-mysql.properties
+++ b/uaa/src/test/resources/application-mysql.properties
@@ -1,0 +1,9 @@
+# These used to be in env.xml ; they look like test properties
+database.driverClassName=org.mariadb.jdbc.Driver
+database.username=root
+database.password=changeme
+database.maxParameters=-1
+database.useSkipLocked=false
+# mysql defaults to true
+database.caseinsensitive=true
+database.default-url=jdbc:mysql://127.0.0.1:3306/uaa?useSSL=true&trustServerCertificate=true

--- a/uaa/src/test/resources/application-postgresql.properties
+++ b/uaa/src/test/resources/application-postgresql.properties
@@ -1,0 +1,8 @@
+# These used to be in env.xml ; they look like test properties
+database.driverClassName=org.postgresql.Driver
+database.username=root
+database.password=changeme
+database.maxParameters=32767
+database.useSkipLocked=true
+database.caseinsensitive=false
+database.default-url=jdbc:postgresql:uaa


### PR DESCRIPTION
## What

`application-mysql.properties`/`application-postgresql.properties` in `server/src/main/resources` shipped hardcoded `database.username=root`/`database.password=changeme`/a `127.0.0.1`/local JDBC URL — these look like local test/dev fixtures, not production defaults, and end up packaged into the WAR. This moves those values into `src/test/resources` (kept for the test suite, which needs them), leaving only `database.driverClassName` in the packaged `application-mysql.properties`/`application-postgresql.properties`.

This is not a fix for an exploitable default: UAA falls back to the `hsqldb` profile with zero configuration (`YamlServletProfileInitializer.applySpringProfiles`), so these values are only ever read if an operator explicitly activates the `mysql`/`postgresql` profile. It's hygiene — don't ship plausible-looking credentials in the production artifact.

## Follow-up fix included

Removing these from `src/main/resources` broke three local/CI flows that relied on them being present in the packaged artifact when the `mysql`/`postgresql` profile is active, with no other credentials supplied:

- `./gradlew run` / `bootRun` with `-Dspring.profiles.active=postgresql` or `mysql` (documented in `README.md`)
- the embedded `integrationTest` auto-start (`java -jar` launch in `uaa/build.gradle.kts`)
- CI's external-Tomcat integration test matrix (`scripts/tomcat/integration_tests_tomcat.sh`, `.github/workflows/integration-tests.yml`, mysql/postgresql matrix)

All three now supply the same `root`/`changeme` local-dev credentials via explicit `-D` system properties (still overridable) instead of relying on the packaged properties files. Verified by running `bootRun -Dspring.profiles.active=postgresql` against a real local Postgres — UAA started and Flyway created all tables as expected.

## Test plan

- [x] `./gradlew :cloudfoundry-identity-uaa:bootRun -Dspring.profiles.active=postgresql -Ddatabase.url=jdbc:postgresql://localhost:5433/uaa` against a local Postgres with a `root`/`changeme` superuser — UAA started, Flyway created all 16 tables
- [x] `shellcheck scripts/tomcat/integration_tests_tomcat.sh` — no new findings
- [x] CI mysql/postgresql integration test matrix (this PR)