### PR TITLE
Fix SAML Metadata when EntityID is a URL

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 import lombok.extern.slf4j.Slf4j;
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.util.KeyWithCert;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -49,7 +50,8 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
         List<KeyWithCert> defaultKeysWithCerts = samlKeyManager.getAvailableCredentials();
 
         List<RelyingPartyRegistration> relyingPartyRegistrations = new ArrayList<>();
-        String uaaWideSamlEntityIDAlias = samlConfigProps.getEntityIDAlias() != null ? samlConfigProps.getEntityIDAlias() : samlEntityID;
+        String uaaWideSamlEntityIDAlias = samlConfigProps.getEntityIDAlias() != null ? samlConfigProps.getEntityIDAlias() :
+                UaaStringUtils.getHostIfArgIsURL(samlEntityID);
 
         @SuppressWarnings("java:S125")
         // Spring Security requires at least one relyingPartyRegistration before SAML SP metadata generation;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlMetadataEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlMetadataEndpointMockMvcTests.java
@@ -177,6 +177,44 @@ class SamlMetadataEndpointMockMvcTests {
         }
     }
 
+    @Nested
+    @DefaultTestContext
+    @TestPropertySource(properties = {
+            "login.entityID = http://some.saml.provider/url/entityId"
+    })
+    class SamlMetadataWhenEntityIDIsAUrlMockMvcTests {
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void samlMetadataXMLValidation() throws Exception {
+
+            mockMvc.perform(get(new URI("/saml/metadata")))
+                    .andDo(print())
+                    .andExpectAll(
+                            status().isOk(),
+                            header().string(HttpHeaders.CONTENT_DISPOSITION, containsString("filename=\"saml-sp.xml\";")),
+                            xpath("/EntityDescriptor/SPSSODescriptor/AssertionConsumerService/@Location").string(containsString("/saml/SSO/alias/some.saml.provider")),
+                            xpath("/EntityDescriptor/@entityID").string("http://some.saml.provider/url/entityId")
+                    );
+        }
+
+        @Test
+        void samlMetadataXMLValidationInZone() throws Exception {
+            IdentityZone alternativeSpZone = setupIdentityZone(false);
+            String zoneSubdomain = alternativeSpZone.getSubdomain();
+            mockMvc.perform(get(new URI("/saml/metadata"))
+                    .header(HOST, zoneSubdomain + ".localhost:8080"))
+                    .andDo(print())
+                    .andExpectAll(
+                            status().isOk(),
+                            header().string(HttpHeaders.CONTENT_DISPOSITION, containsString("filename=\"saml-%s-sp.xml\";".formatted(zoneSubdomain))),
+                            xpath("/EntityDescriptor/SPSSODescriptor/AssertionConsumerService/@Location").string(containsString("/saml/SSO/alias/%s.some.saml.provider".formatted(zoneSubdomain))),
+                            xpath("/EntityDescriptor/@entityID").string("http://%s.some.saml.provider/url/entityId".formatted(zoneSubdomain))
+                    );
+        }
+    }
+
     private IdentityZone setupIdentityZone(boolean hasEntityId) throws Exception {
         UaaClientDetails adminClient = new UaaClientDetails("admin", "", "", "client_credentials", "uaa.admin");
         adminClient.setClientSecret("adminsecret");


### PR DESCRIPTION
https://github.com/cloudfoundry/uaa/issues/3661

The alias cannot be a URL. Backwards compatible behavior is to use the hostname for the alias