### PR TITLE
Fix UAA start with legacy key setup

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidator.java
@@ -62,7 +62,7 @@ public class GeneralIdentityZoneConfigurationValidator implements IdentityZoneCo
                     }
                 }
             }
-            if (UaaStringUtils.isNotEmpty(config.getIssuer()) && (tokenPolicy == null || UaaStringUtils.isNullOrEmpty(tokenPolicy.getActiveKeyId()))) {
+            if (!zone.isUaa() && UaaStringUtils.isNotEmpty(config.getIssuer()) && (tokenPolicy == null || UaaStringUtils.isNullOrEmpty(tokenPolicy.getActiveKeyId()))) {
                 throw new InvalidIdentityZoneConfigurationException("You cannot set issuer value unless you have set your own signing key for this identity zone.");
             }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneConfigurationValidatorTests.java
@@ -316,6 +316,43 @@ class GeneralIdentityZoneConfigurationValidatorTests {
                 .hasMessageContaining("You cannot set issuer value unless you have set your own signing key for this identity zone.");
     }
 
+    // Tests for: if (!zone.isUaa() && isNotEmpty(issuer) && (tokenPolicy == null || isNullOrEmpty(activeKeyId)))
+    @MethodSource("parameters")
+    @ParameterizedTest
+    void validate_nonUaaZone_withIssuer_andNoTokenPolicy_throwsException(IdentityZoneValidator.Mode mode) {
+        // non-UAA zone with issuer set but no token policy -> should fail
+        zone.setId("custom-zone");
+        zone.getConfig().setIssuer("http://custom.example.com/issuer");
+        zone.getConfig().setTokenPolicy(null);
+        assertThatThrownBy(() -> validator.validate(zone, mode))
+                .isInstanceOf(InvalidIdentityZoneConfigurationException.class)
+                .hasMessageContaining("You cannot set issuer value unless you have set your own signing key for this identity zone.");
+    }
+
+    @MethodSource("parameters")
+    @ParameterizedTest
+    void validate_nonUaaZone_withoutIssuer_andNoActiveKey_succeeds(IdentityZoneValidator.Mode mode) throws InvalidIdentityZoneConfigurationException {
+        // non-UAA zone without issuer -> condition not triggered, should pass
+        zone.setId("custom-zone");
+        zone.getConfig().setIssuer("http://localhost:8080/uaa");
+        zone.getConfig().setTokenPolicy(null);
+        // validate should not throw
+        assertThatThrownBy(() -> validator.validate(zone, mode))
+            .isInstanceOf(InvalidIdentityZoneConfigurationException.class)
+            .hasMessageContaining("You cannot set issuer value unless you have set your own signing key for this identity zone.");
+    }
+
+    @MethodSource("parameters")
+    @ParameterizedTest
+    void validate_uaaZone_withIssuer_andNoActiveKey_succeeds(IdentityZoneValidator.Mode mode) throws InvalidIdentityZoneConfigurationException {
+        // UAA zone is exempt from the issuer check -> should pass even without an active key
+        zone.setId(IdentityZone.getUaaZoneId());
+        zone.getConfig().setIssuer("http://uaa.example.com/issuer");
+        zone.getConfig().setTokenPolicy(null);
+        // validate should not throw
+        validator.validate(zone, mode);
+    }
+
     @MethodSource("parameters")
     @ParameterizedTest
     void validate_invalid_corsPolicy_xhrConfiguration_allowedUris(IdentityZoneValidator.Mode mode) {


### PR DESCRIPTION
Fir #issue 3835

Ony do the issuer validation in custom zones, but not in UAA zone