### PR TITLE
Use single boot start check logic

### DIFF
--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -40,11 +40,11 @@ function main() {
 
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
       set -x
-      # Assemble and compile tests; integrationTest doFirst in uaa/build.gradle starts UAA and waits for it
+      # Assemble and compile production code and tests
       ./gradlew -Dspring.profiles.active="${test_profile}" \
         -Djava.security.egd=file:/dev/./urandom \
         -Dorg.gradle.jvmargs="-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100" \
-        assemble \
+        assemble compileTestJava \
         --no-watch-fs \
         --no-daemon \
         --no-configuration-cache \
@@ -52,12 +52,7 @@ function main() {
         --stacktrace \
         --console=plain
 
-      ./gradlew \
-        -Dspring.profiles.active="${test_profile}" \
-        --no-daemon \
-        --no-configuration-cache \
-        compileTestJava
-
+      # integrationTest doFirst in uaa/build.gradle starts UAA and waits for it
       ./gradlew \
         -Dspring.profiles.active="${test_profile}" \
         -Djava.security.egd=file:/dev/./urandom \

--- a/scripts/integration_tests.sh
+++ b/scripts/integration_tests.sh
@@ -6,10 +6,9 @@ set -eu
 # Global env vars:
 #   UAA_GRADLE_INT_TEST_COMMAND: Gradle command to run integration tests (default: integrationTest)
 #       this could include :cloudfoundry-identity-server:integrationTest --tests to run specific tests
-#   jvm_heap: JVM heap size for UAA boot server (default: 640m)
-#   jvm_metaspace: JVM metaspace size for UAA boot server (default: 192m)
 #   gradle_heap: JVM heap size for Gradle daemon (default: 1024m)
 #   gradle_test_heap: JVM heap size for Gradle test workers (default: 640m)
+# UAA boot is started and stopped by the integrationTest task in uaa/build.gradle (doFirst/doLast).
 #######################################
 function main() {
   local script_dir; script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -26,25 +25,22 @@ function main() {
   pushd "$(dirname ${script_dir})"
     start_ldap
 
-    local wd launch_boot assemble_code integration_test_code
-    wd=$(pwd)
-    temp_dir=${script_dir}/tmp
-    mkdir -p "${temp_dir}"
-    
     # Memory settings optimized for Gradle 9.0 with Kotlin 2.2
     # Boot server needs enough memory to handle test requests without crashing
     # Increased Gradle daemon heap to 1GB to prevent hanging with 2 workers
     # --no-configuration-cache prevents stale Kotlin compiler state reuse between daemon processes
     # logging.manager is set to org.apache.logging.log4j.jul.LogManager to prevent log4j2 from using java.util.logging
     # See https://docs.gradle.org/9.2.0/userguide/config_gradle.html#sec:configuring_jvm_memory
-    echo "Setting boot heap to ${jvm_heap:=640m}"
-    echo "Setting boot metaspace to ${jvm_metaspace:=192m}"
     echo "Setting Gradle daemon heap to ${gradle_heap:=1024m}"
     echo "Setting test worker heap to ${gradle_test_heap:=640m}"
 
+    if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
+      export DBUS_SESSION_BUS_ADDRESS=/dev/null
+    fi
+
     if [[ "${RUN_TESTS:-true}" = 'true' ]]; then
       set -x
-      # Explicit Gradle daemon memory with additional GC tuning
+      # Assemble and compile tests; integrationTest doFirst in uaa/build.gradle starts UAA and waits for it
       ./gradlew -Dspring.profiles.active="${test_profile}" \
         -Djava.security.egd=file:/dev/./urandom \
         -Dorg.gradle.jvmargs="-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_heap} -XX:MaxMetaspaceSize=384m -XX:+UseG1GC -XX:MaxGCPauseMillis=100" \
@@ -56,71 +52,15 @@ function main() {
         --stacktrace \
         --console=plain
 
-      # Start and ensure the boot server is running before integration tests
-      nohup java \
-        -XX:+UseG1GC \
-        -XX:G1HeapRegionSize=1m \
-        -Xms64m -Xmx${jvm_heap} \
-        -XX:MaxMetaspaceSize=${jvm_metaspace} \
-        -XX:MetaspaceSize=${jvm_metaspace} \
-        -XX:+UseStringDeduplication \
-        -XX:MaxGCPauseMillis=200 \
-        -XX:+HeapDumpOnOutOfMemoryError \
-        -XX:HeapDumpPath="${wd}" \
-        -DCLOUDFOUNDRY_CONFIG_PATH="${wd}/scripts/boot" \
-        -Dlogging.config="${wd}/scripts/boot/log4j2.properties" \
-        -Dlog4j.configurationFile="${wd}/scripts/boot/log4j2.properties" \
-        -Dlog4j2.formatMsgNoLookups=true \
-        -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager \
-        -DSECRETS_DIR="${wd}/scripts/boot" \
-        -Djava.security.egd=file:/dev/./urandom \
-        -Djava.io.tmpdir="${temp_dir}" \
-        -Dorg.bouncycastle.native.loader.install_dir="${temp_dir}" \
-        -Dmetrics.perRequestMetrics=true \
-        -Dserver.servlet.context-path=/uaa \
-        -Dserver.tomcat.basedir="${wd}/scripts/boot/tomcat" \
-        -Dsmtp.host=localhost \
-        -Dsmtp.port=2525 \
-        -Dspring.profiles.active="${test_profile}" \
-        -Dstatsd.enabled=true \
-        -Dfile.encoding=UTF-8 \
-        -Duser.country=US \
-        -Duser.language=en \
-        -Duser.variant \
-        -jar "${wd}/uaa/build/libs/cloudfoundry-identity-uaa-0.0.0.war" \
-        > boot.log 2>&1 &
-      echo $! > boot.pid
-      { set +x; } 2>/dev/null
-
-      if is_boot_running ; then
-        echo "Boot started. Can continue to run tests."
-      else
-        echo "Boot did not start, failing"
-        cat boot.log
-        exit 1
-      fi
-
-      if [[ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ]]; then
-        export DBUS_SESSION_BUS_ADDRESS=/dev/null
-      fi
-
-      set -x
-      # Explicit memory limits for test JVMs with GC tuning and classloader fixes
-      # All flags required to prevent classloading deadlocks and thread starvation during test init
-      # --no-configuration-cache prevents stale Kotlin compiler state reuse between daemon processes
       ./gradlew \
         -Dspring.profiles.active="${test_profile}" \
-        -DskipUaaAutoStart=true \
         --no-daemon \
         --no-configuration-cache \
         compileTestJava
 
-      # Explicit memory limits for test JVMs with GC tuning and classloader fixes
-      # All flags required to prevent classloading deadlocks and thread starvation during test init
       ./gradlew \
         -Dspring.profiles.active="${test_profile}" \
         -Djava.security.egd=file:/dev/./urandom \
-        -DskipUaaAutoStart=true \
         -Dorg.gradle.jvmargs="-Dfile.encoding=utf8 -Xms64m -Xmx${gradle_test_heap} -XX:MaxMetaspaceSize=128m -XX:+UseG1GC -XX:MaxGCPauseMillis=100 -XX:ParallelGCThreads=2 -XX:CICompilerCount=2 -Djdk.lang.processReaperUseDefaultStackSize=true" \
         -Dorg.gradle.daemon.idletimeout=300000 \
         -Dorg.gradle.parallel=false \
@@ -134,21 +74,9 @@ function main() {
         --console=plain
 
       { set +x; } 2>/dev/null
-      
-      # Clean up: kill the boot server
-      if [[ -f boot.pid ]]; then
-        local pid; pid=$(cat boot.pid)
-        echo "Sending SIGKILL (kill -9) to UAA process (pid=${pid})"
-        kill -9 "${pid}" || true
-        rm boot.pid
-      fi
     else
       set -x
-      echo "./gradlew \
-                -Dspring.profiles.active=${test_profile} \
-                -DskipUaaAutoStart=true \
-                ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} \
-                --console=plain"
+      echo "./gradlew -Dspring.profiles.active=${test_profile} ${UAA_GRADLE_INT_TEST_COMMAND:-integrationTest} --console=plain"
       bash
     fi
   popd

--- a/scripts/lib_util_helper.sh
+++ b/scripts/lib_util_helper.sh
@@ -2,69 +2,6 @@
 set -eu
 
 ########################################
-# Check if Boot has started by checking if the port is responding
-##########################################
-function is_boot_running() {
-  local port=${PORT:-8080}
-  local timeout=600 # Timeout in seconds
-
-  local start_time
-  start_time=$(date +%s)
-
-  echo
-  echo "Waiting for the UAA server to start, only partial log messages will be shown as it progresses:"
-  while true; do
-    # Use curl to check if the port is responding
-    # Any HTTP response (even 4xx/5xx) indicates the server is running
-    if curl -ks --max-time 5 -o /dev/null --connect-timeout 2 -u "admin:adminsecret" \
-            --data "client_id=admin&grant_type=client_credentials" \
-            -X POST "http://localhost:${port}/uaa/oauth/token" 2>/dev/null; then
-      echo
-      echo "Boot is running on port ${port}."
-      grep "Started UaaBootApplication" boot.log
-      return 0
-    fi
-
-    local current_time elapsed_time
-    current_time=$(date +%s)
-    elapsed_time=$((current_time - start_time))
-
-    if [[ "$elapsed_time" -ge "$timeout" ]]; then
-      echo
-      echo "Timeout reached. Boot did not start on port ${port}"
-      curl -ksS --max-time 5 --connect-timeout 2 -u "admin:adminsecret" \
-              --data "client_id=admin&grant_type=client_credentials" \
-              -X POST "http://localhost:${port}/uaa/info" || true
-
-      thread_dump_on_boot_pid
-      return 1
-    fi
-
-    tail -n 1 boot.log
-    sleep 1 # Check every second
-  done
-}
-
-########################################
-# thread_dump_on_boot_pid
-# Display Memeory info and Request a thread dump on the pid in boot.pid
-##########################################
-function thread_dump_on_boot_pid() {
-  local pid
-  pid=$(cat boot.pid)
-  if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
-    echo "Collecting JVM diagnostics..."
-    jstat -gccause "${pid}" 2>/dev/null || true
-    jstat -gccapacity "${pid}" 2>/dev/null || true
-    jstat -gcmetacapacity "${pid}" 2>/dev/null || true
-    echo "Sending SIGQUIT (kill -3) to Thread Dump on UAA process (pid=${pid})"
-    kill -3 "$pid" || true
-    # Wait a moment for the thread dump to be written
-    sleep 2
-  fi
-}
-
-########################################
 # setup_hosts_file
 # Appends test-zone and other necessary host entries to /etc/hosts
 ##########################################

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -232,21 +232,16 @@ integrationTest {
     }
     
     doFirst {
-        if (System.getProperty("skipUaaAutoStart", "false").toBoolean()) {
-            logger.lifecycle("Skipping UAA auto-start (skipUaaAutoStart=true)")
-            return
-        }
         logger.lifecycle("Killing UAA before auto-start")
         rootProject.tasks.named('killUaa').get().exec()
-        
+
         def bootPidFile = rootProject.file('build/boot.pid')
         def bootLogFile = rootProject.file('build/boot.log')
-
-        logger.lifecycle("Starting UAA application for integration tests...")
-        
         def springProfile = System.getProperty("spring.profiles.active", "hsqldb")
         def warFile = file("build/libs/cloudfoundry-identity-uaa-0.0.0.war")
         def bootDir = rootProject.file("scripts/boot")
+
+        logger.lifecycle("Starting UAA application for integration tests...")
 
         def javaCmd = """nohup java \\
             -DCLOUDFOUNDRY_CONFIG_PATH=${bootDir.absolutePath} \\
@@ -256,15 +251,15 @@ integrationTest {
             -Dsmtp.port=2525 \\
             -Dspring.profiles.active=${springProfile} \\
             -jar ${warFile.absolutePath} > ${bootLogFile.absolutePath} 2>&1 & echo \$!"""
-        
+
         def proc = ['bash', '-c', javaCmd].execute()
         proc.waitFor()
         def pid = proc.text.trim()
         bootPidFile.text = pid
-        
+
         logger.lifecycle("UAA started with PID: ${pid}, waiting for it to be ready...")
-        
-        def maxWaitSeconds = 120
+
+        def maxWaitSeconds = 300
         def startTime = System.currentTimeMillis()
         while (System.currentTimeMillis() - startTime < maxWaitSeconds * 1000) {
             if (bootLogFile.exists() && bootLogFile.text.contains("Started UaaBootApplication")) {
@@ -278,13 +273,8 @@ integrationTest {
         rootProject.tasks.named('killUaa').get().exec()
         throw new GradleException("UAA failed to start within ${maxWaitSeconds} seconds. Check ${bootLogFile.absolutePath}")
     }
-    
+
     doLast {
-        if (System.getProperty("skipUaaAutoStart", "false").toBoolean()) {
-            logger.lifecycle("Skipping UAA auto-stop (skipUaaAutoStart=true)")
-            return
-        }
-        
         logger.lifecycle("Stopping UAA application...")
         rootProject.tasks.named('killUaa').get().exec()
         rootProject.file('build/boot.pid').delete()


### PR DESCRIPTION
Refactor UAA start/stop logic for integration tests and remove unused helper functions

Instead of duplicating the logic to check for spring boot startup, just use the one in the gradle files.

Does this help with some of the hung integration test runs in github actions?
