### PR TITLE
Boot Migration - Backwards compatible request mappings (end with slash)

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/PasswordResetEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/PasswordResetEndpoint.java
@@ -63,7 +63,7 @@ public class PasswordResetEndpoint {
         this.identityZoneManager = identityZoneManager;
     }
 
-    @PostMapping("/password_resets")
+    @PostMapping({"/password_resets", "/password_resets/"})
     public ResponseEntity<PasswordResetResponse> resetPassword(@RequestBody String email,
             @RequestParam(required = false, value = "client_id") String clientId,
             @RequestParam(required = false, value = "redirect_uri") String redirectUri) {
@@ -95,7 +95,7 @@ public class PasswordResetEndpoint {
         return expiringCode;
     }
 
-    @PostMapping("/password_change")
+    @PostMapping({"/password_change", "/password_change/"})
     public ResponseEntity<LostPasswordChangeResponse> changePassword(@RequestBody LostPasswordChangeRequest passwordChangeRequest) {
         ResponseEntity<LostPasswordChangeResponse> responseEntity;
         if (passwordChangeRequest.getChangeCode() != null) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/ProfileController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/ProfileController.java
@@ -70,7 +70,7 @@ public class ProfileController {
     /**
      * Handle form post for revoking chosen approvals
      */
-    @PostMapping("/profile")
+    @PostMapping({"/profile", "/profile/"})
     public String post(@RequestParam(required = false) Collection<String> checkedScopes,
             @RequestParam(required = false) String update,
             @RequestParam(required = false) String delete,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/RemoteAuthenticationEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/RemoteAuthenticationEndpoint.java
@@ -44,7 +44,7 @@ public class RemoteAuthenticationEndpoint {
         this.loginAuthenticationManager = loginAuthenticationManager;
     }
 
-    @PostMapping({"/authenticate"})
+    @PostMapping({"/authenticate", "/authenticate/"})
     @ResponseBody
     public HttpEntity<AuthenticationResponse> authenticate(HttpServletRequest request,
             @RequestParam String username,
@@ -77,7 +77,7 @@ public class RemoteAuthenticationEndpoint {
         return new ResponseEntity<>(response, status);
     }
 
-    @PostMapping(value = {"/authenticate"}, params = {"source", "origin", UaaAuthenticationDetails.ADD_NEW})
+    @PostMapping(value = {"/authenticate", "/authenticate/"}, params = {"source", "origin", UaaAuthenticationDetails.ADD_NEW})
     @ResponseBody
     public HttpEntity<AuthenticationResponse> authenticate(HttpServletRequest request,
             @RequestParam String username,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
@@ -206,7 +206,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         }
     }
 
-    @PostMapping("/oauth/clients")
+    @PostMapping({"/oauth/clients", "/oauth/clients/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     @Transactional
@@ -234,7 +234,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
     }
 
 
-    @PostMapping("/oauth/clients/restricted")
+    @PostMapping({"/oauth/clients/restricted", "/oauth/clients/restricted/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     public ClientDetails createRestrictedClientDetails(@RequestBody UaaClientDetails client) {
@@ -242,7 +242,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         return createClientDetailsInternal(client);
     }
 
-    @PostMapping("/oauth/clients/tx")
+    @PostMapping({"/oauth/clients/tx", "/oauth/clients/tx/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     @Transactional
@@ -265,7 +265,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         return details;
     }
 
-    @PutMapping("/oauth/clients/tx")
+    @PutMapping({"/oauth/clients/tx", "/oauth/clients/tx/"})
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     @ResponseBody
@@ -340,7 +340,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         return removeSecret(details);
     }
 
-    @PostMapping("/oauth/clients/tx/delete")
+    @PostMapping({"/oauth/clients/tx/delete", "/oauth/clients/tx/delete/"})
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     @ResponseBody
@@ -352,7 +352,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         return doProcessDeletes(result);
     }
 
-    @PostMapping("/oauth/clients/tx/modify")
+    @PostMapping({"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     @ResponseBody
@@ -406,7 +406,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
     }
 
 
-    @PostMapping("/oauth/clients/tx/secret")
+    @PostMapping({"/oauth/clients/tx/secret", "/oauth/clients/tx/secret/"})
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     @ResponseBody
@@ -449,7 +449,7 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         approvalStore.revokeApprovalsForClient(clientId, identityZoneManager.getCurrentIdentityZoneId());
     }
 
-    @GetMapping("/oauth/clients")
+    @GetMapping({"/oauth/clients", "/oauth/clients/"})
     @ResponseBody
     public SearchResults<?> listClientDetails(
             @RequestParam(value = "attributes", required = false) String attributesCommaSeparated,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/CodeStoreEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/CodeStoreEndpoints.java
@@ -29,7 +29,7 @@ public class CodeStoreEndpoints {
         this.identityZoneManager = identityZoneManager;
     }
 
-    @PostMapping({"/Codes"})
+    @PostMapping({"/Codes", "/Codes/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     public ExpiringCode generateCode(@RequestBody ExpiringCode expiringCode) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpoint.java
@@ -67,7 +67,7 @@ public class InvitationsEndpoint {
         this.expiringCodeStore = expiringCodeStore;
     }
 
-    @PostMapping(value = "/invite_users", consumes = "application/json")
+    @PostMapping(value = {"/invite_users", "/invite_users/"}, consumes = "application/json")
     public ResponseEntity<InvitationsResponse> inviteUsers(@RequestBody InvitationsRequest invitations,
             @RequestParam(value = "client_id", required = false) String clientId,
             @RequestParam(value = "redirect_uri") String redirectUri) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/ForcePasswordChangeController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/ForcePasswordChangeController.java
@@ -32,14 +32,14 @@ public class ForcePasswordChangeController {
     private final ResetPasswordService resetPasswordService;
     private final IdentityZoneManager identityZoneManager;
 
-    @GetMapping("/force_password_change")
+    @GetMapping({"/force_password_change", "/force_password_change/"})
     public String forcePasswordChangePage(Model model) {
         String email = ((UaaAuthentication) SecurityContextHolder.getContext().getAuthentication()).getPrincipal().getEmail();
         model.addAttribute("email", email);
         return "force_password_change";
     }
 
-    @PostMapping("/force_password_change")
+    @PostMapping({"/force_password_change", "/force_password_change/"})
     public String handleForcePasswordChange(Model model,
             @RequestParam String password,
             @RequestParam("password_confirmation") String passwordConfirmation,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpoints.java
@@ -138,7 +138,7 @@ public class ScimGroupEndpoints {
         return response;
     }
 
-    @GetMapping({"/Groups"})
+    @GetMapping({"/Groups", "/Groups/"})
     @ResponseBody
     public SearchResults<?> listGroups(
             @RequestParam(value = "attributes", required = false) String attributesCommaSeparated,
@@ -193,7 +193,7 @@ public class ScimGroupEndpoints {
         return getExternalGroups(startIndex, count, filter, "", "");
     }
 
-    @GetMapping({"/Groups/External"})
+    @GetMapping({"/Groups/External", "/Groups/External/"})
     @ResponseBody
     public SearchResults<?> getExternalGroups(
             @RequestParam(required = false, defaultValue = "1") int startIndex,
@@ -241,7 +241,7 @@ public class ScimGroupEndpoints {
                 Arrays.asList(ScimCore.SCHEMAS));
     }
 
-    @PostMapping({"/Groups/External"})
+    @PostMapping({"/Groups/External", "/Groups/External/"})
     @ResponseBody
     @ResponseStatus(HttpStatus.CREATED)
     public ScimGroupExternalMember mapExternalGroup(@RequestBody ScimGroupExternalMember sgm) {
@@ -366,7 +366,7 @@ public class ScimGroupEndpoints {
         return group;
     }
 
-    @PostMapping({"/Groups"})
+    @PostMapping({"/Groups", "/Groups/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     public ScimGroup createGroup(@RequestBody ScimGroup group, HttpServletResponse httpServletResponse) {
@@ -472,7 +472,7 @@ public class ScimGroupEndpoints {
         return group;
     }
 
-    @PostMapping({"/Groups/zones"})
+    @PostMapping({"/Groups/zones", "/Groups/zones/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     @Deprecated

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
@@ -228,7 +228,7 @@ public class ScimUserEndpoints implements InitializingBean, ApplicationEventPubl
         return scimUser;
     }
 
-    @PostMapping("/Users")
+    @PostMapping({"/Users", "/Users/"})
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     public ScimUser createUser(@RequestBody ScimUser user, HttpServletRequest request, HttpServletResponse response) {
@@ -489,7 +489,7 @@ public class ScimUserEndpoints implements InitializingBean, ApplicationEventPubl
         }
     }
 
-    @GetMapping("/Users")
+    @GetMapping({"/Users", "/Users/"})
     @ResponseBody
     public SearchResults<?> findUsers(
             @RequestParam(value = "attributes", required = false) String attributesCommaSeparated,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneEndpoints.java
@@ -355,7 +355,7 @@ public class IdentityZoneEndpoints implements ApplicationEventPublisherAware {
         }
     }
 
-    @PostMapping("{identityZoneId}/clients")
+    @PostMapping({"{identityZoneId}/clients", "{identityZoneId}/clients/"})
     public ResponseEntity<? extends ClientDetails> createClient(
             @PathVariable String identityZoneId, @RequestBody UaaClientDetails clientDetails) {
         if (identityZoneId == null) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/account/PasswordResetEndpointTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/account/PasswordResetEndpointTest.java
@@ -20,6 +20,8 @@ import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -98,8 +100,9 @@ class PasswordResetEndpointTest {
                 .thenReturn(new ExpiringCode("secret_code", new Timestamp(System.currentTimeMillis() + UaaResetPasswordService.PASSWORD_RESET_LIFETIME), JsonUtils.writeValueAsString(change), null));
     }
 
-    @Test
-    void passwordResetWithClientIdAndRedirectUri() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/password_resets", "/password_resets/"})
+    void passwordResetWithClientIdAndRedirectUri(String url) throws Exception {
         String email = "user@example.com";
         String clientId = "test-client";
         String redirectUri = "redirect.example.com";
@@ -116,7 +119,7 @@ class PasswordResetEndpointTest {
         when(mockExpiringCodeStore.generateCode(anyString(), any(Timestamp.class), anyString(), anyString()))
                 .thenReturn(new ExpiringCode("secret_code", new Timestamp(System.currentTimeMillis() + UaaResetPasswordService.PASSWORD_RESET_LIFETIME), JsonUtils.writeValueAsString(change), null));
 
-        MockHttpServletRequestBuilder post = post("/password_resets")
+        MockHttpServletRequestBuilder post = post(url)
                 .contentType(APPLICATION_JSON)
                 .param("client_id", clientId)
                 .param("redirect_uri", redirectUri)
@@ -265,8 +268,9 @@ class PasswordResetEndpointTest {
                 .andExpect(status().isConflict());
     }
 
-    @Test
-    void changingAPasswordWithAValidCode() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/password_change", "/password_change/"})
+    void changingAPasswordWithAValidCode(String url) throws Exception {
         ExpiringCode code = new ExpiringCode("secret_code", new Timestamp(System.currentTimeMillis() + UaaResetPasswordService.PASSWORD_RESET_LIFETIME),
                 "{\"user_id\":\"eyedee\",\"username\":\"user@example.com\",\"passwordModifiedTime\":null,\"client_id\":\"\",\"redirect_uri\":\"\"}", null);
         when(mockExpiringCodeStore.retrieveCode("secret_code", currentZoneId)).thenReturn(code);
@@ -278,7 +282,7 @@ class PasswordResetEndpointTest {
         ExpiringCode autologinCode = new ExpiringCode("autologin-code", new Timestamp(System.currentTimeMillis() + 5 * 60 * 1000), "data", AUTOLOGIN.name());
         when(mockExpiringCodeStore.generateCode(anyString(), any(Timestamp.class), eq(AUTOLOGIN.name()), anyString())).thenReturn(autologinCode);
 
-        MockHttpServletRequestBuilder post = post("/password_change")
+        MockHttpServletRequestBuilder post = post(url)
                 .contentType(APPLICATION_JSON)
                 .content("{\"code\":\"secret_code\",\"new_password\":\"new_secret\"}")
                 .accept(APPLICATION_JSON);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ForcePasswordChangeControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ForcePasswordChangeControllerTest.java
@@ -9,6 +9,8 @@ import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManagerImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.core.io.support.ResourcePropertySource;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -55,25 +57,28 @@ class ForcePasswordChangeControllerTest extends TestClassNullifier {
         SecurityContextHolder.getContext().setAuthentication(mockUaaAuthentication);
     }
 
-    @Test
-    void forcePasswordChange() throws Exception {
-        mockMvc.perform(get("/force_password_change"))
+    @ParameterizedTest
+    @ValueSource(strings = {"/force_password_change", "/force_password_change/"})
+    void forcePasswordChange(String url) throws Exception {
+        mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andExpect(view().name("force_password_change"))
                 .andExpect(model().attribute("email", "mail"));
     }
 
-    @Test
-    void redirectToLogInIfPasswordIsNotExpired() throws Exception {
-        mockMvc.perform(get("/force_password_change"))
+    @ParameterizedTest
+    @ValueSource(strings = {"/force_password_change", "/force_password_change/"})
+    void redirectToLogInIfPasswordIsNotExpired(String url) throws Exception {
+        mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andExpect(view().name("force_password_change"));
     }
 
-    @Test
-    void handleForcePasswordChange() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/uaa/force_password_change", "/uaa/force_password_change/"})
+    void handleForcePasswordChange(String url) throws Exception {
         mockMvc.perform(
-                        post("/uaa/force_password_change")
+                        post(url)
                                 .param("password", "pwd")
                                 .param("password_confirmation", "pwd")
                                 .contextPath("/uaa"))
@@ -82,21 +87,23 @@ class ForcePasswordChangeControllerTest extends TestClassNullifier {
         verify(mockUaaAuthentication, times(1)).setAuthenticatedTime(anyLong());
     }
 
-    @Test
-    void handleForcePasswordChangeWithRedirect() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/force_password_change", "/force_password_change/"})
+    void handleForcePasswordChangeWithRedirect(String url) throws Exception {
         mockMvc.perform(
-                        post("/force_password_change")
+                        post(url)
                                 .param("password", "pwd")
                                 .param("password_confirmation", "pwd"))
                 .andExpect(status().isFound())
                 .andExpect(redirectedUrl("/force_password_change_completed"));
     }
 
-    @Test
-    void passwordAndConfirmAreDifferent() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/force_password_change", "/force_password_change/"})
+    void passwordAndConfirmAreDifferent(String url) throws Exception {
         when(mockResourcePropertySource.getProperty("force_password_change.form_error")).thenReturn("Passwords must match and not be empty.");
         mockMvc.perform(
-                        post("/force_password_change")
+                        post(url)
                                 .param("password", "pwd")
                                 .param("password_confirmation", "nopwd"))
                 .andExpect(status().isUnprocessableEntity());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcTests.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -231,9 +233,10 @@ class ProfileControllerMockMvcTests {
                 .andExpect(content().string(not(containsString("Change Password"))));
     }
 
-    @Test
-    void updateProfile() throws Exception {
-        MockHttpServletRequestBuilder post = post("/profile")
+    @ParameterizedTest
+    @ValueSource(strings = {"/profile", "/profile/"})
+    void updateProfile(String url) throws Exception {
+        MockHttpServletRequestBuilder post = post(url)
                 .param("checkedScopes", "app-thing.read")
                 .param("update", "")
                 .param("clientId", "app");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcTests.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
@@ -147,8 +149,9 @@ class InvitationsEndpointMockMvcTests {
             this.zoneSeeder = zoneSeeder.withDefaults().withAdminClientWithClientCredentialsGrant();
         }
 
-        @Test
-        void inviteUserInZoneWithDefaultZoneZoneAdmin() throws Exception {
+        @ParameterizedTest
+        @ValueSource(strings = {"/invite_users", "/invite_users/"})
+        void inviteUserInZoneWithDefaultZoneZoneAdmin(String url) throws Exception {
             String zonifiedAdminClientId = generator.generate().toLowerCase();
             String zonifiedAdminClientSecret = generator.generate().toLowerCase();
 
@@ -175,7 +178,7 @@ class InvitationsEndpointMockMvcTests {
 
             String requestBody = writeValueAsString(invitations);
 
-            MockHttpServletRequestBuilder post = post("/invite_users")
+            MockHttpServletRequestBuilder post = post(url)
                     .param(OAuth2Utils.REDIRECT_URI, redirectUrl)
                     .header("Authorization", "Bearer " + zonifiedScimInviteToken)
                     .header(SUBDOMAIN_HEADER, zoneSeeder.getIdentityZoneSubdomain())
@@ -190,8 +193,9 @@ class InvitationsEndpointMockMvcTests {
             assertResponseAndCodeCorrect(expiringCodeStore, new String[]{email}, redirectUrl, zoneSeeder.getIdentityZone(), invitationsResponse, zonifiedScimInviteClientDetails);
         }
 
-        @Test
-        void inviteUserInZoneWithDefaultZoneScimInvite() throws Exception {
+        @ParameterizedTest
+        @ValueSource(strings = {"/invite_users", "/invite_users/"})
+        void inviteUserInZoneWithDefaultZoneScimInvite(String url) throws Exception {
             String zonifiedScimInviteClientId = generator.generate().toLowerCase();
             String zonifiedScimInviteClientSecret = generator.generate().toLowerCase();
 
@@ -218,7 +222,7 @@ class InvitationsEndpointMockMvcTests {
 
             String requestBody = writeValueAsString(invitations);
 
-            MockHttpServletRequestBuilder post = post("/invite_users")
+            MockHttpServletRequestBuilder post = post(url)
                     .param(OAuth2Utils.REDIRECT_URI, redirectUrl)
                     .header("Authorization", "Bearer " + zonifiedScimInviteToken)
                     .header(HEADER, zoneSeeder.getIdentityZoneId())
@@ -234,8 +238,9 @@ class InvitationsEndpointMockMvcTests {
 
         }
 
-        @Test
-        void inviteUserInZoneWithDefaultZoneUaaAdmin() throws Exception {
+        @ParameterizedTest
+        @ValueSource(strings = {"/invite_users", "/invite_users/"})
+        void inviteUserInZoneWithDefaultZoneUaaAdmin(String url) throws Exception {
             String email = "user1@example.com";
             String redirectUrl = "example.com";
 
@@ -243,7 +248,7 @@ class InvitationsEndpointMockMvcTests {
 
             String requestBody = writeValueAsString(invitations);
 
-            MockHttpServletRequestBuilder post = post("/invite_users")
+            MockHttpServletRequestBuilder post = post(url)
                     .param(OAuth2Utils.REDIRECT_URI, redirectUrl)
                     .header("Authorization", "Bearer " + adminToken)
                     .header(SUBDOMAIN_HEADER, zoneSeeder.getIdentityZoneSubdomain())

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.mock.mockito.MockBean;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -58,6 +58,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -266,9 +268,10 @@ class AuditCheckMockMvcTests {
         assertLogMessageWithSession(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
     }
 
-    @Test
-    void userLoginAuthenticateEndpointTest() throws Exception {
-        MockHttpServletRequestBuilder loginPost = post("/authenticate")
+    @ParameterizedTest
+    @ValueSource(strings = {"/authenticate", "/authenticate/"})
+    void userLoginAuthenticateEndpointTest(String url) throws Exception {
+        MockHttpServletRequestBuilder loginPost = post(url)
                 .accept(APPLICATION_JSON_VALUE)
                 .session(new MockHttpSession())
                 .param("username", testUser.getUserName())

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointsMockMvcTests.java
@@ -49,6 +49,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -184,11 +187,12 @@ class ClientAdminEndpointsMockMvcTests {
         assertThat(client.getAdditionalInformation()).containsEntry("name", "Client " + client.getClientId());
     }
 
-    @Test
-    void createClientWithJwtBearerGrant() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClientWithJwtBearerGrant(String url) throws Exception {
         String id = new RandomValueStringGenerator().generate();
         ClientDetails client = createBaseClient(id, SECRET, Collections.singletonList(GRANT_TYPE_JWT_BEARER), null, Collections.singletonList(id + ".read"));
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -197,11 +201,12 @@ class ClientAdminEndpointsMockMvcTests {
         verify(mockApplicationEventPublisher, times(1)).publishEvent(abstractUaaEventCaptor.capture());
     }
 
-    @Test
-    void createClientWithJwtBearerGrantInvalid() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClientWithJwtBearerGrantInvalid(String url) throws Exception {
         String id = new RandomValueStringGenerator().generate();
         ClientDetails client = createBaseClient(id, SECRET, Collections.singletonList(GRANT_TYPE_JWT_BEARER), null, null);
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -211,11 +216,12 @@ class ClientAdminEndpointsMockMvcTests {
         verify(mockApplicationEventPublisher, times(0)).publishEvent(abstractUaaEventCaptor.capture());
     }
 
-    @Test
-    void createClientWithInvalidRedirectUrl() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClientWithInvalidRedirectUrl(String url) throws Exception {
         UaaClientDetails client = createBaseClient(new RandomValueStringGenerator().generate(), SECRET, Collections.singleton("implicit"));
         client.setRegisteredRedirectUri(Collections.singleton("*/**"));
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -224,8 +230,9 @@ class ClientAdminEndpointsMockMvcTests {
         verify(mockApplicationEventPublisher, times(0)).publishEvent(abstractUaaEventCaptor.capture());
     }
 
-    @Test
-    void createClientWithValidLongRedirectUri() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClientWithValidLongRedirectUri(String url) throws Exception {
         String id = new RandomValueStringGenerator().generate();
         UaaClientDetails client = createBaseClient(id, SECRET, Collections.singletonList(GRANT_TYPE_JWT_BEARER), null, Collections.singletonList(id + ".read"));
 
@@ -236,7 +243,7 @@ class ClientAdminEndpointsMockMvcTests {
         }
         client.setRegisteredRedirectUri(uris);
 
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -246,8 +253,9 @@ class ClientAdminEndpointsMockMvcTests {
     }
 
     // TODO: put in a nested context to clean up the excluded claims
-    @Test
-    void createClient_withClientAdminToken_withAuthoritiesExcluded() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClient_withClientAdminToken_withAuthoritiesExcluded(String url) throws Exception {
         String clientId = generator.generate().toLowerCase();
         excludedClaims.add("authorities");
         try {
@@ -258,7 +266,7 @@ class ClientAdminEndpointsMockMvcTests {
             List<String> authorities = Arrays.asList("password.write", "scim.write", "scim.read");
             List<String> scopes = Arrays.asList("foo", "bar", "oauth.approvals");
             ClientDetailsModification client = createBaseClient(clientId, SECRET, Collections.singleton("client_credentials"), authorities, scopes);
-            MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+            MockHttpServletRequestBuilder createClientPost = post(url)
                     .header("Authorization", "Bearer " + clientAdminToken)
                     .accept(APPLICATION_JSON)
                     .contentType(APPLICATION_JSON)
@@ -276,10 +284,11 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void createClientWithLongSecret() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClientWithLongSecret(String url) throws Exception {
         UaaClientDetails client = createBaseClient(new RandomValueStringGenerator().generate(), SECRET_TOO_LONG, Collections.singleton("client_credentials"));
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -289,15 +298,16 @@ class ClientAdminEndpointsMockMvcTests {
         verifyNoMoreInteractions(mockApplicationEventPublisher);
     }
 
-    @Test
-    void createClientWithSecondarySecret() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createClientWithSecondarySecret(String url) throws Exception {
         var client = new ClientDetailsCreation();
         client.setClientId(new RandomValueStringGenerator().generate());
         client.setClientSecret("primarySecret");
         client.setSecondaryClientSecret("secondarySecret");
         client.setAuthorizedGrantTypes(List.of("client_credentials"));
 
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -429,10 +439,25 @@ class ClientAdminEndpointsMockMvcTests {
     }
 
     @Test
-    void createClientsTxFailureSecretTooLong() throws Exception {
+    void createRestrictedClientSucceedsWhenEndingInSlash() throws Exception {
+        String id = new RandomValueStringGenerator().generate();
+        List<String> scopes = Collections.singletonList("openid");
+        UaaClientDetails client = createBaseClient(id, SECRET, Arrays.asList("client_credentials", "password"), scopes, scopes);
+
+        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients/restricted/")
+                .header("Authorization", "Bearer " + adminToken)
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
+                .content(JsonUtils.writeValueAsString(client));
+        mockMvc.perform(createClientPost).andExpect(status().isCreated());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx", "/oauth/clients/tx/"})
+    void createClientsTxFailureSecretTooLong(String url) throws Exception {
         int count = 5;
         UaaClientDetails[] details = createBaseClients(count, SECRET_TOO_LONG, null);
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients/tx")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -442,11 +467,12 @@ class ClientAdminEndpointsMockMvcTests {
         verifyNoMoreInteractions(mockApplicationEventPublisher);
     }
 
-    @Test
-    void createClientsTxSuccess() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx", "/oauth/clients/tx/"})
+    void createClientsTxSuccess(String url) throws Exception {
         int count = 5;
         UaaClientDetails[] details = createBaseClients(count, SECRET, null);
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients/tx")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -465,11 +491,12 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void createClientsTxDuplicateId() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx", "/oauth/clients/tx/"})
+    void createClientsTxDuplicateId(String url) throws Exception {
         UaaClientDetails[] details = createBaseClients(5, SECRET, null);
         details[details.length - 1] = details[0];
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients/tx")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -688,12 +715,13 @@ class ClientAdminEndpointsMockMvcTests {
         MockMvcUtils.getClient(mockMvc, zonesClientsReadToken, newclient.getClientId(), result.getIdentityZone());
     }
 
-    @Test
-    void createClientsTxClientCredentialsWithoutSecret() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx", "/oauth/clients/tx/"})
+    void createClientsTxClientCredentialsWithoutSecret(String url) throws Exception {
         UaaClientDetails[] details = createBaseClients(5, null, null);
         details[details.length - 1].setAuthorizedGrantTypes(StringUtils.commaDelimitedListToSet("client_credentials"));
         details[details.length - 1].setClientSecret(null);
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients/tx")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -705,15 +733,16 @@ class ClientAdminEndpointsMockMvcTests {
         verify(mockApplicationEventPublisher, atLeast(5)).publishEvent(abstractUaaEventCaptor.capture());
     }
 
-    @Test
-    void updateClientsTxSuccess() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx", "/oauth/clients/tx/"})
+    void updateClientsTxSuccess(String url) throws Exception {
         int count = 5;
         UaaClientDetails[] details = new UaaClientDetails[count];
         for (int i = 0; i < details.length; i++) {
             details[i] = (UaaClientDetails) createClient(adminToken, null, SECRET, null);
             details[i].setRefreshTokenValiditySeconds(120);
         }
-        MockHttpServletRequestBuilder updateClientPut = put("/oauth/clients/tx")
+        MockHttpServletRequestBuilder updateClientPut = put(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -738,8 +767,9 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void updateClientsTxInvalidId() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx", "/oauth/clients/tx/"})
+    void updateClientsTxInvalidId(String url) throws Exception {
         int count = 5;
         UaaClientDetails[] details = new UaaClientDetails[count];
         for (int i = 0; i < details.length; i++) {
@@ -749,7 +779,7 @@ class ClientAdminEndpointsMockMvcTests {
         String firstId = details[0].getClientId();
         details[0].setClientId("unknown.client.id");
 
-        MockHttpServletRequestBuilder updateClientPut = put("/oauth/clients/tx")
+        MockHttpServletRequestBuilder updateClientPut = put(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -767,14 +797,15 @@ class ClientAdminEndpointsMockMvcTests {
         verify(mockApplicationEventPublisher, times(count)).publishEvent(abstractUaaEventCaptor.capture());
     }
 
-    @Test
-    void deleteClientsTxSuccess() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/delete", "/oauth/clients/tx/delete/"})
+    void deleteClientsTxSuccess(String url) throws Exception {
         int count = 5;
         UaaClientDetails[] details = new UaaClientDetails[count];
         for (int i = 0; i < details.length; i++) {
             details[i] = (UaaClientDetails) createClient(adminToken, null, SECRET, null);
         }
-        MockHttpServletRequestBuilder deleteClientsPost = post("/oauth/clients/tx/delete")
+        MockHttpServletRequestBuilder deleteClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -797,8 +828,9 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void deleteClientsTxRollbackInvalidId() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/delete", "/oauth/clients/tx/delete/"})
+    void deleteClientsTxRollbackInvalidId(String url) throws Exception {
         int count = 5;
         UaaClientDetails[] details = new UaaClientDetails[count];
         for (int i = 0; i < details.length; i++) {
@@ -807,7 +839,7 @@ class ClientAdminEndpointsMockMvcTests {
         String firstId = details[0].getClientId();
         details[0].setClientId("unknown.client.id");
 
-        MockHttpServletRequestBuilder deleteClientsPost = post("/oauth/clients/tx/delete")
+        MockHttpServletRequestBuilder deleteClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -824,8 +856,9 @@ class ClientAdminEndpointsMockMvcTests {
         verify(mockApplicationEventPublisher, times(count)).publishEvent(abstractUaaEventCaptor.capture());
     }
 
-    @Test
-    void addUpdateDeleteClientsTxSuccess() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void addUpdateDeleteClientsTxSuccess(String url) throws Exception {
         int count = 5;
         ClientDetailsModification[] details = new ClientDetailsModification[count * 3];
         for (int i = 0; i < count; i++) {
@@ -842,7 +875,7 @@ class ClientAdminEndpointsMockMvcTests {
             details[i].setAction(ClientDetailsModification.ADD);
         }
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -896,8 +929,9 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void addUpdateDeleteClientsTxDeleteUnsuccessfulRollback() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void addUpdateDeleteClientsTxDeleteUnsuccessfulRollback(String url) throws Exception {
         ClientDetailsModification[] details = new ClientDetailsModification[15];
         for (int i = 0; i < 5; i++) {
             details[i] = (ClientDetailsModification) createClient(adminToken, null, SECRET,
@@ -927,7 +961,7 @@ class ClientAdminEndpointsMockMvcTests {
         String deleteId = details[5].getClientId();
         details[5].setClientId("unknown.client.id");
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -954,8 +988,9 @@ class ClientAdminEndpointsMockMvcTests {
         assertThat(approvals).hasSize(3);
     }
 
-    @Test
-    void approvalsAreDeleted() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/delete", "/oauth/clients/tx/delete/"})
+    void approvalsAreDeleted(String url) throws Exception {
         ClientDetails details = createClient(adminToken, new RandomValueStringGenerator().generate(),
                 SECRET, Collections.singleton("password"));
         String userToken = testClient.getUserOAuthAccessToken(
@@ -970,7 +1005,7 @@ class ClientAdminEndpointsMockMvcTests {
         approvals = getApprovals(details.getClientId());
         assertThat(approvals).hasSize(3);
 
-        MockHttpServletRequestBuilder deleteClientsPost = post("/oauth/clients/tx/delete")
+        MockHttpServletRequestBuilder deleteClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1020,8 +1055,9 @@ class ClientAdminEndpointsMockMvcTests {
         assertThat(approvals).isEmpty();
     }
 
-    @Test
-    void modifyApprovalsAreDeleted() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void modifyApprovalsAreDeleted(String url) throws Exception {
         ClientDetails details = createClient(adminToken, new RandomValueStringGenerator().generate(),
                 SECRET, Collections.singleton("password"));
         ((ClientDetailsModification) details).setAction(ClientDetailsModification.DELETE);
@@ -1037,7 +1073,7 @@ class ClientAdminEndpointsMockMvcTests {
         approvals = getApprovals(details.getClientId());
         assertThat(approvals).hasSize(3);
 
-        MockHttpServletRequestBuilder deleteClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder deleteClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1059,15 +1095,19 @@ class ClientAdminEndpointsMockMvcTests {
         assertThat(approvals).isEmpty();
     }
 
-    @Test
-    void secretChangeTxApprovalsNotDeleted() throws Exception {
+    @ParameterizedTest
+    @CsvSource({
+            "/oauth/clients/tx/modify,/oauth/clients/tx/secret",
+            "/oauth/clients/tx/modify/,/oauth/clients/tx/secret/"
+    })
+    void secretChangeTxApprovalsNotDeleted(String url, String secretUrl) throws Exception {
         int count = 3;
         //create clients
         ClientDetailsModification[] clients = createBaseClients(count, SECRET, Arrays.asList("client_credentials", "password"));
         for (ClientDetailsModification c : clients) {
             c.setAction(ClientDetailsModification.ADD);
         }
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1105,7 +1145,7 @@ class ClientAdminEndpointsMockMvcTests {
             srs[i].setOldSecret(clients[i].getClientSecret());
             srs[i].setSecret("secret2");
         }
-        modifyClientsPost = post("/oauth/clients/tx/secret")
+        modifyClientsPost = post(secretUrl)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1400,12 +1440,13 @@ class ClientAdminEndpointsMockMvcTests {
         mockMvc.perform(modifySecret).andExpect(status().isOk());
     }
 
-    @Test
-    void unsuccessfulSecretChangeEvent() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void unsuccessfulSecretChangeEvent(String url) throws Exception {
 
         List<String> scopes = Arrays.asList("oauth.approvals", "clients.secret");
         UaaClientDetails client = createBaseClient(null, SECRET, Arrays.asList("password", "client_credentials"), scopes, scopes);
-        MockHttpServletRequestBuilder createClientPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder createClientPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1428,15 +1469,16 @@ class ClientAdminEndpointsMockMvcTests {
         assertThat(event.getAuditEvent().getPrincipalId()).isEqualTo(client.getClientId());
     }
 
-    @Test
-    void secretChangeModifyTxApprovalsDeleted() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void secretChangeModifyTxApprovalsDeleted(String url) throws Exception {
         int count = 3;
         //create clients
         ClientDetailsModification[] clients = createBaseClients(count, SECRET, Arrays.asList("client_credentials", "password"));
         for (ClientDetailsModification c : clients) {
             c.setAction(ClientDetailsModification.ADD);
         }
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1473,7 +1515,7 @@ class ClientAdminEndpointsMockMvcTests {
             c.setClientSecret("secret2");
             c.setAction(ClientDetailsModification.UPDATE_SECRET);
         }
-        modifyClientsPost = post("/oauth/clients/tx/modify")
+        modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1516,14 +1558,15 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void secretChangeModifyTxApprovalsNotDeleted() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void secretChangeModifyTxApprovalsNotDeleted(String url) throws Exception {
         //create clients
         ClientDetailsModification[] clients = createBaseClients(3, SECRET, Arrays.asList("client_credentials", "password"));
         for (ClientDetailsModification c : clients) {
             c.setAction(ClientDetailsModification.ADD);
         }
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1560,7 +1603,7 @@ class ClientAdminEndpointsMockMvcTests {
             c.setClientSecret("secret");
             c.setAction(ClientDetailsModification.UPDATE_SECRET);
         }
-        modifyClientsPost = post("/oauth/clients/tx/modify")
+        modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + adminToken)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1583,8 +1626,9 @@ class ClientAdminEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void clientsAdminPermissions() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void clientsAdminPermissions(String url) throws Exception {
         ClientDetails adminsClient = createClientAdminsClient(adminToken);
 
         //create clients
@@ -1599,7 +1643,7 @@ class ClientAdminEndpointsMockMvcTests {
                 "secret",
                 "clients.admin");
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + token)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1608,8 +1652,9 @@ class ClientAdminEndpointsMockMvcTests {
         result.andExpect(status().isOk());
     }
 
-    @Test
-    void nonClientsAdminPermissions() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients/tx/modify", "/oauth/clients/tx/modify/"})
+    void nonClientsAdminPermissions(String url) throws Exception {
         ClientDetails adminsClient = createReadWriteClient(adminToken);
 
         //create clients
@@ -1624,7 +1669,7 @@ class ClientAdminEndpointsMockMvcTests {
                 "secret",
                 "clients.write");
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients/tx/modify")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + token)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1633,8 +1678,9 @@ class ClientAdminEndpointsMockMvcTests {
         result.andExpect(status().isForbidden());
     }
 
-    @Test
-    void createAsAdminPermissions() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createAsAdminPermissions(String url) throws Exception {
         ClientDetails adminsClient = createClientAdminsClient(adminToken);
 
         //create clients
@@ -1649,7 +1695,7 @@ class ClientAdminEndpointsMockMvcTests {
                 "secret",
                 "clients.admin");
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + token)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1658,8 +1704,9 @@ class ClientAdminEndpointsMockMvcTests {
         result.andExpect(status().isCreated());
     }
 
-    @Test
-    void createAsReadPermissions() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createAsReadPermissions(String url) throws Exception {
         ClientDetails adminsClient = createReadWriteClient(adminToken);
 
         //create clients
@@ -1674,7 +1721,7 @@ class ClientAdminEndpointsMockMvcTests {
                 "secret",
                 "clients.read");
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + token)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1683,8 +1730,9 @@ class ClientAdminEndpointsMockMvcTests {
         result.andExpect(status().isForbidden());
     }
 
-    @Test
-    void createAsWritePermissions() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void createAsWritePermissions(String url) throws Exception {
         ClientDetails adminsClient = createReadWriteClient(adminToken);
 
         //create clients
@@ -1699,7 +1747,7 @@ class ClientAdminEndpointsMockMvcTests {
                 "secret",
                 "clients.write");
 
-        MockHttpServletRequestBuilder modifyClientsPost = post("/oauth/clients")
+        MockHttpServletRequestBuilder modifyClientsPost = post(url)
                 .header("Authorization", "Bearer " + token)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
@@ -1708,8 +1756,9 @@ class ClientAdminEndpointsMockMvcTests {
         result.andExpect(status().isCreated());
     }
 
-    @Test
-    void getClientDetailsSortedByLastModified() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/oauth/clients", "/oauth/clients/"})
+    void getClientDetailsSortedByLastModified(String url) throws Exception {
 
         ClientDetails adminsClient = createReadWriteClient(adminToken);
 
@@ -1719,7 +1768,7 @@ class ClientAdminEndpointsMockMvcTests {
                 "secret",
                 "clients.read");
 
-        MockHttpServletRequestBuilder get = get("/oauth/clients")
+        MockHttpServletRequestBuilder get = get(url)
                 .header("Authorization", "Bearer " + token)
                 .param("sortBy", "lastmodified")
                 .param("sortOrder", "descending")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/codestore/CodeStoreEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/codestore/CodeStoreEndpointsMockMvcTests.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
@@ -58,13 +60,14 @@ class CodeStoreEndpointsMockMvcTests {
         jdbcTemplate.update("DELETE FROM expiring_code_store");
     }
 
-    @Test
-    void generateCode() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void generateCode(String url) throws Exception {
         Timestamp ts = new Timestamp(System.currentTimeMillis() + 60000);
         ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
 
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -78,14 +81,15 @@ class CodeStoreEndpointsMockMvcTests {
 
     }
 
-    @Test
-    void generateCodeWithInvalidScope() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void generateCodeWithInvalidScope(String url) throws Exception {
         Timestamp ts = new Timestamp(System.currentTimeMillis() + 60000);
         ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
         String loginToken = testClient.getClientCredentialsOAuthAccessToken("admin", "adminsecret", "scim.read");
 
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -95,13 +99,14 @@ class CodeStoreEndpointsMockMvcTests {
                 .andExpect(status().isForbidden());
     }
 
-    @Test
-    void generateCodeAnonymous() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void generateCodeAnonymous(String url) throws Exception {
         Timestamp ts = new Timestamp(System.currentTimeMillis() + 60000);
         ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
 
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
                 .content(requestBody);
@@ -110,12 +115,13 @@ class CodeStoreEndpointsMockMvcTests {
                 .andExpect(status().isUnauthorized());
     }
 
-    @Test
-    void generateCodeWithNullData() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void generateCodeWithNullData(String url) throws Exception {
         Timestamp ts = new Timestamp(System.currentTimeMillis() + 60000);
         ExpiringCode code = new ExpiringCode(null, ts, null, null);
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -126,11 +132,12 @@ class CodeStoreEndpointsMockMvcTests {
 
     }
 
-    @Test
-    void generateCodeWithNullExpiresAt() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void generateCodeWithNullExpiresAt(String url) throws Exception {
         ExpiringCode code = new ExpiringCode(null, null, "{}", null);
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -141,12 +148,13 @@ class CodeStoreEndpointsMockMvcTests {
 
     }
 
-    @Test
-    void generateCodeWithExpiresAtInThePast() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void generateCodeWithExpiresAtInThePast(String url) throws Exception {
         Timestamp ts = new Timestamp(System.currentTimeMillis() - 60000);
         ExpiringCode code = new ExpiringCode(null, ts, null, null);
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -157,12 +165,13 @@ class CodeStoreEndpointsMockMvcTests {
 
     }
 
-    @Test
-    void retrieveCode() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void retrieveCode(String url) throws Exception {
         Timestamp ts = new Timestamp(System.currentTimeMillis() + 60000);
         ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -187,12 +196,13 @@ class CodeStoreEndpointsMockMvcTests {
         assertThat(rc1).isEqualTo(rc);
     }
 
-    @Test
-    void retrieveCodeThatIsExpired() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void retrieveCodeThatIsExpired(String url) throws Exception {
         Timestamp ts = new Timestamp(Long.MAX_VALUE);
         ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -213,12 +223,13 @@ class CodeStoreEndpointsMockMvcTests {
                 .andReturn();
     }
 
-    @Test
-    void codeThatIsExpiredIsDeletedOnCreateOfNewCode() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Codes", "/Codes/"})
+    void codeThatIsExpiredIsDeletedOnCreateOfNewCode(String url) throws Exception {
         Timestamp ts = new Timestamp(Long.MAX_VALUE);
         ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
         String requestBody = JsonUtils.writeValueAsString(code);
-        MockHttpServletRequestBuilder post = post("/Codes")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -235,7 +246,7 @@ class CodeStoreEndpointsMockMvcTests {
         ts = new Timestamp(Long.MAX_VALUE);
         code = new ExpiringCode(null, ts, "{}", null);
         requestBody = JsonUtils.writeValueAsString(code);
-        post = post("/Codes")
+        post = post(url)
                 .header("Authorization", "Bearer " + loginToken)
                 .contentType(APPLICATION_JSON)
                 .accept(MediaType.APPLICATION_JSON)
@@ -280,13 +291,14 @@ class CodeStoreEndpointsMockMvcTests {
             jdbcExpiringCodeStore.setExpirationInterval(priorExpirationInterval);
         }
 
-        @Test
-        void verifyExpirationIntervalWorks() throws Exception {
+        @ParameterizedTest
+        @ValueSource(strings = {"/Codes", "/Codes/"})
+        void verifyExpirationIntervalWorks(String url) throws Exception {
             jdbcExpiringCodeStore.setExpirationInterval(10000000);
             Timestamp ts = new Timestamp(System.currentTimeMillis() + 1000);
             ExpiringCode code = new ExpiringCode(null, ts, "{}", null);
             String requestBody = JsonUtils.writeValueAsString(code);
-            MockHttpServletRequestBuilder post = post("/Codes")
+            MockHttpServletRequestBuilder post = post(url)
                     .header("Authorization", "Bearer " + loginToken)
                     .contentType(APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
@@ -522,8 +523,9 @@ class IdentityZoneEndpointsMockMvcTests {
         assertThat(zoneModifiedEventListener.getEventCount()).isZero();
     }
 
-    @Test
-    void createZone_ShouldOnlyCreateGroupsForSystemScopesThatAreInAllowList() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/identity-zones", "/identity-zones/"})
+    void createZone_ShouldOnlyCreateGroupsForSystemScopesThatAreInAllowList(String url) throws Exception {
         final String idzId = generator.generate();
 
         final IdentityZone idz = createSimpleIdentityZone(idzId);
@@ -532,7 +534,7 @@ class IdentityZoneEndpointsMockMvcTests {
 
         // create the zone
         mockMvc.perform(
-                post("/identity-zones")
+                post(url)
                         .header("Authorization", "Bearer " + identityClientToken)
                         .contentType(APPLICATION_JSON)
                         .content(JsonUtils.writeValueAsString(idz))
@@ -1876,15 +1878,16 @@ class IdentityZoneEndpointsMockMvcTests {
         assertThat(clientDeleteEventListener.getEventCount()).isZero();
     }
 
-    @Test
-    void createAdminClientInNewZoneUsingZoneEndpointReturns400() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/clients", "/clients/"})
+    void createAdminClientInNewZoneUsingZoneEndpointReturns400(String endUrl) throws Exception {
         String id = generator.generate();
         IdentityZone zone = createZone(id, HttpStatus.CREATED, identityClientToken, new IdentityZoneConfiguration());
         UaaClientDetails client =
                 new UaaClientDetails("admin-client", null, null, "client_credentials", "clients.write");
         client.setClientSecret("secret");
         mockMvc.perform(
-                        post("/identity-zones/" + zone.getId() + "/clients")
+                        post("/identity-zones/" + zone.getId() + endUrl)
                                 .header("Authorization", "Bearer " + identityClientToken)
                                 .contentType(APPLICATION_JSON)
                                 .accept(APPLICATION_JSON)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpointsMockMvcTests.java
@@ -35,6 +35,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -148,13 +150,14 @@ class ScimGroupEndpointsMockMvcTests {
         ephemeralResources.clear();
     }
 
-    @Test
-    void identityClientManagesZoneAdmins() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Groups/zones", "/Groups/zones/"})
+    void identityClientManagesZoneAdmins(String url) throws Exception {
         IdentityZone zone = MockMvcUtils.createZoneUsingWebRequest(mockMvc, identityClientToken);
         ScimGroupMember member = new ScimGroupMember(scimUser.getId());
         ScimGroup group = new ScimGroup(null, "zones." + zone.getId() + ".admin", zone.getId());
         group.setMembers(Collections.singletonList(member));
-        MockHttpServletRequestBuilder post = post("/Groups/zones")
+        MockHttpServletRequestBuilder post = post(url)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .header("Authorization", "Bearer " + identityClientToken)
@@ -171,7 +174,7 @@ class ScimGroupEndpointsMockMvcTests {
         mockMvc.perform(delete).andExpect(status().isNotFound());
 
         //try a regular scim token
-        mockMvc.perform(post("/Groups/zones")
+        mockMvc.perform(post(url)
                         .accept(APPLICATION_JSON)
                         .contentType(APPLICATION_JSON)
                         .header("Authorization", "Bearer " + scimWriteToken)
@@ -186,7 +189,7 @@ class ScimGroupEndpointsMockMvcTests {
                         .header("Authorization", "Bearer " + identityClientToken))
                 .andExpect(status().isNotFound());
 
-        mockMvc.perform(post("/Groups/zones")
+        mockMvc.perform(post(url)
                         .accept(APPLICATION_JSON)
                         .contentType(APPLICATION_JSON)
                         .header("Authorization", "Bearer " + identityClientToken)
@@ -200,7 +203,7 @@ class ScimGroupEndpointsMockMvcTests {
             group = new ScimGroup(null, "zones." + zone.getId() + ".admin", zone.getId());
             group.setMembers(Collections.singletonList(member));
 
-            post = post("/Groups/zones")
+            post = post(url)
                     .accept(APPLICATION_JSON)
                     .contentType(APPLICATION_JSON)
                     .header("Authorization", "Bearer " + identityClientToken)
@@ -211,12 +214,13 @@ class ScimGroupEndpointsMockMvcTests {
         }
     }
 
-    @Test
-    void limitedScopesWithoutMember() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Groups/zones", "/Groups/zones/"})
+    void limitedScopesWithoutMember(String url) throws Exception {
         IdentityZone zone = MockMvcUtils.createZoneUsingWebRequest(mockMvc, identityClientToken);
         ScimGroup group = new ScimGroup("zones." + zone.getId() + ".admin");
 
-        MockHttpServletRequestBuilder post = post("/Groups/zones")
+        MockHttpServletRequestBuilder post = post(url)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .header("Authorization", "Bearer " + identityClientToken)
@@ -272,8 +276,9 @@ class ScimGroupEndpointsMockMvcTests {
         return mockMvc.perform(post);
     }
 
-    @Test
-    void groupOperationsAsZoneAdmin() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Groups", "/Groups/"})
+    void groupOperationsAsZoneAdmin(String url) throws Exception {
         String subdomain = generator.generate();
         MockMvcUtils.IdentityZoneCreationResult result = MockMvcUtils.createOtherIdentityZoneAndReturnResult(subdomain, mockMvc, webApplicationContext, null, IdentityZoneHolder.getCurrentZoneId());
         String zoneAdminToken = result.getZoneAdminToken();
@@ -285,7 +290,7 @@ class ScimGroupEndpointsMockMvcTests {
 
         ScimGroup group = new ScimGroup(null, groupName, null);
 
-        MockHttpServletRequestBuilder create = post("/Groups")
+        MockHttpServletRequestBuilder create = post(url)
                 .header(headerName, headerValue)
                 .header("Authorization", "bearer " + zoneAdminToken)
                 .accept(APPLICATION_JSON)
@@ -324,12 +329,13 @@ class ScimGroupEndpointsMockMvcTests {
                 ScimGroup.class)).isEqualTo(group);
     }
 
-    @Test
-    void getGroups_withScimReadTokens_returnsOkWithResults() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Groups", "/Groups/"})
+    void getGroups_withScimReadTokens_returnsOkWithResults(String url) throws Exception {
         String filterNarrow = "displayName eq \"clients.read\" or displayName eq \"clients.write\"";
         String filterWide = "displayName eq \"clients.read\" or displayName eq \"clients.write\" or displayName eq \"zones.read\" or displayName eq \"zones.write\"";
 
-        MockHttpServletRequestBuilder get = get("/Groups")
+        MockHttpServletRequestBuilder get = get(url)
                 .header("Authorization", "Bearer " + scimReadToken)
                 .param("attributes", "displayName")
                 .param("filter", filterNarrow)
@@ -1266,7 +1272,7 @@ class ScimGroupEndpointsMockMvcTests {
     void checkGetExternalGroups() throws Exception {
         String path = "/Groups/External";
         checkGetExternalGroups(path);
-        path = "/Groups/External";
+        path = "/Groups/External/";
         checkGetExternalGroups(path);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
@@ -40,6 +40,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
@@ -141,6 +143,21 @@ class ScimUserEndpointsMockMvcTests {
                         put("/Users")
                 )
                 .andExpect(status().isUnauthorized());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/Users", "/Users/"})
+    public void canCreateUsersWithEndpointEndingWithSlash(String url) throws Exception {
+        ScimUser user = getScimUser();
+        String password = hasText(user.getPassword()) ? user.getPassword() : "pas5word";
+        user.setPassword(password);
+        createUserAndReturnResult(url, user, scimCreateToken, null, null)
+                .andExpect(status().isCreated())
+                .andExpect(header().string("ETag", "\"0\""))
+                .andExpect(jsonPath("$.userName").value(user.getUserName()))
+                .andExpect(jsonPath("$.emails[0].value").value(user.getUserName()))
+                .andExpect(jsonPath("$.name.familyName").value(user.getFamilyName()))
+                .andExpect(jsonPath("$.name.givenName").value(user.getGivenName()));
     }
 
     @Test
@@ -373,12 +390,13 @@ class ScimUserEndpointsMockMvcTests {
                                         .put("error", "invalid_scim_resource"))));
     }
 
-    @Test
-    void create_user_without_email() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Users", "/Users/"})
+    void create_user_without_email(String url) throws Exception {
         ScimUser user = new ScimUser(null, "a_user", "Joel", "D'sa");
         user.setPassword("password");
 
-        mockMvc.perform(post("/Users")
+        mockMvc.perform(post(url)
                         .header("Authorization", "Bearer " + scimReadWriteToken)
                         .contentType(APPLICATION_JSON)
                         .content(JsonUtils.writeValueAsString(user)))
@@ -508,8 +526,9 @@ class ScimUserEndpointsMockMvcTests {
                                         .put("error", "scim_resource_not_found"))));
     }
 
-    @Test
-    void listUsers_in_anotherZone() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Users", "/Users/"})
+    void listUsers_in_anotherZone(String url) throws Exception {
         String subdomain = generator.generate();
         MockMvcUtils.IdentityZoneCreationResult result = MockMvcUtils.createOtherIdentityZoneAndReturnResult(subdomain, mockMvc, webApplicationContext, null, IdentityZoneHolder.getCurrentZoneId());
         String zoneAdminToken = result.getZoneAdminToken();
@@ -519,7 +538,7 @@ class ScimUserEndpointsMockMvcTests {
             createUser(getScimUser(), zoneAdminToken, IdentityZone.getUaa().getSubdomain(), result.getIdentityZone().getId());
         }
 
-        MockHttpServletRequestBuilder get = MockMvcRequestBuilders.get("/Users").param("count", Integer.toString(usersMaxCountWithOffset))
+        MockHttpServletRequestBuilder get = MockMvcRequestBuilders.get(url).param("count", Integer.toString(usersMaxCountWithOffset))
                 .header("X-Identity-Zone-Subdomain", subdomain)
                 .header("Authorization", "Bearer " + zoneAdminToken)
                 .accept(APPLICATION_JSON);
@@ -577,8 +596,9 @@ class ScimUserEndpointsMockMvcTests {
         getAndReturnUser(HttpStatus.OK.value(), updatedUser, selfToken);
     }
 
-    @Test
-    void createUserInOtherZoneIsUnauthorized() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Users", "/Users/"})
+    void createUserInOtherZoneIsUnauthorized(String url) throws Exception {
         String subdomain = generator.generate();
         MockMvcUtils.createOtherIdentityZone(subdomain, mockMvc, webApplicationContext, IdentityZoneHolder.getCurrentZoneId());
 
@@ -590,7 +610,7 @@ class ScimUserEndpointsMockMvcTests {
         ScimUser user = getScimUser();
 
         byte[] requestBody = JsonUtils.writeValueAsBytes(user);
-        MockHttpServletRequestBuilder post = post("/Users")
+        MockHttpServletRequestBuilder post = post(url)
                 .with(new SetServerNameRequestPostProcessor(otherSubdomain + ".localhost"))
                 .header("Authorization", "Bearer " + zoneAdminToken)
                 .contentType(APPLICATION_JSON)
@@ -740,12 +760,13 @@ class ScimUserEndpointsMockMvcTests {
         getUser(scimReadWriteToken, HttpStatus.OK.value());
     }
 
-    @Test
-    void getUserWithInvalidAttributes() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Users", "/Users/"})
+    void getUserWithInvalidAttributes(String url) throws Exception {
 
         String nonexistentAttribute = "displayBlaBla";
 
-        MockHttpServletRequestBuilder get = get("/Users")
+        MockHttpServletRequestBuilder get = get(url)
                 .header("Authorization", "Bearer " + scimReadWriteToken)
                 .contentType(MediaType.APPLICATION_JSON)
                 .param("attributes", nonexistentAttribute)
@@ -768,11 +789,12 @@ class ScimUserEndpointsMockMvcTests {
         getUser(scimCreateToken, HttpStatus.FORBIDDEN.value());
     }
 
-    @Test
-    void getUsersWithUaaAdminToken() throws Exception {
+    @ParameterizedTest
+    @ValueSource(strings = {"/Users", "/Users/"})
+    void getUsersWithUaaAdminToken(String url) throws Exception {
         setUpScimUser();
 
-        MockHttpServletRequestBuilder get = MockMvcRequestBuilders.get("/Users")
+        MockHttpServletRequestBuilder get = MockMvcRequestBuilders.get(url)
                 .header("Authorization", "Bearer " + uaaAdminToken)
                 .accept(APPLICATION_JSON);
 
@@ -1267,8 +1289,12 @@ class ScimUserEndpointsMockMvcTests {
     }
 
     private ResultActions createUserAndReturnResult(ScimUser user, String token, String subdomain, String switchZone) throws Exception {
+        return createUserAndReturnResult("/Users",  user, token, subdomain, switchZone);
+    }
+
+    private ResultActions createUserAndReturnResult(String url, ScimUser user, String token, String subdomain, String switchZone) throws Exception {
         byte[] requestBody = JsonUtils.writeValueAsBytes(user);
-        MockHttpServletRequestBuilder post = post("/Users")
+        MockHttpServletRequestBuilder post = post(url)
                 .header("Authorization", "Bearer " + token)
                 .contentType(APPLICATION_JSON)
                 .content(requestBody);


### PR DESCRIPTION
we went from 

```
@RequestMapping(value = "/oauth/clients/restricted", method = RequestMethod.POST)
```

to

```
@PostMapping("/oauth/clients/restricted")
```

**It breaks here**, urls ending with `/` no longer work properly, whereas they worked before


and it needs to be

```
@PostMapping({"/oauth/clients/restricted", "/oauth/clients/restricted/"})
```

The following URLs now support ending with `/`. The only endpoint that did *not* support an ending slash prior to the boot migration was `/Users`

1. /Codes
1. /Groups
1. /Groups/External
1. /Groups/zones
1. /Users
1. /authenticate
1. /force_password_change
1. /identity-zones
1. /identity-zones/{zoneId}/clients
1. “{zoneId}/clients
1. /invite_users
1. /oauth/clients
1. /oauth/clients/tx
1. /oauth/clients/tx/delete
1. /oauth/clients/tx/modify
1. /oauth/clients/tx/secret
1. /password_change
1. /password_resets
1. /profile
