### PR TITLE
Allow configuration of logged_out page content

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -35,6 +35,7 @@ or `$CLOUDFOUNDRY_CONFIG_PATH/uaa.yml`.
   - [Metrics](#metrics)
   - [Zone Paths](#zone-paths)
   - [CSP (Content Security Policy)](#csp-content-security-policy)
+  - [Logged Out Page](#logged-out-page)
   - [Miscellaneous](#miscellaneous)
 
 ---
@@ -363,11 +364,20 @@ or `$CLOUDFOUNDRY_CONFIG_PATH/uaa.yml`.
 |----------|---------|-------------|
 | <a href="#cspscript-src"><img src="images/click-me.png" width="14" height="14"/></a> `csp.script-src` | `['self']`| CSP script-src directive|
 
+### Logged Out Page
+
+| Property                                                                                                          | Default | Description |
+|-------------------------------------------------------------------------------------------------------------------|---------|-------------|
+| <a href="#logged_outmessage"><img src="images/click-me.png" width="14" height="14"/></a> `logged_out.message`     | `You have successfully logged out.`| Logged out page message|
+| <a href="#logged_outlink_text"><img src="images/click-me.png" width="14" height="14"/></a> `logged_out.link_text` | `Back to Sign In`| Logged out page link text|
+| <a href="#logged_outlink_url"><img src="images/click-me.png" width="14" height="14"/></a> `logged_out.link_url`   | `/login`| Logged out page link URL|
+
 ### Miscellaneous
 
 | Property | Default | Description |
 |----------|---------|-------------|
 | <a href="#loggingfilenamepath"><img src="images/click-me.png" width="14" height="14"/></a> `logging.file.name.path` | —| Log file directory|
+
 
 ---
 
@@ -2939,6 +2949,42 @@ Content Security Policy `script-src` directive values. Controls which sources ar
 to execute JavaScript on UAA pages.
 
 [Back to table](#csp-content-security-policy)
+
+---
+
+### `logged_out.message`
+
+**Default:** `You have successfully logged out.`
+**Source:** `@Value("${logged_out.message:You have successfully logged out.}")` in [`LoggedOutEndpoint`](../server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java)
+**Type:** `String`
+
+Customizable message displayed on the logged out page after a user successfully logs out.
+
+[Back to table](#logged-out-page)
+
+---
+
+### `logged_out.link_text`
+
+**Default:** `Back to Sign In`
+**Source:** `@Value("${logged_out.link_text:Back to Sign In}")` in [`LoggedOutEndpoint`](../server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java)
+**Type:** `String`
+
+Customizable text for the link displayed on the logged out page that takes users back to the login page.
+
+[Back to table](#logged-out-page)
+
+---
+
+### `logged_out.link_url`
+
+**Default:** `/login`
+**Source:** `@Value("${logged_out.link_url:/login}")` in [`LoggedOutEndpoint`](../server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java)
+**Type:** `String`
+
+Customizable URL for the link displayed on the logged out page. Can be a relative path (e.g., `/login`) or an absolute URL (e.g., `http://localhost:8080/uaa/login`). Relative URLs are resolved against the UAA base URL.
+
+[Back to table](#logged-out-page)
 
 ---
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java
@@ -1,14 +1,32 @@
 package org.cloudfoundry.identity.uaa.logout;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class LoggedOutEndpoint {
 
-    @GetMapping("/logged_out")
-    public String loggedOut() {
-        return "logged_out";
+    private final String message;
+    private final String linkText;
+    private final String linkUrl;
+
+    public LoggedOutEndpoint(
+            @Value("${logged_out.message:You have successfully logged out.}") String message,
+            @Value("${logged_out.link_text:Back to Sign In}") String linkText,
+            @Value("${logged_out.link_url:/login}") String linkUrl) {
+        this.message = message;
+        this.linkText = linkText;
+        this.linkUrl = linkUrl;
     }
 
+    @GetMapping("/logged_out")
+    public String loggedOut(Model model) {
+        model.addAttribute("message", message);
+        model.addAttribute("linkText", linkText);
+        model.addAttribute("linkUrl", linkUrl);
+
+        return "logged_out";
+    }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpoint.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.logout;
 
+import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -18,7 +19,7 @@ public class LoggedOutEndpoint {
             @Value("${logged_out.link_url:/login}") String linkUrl) {
         this.message = message;
         this.linkText = linkText;
-        this.linkUrl = linkUrl;
+        this.linkUrl = UaaUrlUtils.validateAndNormalizeSafeUrl(linkUrl, "/login");
     }
 
     @GetMapping("/logged_out")

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -266,6 +266,43 @@ public abstract class UaaUrlUtils {
         }
     }
 
+    /**
+     * Validates and normalizes a URL for safe use in web contexts to prevent XSS attacks.
+     * Only allows:
+     * - Context-relative paths starting with /
+     * - Absolute HTTP/HTTPS URLs
+     * 
+     * @param url the URL to validate
+     * @param fallbackUrl the fallback URL to use for invalid URLs (should be safe, e.g., "/login")
+     * @return the validated URL, or fallbackUrl for invalid URLs
+     */
+    public static String validateAndNormalizeSafeUrl(String url, String fallbackUrl) {
+        if (url == null || url.trim().isEmpty()) {
+            return fallbackUrl;
+        }
+        
+        String trimmed = url.trim();
+        
+        // Allow context-relative paths starting with /
+        if (trimmed.startsWith("/")) {
+            return trimmed;
+        }
+        
+        // Allow absolute HTTP/HTTPS URLs
+        try {
+            URI uri = new URI(trimmed);
+            String scheme = uri.getScheme();
+            if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
+                return trimmed;
+            }
+        } catch (URISyntaxException e) {
+            // Invalid URI syntax, fall back to default
+        }
+        
+        // For any other scheme (javascript:, data:, etc.) or invalid URLs, fall back to safe default
+        return fallbackUrl;
+    }
+
     public static String addQueryParameter(String url, String name, String value) {
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(url);
         builder.queryParam(name, value);

--- a/server/src/main/resources/templates/web/logged_out.html
+++ b/server/src/main/resources/templates/web/logged_out.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layouts/main}">
 <div class="island" layout:fragment="page-content">
-    <h1>You have successfully logged out.</h1>
+    <h1 th:text="${message}">You have successfully logged out.</h1>
     <div class="island-content">
-        <a href="/login" th:href="@{/login}" class="link-lowlight">Back to Sign In</a>
+        <a th:href="@{${linkUrl}}" th:text="${linkText}" class="link-lowlight">Back to Sign In</a>
     </div>
 </div>
 </html>

--- a/server/src/main/resources/templates/web/logged_out.html
+++ b/server/src/main/resources/templates/web/logged_out.html
@@ -3,7 +3,7 @@
 <div class="island" layout:fragment="page-content">
     <h1 th:text="${message}">You have successfully logged out.</h1>
     <div class="island-content">
-        <a th:href="@{${linkUrl}}" th:text="${linkText}" class="link-lowlight">Back to Sign In</a>
+        <a th:href="@{${linkUrl}}" href="/login" th:text="${linkText}" class="link-lowlight">Back to Sign In</a>
     </div>
 </div>
 </html>

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpointConfigurationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpointConfigurationTest.java
@@ -1,0 +1,88 @@
+package org.cloudfoundry.identity.uaa.logout;
+
+import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
+import org.cloudfoundry.identity.uaa.home.BuildInfo;
+import org.cloudfoundry.identity.uaa.login.ThymeleafConfig;
+import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+@ExtendWith(PollutionPreventionExtension.class)
+@WebAppConfiguration
+@SpringJUnitConfig(classes = LoggedOutEndpointConfigurationTest.ContextConfiguration.class)
+@TestPropertySource(properties = {
+        "logged_out.message=Custom test message from properties",
+        "logged_out.link_text=Custom test link text",
+        "logged_out.link_url=http://test.example.com/login"
+})
+class LoggedOutEndpointConfigurationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Test
+    void loggedOutEndpoint_shouldUseConfigurationProperties() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        mockMvc.perform(get("/logged_out"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("logged_out"))
+                .andExpect(model().attribute("message", "Custom test message from properties"))
+                .andExpect(model().attribute("linkText", "Custom test link text"))
+                .andExpect(model().attribute("linkUrl", "http://test.example.com/login"));
+    }
+
+    @EnableWebMvc
+    @Import({ThymeleafConfig.class, LoggedOutEndpoint.class})
+    static class ContextConfiguration {
+        @Bean
+        BuildInfo buildInfo() {
+            return new TestBuildInfo();
+        }
+    }
+}
+
+@ExtendWith(PollutionPreventionExtension.class)
+@WebAppConfiguration
+@SpringJUnitConfig(classes = LoggedOutEndpointDefaultConfigurationTest.ContextConfiguration.class)
+class LoggedOutEndpointDefaultConfigurationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Test
+    void loggedOutEndpoint_shouldUseDefaultValuesWhenPropertiesNotSet() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
+        mockMvc.perform(get("/logged_out"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("logged_out"))
+                .andExpect(model().attribute("message", "You have successfully logged out."))
+                .andExpect(model().attribute("linkText", "Back to Sign In"))
+                .andExpect(model().attribute("linkUrl", "/login"));
+    }
+
+    @EnableWebMvc
+    @Import({ThymeleafConfig.class, LoggedOutEndpoint.class})
+    static class ContextConfiguration {
+        @Bean
+        BuildInfo buildInfo() {
+            return new TestBuildInfo();
+        }
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpointTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpointTest.java
@@ -1,0 +1,124 @@
+package org.cloudfoundry.identity.uaa.logout;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.ui.Model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class LoggedOutEndpointTest {
+
+    @Test
+    void loggedOutMethod_shouldAddAttributesToModelWithDefaultValues() {
+        // Unit test for the controller method directly with default values
+        LoggedOutEndpoint controller = new LoggedOutEndpoint(
+                "You have successfully logged out.",
+                "Back to Sign In",
+                "/login"
+        );
+        
+        Model model = mock(Model.class);
+        String viewName = controller.loggedOut(model);
+
+        verify(model).addAttribute("message", "You have successfully logged out.");
+        verify(model).addAttribute("linkText", "Back to Sign In");
+        verify(model).addAttribute("linkUrl", "/login");
+        
+        assertThat(viewName).isEqualTo("logged_out");
+    }
+
+    @Test
+    void loggedOutMethod_shouldAddAttributesToModelWithCustomValues() {
+        // Test that constructor properly stores the injected configuration values
+        String expectedMessage = "Custom logout message";
+        String expectedLinkText = "Custom link text";
+        String expectedLinkUrl = "https://custom.example.com/login";
+
+        LoggedOutEndpoint controller = new LoggedOutEndpoint(
+                expectedMessage,
+                expectedLinkText,
+                expectedLinkUrl
+        );
+
+        Model model = mock(Model.class);
+        String viewName = controller.loggedOut(model);
+
+        verify(model).addAttribute("message", expectedMessage);
+        verify(model).addAttribute("linkText", expectedLinkText);
+        verify(model).addAttribute("linkUrl", expectedLinkUrl);
+        
+        assertThat(viewName).isEqualTo("logged_out");
+    }
+
+    @Test
+    void loggedOutMethod_shouldHandleNullValues() {
+        // Test with null values (edge case)
+        LoggedOutEndpoint controller = new LoggedOutEndpoint(null, null, null);
+
+        Model model = mock(Model.class);
+        String viewName = controller.loggedOut(model);
+
+        verify(model).addAttribute("message", null);
+        verify(model).addAttribute("linkText", null);
+        verify(model).addAttribute("linkUrl", null);
+        
+        assertThat(viewName).isEqualTo("logged_out");
+    }
+
+    @Test
+    void loggedOutMethod_shouldHandleEmptyValues() {
+        // Test with empty string values
+        LoggedOutEndpoint controller = new LoggedOutEndpoint("", "", "");
+
+        Model model = mock(Model.class);
+        String viewName = controller.loggedOut(model);
+
+        verify(model).addAttribute("message", "");
+        verify(model).addAttribute("linkText", "");
+        verify(model).addAttribute("linkUrl", "");
+        
+        assertThat(viewName).isEqualTo("logged_out");
+    }
+
+    @Test
+    void loggedOutMethod_shouldHandleSpecialCharacters() {
+        // Test that constructor handles special characters in configuration values
+        String messageWithSpecialChars = "You've successfully logged out! <script>alert('test')</script>";
+        String linkTextWithSpecialChars = "« Back to Sign In »";
+        String linkUrlWithSpecialChars = "https://example.com/login?redirect=https%3A%2F%2Fapp.example.com";
+
+        LoggedOutEndpoint controller = new LoggedOutEndpoint(
+                messageWithSpecialChars,
+                linkTextWithSpecialChars,
+                linkUrlWithSpecialChars
+        );
+
+        Model model = mock(Model.class);
+        String viewName = controller.loggedOut(model);
+
+        verify(model).addAttribute("message", messageWithSpecialChars);
+        verify(model).addAttribute("linkText", linkTextWithSpecialChars);
+        verify(model).addAttribute("linkUrl", linkUrlWithSpecialChars);
+        
+        assertThat(viewName).isEqualTo("logged_out");
+    }
+
+    @Test
+    void constructor_shouldAcceptConfigurationValues() {
+        // Test that constructor accepts and stores configuration values
+        String message = "Test message";
+        String linkText = "Test link text";
+        String linkUrl = "Test URL";
+
+        LoggedOutEndpoint controller = new LoggedOutEndpoint(message, linkText, linkUrl);
+        
+        // Verify by calling the method and checking the model attributes
+        Model model = mock(Model.class);
+        controller.loggedOut(model);
+
+        verify(model).addAttribute("message", message);
+        verify(model).addAttribute("linkText", linkText);
+        verify(model).addAttribute("linkUrl", linkUrl);
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpointTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/logout/LoggedOutEndpointTest.java
@@ -1,6 +1,8 @@
 package org.cloudfoundry.identity.uaa.logout;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.ui.Model;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,14 +48,14 @@ class LoggedOutEndpointTest {
 
         verify(model).addAttribute("message", expectedMessage);
         verify(model).addAttribute("linkText", expectedLinkText);
-        verify(model).addAttribute("linkUrl", expectedLinkUrl);
+        verify(model).addAttribute("linkUrl", expectedLinkUrl); // Valid HTTPS URL should pass validation
         
         assertThat(viewName).isEqualTo("logged_out");
     }
 
     @Test
     void loggedOutMethod_shouldHandleNullValues() {
-        // Test with null values (edge case)
+        // Test with null values (edge case) - linkUrl should fallback to /login
         LoggedOutEndpoint controller = new LoggedOutEndpoint(null, null, null);
 
         Model model = mock(Model.class);
@@ -61,14 +63,14 @@ class LoggedOutEndpointTest {
 
         verify(model).addAttribute("message", null);
         verify(model).addAttribute("linkText", null);
-        verify(model).addAttribute("linkUrl", null);
+        verify(model).addAttribute("linkUrl", "/login"); // URL validation fallback
         
         assertThat(viewName).isEqualTo("logged_out");
     }
 
     @Test
     void loggedOutMethod_shouldHandleEmptyValues() {
-        // Test with empty string values
+        // Test with empty string values - linkUrl should fallback to /login
         LoggedOutEndpoint controller = new LoggedOutEndpoint("", "", "");
 
         Model model = mock(Model.class);
@@ -76,7 +78,7 @@ class LoggedOutEndpointTest {
 
         verify(model).addAttribute("message", "");
         verify(model).addAttribute("linkText", "");
-        verify(model).addAttribute("linkUrl", "");
+        verify(model).addAttribute("linkUrl", "/login"); // URL validation fallback
         
         assertThat(viewName).isEqualTo("logged_out");
     }
@@ -99,26 +101,88 @@ class LoggedOutEndpointTest {
 
         verify(model).addAttribute("message", messageWithSpecialChars);
         verify(model).addAttribute("linkText", linkTextWithSpecialChars);
-        verify(model).addAttribute("linkUrl", linkUrlWithSpecialChars);
+        verify(model).addAttribute("linkUrl", linkUrlWithSpecialChars); // Valid HTTPS URL should pass validation
         
         assertThat(viewName).isEqualTo("logged_out");
     }
 
-    @Test
-    void constructor_shouldAcceptConfigurationValues() {
-        // Test that constructor accepts and stores configuration values
-        String message = "Test message";
-        String linkText = "Test link text";
-        String linkUrl = "Test URL";
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "javascript:alert('xss')",
+            "data:text/html,<script>alert('xss')</script>",
+            "vbscript:msgbox('xss')",
+            "file:///etc/passwd",
+            "ftp://example.com/file",
+            "mailto:user@example.com",
+            "tel:+1234567890"
+    })
+    void constructor_shouldValidateAndSanitizeDangerousUrls(String dangerousUrl) {
+        // Test XSS prevention - dangerous schemes should be rejected
+        LoggedOutEndpoint controller = new LoggedOutEndpoint("msg", "text", dangerousUrl);
 
-        LoggedOutEndpoint controller = new LoggedOutEndpoint(message, linkText, linkUrl);
-        
-        // Verify by calling the method and checking the model attributes
         Model model = mock(Model.class);
         controller.loggedOut(model);
-
-        verify(model).addAttribute("message", message);
-        verify(model).addAttribute("linkText", linkText);
-        verify(model).addAttribute("linkUrl", linkUrl);
+        
+        verify(model).addAttribute("linkUrl", "/login"); // Should fallback to safe default
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/login",
+            "/auth/login", 
+            "/app/dashboard",
+            "/logout",
+            "/uaa/logout",
+            "/path/with/multiple/segments"
+    })
+    void constructor_shouldAllowValidRelativePaths(String validPath) {
+        // Test that valid relative paths are allowed
+        LoggedOutEndpoint controller = new LoggedOutEndpoint("msg", "text", validPath);
+
+        Model model = mock(Model.class);
+        controller.loggedOut(model);
+        
+        verify(model).addAttribute("linkUrl", validPath);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://example.com/login",
+            "https://secure.example.com/auth",
+            "https://app.example.com:8443/login?redirect=home",
+            "http://localhost:8080/login",
+            "https://subdomain.example.org/path/to/login",
+            "https://example.com/login#fragment"
+    })
+    void constructor_shouldAllowValidAbsoluteUrls(String validUrl) {
+        // Test that valid HTTP/HTTPS URLs are allowed
+        LoggedOutEndpoint controller = new LoggedOutEndpoint("msg", "text", validUrl);
+
+        Model model = mock(Model.class);
+        controller.loggedOut(model);
+        
+        verify(model).addAttribute("linkUrl", validUrl);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "not-a-url",
+            "relative-without-slash", 
+            "://malformed",
+            "   ",
+            "",
+            "http://",
+            "https://",
+            "invalid-scheme://example.com"
+    })
+    void constructor_shouldRejectInvalidUrls(String invalidUrl) {
+        // Test that malformed URLs are rejected
+        LoggedOutEndpoint controller = new LoggedOutEndpoint("msg", "text", invalidUrl);
+
+        Model model = mock(Model.class);
+        controller.loggedOut(model);
+        
+        verify(model).addAttribute("linkUrl", "/login"); // Should fallback
+    }
+
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
@@ -837,4 +837,59 @@ class UaaUrlUtilsTest {
         
         assertThat(UaaUrlUtils.isStaticResource(request)).isTrue();
     }
+
+    // Tests for validateAndNormalizeSafeUrl method
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "javascript:alert('xss')",
+            "data:text/html,<script>alert('xss')</script>",
+            "vbscript:msgbox('xss')",
+            "file:///etc/passwd",
+            "ftp://example.com/file",
+            "mailto:user@example.com",
+            "tel:+1234567890",
+            "not-a-url",
+            "relative-without-slash",
+            "://malformed",
+            "",
+            "   "
+    })
+    void validateAndNormalizeSafeUrl_shouldRejectDangerousAndInvalidUrls(String dangerousUrl) {
+        String result = UaaUrlUtils.validateAndNormalizeSafeUrl(dangerousUrl, "/fallback");
+        assertThat(result).isEqualTo("/fallback");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/login",
+            "/auth/login",
+            "/app/dashboard",
+            "/logout",
+            "/uaa/logout",
+            "/path/with/multiple/segments"
+    })
+    void validateAndNormalizeSafeUrl_shouldAllowValidRelativePaths(String validPath) {
+        String result = UaaUrlUtils.validateAndNormalizeSafeUrl(validPath, "/fallback");
+        assertThat(result).isEqualTo(validPath);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://example.com/login",
+            "https://secure.example.com/auth",
+            "https://app.example.com:8443/login?redirect=home",
+            "http://localhost:8080/login",
+            "https://subdomain.example.org/path/to/login",
+            "https://example.com/login#fragment"
+    })
+    void validateAndNormalizeSafeUrl_shouldAllowValidAbsoluteUrls(String validUrl) {
+        String result = UaaUrlUtils.validateAndNormalizeSafeUrl(validUrl, "/fallback");
+        assertThat(result).isEqualTo(validUrl);
+    }
+
+    @Test
+    void validateAndNormalizeSafeUrl_withNullUrl_returnsFallback() {
+        String result = UaaUrlUtils.validateAndNormalizeSafeUrl(null, "/fallback");
+        assertThat(result).isEqualTo("/fallback");
+    }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
@@ -494,12 +494,6 @@ class UaaUrlUtilsTest {
     }
 
     @Test
-    void addSubdomainToUrl_handlesEmptySubdomain_defaultZone() {
-        String url = UaaUrlUtils.addSubdomainToUrl("http://localhost:8080", UaaStringUtils.EMPTY_STRING);
-        assertThat(url).isEqualTo("http://localhost:8080");
-    }
-
-    @Test
     void addSudomain_handlesExtraSpaceInSubdomain() {
         String url = UaaUrlUtils.addSubdomainToUrl("http://localhost:8080", " somezone  ");
         assertThat(url).isEqualTo("http://somezone.localhost:8080");

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -616,3 +616,8 @@ springdoc:
   writer-with-default-pretty-printer: false
   model-and-view-allowed: false
   override-with-generic-response: false
+
+#logged_out:
+#  message: You have successfully logged out.
+#  link_text: Back to Sign In
+#  link_url: http://localhost:8080/uaa/login


### PR DESCRIPTION
This allows configuration of the logged_out page content, e.g.

```yaml
logged_out:
  message: You have successfully logged out.
  link_text: Back to Sign In
  link_url: http://localhost:8080/uaa/login
```