### PR TITLE
Update Bouncy Castle FIPS dependency versions

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,8 +6,8 @@ ext {
 // Versions shared between multiple dependencies
 versions.apacheDsVersion = "2.0.0.AM27"
 versions.bouncyCastleFipsVersion = "2.1.2"
-versions.bouncyCastlePkixFipsVersion = "2.1.9"
-versions.bouncyCastleTlsFipsVersion = "2.1.20"
+versions.bouncyCastlePkixFipsVersion = "2.1.10"
+versions.bouncyCastleTlsFipsVersion = "2.1.22"
 versions.springBootVersion = "3.5.11"
 versions.guavaVersion = "33.4.8-jre"
 versions.seleniumVersion = "4.40.0"


### PR DESCRIPTION
Updated Bouncy Castle FIPS versions to 2.1.10 and 2.1.22.

https://www.bouncycastle.org/download/bouncy-castle-java-fips/#release-notes