### PR TITLE
Add HANA support for quote identifier

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/DbUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/DbUtils.java
@@ -78,9 +78,10 @@ public class DbUtils {
     private QuoteCharacter computeQuoteCharacter(JdbcTemplate jdbcTemplate) throws SQLException {
         try {
             var metaData = metaDataExtractor.extractDatabaseMetaData(jdbcTemplate.getDataSource());
-            if (metaData.getURL().startsWith("jdbc:hsqldb:")) {
-                // HSQL's databasemetadata's getIdentifierQuoteString returns double quotes, which is incorrect
-                // So we override with the value that actually works with HSQL db
+            var databaseUrl = metaData.getURL();
+            if (databaseUrl.startsWith("jdbc:hsqldb:") || databaseUrl.startsWith("jdbc:sap:")) {
+                // HSQL/HANA's databasemetadata's getIdentifierQuoteString returns double quotes, which is incorrect
+                // So we override with the value that actually works with HSQL db and HANA
                 return QuoteCharacter.NONE;
             }
             return QuoteCharacter.valueOf(getIdentifierQuoteChar(metaData));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/DbUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/DbUtilsTest.java
@@ -35,18 +35,20 @@ class DbUtilsTest {
         when(metaDataExtractor.extractDatabaseMetaData(any())).thenReturn(databaseMetaData);
     }
 
-    @Test
-    void canQuoteHsqldbIdentifiers() throws SQLException {
-        when(databaseMetaData.getURL()).thenReturn("jdbc:hsqldb:mem:uaa");
+    @ParameterizedTest
+    @ValueSource(strings = {"jdbc:hsqldb:mem:uaa", "jdbc:sap:mem:uaa"})
+    void canQuoteHsqldbAndHanaIdentifiers(String databaseUrl) throws SQLException {
+        when(databaseMetaData.getURL()).thenReturn(databaseUrl);
 
         String quotedIdentifier = dbUtils.getQuotedIdentifier(IDENTIFIER_NAME, jdbcTemplate);
         assertThat(quotedIdentifier).isEqualTo(IDENTIFIER_NAME);
     }
 
-    @Test
-    void canCacheForHsqldb() throws SQLException {
+    @ParameterizedTest
+    @ValueSource(strings = {"jdbc:hsqldb:mem:uaa", "jdbc:sap:mem:uaa"})
+    void canCacheForHsqldbAndHana(String databaseUrl) throws SQLException {
         when(databaseMetaData.getURL())
-                .thenReturn("jdbc:hsqldb:mem:uaa", "SHOULD NOT SEE THIS");
+                .thenReturn(databaseUrl, "SHOULD NOT SEE THIS");
         dbUtils.getQuotedIdentifier(IDENTIFIER_NAME, jdbcTemplate);
 
         String subsequentQuotedIdentifier = dbUtils.getQuotedIdentifier(IDENTIFIER_NAME, jdbcTemplate);


### PR DESCRIPTION
HANA DB getIdentifierQuoteString() returns double quotes, which breaks the queries if column/table name is with lower case.

Therefore, apply the same workaround as for HSQL db.