### PR TITLE
Fix legacy SAML bootstrap with newer OpenSAML

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlConfiguration.java
@@ -13,11 +13,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
 @EnableConfigurationProperties({SamlConfigProps.class})
+@DependsOn({"setUpBouncyCastle", "setupOpenSaml"})
 @Configuration
 @Data
 public class SamlConfiguration {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import static org.cloudfoundry.identity.uaa.provider.saml.SamlMetadataEndpoint.DEFAULT_REGISTRATION_ID;
 
+@DependsOn({"setUpBouncyCastle", "setupOpenSaml"})
 @Configuration
 @Slf4j
 public class SamlRelyingPartyRegistrationRepositoryConfig {
@@ -43,7 +44,6 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
         this.signatureAlgorithms = signatureAlgorithms;
     }
 
-    @DependsOn({"setUpBouncyCastle", "setupOpenSaml"})
     @Bean
     RelyingPartyRegistrationRepository relyingPartyRegistrationRepository(SamlIdentityProviderConfigurator samlIdentityProviderConfigurator) {
         SamlKeyManagerFactory.SamlConfigPropsSamlKeyManagerImpl samlKeyManager = new SamlKeyManagerFactory.SamlConfigPropsSamlKeyManagerImpl(samlConfigProps);


### PR DESCRIPTION
Fix legacy SAML bootstrap with newer OpenSAML

Depends on was before only on relyingPartyRegistrationRepository now pinned it to classes so that it should be done always before touching any SAML logic