### PR TITLE
Fix Apache Http Client dependency

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -28,6 +28,7 @@ import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
 import org.apache.hc.core5.http.HeaderElement;
+import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.config.Registry;
@@ -37,7 +38,6 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.util.TextUtils;
 import org.apache.hc.core5.util.TimeValue;
-import org.apache.http.protocol.HTTP;
 import org.cloudfoundry.identity.uaa.impl.config.RestTemplateConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -173,7 +173,7 @@ public abstract class UaaHttpRequestUtils {
 
         @Override
         public TimeValue getKeepAliveDuration(HttpResponse httpResponse, HttpContext httpContext) {
-            BasicHeaderElementIterator elementIterator = new BasicHeaderElementIterator(httpResponse.headerIterator(HTTP.CONN_KEEP_ALIVE));
+            BasicHeaderElementIterator elementIterator = new BasicHeaderElementIterator(httpResponse.headerIterator(HttpHeaders.KEEP_ALIVE));
             long result = connectionKeepAliveMax;
 
             while (elementIterator.hasNext()) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/test/OAuth2ContextExtension.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/test/OAuth2ContextExtension.java
@@ -319,7 +319,7 @@ public final class OAuth2ContextExtension implements BeforeAllCallback, BeforeEa
 
     private void setupConnectionFactory(OAuth2RestTemplate client) {
         if (Boolean.getBoolean("http.components.enabled")
-                && ClassUtils.isPresent("org.apache.http.client.config.RequestConfig",
+                && ClassUtils.isPresent("org.apache.hc.client5.http.config.RequestConfig",
                 null)) {
             client.setRequestFactory(new HttpComponentsClientHttpRequestFactory() {
                 @Override


### PR DESCRIPTION
Fix Apache dependency

Found during working on OpenSAML 5 update. With opensaml 5 we do not have any furhter library deps for apache 4 clients thus this fails