### PR TITLE
Eliminate test setup on skipped tests

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/extensions/profiles/ProfileSelectionExtension.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/extensions/profiles/ProfileSelectionExtension.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.extensions.profiles;
 
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -17,10 +17,10 @@ import java.util.List;
  * @see DisabledIfProfile
  * @see EnabledIfProfile
  */
-public class ProfileSelectionExtension implements BeforeTestExecutionCallback {
+public class ProfileSelectionExtension implements BeforeEachCallback {
 
     @Override
-    public void beforeTestExecution(ExtensionContext context) {
+    public void beforeEach(ExtensionContext context) {
         var activeProfiles = getActiveProfilesOrNull(context);
         if (activeProfiles == null) {
             return;


### PR DESCRIPTION
Update ProfileSelectionExtension to use BeforeEachCallback for JUnit tests instead of BeforeTestExecutionCallback

MySqlDbMigrationIntegrationTest, HsqlDbMigrationIntegrationTest, PostgresDbMigrationIntegrationTest were all doing test setup even when the tests were skipped.