### PR TITLE
Fix Integration Tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,6 +122,9 @@ subprojects {
     tasks.register('integrationTest', Test) {
         useJUnitPlatform()
 
+        // This prevents integrationTests from hanging indefinitely
+        timeout = Duration.ofMinutes(180)
+
         // Enable JaCoCo for integration tests
         jacoco {
             enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,6 @@ buildscript {
 
 apply(from: "dependencies.gradle")
 
-def applicationPort = project.hasProperty('port') ? project.getProperty('port').toInteger() : 8080
-
 allprojects {
     apply(plugin: "io.spring.dependency-management")
     apply(plugin: "org.barfuin.gradle.jacocolog")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -5,7 +5,7 @@ ext {
 
 // Versions shared between multiple dependencies
 versions.apacheDsVersion = "2.0.0.AM27"
-versions.bouncyCastleFipsVersion = "2.1.1"
+versions.bouncyCastleFipsVersion = "2.1.2"
 versions.bouncyCastlePkixFipsVersion = "2.1.9"
 versions.bouncyCastleTlsFipsVersion = "2.1.20"
 versions.springBootVersion = "3.5.7"

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -30,7 +30,8 @@ function main() {
     echo "Setting metaspace to ${jvm_metaspace:=256m}"
 
     readonly launch_boot="nohup java \
-               -XX:+UseG1GC -XX:G1HeapRegionSize=1m \
+               -XX:+UseG1GC \
+               -XX:G1HeapRegionSize=1m \
                -Xmx${jvm_heap} \
                -XX:MaxMetaspaceSize=${jvm_metaspace} \
                -XX:+HeapDumpOnOutOfMemoryError \
@@ -95,6 +96,11 @@ function main() {
       if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
         export DBUS_SESSION_BUS_ADDRESS=/dev/null
       fi
+      export GRADLE_OPTS="\
+        -XX:+UseG1GC \
+        -XX:G1HeapRegionSize=1m \
+        -Xmx1024m \
+      "
       eval "$integration_test_code"
 
       # Clean up: kill the boot server

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -74,7 +74,7 @@ function main() {
                 ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
                 --no-watch-fs \
                 --no-daemon \
-                --max-workers=4 \
+                --max-workers=2 \
                 --stacktrace \
                 --console=plain"
 

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -25,7 +25,7 @@ function main() {
     local wd launch_boot assemble_code integration_test_code
     wd=$(pwd)
     temp_dir=${script_dir}/tmp
-    mkdir "${temp_dir}"
+    mkdir -p "${temp_dir}"
     echo "Setting heap to ${jvm_heap:=768m}"
     echo "Setting metaspace to ${jvm_metaspace:=256m}"
 

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -78,13 +78,15 @@ function main() {
                 --stacktrace \
                 --console=plain"
 
-    set -x
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
+      set -x
       eval "$compile_assemble_code"
 
       # Start and ensure the boot server is running before integration tests
       eval "$launch_boot"
       echo $! > boot.pid
+      { set +x; } 2>/dev/null
+
       if is_boot_running ; then
         echo "Boot started. Can continue to run tests."
       else
@@ -96,12 +98,14 @@ function main() {
       if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
         export DBUS_SESSION_BUS_ADDRESS=/dev/null
       fi
+      set -x
       export GRADLE_OPTS="\
         -XX:+UseG1GC \
         -XX:G1HeapRegionSize=1m \
         -Xmx1024m \
       "
       eval "$run_integration_tests"
+      { set +x; } 2>/dev/null
 
       # Clean up: kill the boot server
       if [[ -f boot.pid ]]; then
@@ -111,6 +115,7 @@ function main() {
         rm boot.pid
       fi
     else
+      set -x
       echo "$run_integration_tests"
       bash
     fi

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -22,7 +22,7 @@ function main() {
   pushd "$(dirname ${script_dir})"
     start_ldap
 
-    local wd launch_boot assemble_code integration_test_code
+    local wd launch_boot compile_assemble_code run_integration_tests
     wd=$(pwd)
     temp_dir=${script_dir}/tmp
     mkdir -p "${temp_dir}"
@@ -58,16 +58,16 @@ function main() {
                -jar ${wd}/uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war \
                > boot.log 2>&1 &"
 
-    readonly assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
+    readonly compile_assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
-                assemble \
+                assemble compileTestJava \
                 --no-watch-fs \
                 --no-daemon \
                 --max-workers=4 \
                 --stacktrace \
                 --console=plain"
 
-    readonly integration_test_code="./gradlew \
+    readonly run_integration_tests="./gradlew \
                 '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
                 '-DskipUaaAutoStart=true' \
@@ -80,7 +80,7 @@ function main() {
 
     set -x
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
-      eval "$assemble_code"
+      eval "$compile_assemble_code"
 
       # Start and ensure the boot server is running before integration tests
       eval "$launch_boot"
@@ -101,7 +101,7 @@ function main() {
         -XX:G1HeapRegionSize=1m \
         -Xmx1024m \
       "
-      eval "$integration_test_code"
+      eval "$run_integration_tests"
 
       # Clean up: kill the boot server
       if [[ -f boot.pid ]]; then
@@ -111,7 +111,7 @@ function main() {
         rm boot.pid
       fi
     else
-      echo "$integration_test_code"
+      echo "$run_integration_tests"
       bash
     fi
   popd

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -92,6 +92,9 @@ function main() {
         exit 1
       fi
 
+      if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+        export DBUS_SESSION_BUS_ADDRESS=/dev/null
+      fi
       eval "$integration_test_code"
 
       # Clean up: kill the boot server

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -24,6 +24,8 @@ function main() {
 
     local wd launch_boot assemble_code integration_test_code
     wd=$(pwd)
+    temp_dir=${script_dir}/tmp
+    mkdir "${temp_dir}"
     echo "Setting heap to ${jvm_heap:=768m}"
     echo "Setting metaspace to ${jvm_metaspace:=256m}"
 
@@ -36,6 +38,8 @@ function main() {
                -DCLOUDFOUNDRY_CONFIG_PATH=${wd}/scripts/boot \
                -DSECRETS_DIR=${wd}/scripts/boot \
                -Djava.security.egd=file:/dev/./urandom \
+               -Djava.io.tmpdir=${temp_dir} \
+               -Dorg.bouncycastle.native.loader.install_dir=${temp_dir} \
                -Dmetrics.perRequestMetrics=true \
                -Dserver.servlet.context-path=/uaa \
                -Dserver.tomcat.basedir=${wd}/scripts/boot/tomcat \

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -30,7 +30,7 @@ function main() {
     echo "Setting metaspace to ${jvm_metaspace:=256m}"
 
     readonly launch_boot="nohup java \
-               -XX:+UseParallelGC \
+               -XX:+UseG1GC -XX:G1HeapRegionSize=1m \
                -Xmx${jvm_heap} \
                -XX:MaxMetaspaceSize=${jvm_metaspace} \
                -XX:+HeapDumpOnOutOfMemoryError \
@@ -60,6 +60,7 @@ function main() {
     readonly assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
                 assemble \
+                --no-watch-fs \
                 --no-daemon \
                 --max-workers=4 \
                 --stacktrace \
@@ -70,6 +71,7 @@ function main() {
                 '-Djava.security.egd=file:/dev/./urandom' \
                 '-DskipUaaAutoStart=true' \
                 ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
+                --no-watch-fs \
                 --no-daemon \
                 --max-workers=4 \
                 --stacktrace \

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -36,6 +36,9 @@ function main() {
                -XX:+HeapDumpOnOutOfMemoryError \
                -XX:HeapDumpPath=${wd} \
                -DCLOUDFOUNDRY_CONFIG_PATH=${wd}/scripts/boot \
+               -Dlogging.config=${wd}/scripts/boot/log4j2.properties \
+               -Dlog4j.configurationFile=${wd}/scripts/boot/log4j2.properties \
+               -Dlog4j2.formatMsgNoLookups=true \
                -DSECRETS_DIR=${wd}/scripts/boot \
                -Djava.security.egd=file:/dev/./urandom \
                -Djava.io.tmpdir=${temp_dir} \
@@ -67,21 +70,22 @@ function main() {
                 '-Djava.security.egd=file:/dev/./urandom' \
                 '-DskipUaaAutoStart=true' \
                 ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
-                --stacktrace \
                 --no-daemon \
+                --max-workers=4 \
+                --stacktrace \
                 --console=plain"
 
     set -x
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
       eval "$assemble_code"
 
-      # Always start the boot server before running integration tests
+      # Start and ensure the boot server is running before integration tests
       eval "$launch_boot"
       echo $! > boot.pid
       if is_boot_running ; then
         echo "Boot started. Can continue to run tests."
       else
-        echo "Boot did not start - failing"
+        echo "Boot did not start, failing"
         cat boot.log
         exit 1
       fi
@@ -90,7 +94,9 @@ function main() {
 
       # Clean up: kill the boot server
       if [[ -f boot.pid ]]; then
-        kill -9 "$(cat boot.pid)" || true
+        local pid; pid=$(cat boot.pid)
+        echo "Sending SIGKILL (kill -9) to UAA process (pid=${pid})"
+        kill -9 "${pid}" || true
         rm boot.pid
       fi
     else

--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -2,19 +2,20 @@
 set -eu
 
 ########################################
-# Check if Boot has started by looking for a specific line in the log file
+# Check if Boot has started by checking if the port is responding
 ##########################################
 function is_boot_running() {
-  local log_file="boot.log"
-  local target_line="Started UaaBootApplication"
+  local port=${PORT:-8080}
   local timeout=600 # Timeout in seconds
 
   local start_time
   start_time=$(date +%s)
 
   while true; do
-    if grep "$target_line" "$log_file"; then
-      echo "Boot Start was found in the log file."
+    # Use curl to check if the port is responding
+    # Any HTTP response (even 4xx/5xx) indicates the server is running
+    if curl -ksS --max-time 5 --connect-timeout 2 "http://127.0.0.1:${port}/uaa/info"; then
+      echo "Boot is running on port ${port}."
       return 0
     fi
 
@@ -23,11 +24,16 @@ function is_boot_running() {
     elapsed_time=$((current_time - start_time))
 
     if [[ "$elapsed_time" -ge "$timeout" ]]; then
-      echo "Timeout reached. Boot did not start"
+      echo "Timeout reached. Boot did not start on port ${port}"
+      local pid; pid=$(cat boot.pid)
+      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        echo "Sending SIGQUIT (kill -3) to UAA process (pid=$pid)"
+        kill -3 "$pid" || true
+      fi
       return 1
     fi
 
-    tail -n 1 "$log_file"
+    tail -n 1 boot.log
     sleep 1 # Check every second
   done
 }

--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -14,7 +14,7 @@ function is_boot_running() {
   while true; do
     # Use curl to check if the port is responding
     # Any HTTP response (even 4xx/5xx) indicates the server is running
-    if curl -ksS --max-time 5 --connect-timeout 2 "http://127.0.0.1:${port}/uaa/info"; then
+    if curl -ksS --max-time 5 --connect-timeout 2 -u "admin:adminsecret" --data "client_id=admin&grant_type=client_credentials" -X POST "http://localhost:${port}/uaa/oauth/token"; then
       echo "Boot is running on port ${port}."
       return 0
     fi

--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -25,17 +25,32 @@ function is_boot_running() {
 
     if [[ "$elapsed_time" -ge "$timeout" ]]; then
       echo "Timeout reached. Boot did not start on port ${port}"
-      local pid; pid=$(cat boot.pid)
-      if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-        echo "Sending SIGQUIT (kill -3) to UAA process (pid=$pid)"
-        kill -3 "$pid" || true
-      fi
+      thread_dump_on_boot_pid
       return 1
     fi
 
     tail -n 1 boot.log
     sleep 1 # Check every second
   done
+}
+
+########################################
+# thread_dump_on_boot_pid
+# Display Memeory info and Request a thread dump on the pid in boot.pid
+##########################################
+function thread_dump_on_boot_pid() {
+  local pid
+  pid=$(cat boot.pid)
+  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+    echo "Collecting JVM diagnostics..."
+    jstat -gccause "${pid}" 2>/dev/null || true
+    jstat -gccapacity "${pid}" 2>/dev/null || true
+    jstat -gcmetacapacity "${pid}" 2>/dev/null || true
+    echo "Sending SIGQUIT (kill -3) to Thread Dump on UAA process (pid=${pid})"
+    kill -3 "$pid" || true
+    # Wait a moment for the thread dump to be written
+    sleep 2
+  fi
 }
 
 ########################################

--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -11,11 +11,17 @@ function is_boot_running() {
   local start_time
   start_time=$(date +%s)
 
+  echo
+  echo "Waiting for the UAA server to start, only partial log messages will be shown as it progresses:"
   while true; do
     # Use curl to check if the port is responding
     # Any HTTP response (even 4xx/5xx) indicates the server is running
-    if curl -ksS --max-time 5 --connect-timeout 2 -u "admin:adminsecret" --data "client_id=admin&grant_type=client_credentials" -X POST "http://localhost:${port}/uaa/oauth/token"; then
+    if curl -ks --max-time 5 -o /dev/null --connect-timeout 2 -u "admin:adminsecret" \
+            --data "client_id=admin&grant_type=client_credentials" \
+            -X POST "http://localhost:${port}/uaa/oauth/token" 2>/dev/null; then
+      echo
       echo "Boot is running on port ${port}."
+      grep "Started UaaBootApplication" boot.log
       return 0
     fi
 
@@ -24,7 +30,12 @@ function is_boot_running() {
     elapsed_time=$((current_time - start_time))
 
     if [[ "$elapsed_time" -ge "$timeout" ]]; then
+      echo
       echo "Timeout reached. Boot did not start on port ${port}"
+      curl -ksS --max-time 5 --connect-timeout 2 -u "admin:adminsecret" \
+              --data "client_id=admin&grant_type=client_credentials" \
+              -X POST "http://localhost:${port}/uaa/info" || true
+
       thread_dump_on_boot_pid
       return 1
     fi

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
@@ -74,14 +74,20 @@ public class DefaultIntegrationTestConfig {
         options.addArguments(
                 "--verbose",
                 // Comment the following line to run selenium test browser in Headed Mode
-                "--headless",
+                "--headless=new", // Use new headless mode (more stable)
                 "--guest", //attempt to disable password checkups that disrupt the flow
                 "--disable-web-security",
                 "--ignore-certificate-errors",
                 "--allow-running-insecure-content",
                 "--allow-insecure-localhost",
-                "--no-sandbox",
+                "--no-sandbox", // Required for Docker/CI environments
+                "--disable-dev-shm-usage", // Overcome limited resource problems in Docker
                 "--disable-gpu",
+                "--disable-extensions",
+                "--disable-software-rasterizer",
+                "--disable-background-timer-throttling",
+                "--disable-backgrounding-occluded-windows",
+                "--disable-renderer-backgrounding",
                 "--remote-allow-origins=*"
         );
         options.setAcceptInsecureCerts(true);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/DefaultIntegrationTestConfig.java
@@ -72,7 +72,6 @@ public class DefaultIntegrationTestConfig {
     private static ChromeOptions getChromeOptions() {
         ChromeOptions options = new ChromeOptions();
         options.addArguments(
-                "--verbose",
                 // Comment the following line to run selenium test browser in Headed Mode
                 "--headless=new", // Use new headless mode (more stable)
                 "--guest", //attempt to disable password checkups that disrupt the flow
@@ -81,16 +80,37 @@ public class DefaultIntegrationTestConfig {
                 "--allow-running-insecure-content",
                 "--allow-insecure-localhost",
                 "--no-sandbox", // Required for Docker/CI environments
-                "--disable-dev-shm-usage", // Overcome limited resource problems in Docker
                 "--disable-gpu",
+                "--remote-allow-origins=*",
+                "--disable-dev-shm-usage", // Overcome limited resource problems in Docker
+                // Additional stability flags
                 "--disable-extensions",
                 "--disable-software-rasterizer",
                 "--disable-background-timer-throttling",
                 "--disable-backgrounding-occluded-windows",
                 "--disable-renderer-backgrounding",
-                "--remote-allow-origins=*"
+                "--disable-blink-features=AutomationControlled",
+                "--disable-features=TranslateUI",
+                // Hang detection and renderer stability flags
+                "--disable-hang-monitor", // Prevents Chrome from killing "hung" renderer processes (useful for slow backend responses)
+                "--disable-background-networking", // Reduces background network activity that could interfere with test requests
+                "--disable-features=RendererScheduling", // Disables aggressive renderer scheduling that might cause timeouts
+                "--run-all-compositor-stages-before-draw", // Ensures all rendering stages complete before drawing (prevents partial renders)
+                "--disable-prompt-on-repost",
+                "--disable-sync",
+                "--disable-component-extensions-with-background-pages",
+                "--force-color-profile=srgb",
+                "--no-first-run",
+                "--no-default-browser-check",
+                "--disable-default-apps",
+                "--disable-popup-blocking",
+                "--test-type",
+                "--disable-infobars"
         );
         options.setAcceptInsecureCerts(true);
+        
+        // Set page load strategy to 'normal' to ensure proper page load detection
+        options.setPageLoadStrategy(org.openqa.selenium.PageLoadStrategy.NORMAL);
 
         return options;
     }


### PR DESCRIPTION
- Bump `bouncyCastleFipsVersion` to 2.1.2 in dependencies.
  - org.bouncycastle.native.loader.install_dir allows a user to specify where the .so files should be found
  - Docker may not have system tmp mounted as executable
  - Create and utilize separate temporary directory for integration tests.
  - Adjust JVM options to reference the new temp directory in the script.
- Check server readiness via HTTP instead of log file parsing
  - Handle boot timeout with additional logging: JVM diagnostics and `SIGQUIT` for stuck processes.
- Add logging config to integration tests
  - Eliminate the error that log config was not found
- Adjust Gradle settings
  - Add timeout to gradle integrationTest task
  - Reduce Gradle max workers to 2 in integration tests
  - Compiling test Java classes separate from execution
  - Change memory settings on integration Test task
- Update Selenium headless mode and Chrome flags for improved reliability in Docker/CI environments.
- Update JVM GC strategy to G1 in integration tests