### PR TITLE
Change nonce and state to length 22

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfigurator.java
@@ -108,7 +108,7 @@ public class ExternalOAuthProviderConfigurator implements IdentityProviderProvis
         }
 
         if (OIDCIdentityProviderDefinition.class.equals(definition.getParameterizedClass())) {
-            var nonceGenerator = new RandomValueStringGenerator(12);
+            var nonceGenerator = new RandomValueStringGenerator(22);
             uriBuilder.queryParam("nonce", nonceGenerator.generate());
 
             Map<String, String> additionalParameters = ofNullable(((OIDCIdentityProviderDefinition) definition).getAdditionalAuthzParameters()).orElse(emptyMap());
@@ -123,7 +123,7 @@ public class ExternalOAuthProviderConfigurator implements IdentityProviderProvis
     }
 
     private String generateStateParam() {
-        return uaaRandomStringUtil.getSecureRandom(10);
+        return uaaRandomStringUtil.getSecureRandom(22);
     }
 
     private String generateCodeVerifier() {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfiguratorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfiguratorTests.java
@@ -585,4 +585,30 @@ class ExternalOAuthProviderConfiguratorTests {
         when(mockIdentityProviderProvisioning.idpWithAliasExistsInZone(zoneId)).thenReturn(resultFromDelegate);
         assertThat(configurator.idpWithAliasExistsInZone(zoneId)).isEqualTo(resultFromDelegate);
     }
+
+    @Test
+    void getIdpAuthenticationUrl_verifyNonceAndStateLength() {
+        // Mock state generation (22 characters)
+        String stateValue = "a".repeat(22); // exactly 22 characters
+        when(mockUaaRandomStringUtil.getSecureRandom(22)).thenReturn(stateValue);
+        
+        // Mock code verifier generation (128 characters) - needed for PKCE
+        String codeVerifierValue = "b".repeat(128);
+        when(mockUaaRandomStringUtil.getSecureRandom(128)).thenReturn(codeVerifierValue);
+        
+        String authzUri = configurator.getIdpAuthenticationUrl(oidc, "alias", mockHttpServletRequest);
+        Map<String, String> queryParams =
+                UriComponentsBuilder.fromUriString(authzUri).build().getQueryParams().toSingleValueMap();
+        
+        // Verify state is at least 22 characters
+        assertThat(queryParams.get("state"))
+                .as("State parameter should be at least 22 characters")
+                .hasSizeGreaterThanOrEqualTo(22);
+        
+        // Verify nonce exists and has expected length (RandomValueStringGenerator(22) generates 22 chars)
+        assertThat(queryParams.get("nonce"))
+                .as("Nonce parameter should be at least 22 characters")
+                .isNotNull()
+                .hasSizeGreaterThanOrEqualTo(22);
+    }
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

 - Change the length of `nonce` from 12 to 22
 - Change the length of `state` from 10 to 22
 - Part of issue https://github.com/cloudfoundry/uaa/issues/3644
 
 ## Security considerations
 
Increases the entropy making brute force attacks more difficult