### PR TITLE
Update password change audit events to include principal name

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeEvent.java
@@ -31,7 +31,7 @@ public class PasswordChangeEvent extends AbstractPasswordChangeEvent {
 
     @Override
     public AuditEvent getAuditEvent() {
-        return createAuditRecord(getUser().getId(), AuditEventType.PasswordChangeSuccess,
+        return createAuditRecord(getUser().getId(), getUser().getUsername(), AuditEventType.PasswordChangeSuccess,
                 getOrigin(getPrincipal()), getMessage());
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeEvent.java
@@ -31,8 +31,8 @@ public class PasswordChangeEvent extends AbstractPasswordChangeEvent {
 
     @Override
     public AuditEvent getAuditEvent() {
-        return createAuditRecord(getUser().getId(), getUser().getUsername(), AuditEventType.PasswordChangeSuccess,
-                getOrigin(getPrincipal()), getMessage());
+        return createAuditRecord(getUser().getId(), AuditEventType.PasswordChangeSuccess,
+                getOrigin(getPrincipal()), getMessage(), getUser().getUsername());
     }
 
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeFailureEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeFailureEvent.java
@@ -33,11 +33,11 @@ public class PasswordChangeFailureEvent extends AbstractPasswordChangeEvent {
     public AuditEvent getAuditEvent() {
         UaaUser user = getUser();
         if (user == null) {
-            return createAuditRecord(getPrincipal().getName(), getPrincipal().getName(), AuditEventType.PasswordChangeFailure,
-                    getOrigin(getPrincipal()), getMessage());
+            return createAuditRecord(getPrincipal().getName(), AuditEventType.PasswordChangeFailure,
+                    getOrigin(getPrincipal()), getMessage(), getPrincipal().getName());
         } else {
-            return createAuditRecord(user.getId(), user.getUsername(), AuditEventType.PasswordChangeFailure,
-                    getOrigin(getPrincipal()), getMessage());
+            return createAuditRecord(user.getId(), AuditEventType.PasswordChangeFailure,
+                    getOrigin(getPrincipal()), getMessage(), user.getUsername());
         }
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeFailureEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/event/PasswordChangeFailureEvent.java
@@ -33,10 +33,10 @@ public class PasswordChangeFailureEvent extends AbstractPasswordChangeEvent {
     public AuditEvent getAuditEvent() {
         UaaUser user = getUser();
         if (user == null) {
-            return createAuditRecord(getPrincipal().getName(), AuditEventType.PasswordChangeFailure,
+            return createAuditRecord(getPrincipal().getName(), getPrincipal().getName(), AuditEventType.PasswordChangeFailure,
                     getOrigin(getPrincipal()), getMessage());
         } else {
-            return createAuditRecord(user.getUsername(), AuditEventType.PasswordChangeFailure,
+            return createAuditRecord(user.getId(), user.getUsername(), AuditEventType.PasswordChangeFailure,
                     getOrigin(getPrincipal()), getMessage());
         }
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/AuditEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/AuditEvent.java
@@ -20,6 +20,7 @@ public class AuditEvent {
 
     private final AuditEventType type;
     private final String principalId;
+    private final String principalName;
     private final String origin;
     private final long time;
     private final String data;
@@ -28,11 +29,16 @@ public class AuditEvent {
     private final String authenticationType;
 
     public AuditEvent(AuditEventType type, String principalId, String origin, String data, long time, String identityZoneId, String authenticationType, String description) {
+        this(type, principalId, null, origin, data, time, identityZoneId, authenticationType, description);
+    }
+
+    public AuditEvent(AuditEventType type, String principalId, String principalName, String origin, String data, long time, String identityZoneId, String authenticationType, String description) {
         this.type = type;
         this.data = data;
         this.origin = origin;
         this.time = time;
         this.principalId = principalId;
+        this.principalName = principalName;
         this.identityZoneId = identityZoneId;
         this.description = description;
         this.authenticationType = authenticationType;
@@ -44,6 +50,10 @@ public class AuditEvent {
 
     public String getPrincipalId() {
         return principalId;
+    }
+
+    public String getPrincipalName() {
+        return principalName;
     }
 
     public String getOrigin() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/AuditEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/AuditEvent.java
@@ -29,10 +29,10 @@ public class AuditEvent {
     private final String authenticationType;
 
     public AuditEvent(AuditEventType type, String principalId, String origin, String data, long time, String identityZoneId, String authenticationType, String description) {
-        this(type, principalId, null, origin, data, time, identityZoneId, authenticationType, description);
+        this(type, principalId, origin, data, time, identityZoneId, authenticationType, description, null);
     }
 
-    public AuditEvent(AuditEventType type, String principalId, String principalName, String origin, String data, long time, String identityZoneId, String authenticationType, String description) {
+    public AuditEvent(AuditEventType type, String principalId, String origin, String data, long time, String identityZoneId, String authenticationType, String description, String principalName) {
         this.type = type;
         this.data = data;
         this.origin = origin;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditService.java
@@ -110,6 +110,10 @@ public class LoggingAuditService implements UaaAuditService {
                 auditEvent.getIdentityZoneId()
         );
 
+        if (auditEvent.getPrincipalName() != null) {
+            logMessage = "%s, principalName=[%s]".formatted(logMessage, auditEvent.getPrincipalName());
+        }
+
         if (auditEvent.getAuthenticationType() != null) {
             logMessage = "%s, authenticationType=[%s]".formatted(logMessage, auditEvent.getAuthenticationType());
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
@@ -79,6 +79,10 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
         return new AuditEvent(type, principalId, origin, data, System.currentTimeMillis(), zoneId, null, null);
     }
 
+    protected AuditEvent createAuditRecord(String principalId, String principalName, AuditEventType type, String origin, String data) {
+        return new AuditEvent(type, principalId, principalName, origin, data, System.currentTimeMillis(), zoneId, null, null);
+    }
+
     protected AuditEvent createAuditRecord(String principalId, AuditEventType type, String origin, String data, String authenticationType, String message) {
         return new AuditEvent(type, principalId, origin, data, System.currentTimeMillis(), zoneId, authenticationType, message);
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
@@ -79,8 +79,8 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
         return new AuditEvent(type, principalId, origin, data, System.currentTimeMillis(), zoneId, null, null);
     }
 
-    protected AuditEvent createAuditRecord(String principalId, String principalName, AuditEventType type, String origin, String data) {
-        return new AuditEvent(type, principalId, principalName, origin, data, System.currentTimeMillis(), zoneId, null, null);
+    protected AuditEvent createAuditRecord(String principalId, AuditEventType type, String origin, String data, String principalName) {
+        return new AuditEvent(type, principalId, origin, data, System.currentTimeMillis(), zoneId, null, null, principalName);
     }
 
     protected AuditEvent createAuditRecord(String principalId, AuditEventType type, String origin, String data, String authenticationType, String message) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditServiceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditServiceTest.java
@@ -51,7 +51,7 @@ class LoggingAuditServiceTest {
 
     @Test
     void log_format_whenPrincipalNameIsPresent() {
-        AuditEvent auditEvent = new AuditEvent(PasswordChangeSuccess, "thePrincipalId", "thePrincipalName", "theOrigin", "theData", 42L, "theZoneId", null, null);
+        AuditEvent auditEvent = new AuditEvent(PasswordChangeSuccess, "thePrincipalId", "theOrigin", "theData", 42L, "theZoneId", null, null, "thePrincipalName");
 
         loggingAuditService.log(auditEvent, "not-used");
 
@@ -63,7 +63,7 @@ class LoggingAuditServiceTest {
 
     @Test
     void log_format_whenPrincipalNameAndAuthTypeArePresent() {
-        AuditEvent auditEvent = new AuditEvent(PasswordChangeFailure, "thePrincipalId", "thePrincipalName", "theOrigin", "theData", 42L, "theZoneId", "theAuthType", "theDescription");
+        AuditEvent auditEvent = new AuditEvent(PasswordChangeFailure, "thePrincipalId", "theOrigin", "theData", 42L, "theZoneId", "theAuthType", "theDescription", "thePrincipalName");
 
         loggingAuditService.log(auditEvent, "not-used");
 
@@ -76,6 +76,20 @@ class LoggingAuditServiceTest {
     @Test
     void log_sanitizesMaliciousInput() {
         AuditEvent auditEvent = new AuditEvent(UserAuthenticationSuccess, "principalId", "origin", "data", 100L, "malicious-zone\r\n\t", null, null);
+
+        loggingAuditService.log(auditEvent, "not-used");
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger).info(stringCaptor.capture());
+        assertThat(stringCaptor.getValue()).doesNotContain("\r")
+                .doesNotContain("\n")
+                .doesNotContain("\t")
+                .contains(LogSanitizerUtil.SANITIZED_FLAG);
+    }
+
+    @Test
+    void log_sanitizesMaliciousPrincipalName() {
+        AuditEvent auditEvent = new AuditEvent(PasswordChangeSuccess, "principalId", "origin", "data", 100L, "safe-zone", null, null, "malicious\r\n\tname");
 
         loggingAuditService.log(auditEvent, "not-used");
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditServiceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/audit/LoggingAuditServiceTest.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cloudfoundry.identity.uaa.audit.AuditEventType.PasswordChangeFailure;
+import static org.cloudfoundry.identity.uaa.audit.AuditEventType.PasswordChangeSuccess;
 import static org.cloudfoundry.identity.uaa.audit.AuditEventType.UserAuthenticationSuccess;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -46,6 +47,30 @@ class LoggingAuditServiceTest {
         verify(mockLogger).info(stringCaptor.capture());
         String logMessage = stringCaptor.getValue();
         assertThat(logMessage).isEqualTo("PasswordChangeFailure ('theData'): principal=thePrincipalId, origin=[theOrigin], identityZoneId=[theZoneId], detailedDescription=[theDescription]");
+    }
+
+    @Test
+    void log_format_whenPrincipalNameIsPresent() {
+        AuditEvent auditEvent = new AuditEvent(PasswordChangeSuccess, "thePrincipalId", "thePrincipalName", "theOrigin", "theData", 42L, "theZoneId", null, null);
+
+        loggingAuditService.log(auditEvent, "not-used");
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger).info(stringCaptor.capture());
+        String logMessage = stringCaptor.getValue();
+        assertThat(logMessage).isEqualTo("PasswordChangeSuccess ('theData'): principal=thePrincipalId, origin=[theOrigin], identityZoneId=[theZoneId], principalName=[thePrincipalName]");
+    }
+
+    @Test
+    void log_format_whenPrincipalNameAndAuthTypeArePresent() {
+        AuditEvent auditEvent = new AuditEvent(PasswordChangeFailure, "thePrincipalId", "thePrincipalName", "theOrigin", "theData", 42L, "theZoneId", "theAuthType", "theDescription");
+
+        loggingAuditService.log(auditEvent, "not-used");
+
+        ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
+        verify(mockLogger).info(stringCaptor.capture());
+        String logMessage = stringCaptor.getValue();
+        assertThat(logMessage).isEqualTo("PasswordChangeFailure ('theData'): principal=thePrincipalId, origin=[theOrigin], identityZoneId=[theZoneId], principalName=[thePrincipalName], authenticationType=[theAuthType], detailedDescription=[theDescription]");
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -582,8 +582,11 @@ class AuditCheckMockMvcTests {
         assertThat(pw.getUser().getUsername()).isEqualTo(testUser.getUserName());
         assertThat(pw.getMessage()).isEqualTo("Password changed");
         assertThat(pw.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
+        assertThat(pw.getAuditEvent().getPrincipalName()).isEqualTo(testUser.getUserName());
 
-        assertLogMessageWithSession(testLogger.getLatestMessage(), PasswordChangeSuccess, testUser.getId(), "Password changed");
+        String pwLogMsg = testLogger.getLatestMessage();
+        assertLogMessageWithSession(pwLogMsg, PasswordChangeSuccess, testUser.getId(), "Password changed");
+        assertThat(pwLogMsg).contains("principalName=[%s]".formatted(testUser.getUserName()));
     }
 
     @Test
@@ -644,8 +647,11 @@ class AuditCheckMockMvcTests {
         assertThat(pwfe.getUser().getUsername()).isEqualTo(testUser.getUserName());
         assertThat(pwfe.getMessage()).isEqualTo("Old password is incorrect");
         assertThat(pwfe.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
+        assertThat(pwfe.getAuditEvent().getPrincipalName()).isEqualTo(testUser.getUserName());
 
-        assertLogMessageWithSession(testLogger.getLatestMessage(), PasswordChangeFailure, testUser.getUserName(), "Old password is incorrect");
+        String pwfeLogMsg = testLogger.getLatestMessage();
+        assertLogMessageWithSession(pwfeLogMsg, PasswordChangeFailure, testUser.getId(), "Old password is incorrect");
+        assertThat(pwfeLogMsg).contains("principalName=[%s]".formatted(testUser.getUserName()));
     }
 
     @Test
@@ -661,8 +667,11 @@ class AuditCheckMockMvcTests {
         PasswordChangeEvent pw = (PasswordChangeEvent) testListener.getLatestEvent();
         assertThat(pw.getUser().getUsername()).isEqualTo(user.getUserName());
         assertThat(pw.getMessage()).isEqualTo("Password changed");
+        assertThat(pw.getAuditEvent().getPrincipalName()).isEqualTo(user.getUserName());
 
-        assertLogMessageWithoutSession(testLogger.getLatestMessage(), PasswordChangeSuccess, user.getId(), "Password changed");
+        String pwLogMsg = testLogger.getLatestMessage();
+        assertLogMessageWithoutSession(pwLogMsg, PasswordChangeSuccess, user.getId(), "Password changed");
+        assertThat(pwLogMsg).contains("principalName=[%s]".formatted(user.getUserName()));
     }
 
     @Test
@@ -691,8 +700,11 @@ class AuditCheckMockMvcTests {
         assertThat(pce.getMessage()).isEqualTo("Password changed");
         //PasswordChangeEvent does not contain session in this case
         assertThat(pce.getAuditEvent().getOrigin()).doesNotContain("sessionId=<SESSION>");
+        assertThat(pce.getAuditEvent().getPrincipalName()).isEqualTo(testUser.getUserName());
 
-        assertLogMessageWithoutSession(testLogger.getLatestMessage(), PasswordChangeSuccess, testUser.getId(), "Password changed");
+        String pceLogMsg = testLogger.getLatestMessage();
+        assertLogMessageWithoutSession(pceLogMsg, PasswordChangeSuccess, testUser.getId(), "Password changed");
+        assertThat(pceLogMsg).contains("principalName=[%s]".formatted(testUser.getUserName()));
     }
 
     @Test


### PR DESCRIPTION
Password change audit events (PasswordChangeSuccess/PasswordChangeFailure) log the user ID in the principal field but security audit teams need the human-readable username for compliance.


This change introduces a new principalName field in AuditEvent that is included in the log output when present, without modifying the existing principal field.


Changes:
- Add principalName field to AuditEvent with a new constructor overload (existing constructor delegates with null for backwards compatibility)
- Add createAuditRecord overload in AbstractUaaEvent that accepts principalName
- Update LoggingAuditService to append principalName=[...] to log messages when set
- Update PasswordChangeEvent to populate principalName with the username
- Update PasswordChangeFailureEvent to populate principalName with the username, and align principalId to use user ID (was previously username) for consistency with success events