### PR TITLE
Expose StatsDClient as a Bean

### DIFF
--- a/statsd-lib/src/main/java/org/cloudfoundry/identity/statsd/StatsdConfiguration.java
+++ b/statsd-lib/src/main/java/org/cloudfoundry/identity/statsd/StatsdConfiguration.java
@@ -15,6 +15,7 @@
 package org.cloudfoundry.identity.statsd;
 
 import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.StatsDClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -22,18 +23,22 @@ import org.springframework.scheduling.annotation.SchedulingConfigurer;
 
 import java.lang.management.ManagementFactory;
 import java.time.Instant;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.temporal.ChronoUnit;
 
 @Configuration
 @EnableScheduling
 public class StatsdConfiguration {
 
     @Bean
-    public UaaMetricsEmitter statsDClientWrapper() {
+    public StatsDClient statsDClient() {
+        return new NonBlockingStatsDClient("uaa", "localhost", 8125);
+    }
+
+    @Bean
+    public UaaMetricsEmitter statsDClientWrapper(StatsDClient statsDClient) {
         return new UaaMetricsEmitter(
                 new MetricsUtils(),
-                new NonBlockingStatsDClient("uaa", "localhost", 8125),
+                statsDClient,
                 ManagementFactory.getPlatformMBeanServer());
     }
 
@@ -45,16 +50,12 @@ public class StatsdConfiguration {
                     if (uaaMetricsEmitter.isNotificationEnabled()) {
                         return null;
                     }
-                    return triggerContext.lastCompletionTime() != null
-                            ? getFiveSecondsFrom(triggerContext.lastCompletionTime())
-                            : getFiveSecondsFrom(new Date());
+                    Instant lastCompletion = triggerContext.lastCompletion();
+                    return getFiveSecondsFrom(lastCompletion != null ? lastCompletion : Instant.now());
                 });
     }
 
-    private Instant getFiveSecondsFrom(Date date) {
-        Calendar calendar = Calendar.getInstance();
-        calendar.setTime(date);
-        calendar.add(Calendar.SECOND, 5);
-        return calendar.getTime().toInstant();
+    private Instant getFiveSecondsFrom(Instant instant) {
+        return instant.plus(5, ChronoUnit.SECONDS);
     }
 }

--- a/statsd-lib/src/test/java/org/cloudfoundry/identity/statsd/StatsdConfigurationTest.java
+++ b/statsd-lib/src/test/java/org/cloudfoundry/identity/statsd/StatsdConfigurationTest.java
@@ -1,0 +1,30 @@
+package org.cloudfoundry.identity.statsd;
+
+import com.timgroup.statsd.StatsDClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = StatsdConfiguration.class)
+class StatsdConfigurationTest {
+    @Autowired
+    private StatsDClient statsDClient;
+    @Autowired
+    private UaaMetricsEmitter metricsEmitter;
+
+    @Test
+    void wiresUaaMetricsEmitter() {
+        assertThat(metricsEmitter)
+                .isInstanceOf(UaaMetricsEmitter.class);
+
+        assertThat(statsDClient)
+                .isInstanceOf(StatsDClient.class);
+
+        StatsDClient emitterClient = (StatsDClient) ReflectionTestUtils.getField(metricsEmitter, "statsDClient");
+        assertThat(emitterClient)
+                .isSameAs(statsDClient);
+    }
+}


### PR DESCRIPTION
Create StatsDClient as a Bean, so that it can be used in other places

- lastCompletionTime is deprecated change to the Instant based call