### PR TITLE
Add env vars for Gradle commands in test scripts

### DIFF
--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -3,6 +3,10 @@ set -eu -o pipefail
 
 #######################################
 # main function to run the integration tests
+# Global env vars:
+#   UAA_DOCKER_ARGS: Additional args to pass to docker run
+#   UAA_GRADLE_INT_TEST_COMMAND: Gradle command to run integration tests (default: integrationTest)
+#       this could include :cloudfoundry-identity-server:integrationTest --tests to run specific tests
 #######################################
 main() {
   local script_dir;  script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -30,6 +34,8 @@ main() {
     --env DB="${DB}" \
     --env RUN_TESTS="${RUN_TESTS:-true}" \
     --publish 8081:8080 \
+    ${UAA_DOCKER_ARGS:-} \
+    --env UAA_GRADLE_INT_TEST_COMMAND="${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest}" \
     "${DOCKER_IMAGE}" \
     /root/uaa/scripts/integration_tests.sh "${PROFILE_NAME}" "${run_as_boot}"
 }

--- a/run-unit-tests.sh
+++ b/run-unit-tests.sh
@@ -3,9 +3,13 @@ set -eu -o pipefail
 
 #######################################
 # main function to run the unit tests
+# Global env vars:
+#   UAA_DOCKER_ARGS: Additional args to pass to docker run
+#   UAA_GRADLE_UNIT_TEST_COMMAND: Gradle command to run unit tests (default: test)
+#       this could include :cloudfoundry-identity-server:test --tests to run specific tests
 #######################################
 main() {
-  local script_dir;  script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  local script_dir; script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
   source "${script_dir}/scripts/lib_timer.sh"
   start_timer
 
@@ -27,6 +31,8 @@ main() {
     --volume "${script_dir}":"${container_script_dir}" \
     --volume "${gradle_lock_dir}" \
     --env DB="${DB}" \
+    ${UAA_DOCKER_ARGS:-} \
+    --env UAA_GRADLE_UNIT_TEST_COMMAND="${UAA_GRADLE_UNIT_TEST_COMMAND:-test}" \
     "${DOCKER_IMAGE}" \
     /root/uaa/scripts/unit_tests.sh "${PROFILE_NAME}"
 }

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -3,6 +3,9 @@ set -eu
 
 #######################################
 # The main function to run the integration tests within a container
+# Global env vars:
+#   UAA_GRADLE_INT_TEST_COMMAND: Gradle command to run integration tests (default: integrationTest)
+#       this could include :cloudfoundry-identity-server:integrationTest --tests to run specific tests
 #######################################
 function main() {
   local script_dir; script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -50,7 +53,7 @@ function main() {
 
     readonly integration_test_code="./gradlew '-Dspring.profiles.active=${test_profile}' '${skip_boot_run}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
-                integrationTest \
+                ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
                 --stacktrace \
                 --console=plain"
 

--- a/scripts/start_docker_database.sh
+++ b/scripts/start_docker_database.sh
@@ -5,6 +5,10 @@ set -eu -o pipefail
 # main function to start a docker container with the specified database
 # usage: start_docker_database.sh [db_name]
 #   db_name: one of "mysql(-*)", "postgres(-*)", etc. (default: "mysql")
+# Global env vars:
+#   DEBUG_MODE: if set to any value, enables remote debugging on port 5005
+#   WEB_MODE: if set to any value, enables web access on port 8080
+#   UAA_DOCKER_ARGS: Additional args to pass to docker run
 #######################################
 main() {
   local uaa_dir;  uaa_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
@@ -43,6 +47,7 @@ main() {
     --publish "${db_port}:${db_port}" \
     ${DEBUG_MODE:+--publish "5005:5005"} \
     ${WEB_MODE:+--publish "8080:8080"} \
+    ${UAA_DOCKER_ARGS:-} \
     "${DOCKER_IMAGE}"
 }
 

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -3,6 +3,9 @@ set -eu
 
 #######################################
 # The main function to run the unit tests within a container
+# Global env vars:
+#   UAA_GRADLE_UNIT_TEST_COMMAND: Gradle command to run unit tests (default: test)
+#       this could include :cloudfoundry-identity-server:test --tests to run specific tests
 #######################################
 function main() {
   local script_dir; script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -23,7 +26,7 @@ function main() {
     export GRADLE_OPTS="-Xmx2048m"
     ./gradlew "-Dspring.profiles.active=${test_profile}" \
             "-Djava.security.egd=file:/dev/./urandom" \
-            test \
+            ${UAA_GRADLE_UNIT_TEST_COMMAND:-test} \
             --stacktrace  \
             --console=plain
   popd


### PR DESCRIPTION

The following env vars can be set to control which tests are run
UAA_GRADLE_INT_TEST_COMMAND
UAA_GRADLE_UNIT_TEST_COMMAND

the UAA_DOCKER_ARGS env var can be set to pass additional settings to the docker container