### PR TITLE
feat: omit explicit DB Statement for health check 

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -24,11 +24,14 @@ public class HealthzEndpoint {
     private volatile boolean stopping;
     private volatile Boolean wasLastConnectionSuccessful = null;
     private DataSource dataSource;
+    private String healthCheckStatement;
+
 
     public HealthzEndpoint(
             @Value("${uaa.shutdown.sleep:10000}") final long sleepTime,
             final Runtime runtime,
-            final DataSource dataSource) {
+            final DataSource dataSource,
+            @Value("${uaa.health.db.statement:SELECT 1 from identity_zone;}") final String healthCheckStatement) {
         Thread shutdownHook = new Thread(() -> {
             stopping = true;
             logger.warn("Shutdown hook received, future requests to this endpoint will return 503");
@@ -43,6 +46,7 @@ public class HealthzEndpoint {
         });
         runtime.addShutdownHook(shutdownHook);
         this.dataSource = dataSource;
+        this.healthCheckStatement = healthCheckStatement;
     }
 
     @GetMapping({"/healthz", "/healthz/**"})
@@ -72,7 +76,7 @@ public class HealthzEndpoint {
     @Scheduled(fixedRateString = "${uaa.health.db.rate:10000}")
     void isDataSourceConnectionAvailable() {
         try (Connection c = dataSource.getConnection(); Statement statement = c.createStatement()) {
-            statement.execute("SELECT 1 from identity_zone;"); //"SELECT 1;" Not supported by HSQLDB
+            statement.execute(healthCheckStatement);
             wasLastConnectionSuccessful = true;
             return;
         } catch (Exception ex) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/health/HealthzEndpoint.java
@@ -11,12 +11,15 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
-import java.sql.Statement;
 
 /**
  * Simple controller that just returns "ok" in a request body for the purposes
  * of monitoring health of the application. It also registers a shutdown hook
  * and returns "stopping" and a 503 when the process is shutting down.
+ * The background database check only establishes a connection from the pool
+ * without executing an additional query. The configured DataSource already
+ * runs a validation query on every connection borrow ({@code testOnBorrow=true}),
+ * so obtaining a connection is sufficient to verify database connectivity.
  */
 @Controller
 public class HealthzEndpoint {
@@ -24,14 +27,12 @@ public class HealthzEndpoint {
     private volatile boolean stopping;
     private volatile Boolean wasLastConnectionSuccessful = null;
     private DataSource dataSource;
-    private String healthCheckStatement;
 
 
     public HealthzEndpoint(
             @Value("${uaa.shutdown.sleep:10000}") final long sleepTime,
             final Runtime runtime,
-            final DataSource dataSource,
-            @Value("${uaa.health.db.statement:SELECT 1 from identity_zone;}") final String healthCheckStatement) {
+            final DataSource dataSource) {
         Thread shutdownHook = new Thread(() -> {
             stopping = true;
             logger.warn("Shutdown hook received, future requests to this endpoint will return 503");
@@ -46,7 +47,6 @@ public class HealthzEndpoint {
         });
         runtime.addShutdownHook(shutdownHook);
         this.dataSource = dataSource;
-        this.healthCheckStatement = healthCheckStatement;
     }
 
     @GetMapping({"/healthz", "/healthz/**"})
@@ -75,8 +75,7 @@ public class HealthzEndpoint {
 
     @Scheduled(fixedRateString = "${uaa.health.db.rate:10000}")
     void isDataSourceConnectionAvailable() {
-        try (Connection c = dataSource.getConnection(); Statement statement = c.createStatement()) {
-            statement.execute(healthCheckStatement);
+        try (Connection c = dataSource.getConnection()) {
             wasLastConnectionSuccessful = true;
             return;
         } catch (Exception ex) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
@@ -36,7 +36,8 @@ class HealthzEndpointTests {
         statement = mock(Statement.class);
         when(dataSource.getConnection()).thenReturn(connection);
         when(connection.createStatement()).thenReturn(statement);
-        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, dataSource);
+        String healthCheckStatement = "SELECT 1 FROM identity_zone;";
+        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, dataSource, healthCheckStatement);
         response = new MockHttpServletResponse();
 
         ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);
@@ -51,9 +52,10 @@ class HealthzEndpointTests {
     }
 
     @Test
-    void getHealthz_connectionSuccess() {
+    void getHealthz_connectionSuccess() throws SQLException {
         endpoint.isDataSourceConnectionAvailable();
         assertThat(endpoint.getHealthz(response)).isEqualTo("ok\n");
+        verify(statement).execute("SELECT 1 FROM identity_zone;");
     }
 
     @Test
@@ -62,6 +64,24 @@ class HealthzEndpointTests {
         endpoint.isDataSourceConnectionAvailable();
         assertThat(endpoint.getHealthz(response)).isEqualTo("Database Connection failed.\n");
         assertThat(response.getStatus()).isEqualTo(503);
+    }
+
+    @Test
+    void getHealthz_withChangedStatement() throws SQLException {
+        Runtime mockRuntime = mock(Runtime.class);
+        DataSource changedDataSource = mock(DataSource.class);
+        Connection changedConnection = mock(Connection.class);
+        Statement changeStatement = mock(Statement.class);
+        when(changedDataSource.getConnection()).thenReturn(changedConnection);
+        when(changedConnection.createStatement()).thenReturn(changeStatement);
+
+        String changedHealthCheckStatement = "SELECT 1;";
+        HealthzEndpoint changedEndpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, changedDataSource, changedHealthCheckStatement);
+        MockHttpServletResponse changedResponse = new MockHttpServletResponse();
+
+        changedEndpoint.isDataSourceConnectionAvailable();
+        assertThat(changedEndpoint.getHealthz(changedResponse)).isEqualTo("ok\n");
+        verify(changeStatement).execute(changedHealthCheckStatement);
     }
 
     @Test
@@ -81,7 +101,8 @@ class HealthzEndpointTests {
         void setUp() {
             Runtime mockRuntime = mock(Runtime.class);
             DataSource dataSource = mock(DataSource.class);
-            endpoint = new HealthzEndpoint(-1, mockRuntime, dataSource);
+            String healthCheckStatement = "SELECT 1 FROM identity_zone;";
+            endpoint = new HealthzEndpoint(-1, mockRuntime, dataSource, healthCheckStatement);
             response = new MockHttpServletResponse();
 
             ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/health/HealthzEndpointTests.java
@@ -9,10 +9,8 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,18 +24,14 @@ class HealthzEndpointTests {
     private Thread shutdownHook;
     private DataSource dataSource;
     private Connection connection;
-    private Statement statement;
 
     @BeforeEach
     void setUp() throws SQLException {
         Runtime mockRuntime = mock(Runtime.class);
         dataSource = mock(DataSource.class);
         connection = mock(Connection.class);
-        statement = mock(Statement.class);
         when(dataSource.getConnection()).thenReturn(connection);
-        when(connection.createStatement()).thenReturn(statement);
-        String healthCheckStatement = "SELECT 1 FROM identity_zone;";
-        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, dataSource, healthCheckStatement);
+        endpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, dataSource);
         response = new MockHttpServletResponse();
 
         ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);
@@ -55,33 +49,15 @@ class HealthzEndpointTests {
     void getHealthz_connectionSuccess() throws SQLException {
         endpoint.isDataSourceConnectionAvailable();
         assertThat(endpoint.getHealthz(response)).isEqualTo("ok\n");
-        verify(statement).execute("SELECT 1 FROM identity_zone;");
+        verify(dataSource).getConnection();
     }
 
     @Test
     void getHealthz_connectionFailed() throws SQLException {
-        when(statement.execute(anyString())).thenThrow(new SQLException());
+        when(dataSource.getConnection()).thenThrow(new SQLException());
         endpoint.isDataSourceConnectionAvailable();
         assertThat(endpoint.getHealthz(response)).isEqualTo("Database Connection failed.\n");
         assertThat(response.getStatus()).isEqualTo(503);
-    }
-
-    @Test
-    void getHealthz_withChangedStatement() throws SQLException {
-        Runtime mockRuntime = mock(Runtime.class);
-        DataSource changedDataSource = mock(DataSource.class);
-        Connection changedConnection = mock(Connection.class);
-        Statement changeStatement = mock(Statement.class);
-        when(changedDataSource.getConnection()).thenReturn(changedConnection);
-        when(changedConnection.createStatement()).thenReturn(changeStatement);
-
-        String changedHealthCheckStatement = "SELECT 1;";
-        HealthzEndpoint changedEndpoint = new HealthzEndpoint(SLEEP_UPON_SHUTDOWN, mockRuntime, changedDataSource, changedHealthCheckStatement);
-        MockHttpServletResponse changedResponse = new MockHttpServletResponse();
-
-        changedEndpoint.isDataSourceConnectionAvailable();
-        assertThat(changedEndpoint.getHealthz(changedResponse)).isEqualTo("ok\n");
-        verify(changeStatement).execute(changedHealthCheckStatement);
     }
 
     @Test
@@ -101,8 +77,7 @@ class HealthzEndpointTests {
         void setUp() {
             Runtime mockRuntime = mock(Runtime.class);
             DataSource dataSource = mock(DataSource.class);
-            String healthCheckStatement = "SELECT 1 FROM identity_zone;";
-            endpoint = new HealthzEndpoint(-1, mockRuntime, dataSource, healthCheckStatement);
+            endpoint = new HealthzEndpoint(-1, mockRuntime, dataSource);
             response = new MockHttpServletResponse();
 
             ArgumentCaptor<Thread> threadArgumentCaptor = ArgumentCaptor.forClass(Thread.class);


### PR DESCRIPTION
With #2718 and #2763 we introduced an (asynchronous) check to the Database via a simple query to the health check of the UAA. As HSQLDB does not support the simple query "SELECT 1;" we used "SELECT 1 from identity_zone;" as the query that is executed in the health check. Usually this is still simple enough and it remains to be a good choice as default statement. 

However in some specific scenarios this statement produces too much work for a simple health check. Especially in an environment with a lot of identity_zones and many uaa instances that do such a health check in regular interval, we saw that it produces unnecessary load on the database. 

To avoid this unnecessary load on the database, we would like to make the statement that is used for the health check of the DB configurable with this PR. The default will stay the same, as this statement will work on all supported vendors. But for scenarios where you don't want this default statement, you have the possibility to change the statement to whatever suits your needs better. The property shares the same prefix as the rate of the DB checks, so you have both configurations in the same place.