### PR TITLE
Handle custom issuer configuration in `getTokenEndpointUrl` method

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/KeyInfoService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/KeyInfoService.java
@@ -16,6 +16,7 @@ package org.cloudfoundry.identity.uaa.oauth;
 
 import org.cloudfoundry.identity.uaa.impl.config.LegacyTokenKey;
 import org.cloudfoundry.identity.uaa.util.UaaTokenUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.TokenPolicy;
@@ -24,6 +25,7 @@ import org.springframework.util.StringUtils;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.cloudfoundry.identity.uaa.util.UaaUrlUtils.addSubdomainToUrl;
 
@@ -95,6 +97,10 @@ public class KeyInfoService {
     }
 
     public String getTokenEndpointUrl() throws URISyntaxException {
-        return UaaTokenUtils.constructTokenEndpointUrl(uaaBaseURL, IdentityZoneHolder.get());
+        IdentityZone identityZone = IdentityZoneHolder.get();
+        String issuer = Optional.ofNullable(identityZone.getConfig())
+                .map(IdentityZoneConfiguration::getIssuer)
+                .orElse(uaaBaseURL);
+        return UaaTokenUtils.constructTokenEndpointUrl(issuer, identityZone);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/KeyInfoServiceTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/KeyInfoServiceTests.java
@@ -152,10 +152,18 @@ class KeyInfoServiceTests {
     }
 
     @Test
-    void tokenEndpointUrl() throws URISyntaxException {
+    void tokenEndpointUrl_whenIssuerIsNull() throws URISyntaxException {
         configureDefaultZoneKeys(Collections.emptyMap());
 
         assertThat(keyInfoService.getTokenEndpointUrl()).isEqualTo("https://localhost/uaa/oauth/token");
+    }
+
+    @Test
+    void tokenEndpointUrl_whenIssuerSet() throws URISyntaxException {
+        configureDefaultZoneKeys(Collections.emptyMap());
+        IdentityZoneHolder.get().getConfig().setIssuer("https://issuer.set/uaa");
+
+        assertThat(keyInfoService.getTokenEndpointUrl()).isEqualTo("https://issuer.set/uaa/oauth/token");
     }
 
     private void configureDefaultZoneKeys(Map<String, String> keys) {


### PR DESCRIPTION
Inconsistent handling of the issuerUrl. constructTokenEndpointUrl expects issuer, but KeyInfoService was passing in the uaaBaseUrl