### PR TITLE
Resolve session concurrency issues with static resources

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
@@ -50,6 +51,12 @@ public abstract class UaaUrlUtils {
             UaaUrlUtils.class);
 
     private static final int MAX_URI_DECODES = 5;
+
+    /**
+     * Static resource path prefixes that should be treated as static assets.
+     * These paths typically serve CSS, JavaScript, images, and font files.
+     */
+    private static final Set<String> STATIC_RESOURCE_PREFIXES = Set.of("/resources/", "/vendor/");
 
     public static String getUaaUrl(String path, IdentityZone currentIdentityZone) {
         return getUaaUrl(path, false, currentIdentityZone);
@@ -316,6 +323,29 @@ public abstract class UaaUrlUtils {
         }
 
         return "%s%s".formatted(servletPath, pathInfo);
+    }
+
+    /**
+     * Checks if the given request path represents a static resource.
+     *
+     * @param requestPath the request path to check
+     * @return true if the path starts with any of the static resource prefixes
+     */
+    public static boolean isStaticResource(String requestPath) {
+        if (requestPath == null) {
+            return false;
+        }
+        return STATIC_RESOURCE_PREFIXES.stream().anyMatch(requestPath::startsWith);
+    }
+
+    /**
+     * Checks if the given request represents a static resource by extracting and checking its path.
+     *
+     * @param request the HTTP servlet request
+     * @return true if the request path starts with any of the static resource prefixes
+     */
+    public static boolean isStaticResource(HttpServletRequest request) {
+        return isStaticResource(getRequestPath(request));
     }
 
     public static boolean uriHasMatchingHost(String uri, String hostname) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneResolvingFilter.java
@@ -39,7 +39,6 @@ import java.util.Set;
 public class IdentityZoneResolvingFilter extends OncePerRequestFilter implements InitializingBean {
 
     private final IdentityZoneProvisioning dao;
-    private final Set<String> staticResources = Set.of("/resources/", "/vendor/font-awesome/");
     private final Set<String> defaultZoneHostnames = new HashSet<>();
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -111,8 +110,7 @@ public class IdentityZoneResolvingFilter extends OncePerRequestFilter implements
      * Handles the case when no zone was found: serve static resources or send 404. Caller must return after calling.
      */
     private void handleZoneNotFound(String subdomain, HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        boolean isStaticResource = staticResources.stream().anyMatch(UaaUrlUtils.getRequestPath(request)::startsWith);
-        if (isStaticResource) {
+        if (UaaUrlUtils.isStaticResource(request)) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionRequestWrapper.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionRequestWrapper.java
@@ -6,11 +6,13 @@ import jakarta.servlet.http.HttpSession;
 
 import org.cloudfoundry.identity.uaa.util.TimeService;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
+import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter.DEFAULT_ZONE_SUBDOMAIN_PATH;
 
@@ -31,6 +33,12 @@ public class ZoneContextPathSessionRequestWrapper extends HttpServletRequestWrap
      */
     public static final String ATTRIBUTE_NAME_PREFIX =
             ZonePathHttpSession.class.getName() + ".";
+
+    /**
+     * Static resource path prefixes that should not trigger session timestamp updates.
+     * Uses the same patterns as IdentityZoneResolvingFilter for consistency.
+     */
+    private static final Set<String> STATIC_RESOURCE_PREFIXES = Set.of("/resources/", "/vendor/");
 
     private final TimeService timeService;
     private ZonePathHttpSession cachedSession;
@@ -65,7 +73,7 @@ public class ZoneContextPathSessionRequestWrapper extends HttpServletRequestWrap
         String attributeName = attributeNameForContextPath(contextPathKey);
 
         cachedSession = new ZonePathHttpSession(containerSession, contextPathKey, attributeName, timeService);
-        if (!cachedSession.isNew()) {
+        if (!cachedSession.isNew() && !isStaticResource()) {
             cachedSession.touchLastAccessedTime();
         }
         return cachedSession;
@@ -123,6 +131,15 @@ public class ZoneContextPathSessionRequestWrapper extends HttpServletRequestWrap
 
     private void restoreOurAttributes(HttpSession containerSession, Map<String, Object> snapshot) {
         snapshot.forEach(containerSession::setAttribute);
+    }
+
+    /**
+     * Checks if the current request is for a static resource that should not trigger session updates.
+     * Uses the same logic as IdentityZoneResolvingFilter for consistency.
+     */
+    private boolean isStaticResource() {
+        String requestPath = UaaUrlUtils.getRequestPath(this);
+        return STATIC_RESOURCE_PREFIXES.stream().anyMatch(requestPath::startsWith);
     }
 
     /**

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionRequestWrapper.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionRequestWrapper.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import static org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter.DEFAULT_ZONE_SUBDOMAIN_PATH;
 
@@ -33,13 +32,6 @@ public class ZoneContextPathSessionRequestWrapper extends HttpServletRequestWrap
      */
     public static final String ATTRIBUTE_NAME_PREFIX =
             ZonePathHttpSession.class.getName() + ".";
-
-    /**
-     * Static resource path prefixes that should not trigger session timestamp updates.
-     * Uses the same patterns as IdentityZoneResolvingFilter for consistency.
-     */
-    private static final Set<String> STATIC_RESOURCE_PREFIXES = Set.of("/resources/", "/vendor/");
-
     private final TimeService timeService;
     private ZonePathHttpSession cachedSession;
 
@@ -73,7 +65,7 @@ public class ZoneContextPathSessionRequestWrapper extends HttpServletRequestWrap
         String attributeName = attributeNameForContextPath(contextPathKey);
 
         cachedSession = new ZonePathHttpSession(containerSession, contextPathKey, attributeName, timeService);
-        if (!cachedSession.isNew() && !isStaticResource()) {
+        if (!cachedSession.isNew() && !UaaUrlUtils.isStaticResource(this)) {
             cachedSession.touchLastAccessedTime();
         }
         return cachedSession;
@@ -131,15 +123,6 @@ public class ZoneContextPathSessionRequestWrapper extends HttpServletRequestWrap
 
     private void restoreOurAttributes(HttpSession containerSession, Map<String, Object> snapshot) {
         snapshot.forEach(containerSession::setAttribute);
-    }
-
-    /**
-     * Checks if the current request is for a static resource that should not trigger session updates.
-     * Uses the same logic as IdentityZoneResolvingFilter for consistency.
-     */
-    private boolean isStaticResource() {
-        String requestPath = UaaUrlUtils.getRequestPath(this);
-        return STATIC_RESOURCE_PREFIXES.stream().anyMatch(requestPath::startsWith);
     }
 
     /**

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
@@ -761,4 +761,80 @@ class UaaUrlUtilsTest {
         String result = normalizeUrlForPortComparison(null);
         assertThat(result).isNull();
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/resources/oss/stylesheets/application.css",
+            "/resources/oss/images/product-logo.png",
+            "/resources/javascripts/session/session.js",
+            "/resources/",
+            "/vendor/font-awesome/css/font-awesome.min.css",
+            "/vendor/jquery/jquery.min.js",
+            "/vendor/bootstrap/css/bootstrap.min.css",
+            "/vendor/"
+    })
+    void isStaticResource_returnsTrueForStaticPaths(String path) {
+        // Test string version
+        assertThat(UaaUrlUtils.isStaticResource(path)).isTrue();
+        
+        // Test HttpServletRequest version
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath(path);
+        assertThat(UaaUrlUtils.isStaticResource(request)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/login",
+            "/profile",
+            "/oauth/authorize",
+            "/api/users",
+            "/vendorapi/something"
+    })
+    void isStaticResource_returnsFalseForNonStaticPaths(String path) {
+        // Test string version
+        assertThat(UaaUrlUtils.isStaticResource(path)).isFalse();
+        
+        // Test HttpServletRequest version
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath(path);
+        assertThat(UaaUrlUtils.isStaticResource(request)).isFalse();
+    }
+
+    @Test
+    void isStaticResource_returnsFalseForNullPath() {
+        assertThat(UaaUrlUtils.isStaticResource((String) null)).isFalse();
+    }
+
+    @Test
+    void isStaticResource_returnsFalseForEmptyPath() {
+        assertThat(UaaUrlUtils.isStaticResource("")).isFalse();
+    }
+
+    @Test
+    void isStaticResource_withHttpServletRequest_handlesPathInfo() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/resources");
+        request.setPathInfo("/css/style.css");
+        
+        assertThat(UaaUrlUtils.isStaticResource(request)).isTrue();
+    }
+
+    @Test
+    void isStaticResource_withHttpServletRequest_handlesNullServletPath() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath(null);
+        request.setPathInfo("/vendor/jquery/jquery.min.js");
+        
+        assertThat(UaaUrlUtils.isStaticResource(request)).isTrue();
+    }
+
+    @Test
+    void isStaticResource_withHttpServletRequest_handlesNullPathInfo() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setServletPath("/resources/css/app.css");
+        request.setPathInfo(null);
+        
+        assertThat(UaaUrlUtils.isStaticResource(request)).isTrue();
+    }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionTests.java
@@ -10,6 +10,8 @@ import org.cloudfoundry.identity.uaa.util.TimeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.mock.web.MockHttpSession;
@@ -481,8 +483,8 @@ class ZoneContextPathSessionTests {
             ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
 
             HttpSession first = w.getSession(true);
-            long creationTime = first.getLastAccessedTime();
-            assertThat(creationTime).isEqualTo(1_000_000L);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
             // Advance the clock and access the session again on a new request
             clock.set(2_000_000L);
@@ -492,84 +494,72 @@ class ZoneContextPathSessionTests {
             assertThat(second.getLastAccessedTime()).isEqualTo(2_000_000L);
         }
 
-        @Test
-        void getSession_doesNotTouchLastAccessedTimeForStaticResources() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "/resources/oss/stylesheets/application.css",
+            "/resources/oss/images/product-logo.png",
+            "/vendor/font-awesome/css/font-awesome.min.css",
+            "/vendor/jquery/jquery.min.js",
+            "/vendor/bootstrap/css/bootstrap.min.css",
+            "/resources/javascripts/session/session.js"
+        })
+        void getSession_doesNotTouchLastAccessedTimeForStaticResources(String path) {
             AtomicLong clock = new AtomicLong(1_000_000L);
             TimeService controllableClock = new TimeService() {
                 @Override public long getCurrentTimeMillis() { return clock.get(); }
             };
 
-            // Test various static resource paths
-            String[] staticPaths = {
-                "/resources/oss/stylesheets/application.css",
-                "/resources/oss/images/product-logo.png", 
-                "/vendor/font-awesome/css/font-awesome.min.css",
-                "/resources/javascripts/session/session.js",
-                "/vendor/bootstrap/css/bootstrap.min.css"
-            };
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setContextPath("/uaa");
+            req.setServletPath(path);
+            
+            ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession first = w.getSession(true);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
-            for (String path : staticPaths) {
-                // Reset clock for each test case
-                clock.set(1_000_000L);
-                
-                MockHttpServletRequest req = new MockHttpServletRequest();
-                req.setContextPath("/uaa");
-                req.setServletPath(path);
-                
-                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession first = w.getSession(true);
-                long creationTime = first.getLastAccessedTime();
-                assertThat(creationTime).isEqualTo(1_000_000L);
-
-                // Advance clock and access session again - should NOT update lastAccessedTime for static resources
-                clock.set(2_000_000L);
-                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession second = w2.getSession(false);
-                assertThat(second).isNotNull();
-                
-                // For static resources, lastAccessedTime should remain at creation time
-                assertThat(second.getLastAccessedTime()).as("Static resource %s should not update lastAccessedTime", path)
-                    .isEqualTo(creationTime);
-            }
+            // Advance clock and access session again - should NOT update lastAccessedTime for static resources
+            clock.set(2_000_000L);
+            ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession second = w2.getSession(false);
+            assertThat(second).isNotNull();
+            
+            // For static resources, lastAccessedTime should remain at initial value
+            assertThat(second.getLastAccessedTime()).as("Static resource %s should not update lastAccessedTime", path)
+                .isEqualTo(initialLastAccessedTime);
         }
 
-        @Test
-        void getSession_doesNotTouchLastAccessedTimeForZoneBasedStaticResources() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "/resources/oss/stylesheets/application.css",
+            "/resources/oss/images/product-logo.png",
+            "/vendor/font-awesome/css/font-awesome.min.css",
+            "/vendor/jquery/jquery.min.js"
+        })
+        void getSession_doesNotTouchLastAccessedTimeForZoneBasedStaticResources(String path) {
             AtomicLong clock = new AtomicLong(1_000_000L);
             TimeService controllableClock = new TimeService() {
                 @Override public long getCurrentTimeMillis() { return clock.get(); }
             };
 
-            // Test identity zone-based static resource paths
-            String[] zoneStaticPaths = {
-                "/resources/oss/stylesheets/application.css",
-                "/resources/oss/images/product-logo.png",
-                "/vendor/font-awesome/css/font-awesome.min.css"
-            };
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setContextPath("/uaa/z/tenant1");
+            req.setServletPath(path);
+            
+            ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession first = w.getSession(true);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
-            for (String path : zoneStaticPaths) {
-                // Reset clock for each test case
-                clock.set(1_000_000L);
-                
-                MockHttpServletRequest req = new MockHttpServletRequest();
-                req.setContextPath("/uaa/z/tenant1");
-                req.setServletPath(path);
-                
-                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession first = w.getSession(true);
-                long creationTime = first.getLastAccessedTime();
-                assertThat(creationTime).isEqualTo(1_000_000L);
-
-                // Advance clock and access session again
-                clock.set(2_000_000L);
-                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession second = w2.getSession(false);
-                assertThat(second).isNotNull();
-                
-                // For zone-based static resources, lastAccessedTime should remain at creation time
-                assertThat(second.getLastAccessedTime()).as("Zone-based static resource %s should not update lastAccessedTime", path)
-                    .isEqualTo(creationTime);
-            }
+            // Advance clock and access session again
+            clock.set(2_000_000L);
+            ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession second = w2.getSession(false);
+            assertThat(second).isNotNull();
+            
+            // For zone-based static resources, lastAccessedTime should remain at initial value
+            assertThat(second.getLastAccessedTime()).as("Zone-based static resource %s should not update lastAccessedTime", path)
+                .isEqualTo(initialLastAccessedTime);
         }
 
         @Test
@@ -599,8 +589,8 @@ class ZoneContextPathSessionTests {
                 
                 ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
                 HttpSession first = w.getSession(true);
-                long creationTime = first.getLastAccessedTime();
-                assertThat(creationTime).isEqualTo(1_000_000L);
+                long initialLastAccessedTime = first.getLastAccessedTime();
+                assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
                 // Advance clock and access session again
                 clock.set(2_000_000L);
@@ -638,8 +628,8 @@ class ZoneContextPathSessionTests {
                 
                 ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
                 HttpSession first = w.getSession(true);
-                long creationTime = first.getLastAccessedTime();
-                assertThat(creationTime).isEqualTo(1_000_000L);
+                long initialLastAccessedTime = first.getLastAccessedTime();
+                assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
                 // Advance clock and access session again
                 clock.set(2_000_000L);
@@ -679,8 +669,8 @@ class ZoneContextPathSessionTests {
                 
                 ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
                 HttpSession first = w.getSession(true);
-                long creationTime = first.getLastAccessedTime();
-                assertThat(creationTime).isEqualTo(1_000_000L);
+                long initialLastAccessedTime = first.getLastAccessedTime();
+                assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
                 // Advance clock and access session again
                 clock.set(2_000_000L);
@@ -692,6 +682,39 @@ class ZoneContextPathSessionTests {
                 assertThat(second.getLastAccessedTime()).as("Edge case path %s should update lastAccessedTime", path)
                     .isEqualTo(2_000_000L);
             }
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "/login",
+            "/profile", 
+            "/oauth/authorize",
+            "/api/users"
+        })
+        void getSession_touchesLastAccessedTimeForNonStaticPaths(String path) {
+            AtomicLong clock = new AtomicLong(1_000_000L);
+            TimeService controllableClock = new TimeService() {
+                @Override public long getCurrentTimeMillis() { return clock.get(); }
+            };
+
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setContextPath("/uaa");
+            req.setServletPath(path);
+            
+            ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession first = w.getSession(true);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
+
+            // Advance clock and access session again - SHOULD update lastAccessedTime for non-static paths
+            clock.set(2_000_000L);
+            ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession second = w2.getSession(false);
+            assertThat(second).isNotNull();
+            
+            // For non-static paths, lastAccessedTime should be updated
+            assertThat(second.getLastAccessedTime()).as("Non-static path %s should update lastAccessedTime", path)
+                .isEqualTo(2_000_000L);
         }
 
         @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionTests.java
@@ -493,6 +493,208 @@ class ZoneContextPathSessionTests {
         }
 
         @Test
+        void getSession_doesNotTouchLastAccessedTimeForStaticResources() {
+            AtomicLong clock = new AtomicLong(1_000_000L);
+            TimeService controllableClock = new TimeService() {
+                @Override public long getCurrentTimeMillis() { return clock.get(); }
+            };
+
+            // Test various static resource paths
+            String[] staticPaths = {
+                "/resources/oss/stylesheets/application.css",
+                "/resources/oss/images/product-logo.png", 
+                "/vendor/font-awesome/css/font-awesome.min.css",
+                "/resources/javascripts/session/session.js",
+                "/vendor/bootstrap/css/bootstrap.min.css"
+            };
+
+            for (String path : staticPaths) {
+                // Reset clock for each test case
+                clock.set(1_000_000L);
+                
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.setContextPath("/uaa");
+                req.setServletPath(path);
+                
+                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession first = w.getSession(true);
+                long creationTime = first.getLastAccessedTime();
+                assertThat(creationTime).isEqualTo(1_000_000L);
+
+                // Advance clock and access session again - should NOT update lastAccessedTime for static resources
+                clock.set(2_000_000L);
+                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession second = w2.getSession(false);
+                assertThat(second).isNotNull();
+                
+                // For static resources, lastAccessedTime should remain at creation time
+                assertThat(second.getLastAccessedTime()).as("Static resource %s should not update lastAccessedTime", path)
+                    .isEqualTo(creationTime);
+            }
+        }
+
+        @Test
+        void getSession_doesNotTouchLastAccessedTimeForZoneBasedStaticResources() {
+            AtomicLong clock = new AtomicLong(1_000_000L);
+            TimeService controllableClock = new TimeService() {
+                @Override public long getCurrentTimeMillis() { return clock.get(); }
+            };
+
+            // Test identity zone-based static resource paths
+            String[] zoneStaticPaths = {
+                "/resources/oss/stylesheets/application.css",
+                "/resources/oss/images/product-logo.png",
+                "/vendor/font-awesome/css/font-awesome.min.css"
+            };
+
+            for (String path : zoneStaticPaths) {
+                // Reset clock for each test case
+                clock.set(1_000_000L);
+                
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.setContextPath("/uaa/z/tenant1");
+                req.setServletPath(path);
+                
+                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession first = w.getSession(true);
+                long creationTime = first.getLastAccessedTime();
+                assertThat(creationTime).isEqualTo(1_000_000L);
+
+                // Advance clock and access session again
+                clock.set(2_000_000L);
+                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession second = w2.getSession(false);
+                assertThat(second).isNotNull();
+                
+                // For zone-based static resources, lastAccessedTime should remain at creation time
+                assertThat(second.getLastAccessedTime()).as("Zone-based static resource %s should not update lastAccessedTime", path)
+                    .isEqualTo(creationTime);
+            }
+        }
+
+        @Test
+        void getSession_stillTouchesLastAccessedTimeForNonStaticResources() {
+            AtomicLong clock = new AtomicLong(1_000_000L);
+            TimeService controllableClock = new TimeService() {
+                @Override public long getCurrentTimeMillis() { return clock.get(); }
+            };
+
+            // Test non-static resource paths that should still update timestamps
+            String[] nonStaticPaths = {
+                "/login",
+                "/oauth/token", 
+                "/profile",
+                "/logout",
+                "/saml/SSO",
+                "/api/users"
+            };
+
+            for (String path : nonStaticPaths) {
+                // Reset clock for each test case
+                clock.set(1_000_000L);
+                
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.setContextPath("/uaa");
+                req.setServletPath(path);
+                
+                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession first = w.getSession(true);
+                long creationTime = first.getLastAccessedTime();
+                assertThat(creationTime).isEqualTo(1_000_000L);
+
+                // Advance clock and access session again
+                clock.set(2_000_000L);
+                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession second = w2.getSession(false);
+                assertThat(second).isNotNull();
+                
+                // For non-static resources, lastAccessedTime should be updated
+                assertThat(second.getLastAccessedTime()).as("Non-static resource %s should update lastAccessedTime", path)
+                    .isEqualTo(2_000_000L);
+            }
+        }
+
+        @Test
+        void getSession_stillTouchesLastAccessedTimeForZoneBasedNonStaticResources() {
+            AtomicLong clock = new AtomicLong(1_000_000L);
+            TimeService controllableClock = new TimeService() {
+                @Override public long getCurrentTimeMillis() { return clock.get(); }
+            };
+
+            // Test zone-based non-static resource paths
+            String[] zoneNonStaticPaths = {
+                "/login",
+                "/oauth/token",
+                "/profile"
+            };
+
+            for (String path : zoneNonStaticPaths) {
+                // Reset clock for each test case
+                clock.set(1_000_000L);
+                
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.setContextPath("/uaa/z/tenant1");
+                req.setServletPath(path);
+                
+                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession first = w.getSession(true);
+                long creationTime = first.getLastAccessedTime();
+                assertThat(creationTime).isEqualTo(1_000_000L);
+
+                // Advance clock and access session again
+                clock.set(2_000_000L);
+                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession second = w2.getSession(false);
+                assertThat(second).isNotNull();
+                
+                // For zone-based non-static resources, lastAccessedTime should be updated
+                assertThat(second.getLastAccessedTime()).as("Zone-based non-static resource %s should update lastAccessedTime", path)
+                    .isEqualTo(2_000_000L);
+            }
+        }
+
+        @Test
+        void getSession_handlesEdgeCasesCorrectly() {
+            AtomicLong clock = new AtomicLong(1_000_000L);
+            TimeService controllableClock = new TimeService() {
+                @Override public long getCurrentTimeMillis() { return clock.get(); }
+            };
+
+            // Test edge cases that look like static resources but aren't
+            String[] edgeCasePaths = {
+                "/resourcesabc/file.css",  // Not a static resource - should update timestamp
+                "/vendorabc/file.css",     // Not a static resource - should update timestamp
+                "/resources",              // Exact match without trailing slash - should update timestamp
+                "/vendor",                 // Exact match without trailing slash - should update timestamp
+                ""                         // Empty path - should update timestamp
+            };
+
+            for (String path : edgeCasePaths) {
+                // Reset clock for each test case
+                clock.set(1_000_000L);
+                
+                MockHttpServletRequest req = new MockHttpServletRequest();
+                req.setContextPath("/uaa");
+                req.setServletPath(path);
+                
+                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession first = w.getSession(true);
+                long creationTime = first.getLastAccessedTime();
+                assertThat(creationTime).isEqualTo(1_000_000L);
+
+                // Advance clock and access session again
+                clock.set(2_000_000L);
+                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+                HttpSession second = w2.getSession(false);
+                assertThat(second).isNotNull();
+                
+                // For edge cases, lastAccessedTime should be updated (they're not static resources)
+                assertThat(second.getLastAccessedTime()).as("Edge case path %s should update lastAccessedTime", path)
+                    .isEqualTo(2_000_000L);
+            }
+        }
+
+        @Test
         void changeSessionId_preservesSubSessionAttributes() {
             HttpSession subSession = wrapper.getSession(true);
             subSession.setAttribute("key", "value");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZoneContextPathSessionTests.java
@@ -562,126 +562,104 @@ class ZoneContextPathSessionTests {
                 .isEqualTo(initialLastAccessedTime);
         }
 
-        @Test
-        void getSession_stillTouchesLastAccessedTimeForNonStaticResources() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "/login",
+            "/oauth/token",
+            "/profile",
+            "/logout",
+            "/saml/SSO",
+            "/api/users"
+        })
+        void getSession_stillTouchesLastAccessedTimeForNonStaticResources(String path) {
             AtomicLong clock = new AtomicLong(1_000_000L);
             TimeService controllableClock = new TimeService() {
                 @Override public long getCurrentTimeMillis() { return clock.get(); }
             };
 
-            // Test non-static resource paths that should still update timestamps
-            String[] nonStaticPaths = {
-                "/login",
-                "/oauth/token", 
-                "/profile",
-                "/logout",
-                "/saml/SSO",
-                "/api/users"
-            };
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setContextPath("/uaa");
+            req.setServletPath(path);
 
-            for (String path : nonStaticPaths) {
-                // Reset clock for each test case
-                clock.set(1_000_000L);
-                
-                MockHttpServletRequest req = new MockHttpServletRequest();
-                req.setContextPath("/uaa");
-                req.setServletPath(path);
-                
-                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession first = w.getSession(true);
-                long initialLastAccessedTime = first.getLastAccessedTime();
-                assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
+            ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession first = w.getSession(true);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
-                // Advance clock and access session again
-                clock.set(2_000_000L);
-                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession second = w2.getSession(false);
-                assertThat(second).isNotNull();
-                
-                // For non-static resources, lastAccessedTime should be updated
-                assertThat(second.getLastAccessedTime()).as("Non-static resource %s should update lastAccessedTime", path)
-                    .isEqualTo(2_000_000L);
-            }
+            clock.set(2_000_000L);
+            ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession second = w2.getSession(false);
+            assertThat(second).isNotNull();
+
+            assertThat(second.getLastAccessedTime()).as("Non-static resource %s should update lastAccessedTime", path)
+                .isEqualTo(2_000_000L);
         }
 
-        @Test
-        void getSession_stillTouchesLastAccessedTimeForZoneBasedNonStaticResources() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "/login",
+            "/oauth/token",
+            "/profile"
+        })
+        void getSession_stillTouchesLastAccessedTimeForZoneBasedNonStaticResources(String path) {
             AtomicLong clock = new AtomicLong(1_000_000L);
             TimeService controllableClock = new TimeService() {
                 @Override public long getCurrentTimeMillis() { return clock.get(); }
             };
 
-            // Test zone-based non-static resource paths
-            String[] zoneNonStaticPaths = {
-                "/login",
-                "/oauth/token",
-                "/profile"
-            };
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setContextPath("/uaa/z/tenant1");
+            req.setServletPath(path);
 
-            for (String path : zoneNonStaticPaths) {
-                // Reset clock for each test case
-                clock.set(1_000_000L);
-                
-                MockHttpServletRequest req = new MockHttpServletRequest();
-                req.setContextPath("/uaa/z/tenant1");
-                req.setServletPath(path);
-                
-                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession first = w.getSession(true);
-                long initialLastAccessedTime = first.getLastAccessedTime();
-                assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
+            ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession first = w.getSession(true);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
 
-                // Advance clock and access session again
-                clock.set(2_000_000L);
-                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession second = w2.getSession(false);
-                assertThat(second).isNotNull();
-                
-                // For zone-based non-static resources, lastAccessedTime should be updated
-                assertThat(second.getLastAccessedTime()).as("Zone-based non-static resource %s should update lastAccessedTime", path)
-                    .isEqualTo(2_000_000L);
-            }
+            clock.set(2_000_000L);
+            ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession second = w2.getSession(false);
+            assertThat(second).isNotNull();
+
+            assertThat(second.getLastAccessedTime()).as("Zone-based non-static resource %s should update lastAccessedTime", path)
+                .isEqualTo(2_000_000L);
         }
 
-        @Test
-        void getSession_handlesEdgeCasesCorrectly() {
+        @ParameterizedTest
+        @ValueSource(strings = {
+            "/resourcesabc/file.css",  // Not a static resource - should update timestamp
+            "/vendorabc/file.css",     // Not a static resource - should update timestamp
+            "/resources",              // Exact match without trailing slash - should update timestamp
+            "/vendor",                 // Exact match without trailing slash - should update timestamp
+            ""                         // Empty path - should update timestamp
+        })
+        void getSession_handlesEdgeCasesCorrectly(String path) {
             AtomicLong clock = new AtomicLong(1_000_000L);
             TimeService controllableClock = new TimeService() {
                 @Override public long getCurrentTimeMillis() { return clock.get(); }
             };
 
-            // Test edge cases that look like static resources but aren't
-            String[] edgeCasePaths = {
-                "/resourcesabc/file.css",  // Not a static resource - should update timestamp
-                "/vendorabc/file.css",     // Not a static resource - should update timestamp
-                "/resources",              // Exact match without trailing slash - should update timestamp
-                "/vendor",                 // Exact match without trailing slash - should update timestamp
-                ""                         // Empty path - should update timestamp
-            };
+            // Reset clock for each test case
+            clock.set(1_000_000L);
 
-            for (String path : edgeCasePaths) {
-                // Reset clock for each test case
-                clock.set(1_000_000L);
-                
-                MockHttpServletRequest req = new MockHttpServletRequest();
-                req.setContextPath("/uaa");
-                req.setServletPath(path);
-                
-                ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession first = w.getSession(true);
-                long initialLastAccessedTime = first.getLastAccessedTime();
-                assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
+            MockHttpServletRequest req = new MockHttpServletRequest();
+            req.setContextPath("/uaa");
+            req.setServletPath(path);
 
-                // Advance clock and access session again
-                clock.set(2_000_000L);
-                ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
-                HttpSession second = w2.getSession(false);
-                assertThat(second).isNotNull();
-                
-                // For edge cases, lastAccessedTime should be updated (they're not static resources)
-                assertThat(second.getLastAccessedTime()).as("Edge case path %s should update lastAccessedTime", path)
-                    .isEqualTo(2_000_000L);
-            }
+            ZoneContextPathSessionRequestWrapper w = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession first = w.getSession(true);
+            long initialLastAccessedTime = first.getLastAccessedTime();
+            assertThat(initialLastAccessedTime).isEqualTo(1_000_000L);
+
+            // Advance clock and access session again
+            clock.set(2_000_000L);
+            ZoneContextPathSessionRequestWrapper w2 = new ZoneContextPathSessionRequestWrapper(req, controllableClock);
+            HttpSession second = w2.getSession(false);
+            assertThat(second).isNotNull();
+
+            // For edge cases, lastAccessedTime should be updated (they're not static resources)
+            assertThat(second.getLastAccessedTime()).as("Edge case path %s should update lastAccessedTime", path)
+                .isEqualTo(2_000_000L);
         }
 
         @ParameterizedTest


### PR DESCRIPTION
Was seeing HTTP 500 errors on css and js files on initial access to the login page.
Do not update `lastAccessedTime` for static resource requests.