### PR TITLE
Revert "Add OpenSaml work around for FIPS initialization"

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,7 +12,7 @@ versions.springBootVersion = "3.5.13"
 versions.guavaVersion = "33.5.0-jre"
 versions.seleniumVersion = "4.42.0"
 versions.braveVersion = "6.3.1"
-versions.opensaml = "4.3.2"
+versions.opensaml = "4.0.1"
 
 // Versions we're overriding from the Spring Boot Bom (Dependabot does not issue PRs to bump these versions, so we need to manually bump them)
 ext["selenium.version"] = "${versions.seleniumVersion}" // Selenium for integration tests only

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/IdentityZoneConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/IdentityZoneConfig.java
@@ -4,29 +4,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
-import org.opensaml.core.config.ConfigurationService;
-import org.opensaml.core.config.InitializationException;
-import org.opensaml.core.config.Initializer;
-import org.opensaml.security.config.GlobalNamedCurveRegistryInitializer;
-import org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.security.saml2.Saml2Exception;
-import org.springframework.security.saml2.core.OpenSamlInitializationService;
 
 import java.security.Security;
-import java.util.Properties;
-import java.util.ServiceLoader;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.opensaml.xmlsec.config.impl.DefaultSecurityConfigurationBootstrap.CONFIG_PROPERTY_ECDH_DEFAULT_KDF;
 
 @Configuration
 @Slf4j
 public class IdentityZoneConfig {
-
-    private static final AtomicBoolean samlInitialized = new AtomicBoolean(false);
 
     @Bean
     public BouncyCastleFipsProvider setUpBouncyCastle() {
@@ -61,29 +47,5 @@ public class IdentityZoneConfig {
             SamlKeyManagerFactory samlKeyManagerFactory) {
 
         return new IdentityZoneHolder.Initializer(provisioning, samlKeyManagerFactory);
-    }
-
-    @Bean
-    public static Boolean setupOpenSaml() {
-        if (samlInitialized.compareAndSet(false, true)) {
-            Properties props = ConfigurationService.getConfigurationProperties();
-            props.put(CONFIG_PROPERTY_ECDH_DEFAULT_KDF, DefaultSecurityConfigurationBootstrap.PBKDF2);
-            Class<?> toSkip = GlobalNamedCurveRegistryInitializer.class;
-            ServiceLoader.load(Initializer.class).stream().filter((provider) -> provider.type() != toSkip).forEach((provider) -> init(provider));
-            try {
-                OpenSamlInitializationService.initialize();
-            } catch (NoClassDefFoundError | NoSuchMethodError e) {
-                // ignore
-            }
-        }
-        return Boolean.TRUE;
-    }
-
-    private static void init(ServiceLoader.Provider<Initializer> provider) {
-        try {
-            provider.get().init();
-        } catch (InitializationException ex) {
-            throw new Saml2Exception(ex);
-        }
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProvider.java
@@ -69,6 +69,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.saml2.Saml2Exception;
+import org.springframework.security.saml2.core.OpenSamlInitializationService;
 import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ResponseValidatorResult;
@@ -112,7 +113,7 @@ import static org.cloudfoundry.identity.uaa.util.UaaUrlUtils.normalizeUrlForPort
 public final class OpenSaml4AuthenticationProvider implements AuthenticationProvider, ZoneAware {
 
     static {
-        IdentityZoneConfig.setupOpenSaml();
+        OpenSamlInitializationService.initialize();
     }
 
     private final Log logger = LogFactory.getLog(this.getClass());

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2BearerGrantAuthenticationConverter.java
@@ -37,6 +37,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.saml2.Saml2Exception;
+import org.springframework.security.saml2.core.OpenSamlInitializationService;
 import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ResponseValidatorResult;
@@ -72,7 +73,7 @@ import static org.cloudfoundry.identity.uaa.provider.saml.OpenSaml4Authenticatio
 public final class Saml2BearerGrantAuthenticationConverter implements AuthenticationConverter {
 
     static {
-        IdentityZoneConfig.setupOpenSaml();
+        OpenSamlInitializationService.initialize();
     }
 
     private static final AssertionUnmarshaller assertionUnmarshaller;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.provider.service.registration.InMemoryRelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +44,7 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
         this.signatureAlgorithms = signatureAlgorithms;
     }
 
-    @DependsOn({"setUpBouncyCastle", "setupOpenSaml"})
+    @DependsOn({"setUpBouncyCastle"})
     @Bean
     RelyingPartyRegistrationRepository relyingPartyRegistrationRepository(SamlIdentityProviderConfigurator samlIdentityProviderConfigurator) {
         SamlKeyManagerFactory.SamlConfigPropsSamlKeyManagerImpl samlKeyManager = new SamlKeyManagerFactory.SamlConfigPropsSamlKeyManagerImpl(samlConfigProps);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderDataTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderDataTests.java
@@ -153,7 +153,6 @@ public class BootstrapSamlIdentityProviderDataTests {
 
     @BeforeEach
     void beforeEach() {
-        IdentityZoneConfig.setupOpenSaml();
         bootstrap = new BootstrapSamlIdentityProviderData(new SamlIdentityProviderConfigurator(mock(JdbcIdentityProviderProvisioning.class), new IdentityZoneManagerImpl(), mock(FixedHttpMetaDataProvider.class)));
         singleAdd = new SamlIdentityProviderDefinition()
                 .setMetaDataLocation(BootstrapSamlIdentityProviderDataTests.XML_WITHOUT_ID.formatted(new RandomValueStringGenerator().generate()))

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUaaTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUaaTests.java
@@ -45,6 +45,7 @@ import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.opensaml.core.config.InitializationException;
+import org.opensaml.core.config.InitializationService;
 import org.opensaml.saml.saml2.core.AuthnContext;
 import org.opensaml.saml.saml2.core.Response;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -182,7 +183,7 @@ class OpenSaml4AuthenticationProviderUaaTests {
         RequestContextHolder.setRequestAttributes(servletWebRequest);
         DbUtils dbUtils = new DbUtils();
 
-        IdentityZoneConfig.setupOpenSaml();
+        InitializationService.initialize();
 
         ScimGroupProvisioning groupProvisioning = new JdbcScimGroupProvisioning(
                 namedJdbcTemplate, new JdbcPagingListFactory(namedJdbcTemplate, limitSqlAdapter),

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUnitTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/OpenSaml4AuthenticationProviderUnitTests.java
@@ -6,7 +6,6 @@ import org.cloudfoundry.identity.uaa.provider.saml.OpenSaml4AuthenticationProvid
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
@@ -93,11 +92,6 @@ class OpenSaml4AuthenticationProviderUnitTests {
     private static final String ASSERTING_PARTY_ENTITY_ID = "https://some.idp.test/saml2/idp";
 
     private final OpenSaml4AuthenticationProvider provider = new OpenSaml4AuthenticationProvider();
-
-    @BeforeEach
-    void setUp() {
-        IdentityZoneConfig.setupOpenSaml();
-    }
 
     @AfterEach void cleanup() {
         IdentityZoneHolder.clear();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/TestCustomOpenSamlObjects.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/TestCustomOpenSamlObjects.java
@@ -40,6 +40,8 @@ import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.core.AttributeValue;
 import org.w3c.dom.Element;
 
+import org.springframework.security.saml2.core.OpenSamlInitializationService;
+
 /**
  * This was copied from Spring Security Test Classes
  * <p/>
@@ -49,7 +51,7 @@ import org.w3c.dom.Element;
 public final class TestCustomOpenSamlObjects {
 
     static {
-        IdentityZoneConfig.setupOpenSaml();
+        OpenSamlInitializationService.initialize();
         XMLObjectProviderRegistrySupport.getMarshallerFactory()
                 .registerMarshaller(CustomOpenSamlObject.TYPE_NAME,
                         new TestCustomOpenSamlObjects.CustomSamlObjectMarshaller());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/TestOpenSamlObjects.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/TestOpenSamlObjects.java
@@ -63,6 +63,7 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 import org.opensaml.xmlsec.signature.support.SignatureException;
 import org.opensaml.xmlsec.signature.support.SignatureSupport;
 import org.springframework.security.saml2.Saml2Exception;
+import org.springframework.security.saml2.core.OpenSamlInitializationService;
 import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 
@@ -100,7 +101,7 @@ public final class TestOpenSamlObjects {
     public static final String RELYING_PARTY_ENTITY_ID = "https://localhost/saml2/service-provider-metadata/idp-alias";
 
     static {
-        IdentityZoneConfig.setupOpenSaml();
+        OpenSamlInitializationService.initialize();
     }
 
     private TestOpenSamlObjects() {
@@ -132,7 +133,6 @@ public final class TestOpenSamlObjects {
 
     static Response signedResponseWithOneAssertion(Consumer<Response> responseConsumer) {
         Response response = response();
-        response.setIssueInstant(Instant.now());
         response.getAssertions().add(assertion());
         responseConsumer.accept(response);
         return signed(response, TestSaml2X509Credentials.assertingPartySigningCredential(), RELYING_PARTY_ENTITY_ID);
@@ -156,7 +156,6 @@ public final class TestOpenSamlObjects {
         Assertion assertion = build(Assertion.DEFAULT_ELEMENT_NAME);
         assertion.setID("A" + UUID.randomUUID());
         assertion.setVersion(SAMLVersion.VERSION_20);
-        assertion.setIssueInstant(Instant.now());
         assertion.setIssuer(issuer(issuerEntityId));
         assertion.setSubject(subject(username));
         assertion.setConditions(conditions());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/DefaultTestContext.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/DefaultTestContext.java
@@ -5,7 +5,6 @@ import org.cloudfoundry.experimental.boot.UaaBootConfiguration;
 import org.cloudfoundry.identity.uaa.db.beans.JdbcUrlCustomizer;
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer;
-import org.cloudfoundry.identity.uaa.provider.saml.IdentityZoneConfig;
 import org.cloudfoundry.identity.uaa.test.TestClient;
 import org.cloudfoundry.identity.uaa.zone.ZoneContextPathSessionFilter;
 import org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter;
@@ -72,7 +71,6 @@ class TestPropertyInitializer implements ApplicationContextInitializer<Configura
     @Override
     public void initialize(ConfigurableWebApplicationContext applicationContext) {
         System.setProperty("UAA_CONFIG_URL","classpath:integration_test_properties.yml");
-        IdentityZoneConfig.setupOpenSaml();
     }
 }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/YamlConfigurationValidationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/YamlConfigurationValidationTests.java
@@ -2,7 +2,6 @@ package org.cloudfoundry.identity.uaa;
 
 import org.cloudfoundry.identity.uaa.impl.config.YamlConfigurationValidator;
 import org.cloudfoundry.identity.uaa.impl.config.YamlServletProfileInitializer;
-import org.cloudfoundry.identity.uaa.provider.saml.IdentityZoneConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.BeansException;
@@ -49,7 +48,6 @@ class YamlConfigurationValidationTests {
     }
 
     private static TestApplicationContext createApplicationContext() {
-        IdentityZoneConfig.setupOpenSaml();
         var applicationContext = new TestApplicationContext();
         var servletContext = new TestMockContext();
         applicationContext.setServletContext(servletContext);


### PR DESCRIPTION
Reverts cloudfoundry/uaa#3809

The legacy SAML bootstrap is failing- covered in pipeline later
error in
https://bosh.ci.cloudfoundry.org/teams/uaa/pipelines/uaa-acceptance-gcp/jobs/push-oidc10/builds/923


Fix is to setup BC and OpenSAML before that bootstrap, however I would revert this here and then combine all together in one PR so that is is later also easier to see all changes together