### PR TITLE
Fix YAML validator by preventing Spring expression evaluation

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
@@ -91,7 +91,7 @@ public class SpringServletXmlBeansConfiguration {
     UaaProperties.Logout logoutProps;
 
     @Bean
-    YamlConfigurationValidator uaaConfigValidation(@Value("${environmentYamlKey}") String environmentYamlKey) {
+    YamlConfigurationValidator uaaConfigValidation(@Value("#{environment['environmentYamlKey']}") String environmentYamlKey) {
         YamlConfigurationValidator bean = new YamlConfigurationValidator(new UaaConfiguration.UaaConfigConstructor());
         bean.setYaml(environmentYamlKey);
         return bean;

--- a/uaa/src/test/resources/integration_test_properties.yml
+++ b/uaa/src/test/resources/integration_test_properties.yml
@@ -263,6 +263,10 @@ oauth:
       signup_redirect_url: http://localhost:8080/app/
       change_email_redirect_url: http://localhost:8080/app/
       name: The Ultimate Oauth App - Special
+    client_with_spel_chars:
+      id: client_with_spel_chars
+      secret: "pass#{word"
+      authorized-grant-types: client_credentials
     login:
       id: login
       secret: loginsecret


### PR DESCRIPTION
If an oauth client password contained the string #{ it lead to issues during spring startup in UAA due to the bean initialization of `YamlConfigurationValidator`.

Changed `@Value("${environmentYamlKey}")` to `@Value("#{environment['environmentYamlKey']}")` to retrieve raw YAML without Spring's automatic expression evaluation.