### PR TITLE
fix: log at debug when openid scope not included

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenGranter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenGranter.java
@@ -73,7 +73,7 @@ public class IdTokenGranter {
         if (requestedScopes != null &&
                 !requestedScopes.isEmpty() &&
                 !requestedScopes.contains(REQUIRED_OPENID_SCOPE)) {
-            logger.info("an ID token was requested but 'openid' is missing from the requested scopes");
+            logger.debug("an ID token was requested but 'openid' is missing from the requested scopes");
             return false;
         }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -3,10 +3,12 @@ package org.cloudfoundry.identity.uaa.oauth;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.approval.Approval;
 import org.cloudfoundry.identity.uaa.approval.JdbcApprovalStore;
@@ -62,6 +64,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.apache.logging.log4j.Level.DEBUG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.cloudfoundry.identity.uaa.oauth.TokenTestSupport.GRANT_TYPE;
@@ -168,6 +171,7 @@ class UaaTokenServicesTests {
         class WhenUserDoesntRequestOpenIdScope {
             private List<String> logEvents = new ArrayList<>();
             private AbstractAppender appender;
+            private Level originalLevel;
 
             @BeforeEach
             void addLoggerAppender() {
@@ -180,6 +184,8 @@ class UaaTokenServicesTests {
                 appender.start();
 
                 LoggerContext context = (LoggerContext) LogManager.getContext(false);
+                originalLevel = context.getRootLogger().getLevel();
+                Configurator.setRootLevel(DEBUG);
                 context.getRootLogger().addAppender(appender);
             }
 
@@ -189,6 +195,7 @@ class UaaTokenServicesTests {
                 if (appender != null) {
                     context.getRootLogger().removeAppender(appender);
                 }
+                Configurator.setRootLevel(originalLevel);
             }
 
             @BeforeEach


### PR DESCRIPTION
- Should be able to request an access token without openid scope (i.e. ID token not requested) and not log an info-level message. Make the log debug instead.