### PR TITLE
OAuth Group Mapping Behavior - Combine #3814 and #3820 

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -204,6 +204,7 @@ or `$CLOUDFOUNDRY_CONFIG_PATH/uaa.yml`.
 | <a href="#loginalloworiginloop"><img src="images/click-me.png" width="14" height="14"/></a> `login.allowOriginLoop` | `true`| Allow origin loop|
 | <a href="#loginaliasEntitiesenabled"><img src="images/click-me.png" width="14" height="14"/></a> `login.aliasEntitiesEnabled` | `false`| Enable alias entities|
 | <a href="#loginoauthproviders"><img src="images/click-me.png" width="14" height="14"/></a> `login.oauth.providers` | —| External OAuth/OIDC providers|
+| <a href="#loginoauthexternalgroupsfrommappedauthorities"><img src="images/click-me.png" width="14" height="14"/></a> `login.oauth.externalGroupsFromMappedAuthorities` | `false`| Use mapped UAA authorities for external OAuth external groups|
 
 ### SAML Service Provider
 
@@ -1861,6 +1862,18 @@ External OAuth 2.0 and OIDC provider definitions. Each provider entry includes:
 - `linkText` — Text for the login link
 - `relyingPartyId` / `relyingPartySecret` — Client credentials
 - `attributeMappings` — Attribute mapping configuration
+
+[Back to table](#login--branding)
+
+---
+
+### `login.oauth.externalGroupsFromMappedAuthorities`
+
+**Default:** `false`
+**Source:** `@Value("${login.oauth.externalGroupsFromMappedAuthorities:false}")` in [`OauthEndpointBeanConfiguration`](../server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java) (bean `externalOAuthAuthenticationManager`)
+**Type:** `boolean`
+
+When `false` (default), external OAuth login populates `UaaAuthentication` external group names from IdP token authorities **before** UAA group mapping (`externalAuthorities`). When `true`, external group names are taken from **mapped** UAA authorities (`authorities` after `mapExternalGroups`), for deployments that want downstream external-group membership logic to follow mapped group or scope names instead of raw IdP values.
 
 [Back to table](#login--branding)
 

--- a/scripts/boot/uaa.yml
+++ b/scripts/boot/uaa.yml
@@ -63,6 +63,9 @@ login:
   # The entity base url is the location of this application (Used for SAML SP metadata generation)
   # Not set for integration tests - allows UAA to use request URL for zone subdomains
   entityBaseURL: null
+  # Non-default: integration server exercises mapped-authorities path for external OAuth external groups
+  oauth:
+    externalGroupsFromMappedAuthorities: true
   saml:
     activeKeyId: key1
     keys:

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
@@ -555,7 +555,8 @@ public class OauthEndpointBeanConfiguration {
         @Qualifier("keyInfoService") KeyInfoService keyInfoService,
         @Qualifier("oidcMetadataFetcher") OidcMetadataFetcher oidcMetadataFetcher,
         @Qualifier("userDatabase") UaaUserDatabase userDatabase,
-        @Qualifier("externalGroupMembershipManager") ScimGroupExternalMembershipManager externalMembershipManager
+        @Qualifier("externalGroupMembershipManager") ScimGroupExternalMembershipManager externalMembershipManager,
+        @Value("${login.oauth.externalGroupsFromMappedAuthorities:false}") boolean externalGroupsFromMappedAuthorities
     ) {
         ExternalOAuthAuthenticationManager bean = new ExternalOAuthAuthenticationManager(
                 providerProvisioning,
@@ -564,7 +565,8 @@ public class OauthEndpointBeanConfiguration {
                 nonTrustingRestTemplate,
                 tokenEndpointBuilder,
                 keyInfoService,
-                oidcMetadataFetcher
+                oidcMetadataFetcher,
+                externalGroupsFromMappedAuthorities
         );
         bean.setUserDatabase(userDatabase);
         bean.setExternalMembershipManager(externalMembershipManager);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -394,7 +394,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             authentication.setUserAttributes(userAttributes);
 
             authentication.setExternalGroups(
-                    Optional.ofNullable(authenticationData.getExternalAuthorities())
+                    Optional.ofNullable(authenticationData.getAuthorities())
                             .orElse(emptyList())
                             .stream()
                             .map(GrantedAuthority::getAuthority)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -148,6 +148,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     @Getter
     private final KeyInfoService keyInfoService;
     private final IdentityZoneManager identityZoneManager;
+    private final boolean externalGroupsFromMappedAuthorities;
 
     public ExternalOAuthAuthenticationManager(
             IdentityProviderProvisioning providerProvisioning,
@@ -156,7 +157,8 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             RestTemplate nonTrustingRestTemplate,
             TokenEndpointBuilder tokenEndpointBuilder,
             KeyInfoService keyInfoService,
-            OidcMetadataFetcher oidcMetadataFetcher
+            OidcMetadataFetcher oidcMetadataFetcher,
+            boolean externalGroupsFromMappedAuthorities
     ) {
         super(providerProvisioning);
         this.identityZoneManager = identityZoneManager;
@@ -165,6 +167,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         this.tokenEndpointBuilder = tokenEndpointBuilder;
         this.keyInfoService = keyInfoService;
         this.oidcMetadataFetcher = oidcMetadataFetcher;
+        this.externalGroupsFromMappedAuthorities = externalGroupsFromMappedAuthorities;
     }
 
     /**
@@ -393,8 +396,11 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             }
             authentication.setUserAttributes(userAttributes);
 
+            List<SimpleGrantedAuthority> authoritiesForExternalGroups = externalGroupsFromMappedAuthorities
+                    ? authenticationData.getAuthorities()
+                    : authenticationData.getExternalAuthorities();
             authentication.setExternalGroups(
-                    Optional.ofNullable(authenticationData.getAuthorities())
+                    Optional.ofNullable(authoritiesForExternalGroups)
                             .orElse(emptyList())
                             .stream()
                             .map(GrantedAuthority::getAuthority)

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerGithubTest.java
@@ -92,7 +92,7 @@ class ExternalOAuthAuthenticationManagerGithubTest {
                 nonTrustingRestTemplate
         );
         authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), trustingRestTemplate,
-                nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(uaaIssuerBaseUrl), oidcMetadataFetcher);
+                nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(uaaIssuerBaseUrl), oidcMetadataFetcher, false);
     }
 
     @AfterEach

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -230,7 +230,7 @@ class ExternalOAuthAuthenticationManagerIT {
                         identityZoneProvisioning,
                         identityZoneManager)
         );
-        externalOAuthAuthenticationManager = spy(new ExternalOAuthAuthenticationManager(externalOAuthProviderConfigurator, identityZoneManager, trustingRestTemplate, nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_URL), oidcMetadataFetcher));
+        externalOAuthAuthenticationManager = spy(new ExternalOAuthAuthenticationManager(externalOAuthProviderConfigurator, identityZoneManager, trustingRestTemplate, nonTrustingRestTemplate, tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_URL), oidcMetadataFetcher, false));
         externalOAuthAuthenticationManager.setUserDatabase(userDatabase);
         externalOAuthAuthenticationManager.setExternalMembershipManager(externalMembershipManager);
         externalOAuthAuthenticationManager.setApplicationEventPublisher(publisher);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -606,7 +606,7 @@ class ExternalOAuthAuthenticationManagerTest {
     }
 
     @Test
-    void populateAuthenticationAttributes_setsIdpIdTokenAndExternalGroups() {
+    void populateAuthenticationAttributes_setsIdpIdTokenAndExternalGroupsFromMappedAuthorities() {
         UaaAuthentication authentication = new UaaAuthentication(new UaaPrincipal("user-guid", "marissa", "marissa@test.org", "uaa", "", ""), Collections.emptyList(), null);
         Map<String, Object> header = map(
                 entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.RS256.getName()),
@@ -627,10 +627,11 @@ class ExternalOAuthAuthenticationManagerTest {
         String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
         ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, ORIGIN, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
         ExternalOAuthAuthenticationManager.AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oidcAuthentication);
-        authenticationData.setExternalAuthorities(List.of(new SimpleGrantedAuthority("uaa-authorities")));
+        authenticationData.setAuthorities(List.of(new SimpleGrantedAuthority("uaa-authorities")));
+        authenticationData.setExternalAuthorities(List.of(new SimpleGrantedAuthority("raw_external_group")));
         authManager.populateAuthenticationAttributes(authentication, oidcAuthentication, authenticationData);
         assertThat(authentication.getIdpIdToken()).isEqualTo(idTokenJwt);
-        assertThat(authentication.getExternalGroups()).containsAll(List.of("uaa-authorities"));
+        assertThat(authentication.getExternalGroups()).containsExactlyInAnyOrder("uaa-authorities");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -220,7 +220,7 @@ class ExternalOAuthAuthenticationManagerTest {
                 new RestTemplate(),
                 new RestTemplate()
         );
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), oidcMetadataFetcher, false);
         authManager.setExternalMembershipManager(externalMembershipManager);
         authManager.setUserDatabase(userDatabase);
     }
@@ -606,7 +606,40 @@ class ExternalOAuthAuthenticationManagerTest {
     }
 
     @Test
-    void populateAuthenticationAttributes_setsIdpIdTokenAndExternalGroupsFromMappedAuthorities() {
+    void populateAuthenticationAttributes_setsIdpIdTokenAndExternalGroupsFromExternalAuthoritiesByDefault() {
+        UaaAuthentication authentication = new UaaAuthentication(new UaaPrincipal("user-guid", "marissa", "marissa@test.org", "uaa", "", ""), Collections.emptyList(), null);
+        Map<String, Object> header = map(
+                entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.RS256.getName()),
+                entry(HeaderParameterNames.KEY_ID, OIDC_PROVIDER_KEY)
+        );
+        JWSSigner signer = new KeyInfo("uaa-key", OIDC_PROVIDER_TOKEN_SIGNING_KEY, DEFAULT_UAA_URL).getSigner();
+        Map<String, Object> entryMap = map(
+                entry("external_map_name", Arrays.asList("bar", "baz"))
+        );
+        Map<String, Object> claims = map(
+                entry("external_family_name", entryMap),
+                entry(ISS, oidcConfig.getIssuer()),
+                entry(AUD, "uaa-relying-party"),
+                entry(EXPIRY_IN_SECONDS, ((int) (System.currentTimeMillis() / 1000L)) + 60),
+                entry(SUB, "abc-def-asdf")
+        );
+        IdentityZoneHolder.get().getConfig().getTokenPolicy().setKeys(Collections.singletonMap("uaa-key", UAA_IDENTITY_ZONE_TOKEN_SIGNING_KEY));
+        String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
+        ExternalOAuthCodeToken oidcAuthentication = new ExternalOAuthCodeToken(null, ORIGIN, "http://google.com", idTokenJwt, "accesstoken", "signedrequest");
+        ExternalOAuthAuthenticationManager.AuthenticationData authenticationData = authManager.getExternalAuthenticationDetails(oidcAuthentication);
+        authenticationData.setAuthorities(List.of(new SimpleGrantedAuthority("uaa-authorities")));
+        authenticationData.setExternalAuthorities(List.of(new SimpleGrantedAuthority("raw_external_group")));
+        authManager.populateAuthenticationAttributes(authentication, oidcAuthentication, authenticationData);
+        assertThat(authentication.getIdpIdToken()).isEqualTo(idTokenJwt);
+        assertThat(authentication.getExternalGroups()).containsExactlyInAnyOrder("raw_external_group");
+    }
+
+    @Test
+    void populateAuthenticationAttributes_setsExternalGroupsFromMappedAuthoritiesWhenEnabled() {
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), oidcMetadataFetcher, true);
+        authManager.setExternalMembershipManager(externalMembershipManager);
+        authManager.setUserDatabase(userDatabase);
+
         UaaAuthentication authentication = new UaaAuthentication(new UaaPrincipal("user-guid", "marissa", "marissa@test.org", "uaa", "", ""), Collections.emptyList(), null);
         Map<String, Object> header = map(
                 entry(HeaderParameterNames.ALGORITHM, JWSAlgorithm.RS256.getName()),
@@ -654,7 +687,7 @@ class ExternalOAuthAuthenticationManagerTest {
         String idTokenJwt = UaaTokenUtils.constructToken(header, claims, signer);
         ExternalOAuthCodeToken codeToken = new ExternalOAuthCodeToken("thecode", ORIGIN, "http://google.com", null, "accesstoken", "signedrequest");
 
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), null) {
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), null, false) {
             @Override
             protected <T extends AbstractExternalOAuthIdentityProviderDefinition<T>> String getTokenFromCode(
                     ExternalOAuthCodeToken codeToken,
@@ -675,7 +708,7 @@ class ExternalOAuthAuthenticationManagerTest {
     void fetchOidcMetadata() throws OidcMetadataFetchingException {
         OIDCIdentityProviderDefinition mockedProviderDefinition = mock(OIDCIdentityProviderDefinition.class);
         OidcMetadataFetcher mockedOidcMetadataFetcher = mock(OidcMetadataFetcher.class);
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), mockedOidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(), tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), mockedOidcMetadataFetcher, false);
         doThrow(new OidcMetadataFetchingException("error")).when(mockedOidcMetadataFetcher).fetchMetadataAndUpdateDefinition(mockedProviderDefinition);
         assertThatNoException().isThrownBy(() -> authManager.fetchMetadataAndUpdateDefinition(mockedProviderDefinition));
     }
@@ -830,7 +863,7 @@ class ExternalOAuthAuthenticationManagerTest {
         when(rt.exchange(eq("http://localhost:8080/uaa/oauth/token"), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
         when(responseEntity.hasBody()).thenReturn(true);
         when(responseEntity.getBody()).thenReturn(Map.of("id_token", "dummy"));
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher, false);
 
         // When
         authManager.oauthTokenRequest(null, mockOidcIdentityProvider(), GRANT_TYPE_PASSWORD, new LinkedMaskingMultiValueMap<>());
@@ -867,7 +900,7 @@ class ExternalOAuthAuthenticationManagerTest {
         when(rt.exchange(eq("http://localhost:8080/uaa/oauth/token"), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
         when(responseEntity.hasBody()).thenReturn(true);
         when(responseEntity.getBody()).thenReturn(Map.of("id_token", "dummy"));
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher, false);
 
         // When
         assertThat(authManager.oidcJwtBearerGrant(uaaAuthenticationDetails, mockOidcIdentityProvider() , "proxy-token")).isEqualTo("dummy");
@@ -907,7 +940,7 @@ class ExternalOAuthAuthenticationManagerTest {
         when(config.getRelyingPartySecret()).thenReturn("secret");
         doReturn(false).when(config).isClientAuthInBody();
         when(rt.exchange(eq("http://localhost:8080/uaa/oauth/token"), eq(HttpMethod.POST), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenThrow(new HttpClientErrorException(HttpStatus.UNAUTHORIZED));
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher, false);
 
         // When
         assertThatThrownBy(() -> authManager.oidcJwtBearerGrant(uaaAuthenticationDetails, identityProvider, "proxy-token"))
@@ -940,7 +973,7 @@ class ExternalOAuthAuthenticationManagerTest {
         when(auth.getDetails()).thenReturn(details);
 
         RestTemplate rt = mock(RestTemplate.class);
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher, false);
 
         ResponseEntity<Map<String, String>> response = mock(ResponseEntity.class);
         when(response.hasBody()).thenReturn(true);
@@ -993,7 +1026,7 @@ class ExternalOAuthAuthenticationManagerTest {
         when(restTemplate.exchange(anyString(), any(HttpMethod.class), any(HttpEntity.class), any(ParameterizedTypeReference.class))).thenReturn(responseEntity);
         when(responseEntity.hasBody()).thenReturn(true);
         when(responseEntity.getBody()).thenReturn(Map.of("id_token", "dummy"));
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), restTemplate, restTemplate, tokenEndpointBuilder, mockKeyInfoService(), oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), restTemplate, restTemplate, tokenEndpointBuilder, mockKeyInfoService(), oidcMetadataFetcher, false);
 
         final IdentityProvider<OIDCIdentityProviderDefinition> localIdp = new IdentityProvider<>();
         localIdp.setOriginKey(new AlphanumericRandomValueStringGenerator(8).generate().toLowerCase());
@@ -1045,7 +1078,7 @@ class ExternalOAuthAuthenticationManagerTest {
         when(config.getScopes()).thenReturn(null);
 
         RestTemplate rt = mock(RestTemplate.class);
-        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher);
+        authManager = new ExternalOAuthAuthenticationManager(identityProviderProvisioning, new IdentityZoneManagerImpl(), rt, rt, tokenEndpointBuilder, keyInfoService, oidcMetadataFetcher, false);
 
         ResponseEntity<Map<String, String>> response = mock(ResponseEntity.class);
         when(response.hasBody()).thenReturn(true);
@@ -1103,7 +1136,8 @@ class ExternalOAuthAuthenticationManagerTest {
                 restTemplate,
                 tokenEndpointBuilder,
                 new KeyInfoService("http://uaa.example.com"),
-                null
+                null,
+                false
         ) {
             @Override
             protected <T extends AbstractExternalOAuthIdentityProviderDefinition<T>> String getTokenFromCode(

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OIDCLoginIT.java
@@ -14,6 +14,8 @@
 package org.cloudfoundry.identity.uaa.integration.feature;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.JWTParser;
 import org.cloudfoundry.identity.uaa.ServerRunningExtension;
 import org.cloudfoundry.identity.uaa.account.UserInfoResponse;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
@@ -68,18 +70,23 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils.isMember;
 import static org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants.SUB;
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_AUTHORIZATION_CODE;
+import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_PASSWORD;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.USER_NAME_ATTRIBUTE_NAME;
 
 @SpringJUnitConfig(classes = DefaultIntegrationTestConfig.class)
@@ -436,12 +443,49 @@ public class OIDCLoginIT {
     }
 
     @Test
+    void roleMappingAndUserAttributesFromIdTokenOfZone() throws ParseException {
+        // test role and user_attribute claims in id token with external group membership assignment, see issue https://github.com/cloudfoundry/uaa/issues/3813
+        Map<String, Object> attributeMappings = new HashMap<>(identityProvider.getConfig().getAttributeMappings());
+        attributeMappings.remove(USER_NAME_ATTRIBUTE_NAME);
+        attributeMappings.put("user.attribute.roles", "scope");
+        if (identityProvider.getConfig() instanceof OIDCIdentityProviderDefinition oidcConfig) {
+            oidcConfig.setStoreCustomAttributes(true);
+            oidcConfig.setPasswordGrantEnabled(true);
+            oidcConfig.setAttributeMappings(attributeMappings);
+        }
+        updateProvider();
+
+        String clientId = "client" + new RandomValueStringGenerator(5).generate();
+        UaaClientDetails passwordClient = new UaaClientDetails(clientId, null, "openid,roles,user_attributes,"+createdGroup.getDisplayName(), GRANT_TYPE_PASSWORD, "uaa.none", baseUrl);
+        passwordClient.setClientSecret("clientsecret");
+        passwordClient.setAutoApproveScopes(Collections.singletonList("true"));
+        IntegrationTestUtils.createClientAsZoneAdmin(clientCredentialsToken, baseUrl, zone.getId(), passwordClient);
+        Map response = IntegrationTestUtils.getPasswordToken(zoneUrl, passwordClient.getClientId(), "clientsecret", testAccounts.getUserName(), testAccounts.getPassword(), null,
+            identityProvider.getOriginKey());
+        assertThat(response).isNotNull();
+        String idToken = response.get("id_token") instanceof String idString ? idString : null;
+        assertThat(idToken).isNotNull();
+
+        JWTClaimsSet jwtClaimsSet = JWTParser.parse(idToken).getJWTClaimsSet();
+        assertThat(jwtClaimsSet.getStringClaim("origin")).isEqualTo(identityProvider.getOriginKey());
+        Set<String> rolesInJwt = Arrays.stream(jwtClaimsSet.getStringArrayClaim("roles")).collect(Collectors.toSet());
+        assertThat(rolesInJwt).isNotNull().contains(createdGroup.getDisplayName());
+        Map userAttributeJwt = jwtClaimsSet.getJSONObjectClaim("user_attributes");
+        assertThat(userAttributeJwt).isInstanceOf(Map.class);
+        List attr1 = userAttributeJwt.get("the_client_id") instanceof ArrayList<?> arrayList ? arrayList : null;
+        assertThat(attr1).isNotNull().contains("identity");
+        List attr2 = userAttributeJwt.get("roles") instanceof ArrayList<?> arrayList ? arrayList : null;
+        assertThat(attr2).isNotNull().contains("openid");
+    }
+
+    @Test
     void claimsComeFromUserInfoEndpoint() {
         AbstractExternalOAuthIdentityProviderDefinition<?> oldConfig = identityProvider.getConfig();
         Map<String, Object> attributeMappings = new HashMap<>(identityProvider.getConfig().getAttributeMappings());
         attributeMappings.remove(USER_NAME_ATTRIBUTE_NAME);
         oldConfig.setAttributeMappings(attributeMappings);
         oldConfig.setLinkText("My Oauth2.0 Provider");
+        oldConfig.setStoreCustomAttributes(true);
         //change the type so that we will use the /userinfo endpoint
         identityProvider.setType(OriginKeys.OAUTH20);
         updateProvider();
@@ -461,7 +505,7 @@ public class OIDCLoginIT {
         localhostServerRunning.setHostName("localhost");
 
         String clientId = "client" + new RandomValueStringGenerator(5).generate();
-        UaaClientDetails client = new UaaClientDetails(clientId, null, "openid", GRANT_TYPE_AUTHORIZATION_CODE, "openid", baseUrl);
+        UaaClientDetails client = new UaaClientDetails(clientId, null, "openid,roles,user_attributes,"+createdGroup.getDisplayName(), GRANT_TYPE_AUTHORIZATION_CODE, "openid", baseUrl);
         client.setClientSecret("clientsecret");
         client.setAutoApproveScopes(Collections.singletonList("true"));
         IntegrationTestUtils.createClient(adminToken, baseUrl, client);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
@@ -1128,11 +1128,21 @@ public class IntegrationTestUtils {
     }
 
     public static Map getPasswordToken(String baseUrl,
+        String clientId,
+        String clientSecret,
+        String username,
+        String password,
+        String scopes) {
+        return getPasswordToken(baseUrl, clientId, clientSecret, username, password, scopes, null);
+    }
+
+    public static Map getPasswordToken(String baseUrl,
                                        String clientId,
                                        String clientSecret,
                                        String username,
                                        String password,
-                                       String scopes) {
+                                       String scopes,
+                                       String loginHint) {
         RestTemplate template = new RestTemplate();
         template.getMessageConverters().addFirst(new StringHttpMessageConverter(StandardCharsets.UTF_8));
         template.setRequestFactory(new StatelessRequestFactory());
@@ -1144,6 +1154,9 @@ public class IntegrationTestUtils {
         formData.add("response_type", "token id_token");
         if (hasText(scopes)) {
             formData.add("scope", scopes);
+        }
+        if (loginHint != null) {
+            formData.add("login_hint", "{\"origin\": \""+loginHint+"\"}");
         }
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeOverrideAuthManagerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeOverrideAuthManagerMockMvcTests.java
@@ -59,7 +59,8 @@ public class TokenExchangeOverrideAuthManagerMockMvcTests extends TokenExchangeM
                     nonTrustingRestTemplate,
                     tokenEndpointBuilder,
                     keyInfoService,
-                    oidcMetadataFetcher
+                    oidcMetadataFetcher,
+                    false
             ) {
                 @Override
                 public AuthenticationData getExternalAuthenticationDetails(Authentication authentication) {


### PR DESCRIPTION
Combine #3814 and #3820

Implement configurable role mapping behavior. The default is to align with SAML and LDAP, so that roles from the external IDP gets mapped into the id_token. Enabling `login.oauth.externalGroupsFromMappedAuthorities: true` will mimic v77 behavior, where roles become the internal UAA groups after mapping has been completed.