### PR TITLE
Streamline Gradle commands in test jobs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  container-test-job:
+  db-integration-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  container-test-job:
+  db-unit-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,8 @@ subprojects {
         afterSuite { descriptor, result ->
             if (descriptor.parent == null) {
                 def duration = result.endTime - result.startTime
-                logger.lifecycle("[${project.name}] Unit tests completed: ${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped in ${duration}ms")
+                def testLabel = result.testCount == 1 ? "unit-test" : "unit-tests"
+                logger.lifecycle("[${project.name}] Completed ${result.testCount} ${testLabel} in ${duration}ms (passed=${result.successfulTestCount};failed=${result.failedTestCount};skipped=${result.skippedTestCount})")
             }
         }
     }
@@ -195,7 +196,8 @@ subprojects {
         afterSuite { descriptor, result ->
             if (descriptor.parent == null) {
                 def duration = result.endTime - result.startTime
-                logger.lifecycle("[${project.name}] Integration tests completed: ${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped in ${duration}ms")
+                def testLabel = result.testCount == 1 ? "integration-test" : "integration-tests"
+                logger.lifecycle("[${project.name}] Completed ${result.testCount} ${testLabel} in ${duration}ms (passed=${result.successfulTestCount};failed=${result.failedTestCount};skipped=${result.skippedTestCount})")
             }
         }
     }

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -79,7 +79,7 @@ function main() {
     readonly assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
                 '-Djava.security.egd=file:/dev/./urandom' \
                 '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100' \
-                assemble \
+                clean assemble \
                 --no-watch-fs \
                 --no-daemon \
                 --no-configuration-cache \
@@ -98,7 +98,7 @@ function main() {
                 '-Dorg.gradle.daemon.idletimeout=300000' \
                 '-Dorg.gradle.parallel=false' \
                 '-Dorg.gradle.workers.max=2' \
-                clean assemble compileTestJava \
+                compileTestJava \
                 --no-watch-fs \
                 --no-daemon \
                 --no-configuration-cache \

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -42,94 +42,53 @@ function main() {
     echo "Setting Gradle daemon heap to ${gradle_heap:=1024m}"
     echo "Setting test worker heap to ${gradle_test_heap:=640m}"
 
-    readonly launch_boot="nohup java \
-               -XX:+UseG1GC \
-               -XX:G1HeapRegionSize=1m \
-               -Xms64m -Xmx${jvm_heap} \
-               -XX:MaxMetaspaceSize=${jvm_metaspace} \
-               -XX:MetaspaceSize=${jvm_metaspace} \
-               -XX:+UseStringDeduplication \
-               -XX:MaxGCPauseMillis=200 \
-               -XX:+HeapDumpOnOutOfMemoryError \
-               -XX:HeapDumpPath=${wd} \
-               -DCLOUDFOUNDRY_CONFIG_PATH=${wd}/scripts/boot \
-               -Dlogging.config=${wd}/scripts/boot/log4j2.properties \
-               -Dlog4j.configurationFile=${wd}/scripts/boot/log4j2.properties \
-               -Dlog4j2.formatMsgNoLookups=true \
-               -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
-               -DSECRETS_DIR=${wd}/scripts/boot \
-               -Djava.security.egd=file:/dev/./urandom \
-               -Djava.io.tmpdir=${temp_dir} \
-               -Dorg.bouncycastle.native.loader.install_dir=${temp_dir} \
-               -Dmetrics.perRequestMetrics=true \
-               -Dserver.servlet.context-path=/uaa \
-               -Dserver.tomcat.basedir=${wd}/scripts/boot/tomcat \
-               -Dsmtp.host=localhost \
-               -Dsmtp.port=2525 \
-               -Dspring.profiles.active=${test_profile} \
-               -Dstatsd.enabled=true \
-               -Dfile.encoding=UTF-8 \
-               -Duser.country=US \
-               -Duser.language=en \
-               -Duser.variant \
-               -jar ${wd}/uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war \
-               > boot.log 2>&1 &"
-
-    # Explicit Gradle daemon memory for Kotlin 2.2 with additional GC tuning
-    readonly assemble_code="./gradlew '-Dspring.profiles.active=${test_profile}' \
-                '-Djava.security.egd=file:/dev/./urandom' \
-                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100' \
-                clean assemble \
-                --no-watch-fs \
-                --no-daemon \
-                --no-configuration-cache \
-                --max-workers=2 \
-                --stacktrace \
-                --console=plain"
-
-    # Explicit memory limits for test JVMs with GC tuning and classloader fixes
-    # All flags required to prevent classloading deadlocks and thread starvation during test init
-    # --no-configuration-cache prevents stale Kotlin compiler state reuse between daemon processes
-    readonly compile_test_code="./gradlew \
-                '-Dspring.profiles.active=${test_profile}' \
-                '-Djava.security.egd=file:/dev/./urandom' \
-                '-DskipUaaAutoStart=true' \
-                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true' \
-                '-Dorg.gradle.daemon.idletimeout=300000' \
-                '-Dorg.gradle.parallel=false' \
-                '-Dorg.gradle.workers.max=2' \
-                compileTestJava \
-                --no-watch-fs \
-                --no-daemon \
-                --no-configuration-cache \
-                --max-workers=2 \
-                --stacktrace \
-                --console=plain"
-
-    # Explicit memory limits for test JVMs with GC tuning and classloader fixes
-    # All flags required to prevent classloading deadlocks and thread starvation during test init
-    readonly integration_test_code="./gradlew \
-                '-Dspring.profiles.active=${test_profile}' \
-                '-Djava.security.egd=file:/dev/./urandom' \
-                '-DskipUaaAutoStart=true' \
-                '-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true' \
-                '-Dorg.gradle.daemon.idletimeout=300000' \
-                '-Dorg.gradle.parallel=false' \
-                '-Dorg.gradle.workers.max=2' \
-                ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
-                --no-watch-fs \
-                --no-daemon \
-                --no-configuration-cache \
-                --max-workers=2 \
-                --stacktrace \
-                --console=plain"
-
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
       set -x
-      eval "$assemble_code"
+      # Explicit Gradle daemon memory with additional GC tuning
+      ./gradlew -Dspring.profiles.active="${test_profile}" \
+        -Djava.security.egd=file:/dev/./urandom \
+        -Dorg.gradle.jvmargs="-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100" \
+        assemble \
+        --no-watch-fs \
+        --no-daemon \
+        --no-configuration-cache \
+        --max-workers=2 \
+        --stacktrace \
+        --console=plain
 
       # Start and ensure the boot server is running before integration tests
-      eval "$launch_boot"
+      nohup java \
+        -XX:+UseG1GC \
+        -XX:G1HeapRegionSize=1m \
+        -Xms64m -Xmx${jvm_heap} \
+        -XX:MaxMetaspaceSize=${jvm_metaspace} \
+        -XX:MetaspaceSize=${jvm_metaspace} \
+        -XX:+UseStringDeduplication \
+        -XX:MaxGCPauseMillis=200 \
+        -XX:+HeapDumpOnOutOfMemoryError \
+        -XX:HeapDumpPath="${wd}" \
+        -DCLOUDFOUNDRY_CONFIG_PATH="${wd}/scripts/boot" \
+        -Dlogging.config="${wd}/scripts/boot/log4j2.properties" \
+        -Dlog4j.configurationFile="${wd}/scripts/boot/log4j2.properties" \
+        -Dlog4j2.formatMsgNoLookups=true \
+        -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
+        -DSECRETS_DIR="${wd}/scripts/boot" \
+        -Djava.security.egd=file:/dev/./urandom \
+        -Djava.io.tmpdir="${temp_dir}" \
+        -Dorg.bouncycastle.native.loader.install_dir="${temp_dir}" \
+        -Dmetrics.perRequestMetrics=true \
+        -Dserver.servlet.context-path=/uaa \
+        -Dserver.tomcat.basedir="${wd}/scripts/boot/tomcat" \
+        -Dsmtp.host=localhost \
+        -Dsmtp.port=2525 \
+        -Dspring.profiles.active="${test_profile}" \
+        -Dstatsd.enabled=true \
+        -Dfile.encoding=UTF-8 \
+        -Duser.country=US \
+        -Duser.language=en \
+        -Duser.variant \
+        -jar "${wd}/uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war" \
+        > boot.log 2>&1 &
       echo $! > boot.pid
       { set +x; } 2>/dev/null
 
@@ -144,9 +103,36 @@ function main() {
       if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
         export DBUS_SESSION_BUS_ADDRESS=/dev/null
       fi
+
       set -x
-      eval "$compile_test_code"
-      eval "$integration_test_code"
+      # Explicit memory limits for test JVMs with GC tuning and classloader fixes
+      # All flags required to prevent classloading deadlocks and thread starvation during test init
+      # --no-configuration-cache prevents stale Kotlin compiler state reuse between daemon processes
+      ./gradlew \
+        -Dspring.profiles.active=${test_profile} \
+        -DskipUaaAutoStart=true \
+        --no-daemon \
+        --no-configuration-cache \
+        compileTestJava
+
+      # Explicit memory limits for test JVMs with GC tuning and classloader fixes
+      # All flags required to prevent classloading deadlocks and thread starvation during test init
+      ./gradlew \
+        -Dspring.profiles.active="${test_profile}" \
+        -Djava.security.egd=file:/dev/./urandom \
+        -DskipUaaAutoStart=true \
+        -Dorg.gradle.jvmargs="-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true" \
+        -Dorg.gradle.daemon.idletimeout=300000 \
+        -Dorg.gradle.parallel=false \
+        -Dorg.gradle.workers.max=2 \
+        ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
+        --no-watch-fs \
+        --no-daemon \
+        --no-configuration-cache \
+        --max-workers=2 \
+        --stacktrace \
+        --console=plain
+
       { set +x; } 2>/dev/null
       
       # Clean up: kill the boot server
@@ -158,7 +144,11 @@ function main() {
       fi
     else
       set -x
-      echo "$integration_test_code"
+      echo "./gradlew \
+                -Dspring.profiles.active=${test_profile} \
+                -DskipUaaAutoStart=true \
+                ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
+                --console=plain"
       bash
     fi
   popd

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -109,7 +109,7 @@ function main() {
       # All flags required to prevent classloading deadlocks and thread starvation during test init
       # --no-configuration-cache prevents stale Kotlin compiler state reuse between daemon processes
       ./gradlew \
-        -Dspring.profiles.active=${test_profile} \
+        -Dspring.profiles.active="${test_profile}" \
         -DskipUaaAutoStart=true \
         --no-daemon \
         --no-configuration-cache \

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -26,7 +26,7 @@ function main() {
   echo "Setting test worker heap to ${gradle_test_heap:=640m}"
 
   set -x
-  ./gradlew -Dspring.profiles.active=${test_profile} \
+  ./gradlew -Dspring.profiles.active="${test_profile}" \
             -Djava.security.egd=file:/dev/./urandom \
             "-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100" \
             clean compileTestJava \
@@ -37,7 +37,7 @@ function main() {
             --stacktrace \
             --console=plain
 
-    ./gradlew "-Dspring.profiles.active=${test_profile}" \
+    ./gradlew -Dspring.profiles.active="${test_profile}" \
             -Djava.security.egd=file:/dev/./urandom \
             "-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true" \
             -Dorg.gradle.daemon.idletimeout=300000 \

--- a/scripts/unit_tests.sh
+++ b/scripts/unit_tests.sh
@@ -29,7 +29,7 @@ function main() {
   ./gradlew -Dspring.profiles.active=${test_profile} \
             -Djava.security.egd=file:/dev/./urandom \
             "-Dorg.gradle.jvmargs=-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100" \
-            clean assemble compileTestJava \
+            clean compileTestJava \
             --no-watch-fs \
             --no-daemon \
             --no-configuration-cache \


### PR DESCRIPTION
also rename jobs to make it easier to distinguish unit/int test runs