### PR TITLE
Fix external OAuth role mapping regression in v78

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -394,7 +394,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             authentication.setUserAttributes(userAttributes);
 
             authentication.setExternalGroups(
-                    Optional.ofNullable(authenticationData.getExternalAuthorities())
+                    Optional.ofNullable(authenticationData.getAuthorities())
                             .orElse(emptyList())
                             .stream()
                             .map(GrantedAuthority::getAuthority)

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -606,7 +606,7 @@ class ExternalOAuthAuthenticationManagerTest {
     }
 
     @Test
-    void populateAuthenticationAttributes_setsIdpIdTokenAndExternalGroups() {
+    void populateAuthenticationAttributes_setsIdpIdTokenAndExternalGroupsFromMappedAuthorities() {
         UaaAuthentication authentication = new UaaAuthentication(new UaaPrincipal("user-guid", "marissa", "marissa@test.org", "uaa", "", ""), Collections.emptyList(), null);
         Map<String, Object> header = map(
                 entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.RS256.getName()),
@@ -627,10 +627,11 @@ class ExternalOAuthAuthenticationManagerTest {
         String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
         ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, ORIGIN, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
         ExternalOAuthAuthenticationManager.AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oidcAuthentication);
-        authenticationData.setExternalAuthorities(List.of(new SimpleGrantedAuthority("uaa-authorities")));
+        authenticationData.setAuthorities(List.of(new SimpleGrantedAuthority("uaa-authorities")));
+        authenticationData.setExternalAuthorities(List.of(new SimpleGrantedAuthority("raw_external_group")));
         authManager.populateAuthenticationAttributes(authentication, oidcAuthentication, authenticationData);
         assertThat(authentication.getIdpIdToken()).isEqualTo(idTokenJwt);
-        assertThat(authentication.getExternalGroups()).containsAll(List.of("uaa-authorities"));
+        assertThat(authentication.getExternalGroups()).containsExactlyInAnyOrder("uaa-authorities");
     }
 
     @Test


### PR DESCRIPTION
# Summary
This PR fixes a backward-compatibility regression introduced in v78 where token role content for external OAuth or OIDC users changed from mapped internal UAA authorities to raw upstream IdP groups.

Before this change:
- externalGroups was populated from raw external authorities
- downstream token role content could mirror user attributes roles from the IdP groups claim

After this change:
- externalGroups is populated from mapped internal authorities
- token role semantics match pre-upgrade behavior from v77

# Problem
After upgrading from v77.35.0 to v78.6.0, role-related token content changed:

- expected: mapped internal authorities such as cloud_controller.audit
- actual: raw external groups from the IdP, often duplicating user attributes roles content

This is a behavior regression, not a field ordering issue.

# Root Cause
In `ExternalOAuthAuthenticationManager.populateAuthenticationAttributes`, externalGroups was built from authenticationData.externalAuthorities, which contains raw groups from the IdP.

That value is later persisted and reused in token construction paths, causing raw groups to appear where mapped internal authorities were expected.

# Fix
Use authenticationData.authorities, which contains mapped internal authorities, when populating externalGroups.
In short:

- from: externalAuthorities (raw)
- to: authorities (mapped)

# Why this is correct
- Preserves established v77 token role semantics
- Keeps raw IdP groups separate from mapped internal authorization output
- Avoids compatibility break for consumers expecting internal UAA authority values

# Tests
Added or updated focused regression coverage in ExternalOAuthAuthenticationManagerTest to verify:

- externalGroups is derived from mapped authorities
- raw external groups are not used for externalGroups in this path

Targeted test execution:
- module tests passed for the focused regression scenario on v78 code path

# Compatibility Impact
This change restores prior behavior and reduces upgrade risk for installations relying on mapped internal authorities in token role content.

# Issue
Fixes [issue](https://github.com/cloudfoundry/uaa/issues/3813)
