### PR TITLE
Fix bean field naming conflict in SpringServletXmlBeansConfiguration

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
@@ -79,10 +79,10 @@ public class SpringServletXmlBeansConfiguration {
     Collection<String> defaultAuthorities;
 
     @Autowired
-    UaaProperties.GlobalClientSecretPolicy globalClientSecretPolicy;
+    UaaProperties.GlobalClientSecretPolicy globalClientSecretPolicyConfig;
 
     @Autowired
-    UaaProperties.DefaultClientSecretPolicy defaultClientSecretPolicy;
+    UaaProperties.DefaultClientSecretPolicy defaultClientSecretPolicyConfig;
 
     @Autowired
     UaaProperties.Login loginProps;
@@ -365,26 +365,26 @@ public class SpringServletXmlBeansConfiguration {
     @Bean
     ClientSecretPolicy globalClientSecretPolicy() {
         return new ClientSecretPolicy(
-                globalClientSecretPolicy.minLength(),
-                globalClientSecretPolicy.maxLength(),
-                globalClientSecretPolicy.requireUpperCaseCharacter(),
-                globalClientSecretPolicy.requireLowerCaseCharacter(),
-                globalClientSecretPolicy.requireDigit(),
-                globalClientSecretPolicy.requireSpecialCharacter(),
-                globalClientSecretPolicy.expireSecretInMonths()
+                globalClientSecretPolicyConfig.minLength(),
+                globalClientSecretPolicyConfig.maxLength(),
+                globalClientSecretPolicyConfig.requireUpperCaseCharacter(),
+                globalClientSecretPolicyConfig.requireLowerCaseCharacter(),
+                globalClientSecretPolicyConfig.requireDigit(),
+                globalClientSecretPolicyConfig.requireSpecialCharacter(),
+                globalClientSecretPolicyConfig.expireSecretInMonths()
         );
     }
 
     @Bean
     ClientSecretPolicy defaultUaaClientSecretPolicy() {
         return new ClientSecretPolicy(
-                defaultClientSecretPolicy.minLength(),
-                defaultClientSecretPolicy.maxLength(),
-                defaultClientSecretPolicy.requireUpperCaseCharacter(),
-                defaultClientSecretPolicy.requireLowerCaseCharacter(),
-                defaultClientSecretPolicy.requireDigit(),
-                defaultClientSecretPolicy.requireSpecialCharacter(),
-                defaultClientSecretPolicy.expireSecretInMonths()
+                defaultClientSecretPolicyConfig.minLength(),
+                defaultClientSecretPolicyConfig.maxLength(),
+                defaultClientSecretPolicyConfig.requireUpperCaseCharacter(),
+                defaultClientSecretPolicyConfig.requireLowerCaseCharacter(),
+                defaultClientSecretPolicyConfig.requireDigit(),
+                defaultClientSecretPolicyConfig.requireSpecialCharacter(),
+                defaultClientSecretPolicyConfig.expireSecretInMonths()
         );
     }
 


### PR DESCRIPTION
In SpringServletXmlBeansConfiguration, two @Autowired fields had the same names as the @Bean methods they were used in: 
- globalClientSecretPolicy (field) clashed with globalClientSecretPolicy() (bean method)                                                                                                                                         
- defaultClientSecretPolicy (field) clashed with defaultUaaClientSecretPolicy() (bean method)

This naming conflict is flagged by SonarQube as a code smell, since the field name shadows the method name within the same class, which can cause confusion and potential Spring wiring issues.
                                                                                                                                                                                                                                
The fix renames the two injected fields to globalClientSecretPolicyConfig and defaultClientSecretPolicyConfig respectively, making them clearly distinct from the @Bean factory methods and resolving the Sonar warning.