### PR TITLE
Fix ClassCastException in isAddNewShadowUser when ID token issued by UAA

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -578,8 +578,12 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
 
     @Override
     protected boolean isAddNewShadowUser(final String origin) {
-        IdentityProvider<AbstractExternalOAuthIdentityProviderDefinition> provider = getProviderProvisioning().retrieveByOrigin(origin, identityZoneManager.getCurrentIdentityZoneId());
-        return provider.getConfig().isAddShadowUserOnLogin();
+        try {
+            IdentityProvider<AbstractExternalOAuthIdentityProviderDefinition> provider = getProviderProvisioning().retrieveByOrigin(origin, identityZoneManager.getCurrentIdentityZoneId());
+            return provider.getConfig().isAddShadowUserOnLogin();
+        } catch (EmptyResultDataAccessException | ClassCastException e) {
+            return true;
+        }
     }
 
     public RestTemplate getRestTemplate(AbstractExternalOAuthIdentityProviderDefinition config) {


### PR DESCRIPTION
Fixes #3655. When an ID token is issued by UAA itself (not an external OAuth provider), calling retrieveByOrigin() can throw EmptyResultDataAccessException or ClassCastException. This change catches these exceptions in isAddNewShadowUser() and returns the default value true to allow shadow user creation, consistent with how LdapLoginAuthenticationManager handles similar scenarios.