### PR TITLE
Increase boot timeout from 60 to 300

### DIFF
--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -7,7 +7,7 @@ set -eu
 function is_boot_running() {
   local log_file="boot.log"
   local target_line="Started UaaBootApplication"
-  local timeout=60 # Timeout in seconds
+  local timeout=300 # Timeout in seconds
 
   local start_time
   start_time=$(date +%s)


### PR DESCRIPTION
Increased the timeout duration for boot check from 60 to 300 seconds.