### PR TITLE
Fix SCIM DateTime Filter Timezone Parsing

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -339,7 +339,7 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
 
     private Object getStringOrDate(String s) {
         try {
-            DateFormat timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            DateFormat timestampFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
             return timestampFormat.parse(s);
         } catch (ParseException x) {
             return s;


### PR DESCRIPTION
Fixes #3699

This PR fixes a bug in UAA's SCIM filter implementation where ISO 8601 timestamps with timezone information were incorrectly parsed by ignoring the timezone and using the JVM's local timezone instead.

Changed the SimpleDateFormat pattern from `'Z'` (literal character) to `X` (ISO 8601 timezone):

- **Before**: `'Z'` in quotes treated as literal character → timezone information ignored, timestamp parsed in local time
- **After**: `X` correctly interprets ISO 8601 timezone indicators (Z for UTC, +HH:MM/-HH:MM for offsets) → timestamp parsed with correct timezone