### PR TITLE
Fix Issuer URI Configuration for Default Identity Zone

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
@@ -396,7 +396,8 @@ public class SpringServletXmlBeansConfiguration {
             @Qualifier("uaaTokenPolicy") TokenPolicy uaaTokenPolicy,
             @Qualifier("links") HashMap<String, Object> links,
             @Qualifier("prompts") List<Prompt> prompts,
-            @Qualifier("defaultUserConfig") UserConfig defaultUserConfig
+            @Qualifier("defaultUserConfig") UserConfig defaultUserConfig,
+            @Value("${issuer.uri}") String issuerUri
     ) {
         IdentityZoneConfigurationBootstrap bean = new IdentityZoneConfigurationBootstrap(provisioning);
         bean.setValidator(identityZoneValidator);
@@ -427,6 +428,7 @@ public class SpringServletXmlBeansConfiguration {
         bean.setSamlRequestSigned(loginProps.saml().signRequest());
         bean.setDefaultUserConfig(defaultUserConfig);
         bean.setDefaultIdentityProvider(loginProps.defaultIdentityProvider());
+        bean.setIssuer(issuerUri);
         return bean;
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
@@ -52,6 +52,7 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
     private boolean logoutDisableRedirectParameter = true;
     private List<Prompt> prompts;
     private String defaultIdentityProvider;
+    private String issuer;
 
     private String samlSpPrivateKey;
     private String samlSpPrivateKeyPassphrase;
@@ -92,6 +93,9 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         definition.setAccountChooserEnabled(accountChooserEnabled);
         definition.setDefaultIdentityProvider(defaultIdentityProvider);
         definition.setUserConfig(defaultUserConfig);
+        if (hasText(issuer)) {
+            definition.setIssuer(issuer);
+        }
 
         samlKeys = ofNullable(samlKeys).orElse(Map.of());
         for (Map.Entry<String, Map<String, String>> entry : samlKeys.entrySet()) {
@@ -140,6 +144,11 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
 
     public IdentityZoneConfigurationBootstrap setActiveKeyId(String activeKeyId) {
         this.activeKeyId = activeKeyId != null ? activeKeyId.toLowerCase(Locale.ROOT) : null;
+        return this;
+    }
+
+    public IdentityZoneConfigurationBootstrap setIssuer(String issuer) {
+        this.issuer = issuer;
         return this;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
@@ -63,10 +63,7 @@ public class GeneralIdentityZoneConfigurationValidator implements IdentityZoneCo
                 }
             }
             if (UaaStringUtils.isNotEmpty(config.getIssuer()) && (tokenPolicy == null || UaaStringUtils.isNullOrEmpty(tokenPolicy.getActiveKeyId()))) {
-                // Allow the default zone to have an issuer without a custom signing key
-                if (!zone.isUaa()) {
-                    throw new InvalidIdentityZoneConfigurationException("You cannot set issuer value unless you have set your own signing key for this identity zone.");
-                }
+                throw new InvalidIdentityZoneConfigurationException("You cannot set issuer value unless you have set your own signing key for this identity zone.");
             }
 
             validateRegexStrings(config.getCorsPolicy().getXhrConfiguration().getAllowedUris(), "config.corsPolicy.xhrConfiguration.allowedUris");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
@@ -63,7 +63,10 @@ public class GeneralIdentityZoneConfigurationValidator implements IdentityZoneCo
                 }
             }
             if (UaaStringUtils.isNotEmpty(config.getIssuer()) && (tokenPolicy == null || UaaStringUtils.isNullOrEmpty(tokenPolicy.getActiveKeyId()))) {
-                throw new InvalidIdentityZoneConfigurationException("You cannot set issuer value unless you have set your own signing key for this identity zone.");
+                // Allow the default zone to have an issuer without a custom signing key
+                if (!zone.isUaa()) {
+                    throw new InvalidIdentityZoneConfigurationException("You cannot set issuer value unless you have set your own signing key for this identity zone.");
+                }
             }
 
             validateRegexStrings(config.getCorsPolicy().getXhrConfiguration().getAllowedUris(), "config.corsPolicy.xhrConfiguration.allowedUris");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -304,6 +304,15 @@ public class IdentityZoneConfigurationBootstrapTests {
     @Test
     void issuerConfiguration() throws Exception {
         String testIssuer = "http://test.example.com/uaa";
+        
+        // Set up token policy with keys to satisfy validation
+        TokenPolicy tokenPolicy = new TokenPolicy(3600, 7200);
+        Map<String, String> keys = new HashMap<>();
+        keys.put("testkey", "test-signing-key");
+        tokenPolicy.setKeys(keys);
+        tokenPolicy.setActiveKeyId("testkey");
+        bootstrap.setTokenPolicy(tokenPolicy);
+        
         bootstrap.setIssuer(testIssuer);
         bootstrap.afterPropertiesSet();
         IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
@@ -327,16 +336,24 @@ public class IdentityZoneConfigurationBootstrapTests {
     }
 
     @Test
-    void issuerConfiguration_defaultZoneAllowed() throws Exception {
-        // This test verifies that the default zone can have an issuer set without a custom signing key
+    void issuerConfiguration_defaultZoneWithTokenPolicy() throws Exception {
+        // This test verifies that the default zone can have an issuer set with a proper token policy
         String testIssuer = "http://localhost:8080/uaa";
-        bootstrap.setIssuer(testIssuer);
         
-        // Verify that the default zone allows issuer without custom signing key
+        // Set up token policy with keys to satisfy validation
+        TokenPolicy tokenPolicy = new TokenPolicy(3600, 7200);
+        Map<String, String> keys = new HashMap<>();
+        keys.put("defaultkey", "default-signing-key");
+        tokenPolicy.setKeys(keys);
+        tokenPolicy.setActiveKeyId("defaultkey");
+        bootstrap.setTokenPolicy(tokenPolicy);
+        
+        bootstrap.setIssuer(testIssuer);
         bootstrap.afterPropertiesSet();
         
         IdentityZone defaultZone = provisioning.retrieve(IdentityZone.getUaaZoneId());
         assertThat(defaultZone.isUaa()).isTrue();
         assertThat(defaultZone.getConfig().getIssuer()).isEqualTo(testIssuer);
+        assertThat(defaultZone.getConfig().getTokenPolicy().getActiveKeyId()).isEqualTo("defaultkey");
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -300,4 +300,43 @@ public class IdentityZoneConfigurationBootstrapTests {
         IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
         assertThat(config.isIdpDiscoveryEnabled()).isTrue();
     }
+
+    @Test
+    void issuerConfiguration() throws Exception {
+        String testIssuer = "http://test.example.com/uaa";
+        bootstrap.setIssuer(testIssuer);
+        bootstrap.afterPropertiesSet();
+        IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
+        assertThat(config.getIssuer()).isEqualTo(testIssuer);
+    }
+
+    @Test
+    void issuerConfiguration_nullValue() throws Exception {
+        bootstrap.setIssuer(null);
+        bootstrap.afterPropertiesSet();
+        IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
+        assertThat(config.getIssuer()).isNull();
+    }
+
+    @Test
+    void issuerConfiguration_emptyValue() throws Exception {
+        bootstrap.setIssuer("");
+        bootstrap.afterPropertiesSet();
+        IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
+        assertThat(config.getIssuer()).isNull();
+    }
+
+    @Test
+    void issuerConfiguration_defaultZoneAllowed() throws Exception {
+        // This test verifies that the default zone can have an issuer set without a custom signing key
+        String testIssuer = "http://localhost:8080/uaa";
+        bootstrap.setIssuer(testIssuer);
+        
+        // Verify that the default zone allows issuer without custom signing key
+        bootstrap.afterPropertiesSet();
+        
+        IdentityZone defaultZone = provisioning.retrieve(IdentityZone.getUaaZoneId());
+        assertThat(defaultZone.isUaa()).isTrue();
+        assertThat(defaultZone.getConfig().getIssuer()).isEqualTo(testIssuer);
+    }
 }


### PR DESCRIPTION
The issuer.uri configuration from uaa.yml is not being applied to the default identity zone's configuration.

This appears to be a long-standing bug that has existed for multiple major versions.
The infrastructure to support issuer configuration has been in place since version 4.12.0, but actually applying the issuer.uri configuration to the default zone was never implemented.