### PR TITLE
fix saml and invitations beans

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpoint.java
@@ -20,6 +20,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.cloudfoundry.identity.uaa.oauth.common.util.RandomValueStringGenerator;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.springframework.stereotype.Controller;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -58,7 +59,7 @@ public class InvitationsEndpoint {
     private final ExpiringCodeStore expiringCodeStore;
 
     public InvitationsEndpoint(final ScimUserProvisioning scimUserProvisioning,
-            final IdentityProviderProvisioning identityProviderProvisioning,
+            final @Qualifier("identityProviderProvisioning") IdentityProviderProvisioning identityProviderProvisioning,
             final MultitenantClientServices multitenantClientServices,
             final ExpiringCodeStore expiringCodeStore) {
         this.scimUserProvisioning = scimUserProvisioning;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationFilter.java
@@ -98,7 +98,10 @@ public class ExternalOAuthAuthenticationFilter implements Filter {
         final String accessToken = request.getParameter("access_token");
         final String signedRequest = request.getParameter("signed_request");
 
-        final String redirectUrl = request.getRequestURL().toString();
+        final String redirectUrl = ofNullable(request.getSession(false))
+                .map(s -> SessionUtils.getStateParam(s, SessionUtils.redirectUriParameterAttributeKeyForIdp(origin)))
+                .map(Object::toString)
+                .orElse(request.getRequestURL().toString());
         final ExternalOAuthCodeToken codeToken = new ExternalOAuthCodeToken(code,
                 origin,
                 redirectUrl,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthProviderConfigurator.java
@@ -23,6 +23,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -84,6 +85,8 @@ public class ExternalOAuthProviderConfigurator implements IdentityProviderProvis
 
         var state = generateStateParam();
         SessionUtils.setStateParam(request.getSession(), SessionUtils.stateParameterAttributeKeyForIdp(idpOriginKey), state);
+        SessionUtils.setStateParam(request.getSession(), SessionUtils.redirectUriParameterAttributeKeyForIdp(idpOriginKey),
+                URLDecoder.decode(callbackUrl, StandardCharsets.UTF_8));
 
         UriComponentsBuilder uriBuilder = UriComponentsBuilder
                 .fromUriString(idpUrlBase)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
@@ -26,6 +26,7 @@ import org.opensaml.core.xml.config.XMLObjectProviderRegistry;
 import org.opensaml.saml.common.assertion.ValidationContext;
 import org.opensaml.saml.saml2.assertion.SAML2AssertionValidationParameters;
 import org.opensaml.saml.saml2.core.Assertion;
+import org.opensaml.saml.saml2.core.AttributeStatement;
 import org.opensaml.saml.saml2.core.Issuer;
 import org.opensaml.saml.saml2.core.Response;
 import org.opensaml.saml.saml2.core.impl.AssertionUnmarshaller;
@@ -236,6 +237,18 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
                 .orElseThrow(() -> new Saml2AuthenticationException(new Saml2Error(Saml2ErrorCodes.INVALID_ASSERTION, "Missing issuer in bearer assertion")));
     }
 
+    private static boolean hasEncryptedElements(Assertion assertion) {
+        if (assertion.getSubject() != null && assertion.getSubject().getEncryptedID() != null) {
+            return true;
+        }
+        for (AttributeStatement statement : assertion.getAttributeStatements()) {
+            if (!statement.getEncryptedAttributes().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void process(Saml2AuthenticationToken token, Assertion assertion) {
         String issuer = getIssuer(assertion);
         log.debug("Processing SAML response from {}", issuer);
@@ -244,6 +257,14 @@ public final class Saml2BearerGrantAuthenticationConverter implements Authentica
         Saml2ResponseValidatorResult result = this.assertionSignatureValidator.convert(assertionToken);
         if (assertion.isSigned()) {
             this.assertionElementsDecrypter.accept(new OpenSaml4AuthenticationProvider.AssertionToken(assertion, token));
+        } else if (hasEncryptedElements(assertion)) {
+            this.assertionElementsDecrypter.accept(new OpenSaml4AuthenticationProvider.AssertionToken(assertion, token));
+        } else {
+            throw OpenSaml4AuthenticationProvider.createAuthenticationException(
+                    Saml2ErrorCodes.INVALID_SIGNATURE,
+                    "Assertion is missing a signature.",
+                    null
+            );
         }
         result = result.concat(this.assertionValidator.convert(assertionToken));
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/SessionUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/SessionUtils.java
@@ -26,6 +26,7 @@ public final class SessionUtils {
 
     private static final String EXTERNAL_OAUTH_STATE_ATTRIBUTE_PREFIX = "external-oauth-state-";
     private static final String EXTERNAL_OAUTH_CODE_VERIFIER_ATTRIBUTE_PREFIX = "external-oauth-verifier-";
+    private static final String EXTERNAL_OAUTH_REDIRECT_URI_ATTRIBUTE_PREFIX = "external-oauth-redirect-uri-";
 
     private SessionUtils() {
     }
@@ -86,5 +87,9 @@ public final class SessionUtils {
 
     public static String codeVerifierParameterAttributeKeyForIdp(String idpOriginKey) {
         return EXTERNAL_OAUTH_CODE_VERIFIER_ATTRIBUTE_PREFIX + idpOriginKey;
+    }
+
+    public static String redirectUriParameterAttributeKeyForIdp(String idpOriginKey) {
+        return EXTERNAL_OAUTH_REDIRECT_URI_ATTRIBUTE_PREFIX + idpOriginKey;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverterTest.java
@@ -2,10 +2,12 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.shibboleth.utilities.java.support.xml.SerializeSupport;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.cloudfoundry.identity.uaa.impl.config.RestTemplateConfig;
 import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManagerImpl;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensaml.core.xml.XMLObject;
@@ -46,6 +48,7 @@ import org.springframework.util.StringUtils;
 import org.w3c.dom.Element;
 
 import javax.xml.namespace.QName;
+import java.security.Security;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
@@ -73,6 +76,11 @@ class Saml2BearerGrantAuthenticationConverterTest {
     private static final String ASSERTING_PARTY_ENTITY_ID = "https://some.idp.test/saml2/idp";
 
     private Saml2BearerGrantAuthenticationConverter provider;
+
+    @BeforeAll
+    static void beforeAll() {
+        Security.addProvider(new BouncyCastleFipsProvider());
+    }
 
     @BeforeEach
     void beforeEach() {
@@ -137,6 +145,29 @@ class Saml2BearerGrantAuthenticationConverterTest {
     }
 
     @Test
+    void authenticateWhenUnsignedAssertionThenThrowInvalidSignature() {
+        Assertion assertion = assertion();
+        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        assertThatExceptionOfType(Saml2AuthenticationException.class)
+                .isThrownBy(() -> this.provider.authenticate(token))
+                .satisfies(errorOf(Saml2ErrorCodes.INVALID_SIGNATURE));
+    }
+
+    @Test
+    void authenticateWhenUnsignedButEncryptedAssertionThenSucceeds() {
+        Assertion assertion = assertion();
+        EncryptedAttribute attribute = TestOpenSamlObjects.encrypted("name", "value",
+                TestSaml2X509Credentials.assertingPartyEncryptingCredential());
+        AttributeStatement statement = build(AttributeStatement.DEFAULT_ELEMENT_NAME);
+        statement.getEncryptedAttributes().add(attribute);
+        assertion.getAttributeStatements().add(statement);
+        Saml2AuthenticationToken token = token(assertion, decrypting(verifying(registration())));
+        Saml2Authentication authentication = (Saml2Authentication) this.provider.authenticate(token);
+        Saml2AuthenticatedPrincipal principal = (Saml2AuthenticatedPrincipal) authentication.getPrincipal();
+        assertThat(principal.getAttribute("name")).containsExactly("value");
+    }
+
+    @Test
     void authenticateWhenOpenSAMLValidationErrorThenThrowAuthenticationException() {
         Assertion assertion = assertion();
         assertion.getSubject()
@@ -145,7 +176,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
                 .getSubjectConfirmationData()
                 .setNotOnOrAfter(Instant.now().minus(Duration.ofDays(3)));
 
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         assertThatExceptionOfType(Saml2AuthenticationException.class)
                 .isThrownBy(() -> this.provider.authenticate(token))
                 .satisfies(errorOf(Saml2ErrorCodes.INVALID_ASSERTION));
@@ -156,7 +187,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         Assertion assertion = assertion();
         assertion.setSubject(null);
 
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         assertThatExceptionOfType(Saml2AuthenticationException.class)
                 .isThrownBy(() -> this.provider.authenticate(token))
                 .satisfies(errorOf(Saml2ErrorCodes.SUBJECT_NOT_FOUND));
@@ -166,7 +197,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
     void authenticateWhenUsernameMissingThenThrowAuthenticationException() {
         Assertion assertion = assertion();
         assertion.getSubject().getNameID().setValue(null);
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         assertThatExceptionOfType(Saml2AuthenticationException.class)
                 .isThrownBy(() -> this.provider.authenticate(token))
                 .satisfies(errorOf(Saml2ErrorCodes.SUBJECT_NOT_FOUND));
@@ -178,7 +209,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         assertion.getSubject()
                 .getSubjectConfirmations()
                 .forEach(sc -> sc.getSubjectConfirmationData().setAddress("10.10.10.10"));
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         this.provider.authenticate(token);
     }
 
@@ -187,7 +218,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         Assertion assertion = assertion();
         AbstractSaml2AuthenticationRequest mockAuthenticationRequest = mockedStoredAuthenticationRequest("SAML2",
                 Saml2MessageBinding.POST, false);
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()), mockAuthenticationRequest);
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()), mockAuthenticationRequest);
         this.provider.authenticate(token);
     }
 
@@ -196,7 +227,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         Assertion assertion = assertion("saml2");
         AbstractSaml2AuthenticationRequest mockAuthenticationRequest = mockedStoredAuthenticationRequest("SAML2",
                 Saml2MessageBinding.POST, false);
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()), mockAuthenticationRequest);
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()), mockAuthenticationRequest);
         assertThatExceptionOfType(Saml2AuthenticationException.class)
                 .isThrownBy(() -> this.provider.authenticate(token))
                 .withStackTraceContaining("invalid_assertion");
@@ -207,7 +238,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         Assertion assertion = assertion();
         List<AttributeStatement> attributes = attributeStatements();
         assertion.getAttributeStatements().addAll(attributes);
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         Authentication authentication = this.provider.authenticate(token);
         Saml2AuthenticatedPrincipal principal = (Saml2AuthenticatedPrincipal) authentication.getPrincipal();
 
@@ -236,7 +267,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
         attributes.subList(2, attributes.size()).clear();
 
         assertion.getAttributeStatements().addAll(attributes);
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         Authentication authentication = this.provider.authenticate(token);
         String result = mapper.writeValueAsString(authentication);
         mapper.readValue(result, Authentication.class);
@@ -250,7 +281,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
                 TestCustomOpenSamlObjects.instance());
         assertion.getAttributeStatements().add(attribute);
         response.getAssertions().add(signed(assertion));
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         Authentication authentication = this.provider.authenticate(token);
         Saml2AuthenticatedPrincipal principal = (Saml2AuthenticatedPrincipal) authentication.getPrincipal();
         TestCustomOpenSamlObjects.CustomOpenSamlObject address = (TestCustomOpenSamlObjects.CustomOpenSamlObject) principal.getAttribute("Address").getFirst();
@@ -343,7 +374,7 @@ class Saml2BearerGrantAuthenticationConverterTest {
                 .getSubjectConfirmations()
                 .forEach(sc -> sc.getSubjectConfirmationData().setAddress("10.10.10.10"));
         response.getAssertions().add(signed(assertion));
-        Saml2AuthenticationToken token = token(assertion, verifying(registration()));
+        Saml2AuthenticationToken token = token(signed(assertion), verifying(registration()));
         token.setDetails("some-details");
         Authentication authentication = this.provider.authenticate(token);
         assertThat(authentication.getDetails()).isEqualTo("some-details");


### PR DESCRIPTION
The bean ExternalOAuthProviderConfigurator("externalOAuthProviderConfigurator") and the bean JdbcIdentityProviderProvisioning("identityProviderProvisioning") implement the same 

This can lead to challenges downstream when one bean wants to be replaced as the @Primary can cause the wrong bean to be injected into the InvitationsEndpoint

Improve SAML error handling and test coverage for saml2-bearer