### PR TITLE
Add documentation for SAML Bearer Grant (two endpoints)

### DIFF
--- a/uaa/slate/lib/toc_data.rb
+++ b/uaa/slate/lib/toc_data.rb
@@ -5,7 +5,7 @@ def toc_data(page_content)
 
   # get a flat list of headers
   headers = []
-  html_doc.css('h1, h2, h3').each do |header|
+  html_doc.css('h1, h2, h3, h4').each do |header|
     headers.push({
       id: header.attribute('id').to_s,
       content: header.children,
@@ -14,7 +14,7 @@ def toc_data(page_content)
     })
   end
 
-  [3,2].each do |header_level|
+  [4, 3, 2].each do |header_level|
     header_to_nest = nil
     headers = headers.reject do |header|
       if header[:level] == header_level

--- a/uaa/slate/source/javascripts/all_nosearch.js
+++ b/uaa/slate/source/javascripts/all_nosearch.js
@@ -5,7 +5,7 @@
 //= require ./lib/_dropdown
 
 $(function() {
-  loadToc($('#toc'), '.toc-link', '.toc-list-h2, .toc-list-h3', 10);
+  loadToc($('#toc'), '.toc-link', '.toc-list-h2, .toc-list-h3, .toc-list-h4', 10);
   setupLanguages($('body').data('languages'));
   $('.content').imagesLoaded( function() {
     window.recacheHeights();

--- a/uaa/slate/source/layouts/layout.erb
+++ b/uaa/slate/source/layouts/layout.erb
@@ -117,6 +117,15 @@ under the License.
                         <% h2[:children].each do |h3| %>
                           <li>
                             <a href="#<%= h3[:id] %>" class="toc-h3 toc-link" data-title="<%= h1[:content] %>"><%= h3[:content] %></a>
+                            <% if h3[:children].length > 0 %>
+                              <ul class="toc-list-h4">
+                                <% h3[:children].each do |h4| %>
+                                  <li>
+                                    <a href="#<%= h4[:id] %>" class="toc-h4 toc-link" data-title="<%= h1[:content] %>"><%= h4[:content] %></a>
+                                  </li>
+                                <% end %>
+                              </ul>
+                            <% end %>
                           </li>
                         <% end %>
                       </ul>

--- a/uaa/slate/source/stylesheets/screen.css.scss
+++ b/uaa/slate/source/stylesheets/screen.css.scss
@@ -177,6 +177,11 @@ html, body {
     background-color: $nav-subitem-bg;
   }
 
+  .toc-list-h4 {
+    display: none;
+    background-color: $nav-subitem-bg;
+  }
+
   .toc-h2 {
     padding-left: $nav-padding + $nav-indent;
     font-size: 12px;
@@ -184,6 +189,11 @@ html, body {
 
   .toc-h3 {
     padding-left: $nav-padding + 2 * $nav-indent;
+    font-size: 12px;
+  }
+
+  .toc-h4 {
+    padding-left: $nav-padding + 3 * $nav-indent;
     font-size: 12px;
   }
 

--- a/uaa/slateCustomizations/source/index.html.md.erb
+++ b/uaa/slateCustomizations/source/index.html.md.erb
@@ -381,10 +381,65 @@ In addition, the requesting client must either allow the IDP in `allowedprovider
 The trust to the assertion issuer is reused from the SAML 2.0 WebSSO profiles.
 
 This grant enables an App2App mechanism with SSO. Typical scenarios are applications outside of CF, which consume a service within the CF world.
-The endpoint of the bearer assertion is `/oauth/token/alias/<endityid>` so the Recipient attribute in
-the bearer assertion must point to the corresponding URI, e.g. http://localhost:8080/uaa/oauth/token/alias/cloudfoundry-saml-login.
+The SAML assertion’s `Recipient` (and related audience conditions) must match the URI derived from the IdP registration—the same URI shown on the SAML SP as
+`/oauth/token/alias/<registrationId>` (for example `http://localhost:8080/uaa/oauth/token/alias/cloudfoundry-saml-login`), regardless of which HTTP URL you POST to below.
+Zone resolution uses the `Host` header (for example `mysubdomain.localhost`).
 
-### Form Authentication
+### SAML Bearer Grant (preferred)
+
+POST to **`/oauth/token`**. Use this path for new integrations.
+
+#### Form Authentication
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecretOnDefaultTokenPath/curl-request.md') %>
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecretOnDefaultTokenPath/http-request.md') %>
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecretOnDefaultTokenPath/http-response.md') %>
+
+_Request Parameters_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecretOnDefaultTokenPath/form-parameters.md') %>
+
+_Response Fields_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecretOnDefaultTokenPath/response-fields.md') %>
+
+#### Basic Authentication
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath/curl-request.md') %>
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath/http-request.md') %>
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath/http-response.md') %>
+
+_Request Headers_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath/request-headers.md') %>
+
+_Request Parameters_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath/form-parameters.md') %>
+
+_Response Fields_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath/response-fields.md') %>
+
+#### Client Assertion
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertionOnDefaultTokenPath/curl-request.md') %>
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertionOnDefaultTokenPath/http-request.md') %>
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertionOnDefaultTokenPath/http-response.md') %>
+
+_Request Parameters_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertionOnDefaultTokenPath/form-parameters.md') %>
+
+_Response Fields_
+
+<%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertionOnDefaultTokenPath/response-fields.md') %>
+
+### SAML Bearer Grant (legacy)
+
+POST to **`/oauth/token/alias/<registrationId>`** (the same path as the SAML assertion `Recipient`). Retained for older clients that already target this URL.
+
+#### Form Authentication
 
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecret/curl-request.md') %>
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecret/http-request.md') %>
@@ -398,7 +453,7 @@ _Response Fields_
 
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientSecret/response-fields.md') %>
 
-### Basic Authentication
+#### Basic Authentication
 
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeader/curl-request.md') %>
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeader/http-request.md') %>
@@ -416,7 +471,7 @@ _Response Fields_
 
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithAuthorizationHeader/response-fields.md') %>
 
-### Client Assertion
+#### Client Assertion
 
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertion/curl-request.md') %>
 <%= render('TokenEndpointDocs/getTokenUsingSaml2BearerGrantWithClientAssertion/http-request.md') %>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/TokenEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/TokenEndpointDocs.java
@@ -594,9 +594,16 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
                                          IdentityZone clientZone, UaaClientDetails oauthClient) {
     }
 
-    private Saml2BearerDocContext prepareSaml2BearerDocumentationContext(String subdomain) throws Exception {
+    /**
+     * @param useDefaultOAuthTokenPath when {@code true}, the documented HTTP request POSTs to {@code /uaa/oauth/token};
+     *                                 the SAML assertion {@code Recipient} must still be the IdP ACS-derived
+     *                                 {@code .../oauth/token/alias/&lt;registrationId&gt;} URI (same as the alias-path flow).
+     */
+    private Saml2BearerDocContext prepareSaml2BearerDocumentationContext(String subdomain, boolean useDefaultOAuthTokenPath) throws Exception {
         final String host = "%s.localhost".formatted(subdomain);
-        final String fullPath = "/uaa/oauth/token/alias/%s.integration-saml-entity-id".formatted(subdomain);
+        final String fullPath = useDefaultOAuthTokenPath
+                ? "/uaa/oauth/token"
+                : "/uaa/oauth/token/alias/%s.integration-saml-entity-id".formatted(subdomain);
         final String origin = "%s.integration-saml-entity-id".formatted(subdomain);
         MockMvcUtils.IdentityZoneCreationResult testZone = MockMvcUtils.createOtherIdentityZoneAndReturnResult(
                 subdomain, mockMvc, this.webApplicationContext, null,
@@ -636,8 +643,150 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
     }
 
     @Test
+    void getTokenUsingSaml2BearerGrantWithClientSecretOnDefaultTokenPath() throws Exception {
+        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues4", true);
+
+        MockHttpServletRequestBuilder post = MockMvcRequestBuilders.post(ctx.fullPath())
+                .with(request -> {
+                    request.setServerPort(8080);
+                    request.setRequestURI(ctx.fullPath());
+                    request.setServerName(ctx.host());
+                    return request;
+                })
+                .contextPath("/uaa")
+                .accept(APPLICATION_JSON)
+                .header(HOST, ctx.host())
+                .contentType(APPLICATION_FORM_URLENCODED)
+                .param("grant_type", TokenConstants.GRANT_TYPE_SAML2_BEARER)
+                .param("client_id", ctx.clientId())
+                .param("client_secret", "secret")
+                .param("assertion", ctx.encodedSamlAssertion())
+                .param("scope", "openid");
+
+        final ParameterDescriptor assertionFormatParameter = parameterWithName("assertion").required().type(STRING).description("An XML based SAML 2.0 bearer assertion, which is Base64URl encoded.");
+        Snippet formParameters = formParameters(
+                clientIdParameter.description("The client ID of the receiving client, this client must have `urn:ietf:params:oauth:grant-type:saml2-bearer` grant type"),
+                clientSecretParameter,
+                grantTypeParameter.description("The type of token grant requested, in this case `" + GRANT_TYPE_SAML2_BEARER + "`"),
+                assertionFormatParameter,
+                scopeParameter
+        );
+
+        Snippet responseFields = responseFields(
+                accessTokenFieldDescriptor,
+                fieldWithPath("token_type").description("The type of the access token issued, always `bearer`"),
+                fieldWithPath("expires_in").description("Number of seconds of lifetime for an access_token, when retrieved"),
+                scopeFieldDescriptorWhenUserToken,
+                refreshTokenFieldDescriptor,
+                jtiFieldDescriptor
+        );
+
+        mockMvc.perform(post)
+                .andDo(document("{ClassName}/{methodName}", preprocessResponse(prettyPrint()), formParameters, responseFields))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.scope").value("openid"));
+    }
+
+    @Test
+    void getTokenUsingSaml2BearerGrantWithAuthorizationHeaderOnDefaultTokenPath() throws Exception {
+        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues5", true);
+
+        String clientAuthorization = new String(ENCODER.encode((ctx.clientId() + ":secret").getBytes()));
+
+        MockHttpServletRequestBuilder post = MockMvcRequestBuilders.post(ctx.fullPath())
+                .with(request -> {
+                    request.setServerPort(8080);
+                    request.setRequestURI(ctx.fullPath());
+                    request.setServerName(ctx.host());
+                    return request;
+                })
+                .contextPath("/uaa")
+                .accept(APPLICATION_JSON)
+                .header(HOST, ctx.host())
+                .header(AUTHORIZATION, "Basic " + clientAuthorization)
+                .contentType(APPLICATION_FORM_URLENCODED)
+                .param("grant_type", TokenConstants.GRANT_TYPE_SAML2_BEARER)
+                .param("client_id", ctx.clientId())
+                .param("assertion", ctx.encodedSamlAssertion())
+                .param("scope", "openid");
+
+        final ParameterDescriptor assertionFormatParameter = parameterWithName("assertion").required().type(STRING).description("An XML based SAML 2.0 bearer assertion, which is Base64URl encoded.");
+        Snippet requestHeaders = requestHeaders(CLIENT_BASIC_AUTH_HEADER);
+        Snippet formParameters = formParameters(
+                clientIdParameter.description("The client ID of the receiving client, this client must have `urn:ietf:params:oauth:grant-type:saml2-bearer` grant type"),
+                grantTypeParameter.description("The type of token grant requested, in this case `" + GRANT_TYPE_SAML2_BEARER + "`"),
+                assertionFormatParameter,
+                scopeParameter
+        );
+
+        Snippet responseFields = responseFields(
+                accessTokenFieldDescriptor,
+                fieldWithPath("token_type").description("The type of the access token issued, always `bearer`"),
+                fieldWithPath("expires_in").description("Number of seconds of lifetime for an access_token, when retrieved"),
+                scopeFieldDescriptorWhenUserToken,
+                refreshTokenFieldDescriptor,
+                jtiFieldDescriptor
+        );
+
+        mockMvc.perform(post)
+                .andDo(document("{ClassName}/{methodName}", preprocessResponse(prettyPrint()), requestHeaders, formParameters, responseFields))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.scope").value("openid"));
+    }
+
+    @Test
+    void getTokenUsingSaml2BearerGrantWithClientAssertionOnDefaultTokenPath() throws Exception {
+        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues6", true);
+
+        MockHttpServletRequestBuilder post = MockMvcRequestBuilders.post(ctx.fullPath())
+                .with(request -> {
+                    request.setServerPort(8080);
+                    request.setRequestURI(ctx.fullPath());
+                    request.setServerName(ctx.host());
+                    return request;
+                })
+                .contextPath("/uaa")
+                .accept(APPLICATION_JSON)
+                .header(HOST, ctx.host())
+                .contentType(APPLICATION_FORM_URLENCODED)
+                .param("grant_type", TokenConstants.GRANT_TYPE_SAML2_BEARER)
+                .param("client_id", ctx.clientId())
+                .param("client_assertion", getClientAssertionJwt(ctx.clientZone(), ctx.oauthClient()))
+                .param("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+                .param("assertion", ctx.encodedSamlAssertion())
+                .param("scope", "openid");
+
+        final ParameterDescriptor assertionFormatParameter = parameterWithName("assertion").required().type(STRING).description("An XML based SAML 2.0 bearer assertion, which is Base64URl encoded.");
+        Snippet formParameters = formParameters(
+                clientIdParameter.description("The client ID of the receiving client, this client must have `urn:ietf:params:oauth:grant-type:saml2-bearer` grant type"),
+                clientAssertion,
+                clientAssertionType,
+                grantTypeParameter.description("The type of token grant requested, in this case `" + GRANT_TYPE_SAML2_BEARER + "`"),
+                assertionFormatParameter,
+                scopeParameter
+        );
+
+        Snippet responseFields = responseFields(
+                accessTokenFieldDescriptor,
+                fieldWithPath("token_type").description("The type of the access token issued, always `bearer`"),
+                fieldWithPath("expires_in").description("Number of seconds of lifetime for an access_token, when retrieved"),
+                scopeFieldDescriptorWhenUserToken,
+                refreshTokenFieldDescriptor,
+                jtiFieldDescriptor
+        );
+
+        mockMvc.perform(post)
+                .andDo(document("{ClassName}/{methodName}", preprocessResponse(prettyPrint()), formParameters, responseFields))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.scope").value("openid"));
+    }
+
+    @Test
     void getTokenUsingSaml2BearerGrantWithClientSecret() throws Exception {
-        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues1");
+        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues1", false);
 
         MockHttpServletRequestBuilder post = MockMvcRequestBuilders.post(ctx.fullPath())
                 .with(request -> {
@@ -683,7 +832,7 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
 
     @Test
     void getTokenUsingSaml2BearerGrantWithAuthorizationHeader() throws Exception {
-        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues3");
+        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues3", false);
 
         String clientAuthorization = new String(ENCODER.encode((ctx.clientId() + ":secret").getBytes()));
 
@@ -731,7 +880,7 @@ class TokenEndpointDocs extends AbstractTokenMockMvcTests {
 
     @Test
     void getTokenUsingSaml2BearerGrantWithClientAssertion() throws Exception {
-        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues2");
+        Saml2BearerDocContext ctx = prepareSaml2BearerDocumentationContext("68ues2", false);
 
         MockHttpServletRequestBuilder post = MockMvcRequestBuilders.post(ctx.fullPath())
                 .with(request -> {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/Saml2BearerGrantMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/Saml2BearerGrantMockMvcTests.java
@@ -60,7 +60,7 @@ class Saml2BearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
                         IdentityZoneHolder.getCurrentZoneId());
 
         //create an IDP in the test zone
-        String idpMetadata = getIdpMetadata(host, origin);
+        String idpMetadata = getIdpMetadata(host, origin, entityId);
         SamlIdentityProviderDefinition idpDef = createLocalSamlIdpDefinition(
                 origin, testZone.getIdentityZone().getId(), idpMetadata);
         idpDef.setIdpEntityId(entityId);
@@ -111,13 +111,79 @@ class Saml2BearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
                 .andExpect(jsonPath("$.scope").value("openid"));
     }
 
-    private String getIdpMetadata(String host, String origin) {
-        // Mock an IDP metadata: %1$s is the host; %2$s is the origin
+    /**
+     * SAML Recipient in the assertion must still match the IdP ACS-derived URI
+     * {@code .../oauth/token/alias/...}; the HTTP POST may use the standard token path {@code /oauth/token}.
+     */
+    @Test
+    void getTokenUsingSaml2BearerGrant_onDefaultTokenEndpoint() throws Exception {
+        final String subdomain = "68uedt";
+        final String host = "%s.localhost".formatted(subdomain);
+        final String defaultTokenPath = "/uaa/oauth/token";
+        final String origin = "%s.integration-saml-entity-id".formatted(subdomain);
+        final String entityId = "%s.cloudfoundry-saml-login".formatted(subdomain);
+        MockMvcUtils.IdentityZoneCreationResult testZone =
+                MockMvcUtils.createOtherIdentityZoneAndReturnResult(
+                        subdomain, mockMvc, this.webApplicationContext, null,
+                        IdentityZoneHolder.getCurrentZoneId());
+
+        String idpMetadata = getIdpMetadata(host, origin, entityId);
+        SamlIdentityProviderDefinition idpDef = createLocalSamlIdpDefinition(
+                origin, testZone.getIdentityZone().getId(), idpMetadata);
+        idpDef.setIdpEntityId(entityId);
+        IdentityProvider<SamlIdentityProviderDefinition> provider = new IdentityProvider<>();
+        provider.setConfig(idpDef);
+        provider.setActive(true);
+        provider.setIdentityZoneId(testZone.getIdentityZone().getId());
+        provider.setName(origin);
+        provider.setOriginKey(origin);
+
+        IdentityZoneHolder.set(testZone.getIdentityZone());
+        identityProviderProvisioning.create(provider, testZone.getIdentityZone().getId());
+        IdentityZoneHolder.clear();
+
+        String spEndpoint = "http://%s:8080/uaa/oauth/token/alias/%s".formatted(host, origin);
+        String assertionStr = TestOpenSamlObjects.getEncodedAssertion(entityId, NameID.UNSPECIFIED,
+                "Saml2BearerIntegrationUser", spEndpoint, origin, true);
+
+        String clientId = "testclient" + generator.generate();
+        setUpClients(clientId, "uaa.none", "uaa.user,openid",
+                GRANT_TYPE_SAML2_BEARER + ",password,refresh_token", true,
+                TEST_REDIRECT_URI, null, 600, testZone.getIdentityZone());
+
+        MockHttpServletRequestBuilder post = MockMvcRequestBuilders.post(defaultTokenPath)
+                .with(request -> {
+                    request.setServerPort(8080);
+                    request.setRequestURI(defaultTokenPath);
+                    request.setServerName(host);
+                    return request;
+                })
+                .contextPath("/uaa")
+                .accept(APPLICATION_JSON)
+                .header(HOST, host)
+                .contentType(APPLICATION_FORM_URLENCODED)
+                .param("grant_type", TokenConstants.GRANT_TYPE_SAML2_BEARER)
+                .param("client_id", clientId)
+                .param("client_secret", "secret")
+                .param("client_assertion", "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IjU4ZDU1YzUwMGNjNmI1ODM3OTYxN2UwNmU3ZGVjNmNhIn0.eyJzdWIiOiJsb2dpbiIsImlzcyI6ImxvZ2luIiwianRpIjoiNThkNTVjNTAwY2M2YjU4Mzc5NjE3ZTA2ZTdhZmZlZSIsImV4cCI6MTIzNDU2NzgsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC91YWEvb2F1dGgvdG9rZW4ifQ.jwWw0OKZecd4ZjtwQ_ievqBVrh2SieqMF6vY74Oo5H6v-Ibcmumq96NLNtoUEwaAEQQOHb8MWcC8Gwi9dVQdCrtpomC86b_LKkihRBSKuqpw0udL9RMH5kgtC04ctsN0yZNifUWMP85VHn97Ual5eZ2miaBFob3H5jUe98CcBj1TSRehr64qBFYuwt9vD19q6U-ONhRt0RXBPB7ayHAOMYtb1LFIzGAiKvqWEy9f-TBPXSsETjKkAtSuM-WVWi4EhACMtSvI6iJN15f7qlverRSkGIdh1j2vPXpKKBJoRhoLw6YqbgcUC9vAr17wfa_POxaRHvh9JPty0ZXLA4XPtA")
+                .param("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+                .param("assertion", assertionStr)
+                .param("scope", "openid");
+
+        mockMvc.perform(post)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.access_token").exists())
+                .andExpect(jsonPath("$.scope").value("openid"));
+    }
+
+    private String getIdpMetadata(String host, String origin, String idpEntityId) {
+        // Mock an IDP metadata: %1$s is the host; %2$s is the origin; %3$s is the IdP entity ID (matches assertion issuer)
         // Maps to TestCredentialObjects.legacyCertificate
         return """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" ID="%2$s"
-                                     entityID="68uexx.cloudfoundry-saml-login">
+                                     entityID="%3$s">
                     <md:IDPSSODescriptor WantAuthnRequestsSigned="false"
                                          protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
                         <md:KeyDescriptor use="signing">
@@ -172,6 +238,6 @@ class Saml2BearerGrantMockMvcTests extends AbstractTokenMockMvcTests {
                         <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
                                                 Location="http://%1$s:8080/uaa/saml/idp/SSO/alias/%2$s"/>
                     </md:IDPSSODescriptor>
-                </md:EntityDescriptor>""".formatted(host, origin);
+                </md:EntityDescriptor>""".formatted(host, origin, idpEntityId);
     }
 }


### PR DESCRIPTION
preferred endpoint - /oauth/token
legacy endpoint - /oauth/token/alias/<registrationId>