### PR TITLE
Adjust test settings to gather timing data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,11 +112,40 @@ subprojects {
                     "-XX:HeapDumpPath=/var/log/uaa-tests.hprof"
         ]
 
+        // Enable test timing to identify slow tests
+        // This helps debug CI performance issues
+        reports {
+            junitXml.required = true
+            html.required = true
+        }
+
         testLogging {
             events("failed")
             exceptionFormat = "full"
-            // Uncomment the following line to see all standard output from tests (there's a ton of it!)
-            //showStandardStreams = true
+            // Set showStandardStreams=true to see all standard output from tests (there's a ton of it!)
+            showStandardStreams = false
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+        }
+
+        // Add system property to enable detailed test timing
+        systemProperty("junit.jupiter.execution.timeout.default", System.getProperty("junit.jupiter.execution.timeout.default", "0"))
+
+        // Log slow tests to help identify bottlenecks
+        afterTest { descriptor, result ->
+            def duration = result.endTime - result.startTime
+            if (duration > 10000) { // 10 seconds
+                logger.warn("SLOW TEST: ${descriptor.className}.${descriptor.name} took ${duration}ms")
+            }
+        }
+
+        // Log summary of test execution times
+        afterSuite { descriptor, result ->
+            if (descriptor.parent == null) {
+                def duration = result.endTime - result.startTime
+                logger.lifecycle("[${project.name}] Unit tests completed: ${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped in ${duration}ms")
+            }
         }
     }
 
@@ -144,8 +173,30 @@ subprojects {
         testLogging {
             events("failed")
             exceptionFormat = "full"
-            // Uncomment the following line to see all standard output from tests (there's a ton of it!)
-            //showStandardStreams = true
+            // Set showStandardStreams=true to see all standard output from tests (there's a ton of it!)
+            showStandardStreams = false
+            showCauses = true
+            showExceptions = true
+            showStackTraces = true
+        }
+
+        // Add system property to enable detailed test timing
+        systemProperty("junit.jupiter.execution.timeout.default", System.getProperty("junit.jupiter.execution.timeout.default", "0"))
+
+        // Log slow tests to help identify bottlenecks
+        afterTest { descriptor, result ->
+            def duration = result.endTime - result.startTime
+            if (duration > 20000) { // 20 seconds
+                logger.warn("SLOW TEST: ${descriptor.className}.${descriptor.name} took ${duration}ms")
+            }
+        }
+
+        // Log summary of test execution times
+        afterSuite { descriptor, result ->
+            if (descriptor.parent == null) {
+                def duration = result.endTime - result.startTime
+                logger.lifecycle("[${project.name}] Integration tests completed: ${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped in ${duration}ms")
+            }
         }
     }
 

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -36,6 +36,7 @@ function main() {
     # Increased Gradle daemon heap to 1GB to prevent hanging with 2 workers
     # --no-configuration-cache prevents stale Kotlin compiler state reuse between daemon processes
     # logging.manager is set to org.apache.logging.log4j.jul.LogManager to prevent log4j2 from using java.util.logging
+    # See https://docs.gradle.org/9.2.0/userguide/config_gradle.html#sec:configuring_jvm_memory
     echo "Setting boot heap to ${jvm_heap:=640m}"
     echo "Setting boot metaspace to ${jvm_metaspace:=192m}"
     echo "Setting Gradle daemon heap to ${gradle_heap:=1024m}"
@@ -77,7 +78,7 @@ function main() {
     # Explicit Gradle daemon memory for Kotlin 2.2 with additional GC tuning
     readonly assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
-                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=100' \
+                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100' \
                 assemble \
                 --no-watch-fs \
                 --no-daemon \
@@ -93,7 +94,7 @@ function main() {
                 '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
                 '-DskipUaaAutoStart=true' \
-                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true' \
+                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true' \
                 '-Dorg.gradle.daemon.idletimeout=300000' \
                 '-Dorg.gradle.parallel=false' \
                 '-Dorg.gradle.workers.max=2' \

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -21,21 +21,37 @@ function main() {
   pushd "$(dirname ${script_dir})"
     start_ldap
 
-    set -x
-    
-    ./gradlew "-Dspring.profiles.active=${test_profile}" \
-                "-Djava.security.egd=file:/dev/./urandom" \
-                clean assemble compileTestJava \
-                --stacktrace  \
-                --no-daemon \
-                --console=plain
+  # See https://docs.gradle.org/9.2.0/userguide/config_gradle.html#sec:configuring_jvm_memory
+  echo "Setting Gradle daemon heap to ${gradle_heap:=1024m}"
+  echo "Setting test worker heap to ${gradle_test_heap:=640m}"
+
+  set -x
+  ./gradlew -Dspring.profiles.active=${test_profile} \
+            -Djava.security.egd=file:/dev/./urandom \
+            "-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100" \
+            clean assemble compileTestJava \
+            --no-watch-fs \
+            --no-daemon \
+            --no-configuration-cache \
+            --max-workers=2 \
+            --stacktrace \
+            --console=plain
 
     ./gradlew "-Dspring.profiles.active=${test_profile}" \
-            "-Djava.security.egd=file:/dev/./urandom" \
+            -Djava.security.egd=file:/dev/./urandom \
+            "-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true" \
+            -Dorg.gradle.daemon.idletimeout=300000 \
+            -Dorg.gradle.parallel=false \
+            -Dorg.gradle.workers.max=2 \
             ${UAA_GRADLE_UNIT_TEST_COMMAND:-test} \
-            --stacktrace  \
+            --no-watch-fs \
             --no-daemon \
+            --no-configuration-cache \
+            --max-workers=2 \
+            --stacktrace \
             --console=plain
+
+    { set +x; } 2>/dev/null
   popd
 }
 


### PR DESCRIPTION
### Update unit test settings

making them closer to the updated integration_tests.sh settings

### Add additional logging for test timing

Display for each gradle subproject and slow tests
e.g.
> [cloudfoundry-identity-metrics-data] Unit tests completed: 42 tests, 42 passed, 0 failed, 0 skipped in 6978ms
> 
> SLOW TEST: org.cloudfoundry.identity.uaa.performance.LoginPagePerformanceMockMvcTest.idpDiscoveryRedirectsToOIDCProvider(JdbcIdentityProviderProvisioning) took 32292ms

### Adjust metaspace size

This gradle default is 384m, as shown in the doc:
https://docs.gradle.org/9.2.0/userguide/config_gradle.html#sec:configuring_jvm_memory

Was seeing the following message:
> The Daemon will expire after the build after running out of JVM Metaspace.
> The project memory settings are likely not configured or are configured to an insufficient value.
> The daemon will restart for the next build, which may increase subsequent build times.
> These settings can be adjusted by setting 'org.gradle.jvmargs' in 'gradle.properties'.
> The currently configured max heap space is '1 GiB' and the configured max metaspace is '128 MiB'.
> For more information on how to set these values, please refer to https://docs.gradle.org/9.2.0/userguide/build_environment.html#sec:configuring_jvm_memory in the Gradle documentation.
> To disable this warning, set 'org.gradle.daemon.performance.disable-logging=true'.
