### PR TITLE
Fix token revocation logic

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointSecurityConfiguration.java
@@ -239,8 +239,7 @@ class OauthEndpointSecurityConfiguration {
                 .authorizeHttpRequests( auth -> {
                     auth.requestMatchers("/oauth/token/revoke/client/**").access(anyOf(true).hasScope("tokens.revoke").isUaaAdmin().isZoneAdmin());
                     auth.requestMatchers("/oauth/token/revoke/user/*/client/**").access(anyOf(true).hasScope("tokens.revoke").isUaaAdmin().isZoneAdmin()
-                            .or(SelfCheckAuthorizationManager.isUserTokenRevocationForSelf(selfCheck, 4))
-                            .or(SelfCheckAuthorizationManager.isClientTokenRevocationForSelf(selfCheck, 6))
+                            .or(SelfCheckAuthorizationManager.isClientUserTokenRevocationForSelf(selfCheck, 6, 4))
                     );
                     auth.requestMatchers("/oauth/token/revoke/user/**").access(anyOf(true)
                             .hasScope("tokens.revoke").isUaaAdmin()

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/SelfCheckAuthorizationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/SelfCheckAuthorizationManager.java
@@ -10,9 +10,16 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 
 public class SelfCheckAuthorizationManager  implements AuthorizationManager<RequestAuthorizationContext> {
-    private enum CheckType {USER, TOKEN_REVOCATION_USER, TOKEN_REVOCATION_CLIENT, TOKEN_REVOCATION_SELF};
+    private enum CheckType {
+        USER,
+        TOKEN_REVOCATION_USER,
+        TOKEN_REVOCATION_CLIENT,
+        TOKEN_REVOCATION_SELF,
+        TOKEN_REVOCATION_CLIENT_USER
+    };
     private final IsSelfCheck selfCheck;
     private final int parameterIndex;
+    private final int parameterIndex2;
     private final CheckType type;
 
 
@@ -28,14 +35,31 @@ public class SelfCheckAuthorizationManager  implements AuthorizationManager<Requ
         return new SelfCheckAuthorizationManager(CheckType.TOKEN_REVOCATION_CLIENT, selfCheck, parameterIndex);
     }
 
+    public static SelfCheckAuthorizationManager isClientUserTokenRevocationForSelf(
+            IsSelfCheck selfCheck,
+            int clientParameterIndex,
+            int userParameterIndex
+    ) {
+        return new SelfCheckAuthorizationManager(
+                CheckType.TOKEN_REVOCATION_CLIENT_USER,
+                selfCheck,
+                clientParameterIndex,
+                userParameterIndex
+        );
+    }
+
     public static SelfCheckAuthorizationManager isTokenRevocationForSelf(IsSelfCheck selfCheck, int parameterIndex) {
         return new SelfCheckAuthorizationManager(CheckType.TOKEN_REVOCATION_SELF, selfCheck, parameterIndex);
     }
 
     private SelfCheckAuthorizationManager(CheckType type, IsSelfCheck selfCheck, int parameterIndex) {
+        this(type, selfCheck, parameterIndex, -1);
+    }
+    private SelfCheckAuthorizationManager(CheckType type, IsSelfCheck selfCheck, int parameterIndex, int parameterIndex2) {
 		this.type = type;
         this.selfCheck = selfCheck;
 		this.parameterIndex = parameterIndex;
+        this.parameterIndex2 = parameterIndex2;
 	}
 
 	@Override
@@ -59,6 +83,13 @@ public class SelfCheckAuthorizationManager  implements AuthorizationManager<Requ
             }
             case TOKEN_REVOCATION_CLIENT -> {
                 if (this.selfCheck.isClientTokenRevocationForSelf(request, this.parameterIndex)) {
+                    return new AuthorizationDecision(true);
+                }
+            }
+            case TOKEN_REVOCATION_CLIENT_USER -> {
+                if (this.selfCheck.isClientTokenRevocationForSelf(request, this.parameterIndex) &&
+                        this.selfCheck.isUserTokenRevocationForSelf(request, this.parameterIndex2)
+                ) {
                     return new AuthorizationDecision(true);
                 }
             }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenRevocationEndpointMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenRevocationEndpointMockMvcTest.java
@@ -428,6 +428,64 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
                 .andExpect(content().string(containsString("\"error\":\"invalid_token\"")));
     }
 
+    @Test
+    void aUserCannotRevokeClientTokens() throws Exception {
+        IdentityZone zone = IdentityZoneHolder.get();
+        UaaClientDetails client = getAClientWithClientsRead();
+        ScimUser user2 = setUpUser(generator.generate().toLowerCase() + "@test.org");
+        user2.setPassword("secret");
+
+        String userInfoToken2 = getUserOAuthAccessToken(
+                mockMvc,
+                client.getClientId(),
+                client.getClientSecret(),
+                user2.getUserName(),
+                user2.getPassword(),
+                "openid",
+                zone,
+                true
+        );
+
+        //ensure our token works
+        mockMvc.perform(
+                get("/userinfo").header("Authorization", "Bearer " + userInfoToken2)
+        ).andExpect(status().isOk());
+
+        ScimUser user1 = setUpUser(generator.generate().toLowerCase() + "@test.org");
+        user1.setPassword("secret");
+
+        String userInfoToken1 = getUserOAuthAccessToken(
+                mockMvc,
+                client.getClientId(),
+                client.getClientSecret(),
+                user1.getUserName(),
+                user1.getPassword(),
+                "openid",
+                zone,
+                true
+        );
+
+        //ensure our token works
+        mockMvc.perform(
+                get("/userinfo").header("Authorization", "Bearer " + userInfoToken1)
+        ).andExpect(status().isOk());
+
+        //revoke our own token
+        mockMvc.perform(
+                get("/oauth/token/revoke/user/" + user1.getId()+"/client/"+client.getClientId())
+                        .header("Authorization", "Bearer " + userInfoToken2)
+        )
+                .andExpect(status().isForbidden());
+
+        //ensure our token works
+        mockMvc.perform(
+                get("/userinfo").header("Authorization", "Bearer " + userInfoToken1)
+        ).andExpect(status().isOk());
+        mockMvc.perform(
+                get("/userinfo").header("Authorization", "Bearer " + userInfoToken2)
+        ).andExpect(status().isOk());
+    }
+
     private void revokeUserClientCombinationTokenWithAuth() throws Exception {
         UaaClientDetails client = getAClientWithClientsRead();
         UaaClientDetails otherClient = getAClientWithClientsRead();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenRevocationEndpointMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenRevocationEndpointMockMvcTest.java
@@ -81,12 +81,14 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
             TokenRevocationEvent tokenRevocationEvent = tokenRevocationEventListener.getEvents().getFirst();
             assertThat(tokenRevocationEvent.getClientId()).isEqualTo(client.getClientId());
             assertThat(tokenRevocationEvent.getUserId()).isNull();
-            assertThat(tokenRevocationEvent.getAuditEvent().getData()).contains(client.getClientId());
-            assertThat(tokenRevocationEvent.getAuditEvent().getData()).doesNotContain("UserID");
+            assertThat(tokenRevocationEvent.getAuditEvent().getData())
+                    .contains(client.getClientId())
+                    .doesNotContain("UserID");
             assertThat(tokenRevocationEvent.getAuditEvent().getOrigin()).contains(client.getClientId());
             revocableTokenProvisioning.retrieve(jti, IdentityZoneHolder.get().getId());
             fail("Expected EmptyResultDataAccessException to be thrown for revoked token");
         } catch (EmptyResultDataAccessException ignored) {
+            // expected
         } finally {
             defaultZone.getConfig().getTokenPolicy().setJwtRevocable(false);
             identityZoneProvisioning.update(defaultZone);
@@ -202,7 +204,7 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
             revocableTokenProvisioning.retrieve(tokenToBeRevoked, IdentityZoneHolder.get().getId());
             fail("Token should have been deleted");
         } catch (EmptyResultDataAccessException e) {
-            //expected
+            // expected
         }
     }
 
@@ -323,8 +325,10 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
         ).andExpect(status().isOk());
         assertThat(tokenRevocationEventListener.getEventCount()).isOne();
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getClientId()).isEqualTo(client.getClientId());
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getUserId()).as("Event for client based revocation should not contain userid").isNull();
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).contains(client.getClientId())
+        assertThat(tokenRevocationEventListener.getEvents().getFirst().getUserId())
+                .as("Event for client based revocation should not contain userid").isNull();
+        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData())
+                .contains(client.getClientId())
                 .doesNotContain("UserID");
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getOrigin()).contains("admin");
 
@@ -376,8 +380,9 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
         assertThat(tokenRevocationEventListener.getEventCount()).isOne();
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getUserId()).isEqualTo(user.getId());
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getClientId()).isNull();
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).contains(user.getId());
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).doesNotContain("ClientID");
+        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData())
+                .contains(user.getId())
+                .doesNotContain("ClientID");
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getOrigin()).contains("admin");
         //should fail with 401
         mockMvc.perform(
@@ -416,8 +421,9 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
         assertThat(tokenRevocationEventListener.getEventCount()).isOne();
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getUserId()).isEqualTo(user.getId());
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getClientId()).isNull();
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).contains(user.getId());
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).doesNotContain("ClientID");
+        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData())
+                .contains(user.getId())
+                .doesNotContain("ClientID");
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getOrigin()).contains(user.getUserName());
 
         //should fail with 401
@@ -429,7 +435,7 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
     }
 
     @Test
-    void aUserCannotRevokeClientTokens() throws Exception {
+    void aUserCannotRevokeAnotherUsersClientTokens() throws Exception {
         IdentityZone zone = IdentityZoneHolder.get();
         UaaClientDetails client = getAClientWithClientsRead();
         ScimUser user2 = setUpUser(generator.generate().toLowerCase() + "@test.org");
@@ -446,7 +452,7 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
                 true
         );
 
-        //ensure our token works
+        //ensure user2's token works
         mockMvc.perform(
                 get("/userinfo").header("Authorization", "Bearer " + userInfoToken2)
         ).andExpect(status().isOk());
@@ -465,19 +471,19 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
                 true
         );
 
-        //ensure our token works
+        //ensure user1's token works
         mockMvc.perform(
                 get("/userinfo").header("Authorization", "Bearer " + userInfoToken1)
         ).andExpect(status().isOk());
 
-        //revoke our own token
+        // attempt to revoke user1's tokens while authenticated as user2
         mockMvc.perform(
-                get("/oauth/token/revoke/user/" + user1.getId()+"/client/"+client.getClientId())
-                        .header("Authorization", "Bearer " + userInfoToken2)
-        )
+                        get("/oauth/token/revoke/user/" + user1.getId() + "/client/" + client.getClientId())
+                                .header("Authorization", "Bearer " + userInfoToken2)
+                )
                 .andExpect(status().isForbidden());
 
-        //ensure our token works
+        //ensure both tokens work
         mockMvc.perform(
                 get("/userinfo").header("Authorization", "Bearer " + userInfoToken1)
         ).andExpect(status().isOk());
@@ -556,8 +562,9 @@ class TokenRevocationEndpointMockMvcTest extends AbstractTokenMockMvcTests {
         assertThat(tokenRevocationEventListener.getEventCount()).isOne();
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getClientId()).isEqualTo(client.getClientId());
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getUserId()).isEqualTo(user1.getId());
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).contains(client.getClientId());
-        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData()).contains(user1.getId());
+        assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getData())
+                .contains(client.getClientId())
+                .contains(user1.getId());
         assertThat(tokenRevocationEventListener.getEvents().getFirst().getAuditEvent().getOrigin()).contains("admin");
 
         //should fail with 401


### PR DESCRIPTION
If I know your user-id, and you have revocable tokens, I can revoke your tokens using my own token
The endpoint /oauth/token/revoke/user//client/: was migrated from XML to Java with commit a1459a3005b old version: required both the user ID and client ID in the token to match the values given in the path new version: or operator effectively used for the two conditions instead of and

Fixes CVE-2026-22723