### PR TITLE
Fallback to client_id when cid is missing

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -217,20 +217,21 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
         Claims claims = getClaims(refreshTokenClaims);
 
+        // Token client id: prefer cid, fall back to client_id for legacy or external tokens
+        String tokenClientId = claims.getCid() != null ? claims.getCid() : claims.getClientId();
+        if (tokenClientId == null || !tokenClientId.equals(request.getClientId())) {
+            throw new InvalidGrantException("Wrong client for this refresh token: " + tokenClientId);
+        }
+
         // default request scopes to what is in the refresh token
         Set<String> requestedScopes = request.getScope().isEmpty() ? Sets.newHashSet(tokenScopes) : request.getScope();
         Map<String, String> requestParams = request.getRequestParameters();
         String requestedTokenFormat = requestParams.get(REQUEST_TOKEN_FORMAT);
-        String requestedClientId = request.getClientId();
-
-        if (claims.getCid() == null || !claims.getCid().equals(requestedClientId)) {
-            throw new InvalidGrantException("Wrong client for this refresh token: " + claims.getCid());
-        }
         boolean isOpaque = OPAQUE.getStringValue().equals(requestedTokenFormat);
         boolean isRevocable = isRevocable(claims, isOpaque);
 
         UaaUser user = new UaaUser(userDatabase.retrieveUserPrototypeById(claims.getUserId()));
-        UaaClientDetails client = (UaaClientDetails) clientDetailsService.loadClientByClientId(claims.getCid());
+        UaaClientDetails client = (UaaClientDetails) clientDetailsService.loadClientByClientId(tokenClientId);
 
         long refreshTokenExpireMillis = claims.getExp().longValue() * MILLIS_PER_SECOND;
         if (new Date(refreshTokenExpireMillis).before(timeService.getCurrentDate())) {
@@ -281,7 +282,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                         user,
                         AuthTimeDateConverter.authTimeToDate(claims.getAuthTime()),
                         getClientPermissions(client),
-                        claims.getCid(),
+                        tokenClientId,
                         Set.copyOf(claims.getAud()),
                         refreshTokenValue,
                         claims.getAzAttr(),
@@ -299,7 +300,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         if (isRevocable && refreshTokenCreator.shouldRotateRefreshTokens(clientAuth)) {
             tokenIdToBeDeleted = (String) jwtToken.getClaims().get(JTI);
         }
-        return persistRevocableToken(accessTokenId, compositeToken, expiringRefreshToken, claims.getClientId(), user.getId(), isOpaque, isRevocable, tokenIdToBeDeleted);
+        return persistRevocableToken(accessTokenId, compositeToken, expiringRefreshToken, tokenClientId, user.getId(), isOpaque, isRevocable, tokenIdToBeDeleted);
     }
 
     private static String getAuthenticationMethod(OAuth2Request oAuth2Request) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAA.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAA.java
@@ -278,20 +278,15 @@ public abstract class JwtTokenSignedByThisUAA {
     }
 
     protected JwtTokenSignedByThisUAA checkClient(Function<String, ClientDetails> getClient) {
-        if (!claims.containsKey(CID)) {
+        String cid = (String) claims.get(CID);
+        String clientIdClaim = (String) claims.get(CLIENT_ID);
+        if (cid == null && clientIdClaim == null) {
             throw new InvalidTokenException("Token bears no client ID.", null);
         }
-
-        if (claims.containsKey(CLIENT_ID) && !equals(claims.get(CID), claims.get(CLIENT_ID))) {
+        if (cid != null && clientIdClaim != null && !equals(cid, clientIdClaim)) {
             throw new InvalidTokenException("Token bears conflicting client ID claims.", null);
         }
-
-        String clientId;
-        try {
-            clientId = (String) claims.get(CID);
-        } catch (ClassCastException ex) {
-            throw new InvalidTokenException("Token bears an invalid or unparseable CID claim.", ex);
-        }
+        String clientId = cid != null ? cid : clientIdClaim;
 
         try {
             ClientDetails client = getClient.apply(clientId);
@@ -467,6 +462,9 @@ public abstract class JwtTokenSignedByThisUAA {
 
     public ClientDetails getClientDetails(MultitenantClientServices clientDetailsService) {
         String clientId = (String) claims.get(CID);
+        if (clientId == null) {
+            clientId = (String) claims.get(CLIENT_ID);
+        }
         try {
             return clientDetailsService.loadClientByClientId(clientId, IdentityZoneHolder.get().getId());
         } catch (NoSuchClientException x) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAATest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/JwtTokenSignedByThisUAATest.java
@@ -323,6 +323,43 @@ public class JwtTokenSignedByThisUAATest {
     }
 
     @Test
+    void getClientDetails_usesClientIdWhenCidIsMissing() {
+        String token = getToken(Lists.newArrayList("cid"));
+        ClientDetails clientDetails = JwtTokenSignedByThisUAA.buildAccessTokenValidator(token, new KeyInfoService("https://localhost"))
+                .getClientDetails(inMemoryMultitenantClientServices);
+        assertThat(clientDetails.getClientId()).isEqualTo(CLIENT_ID);
+    }
+
+    @Test
+    void checkClient_acceptsTokenWithOnlyClientIdNoCid() {
+        String token = getToken(Lists.newArrayList("cid"));
+        buildAccessTokenValidator(token, new KeyInfoService("https://localhost"))
+                .checkIssuer("http://localhost:8080/uaa/oauth/token")
+                .checkClient(clientId -> inMemoryMultitenantClientServices.loadClientByClientId(clientId))
+                .checkExpiry(oneSecondBeforeTheTokenExpires);
+    }
+
+    @Test
+    void checkClient_throwsWhenNeitherCidNorClientIdPresent() {
+        String token = getToken(Lists.newArrayList("cid", "client_id"));
+        assertThatThrownBy(() -> buildAccessTokenValidator(token, new KeyInfoService("https://localhost"))
+                .checkClient(clientId -> inMemoryMultitenantClientServices.loadClientByClientId(clientId)))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Token bears no client ID.");
+    }
+
+    @Test
+    void checkClient_throwsWhenCidAndClientIdConflict() {
+        content.put("cid", "app");
+        content.put("client_id", "other-client");
+        String token = getToken();
+        assertThatThrownBy(() -> buildAccessTokenValidator(token, new KeyInfoService("https://localhost"))
+                .checkClient(clientId -> inMemoryMultitenantClientServices.loadClientByClientId(clientId)))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("Token bears conflicting client ID claims.");
+    }
+
+    @Test
     void getUserById() {
         String token = getToken();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.oauth;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -29,6 +30,7 @@ import org.cloudfoundry.identity.uaa.oauth.token.CompositeToken;
 import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
 import org.cloudfoundry.identity.uaa.user.JdbcUaaUserDatabase;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.util.TimeService;
 import org.cloudfoundry.identity.uaa.util.UaaTokenUtils;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
@@ -67,7 +69,9 @@ import java.util.stream.Stream;
 import static org.apache.logging.log4j.Level.DEBUG;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.assertj.core.api.HamcrestCondition.matching;
 import static org.cloudfoundry.identity.uaa.oauth.TokenTestSupport.GRANT_TYPE;
+import static org.cloudfoundry.identity.uaa.oauth.TokenTestSupport.ISSUER_URI;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.CLIENT_AUTH_NONE;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_AUTHORIZATION_CODE;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_CLIENT_CREDENTIALS;
@@ -77,6 +81,8 @@ import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYP
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_TOKEN_EXCHANGE;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.ISSUED_TOKEN_TYPE;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.TOKEN_TYPE_ACCESS;
+import static org.cloudfoundry.identity.uaa.oauth.token.matchers.OAuth2AccessTokenMatchers.issuerUri;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -117,7 +123,7 @@ class UaaTokenServicesTests {
 
             CompositeToken accessToken = (CompositeToken) tokenServices.createAccessToken(auth2Authentication);
 
-            String issuedTokenType = (String)accessToken.getAdditionalInformation().get(ISSUED_TOKEN_TYPE);
+            String issuedTokenType = (String) accessToken.getAdditionalInformation().get(ISSUED_TOKEN_TYPE);
             assertThat(issuedTokenType)
                     .isNotNull()
                     .isEqualTo(TOKEN_TYPE_ACCESS);
@@ -297,6 +303,8 @@ class UaaTokenServicesTests {
     class WhenRefreshGrant {
         @Autowired
         private RefreshTokenCreator refreshTokenCreator;
+        @Autowired
+        private KeyInfoService keyInfoService;
 
         private CompositeExpiringOAuth2RefreshToken refreshToken;
 
@@ -333,6 +341,52 @@ class UaaTokenServicesTests {
             assertThat(refreshedToken).isNotNull();
             Map<String, Object> claims = UaaTokenUtils.getClaims(refreshedToken.getValue(), Map.class);
             assertThat(claims).containsEntry(ClaimConstants.CLIENT_AUTH_METHOD, CLIENT_AUTH_NONE);
+        }
+
+        /**
+         * Refresh token with only client_id (no cid) is accepted and exchange succeeds.
+         * Legacy or external tokens may omit the cid claim; we fall back to client_id.
+         */
+        @Test
+        void refreshAccessToken_succeedsWhenRefreshTokenHasClientIdButNoCid() {
+            assumeTrue(waitForClient("jku_test", 5), "Test client needs to be setup for this test");
+            RefreshTokenRequestData refreshTokenRequestData = new RefreshTokenRequestData(
+                    GRANT_TYPE_AUTHORIZATION_CODE,
+                    Sets.newHashSet("openid", "user_attributes"),
+                    null,
+                    "",
+                    Sets.newHashSet(""),
+                    "jku_test",
+                    false,
+                    new Date(),
+                    null,
+                    null
+            );
+            UaaUser uaaUser = jdbcUaaUserDatabase.retrieveUserByName("admin", "uaa");
+            refreshToken = refreshTokenCreator.createRefreshToken(uaaUser, refreshTokenRequestData, null);
+            assertThat(refreshToken).isNotNull();
+            String refreshTokenJwt = refreshToken.getValue();
+
+            Jwt decoded = JwtHelper.decode(refreshTokenJwt);
+            String kid = decoded.getHeader().getKid();
+            Map<String, Object> claimsMap = JsonUtils.readValue(decoded.getClaims(), new TypeReference<HashMap<String, Object>>() {
+            });
+            claimsMap.remove(ClaimConstants.CID);
+            assertThat(claimsMap).containsKey(ClaimConstants.CLIENT_ID);
+
+            Map<String, Object> headerMap = new HashMap<>();
+            headerMap.put("alg", decoded.getHeader().getAlg());
+            headerMap.put("kid", kid);
+            headerMap.put("typ", decoded.getHeader().getTyp());
+            String refreshTokenWithOnlyClientId = UaaTokenUtils.constructToken(headerMap, claimsMap,
+                    keyInfoService.getKey(kid).getSigner());
+
+            OAuth2AccessToken refreshedAccessToken = tokenServices.refreshAccessToken(refreshTokenWithOnlyClientId,
+                    new TokenRequest(new HashMap<>(), "jku_test", Lists.newArrayList("openid", "user_attributes"), GRANT_TYPE_REFRESH_TOKEN));
+
+            assertThat(refreshedAccessToken).isNotNull();
+            assertThat(refreshedAccessToken.getScope()).containsExactlyInAnyOrder("openid", "user_attributes");
+            assertThat(refreshedAccessToken).is(matching(issuerUri(is(ISSUER_URI))));
         }
 
         @MethodSource("org.cloudfoundry.identity.uaa.oauth.UaaTokenServicesTests#dates")


### PR DESCRIPTION
Handle missing or conflicting `cid` and `client_id` claims in token validation