### PR TITLE
fix: include NameID Format in SAML LogoutRequest

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
@@ -9,6 +9,8 @@ import org.cloudfoundry.identity.uaa.security.web.CookieBasedCsrfTokenRepository
 import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
 import org.cloudfoundry.identity.uaa.web.UaaSavedRequestAwareAuthenticationSuccessHandler;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
+import org.opensaml.saml.saml2.core.LogoutRequest;
+import org.opensaml.saml.saml2.core.NameID;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -147,7 +149,13 @@ public class SamlAuthenticationFilterConfig {
 
     @Bean
     Saml2LogoutRequestResolver saml2LogoutRequestResolver(RelyingPartyRegistrationResolver relyingPartyRegistrationResolver) {
-        return new OpenSaml4LogoutRequestResolver(relyingPartyRegistrationResolver);
+        OpenSaml4LogoutRequestResolver logoutRequestResolver = new OpenSaml4LogoutRequestResolver(relyingPartyRegistrationResolver);
+        logoutRequestResolver.setParametersConsumer((parameters) -> {
+            LogoutRequest logoutRequest = parameters.getLogoutRequest();
+            NameID nameId = logoutRequest.getNameID();
+            nameId.setFormat(parameters.getRelyingPartyRegistration().getNameIdFormat());
+        });
+        return logoutRequestResolver;
     }
 
     /**

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/TestOpenSamlObjects.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/TestOpenSamlObjects.java
@@ -555,6 +555,7 @@ public final class TestOpenSamlObjects {
         logoutRequest.setID("id");
         NameIDBuilder nameIdBuilder = new NameIDBuilder();
         NameID nameId = nameIdBuilder.buildObject();
+        nameId.setFormat(registration.getNameIdFormat());
         nameId.setValue("user");
         logoutRequest.setNameID(nameId);
         IssuerBuilder issuerBuilder = new IssuerBuilder();


### PR DESCRIPTION
Shibboleth generally requires that the NameID element in a SAML LogoutRequest matches the NameID issued during the initial authentication, including its Format attribute. 

Follows Spring documentation for customizing the SAML2 LogoutRequest resolution:

https://github.com/spring-projects/spring-security/blob/5a7d93ee3b6658fbd03f0f57daeb42d3f382016d/docs/modules/ROOT/pages/servlet/saml2/logout.adoc#customizing-saml2logoutrequest-resolution
