### PR TITLE
Update memory settings on the integration test script

### DIFF
--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -24,7 +24,8 @@ function main() {
 
     local wd launch_boot assemble_code integration_test_code
     wd=$(pwd)
-    readonly launch_boot="nohup java -DCLOUDFOUNDRY_CONFIG_PATH=${wd}/scripts/boot \
+    readonly launch_boot="nohup java \
+                               -DCLOUDFOUNDRY_CONFIG_PATH=${wd}/scripts/boot \
                                -DSECRETS_DIR=${wd}/scripts/boot \
                                -Djava.security.egd=file:/dev/./urandom \
                                -Dmetrics.perRequestMetrics=true \
@@ -42,6 +43,7 @@ function main() {
     readonly assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
                 assemble \
+                --no-daemon \
                 --max-workers=4 \
                 --stacktrace \
                 --console=plain"
@@ -51,11 +53,10 @@ function main() {
                 '-DskipUaaAutoStart=true' \
                 ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
                 --stacktrace \
+                --no-daemon \
                 --console=plain"
 
     set -x
-    # The default max heap size for Gradle is 512MB, increase to avoid DaemonDisappearedException
-    export GRADLE_OPTS="-Xmx2048m"
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
       eval "$assemble_code"
 

--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -27,6 +27,7 @@ function is_boot_running() {
       return 1
     fi
 
+    tail -n 1 "$log_file"
     sleep 1 # Check every second
   done
 }

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -22,12 +22,11 @@ function main() {
     start_ldap
 
     set -x
-    # The default max heap size for Gradle is 512MB, increase to avoid DaemonDisappearedException
-    export GRADLE_OPTS="-Xmx2048m"
     ./gradlew "-Dspring.profiles.active=${test_profile}" \
             "-Djava.security.egd=file:/dev/./urandom" \
             ${UAA_GRADLE_UNIT_TEST_COMMAND:-test} \
             --stacktrace  \
+            --no-daemon \
             --console=plain
   popd
 }


### PR DESCRIPTION
- Restore `--no-daemon` flag to Gradle commands
- Show boot startup progress with `tail -n 1` in loop
- Remove memory settings for gradle