### PR TITLE
Migrate from AntPathRequestMatcher to PathPatternRequestMatcher

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/account/ResetPasswordAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/account/ResetPasswordAuthenticationFilter.java
@@ -20,13 +20,12 @@ import org.cloudfoundry.identity.uaa.codestore.ExpiringCodeStore;
 import org.cloudfoundry.identity.uaa.error.UaaException;
 import org.cloudfoundry.identity.uaa.scim.exception.InvalidPasswordException;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -42,7 +41,7 @@ public class ResetPasswordAuthenticationFilter extends OncePerRequestFilter {
     private final AuthenticationEntryPoint entryPoint;
     private final ExpiringCodeStore expiringCodeStore;
     public static final String RESET_PASSWORD_URL = "/reset_password.do";
-    private static final RequestMatcher matcher = new AntPathRequestMatcher(RESET_PASSWORD_URL, "POST");
+    private static final RequestMatcher matcher = PathPatternRequestMatcher.withDefaults().matcher(HttpMethod.POST, RESET_PASSWORD_URL);
 
     public ResetPasswordAuthenticationFilter(
             ResetPasswordService service,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/BackwardsCompatibleTokenEndpointAuthenticationFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/BackwardsCompatibleTokenEndpointAuthenticationFilter.java
@@ -56,7 +56,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.saml2.provider.service.authentication.Saml2AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 
@@ -81,7 +81,7 @@ import static org.cloudfoundry.identity.uaa.util.UaaStringUtils.hasText;
  */
 @Slf4j
 public class BackwardsCompatibleTokenEndpointAuthenticationFilter implements Filter {
-    public static final String DEFAULT_FILTER_PROCESSES_URI = "/oauth/token/alias/{{registrationId}}";
+    public static final String DEFAULT_FILTER_PROCESSES_URI = "/oauth/token/alias/{registrationId}";
     private final AuthenticationManager tokenExchangeAuthenticationManager;
 
     /**
@@ -105,7 +105,7 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilter implements Fil
 
     private final ExternalOAuthAuthenticationManager externalOAuthAuthenticationManager;
 
-    private final AntPathRequestMatcher requestMatcher;
+    private final RequestMatcher requestMatcher;
 
     private final RevocableTokenProvisioning revocableTokenProvisioning;
 
@@ -142,7 +142,7 @@ public class BackwardsCompatibleTokenEndpointAuthenticationFilter implements Fil
         super();
         Assert.isTrue(requestMatcherUrl.contains("{registrationId}"),
                 "filterProcessesUrl must contain a {registrationId} match variable");
-        requestMatcher = new AntPathRequestMatcher(requestMatcherUrl);
+        requestMatcher = PathPatternRequestMatcher.withDefaults().matcher(requestMatcherUrl);
 
         this.authenticationManager = authenticationManager;
         this.oAuth2RequestFactory = oAuth2RequestFactory;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilter.java
@@ -6,8 +6,9 @@ import org.springframework.lang.NonNull;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.savedrequest.SavedRequest;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.stereotype.Component;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -21,19 +22,19 @@ public class PasswordChangeUiRequiredFilter extends OncePerRequestFilter {
     private static final String MATCH_PATH = "/force_password_change";
     private static final String COMPLETED_PATH = "/force_password_change_completed";
 
-    private final AntPathRequestMatcher matchPath;
-    private final AntPathRequestMatcher completedPath;
+    private final RequestMatcher matchPath;
+    private final RequestMatcher completedPath;
     private final UaaSavedRequestCache cache;
 
     public PasswordChangeUiRequiredFilter() {
         this(new UaaSavedRequestCache());
-        this.cache.setRequestMatcher(new AntPathRequestMatcher("/oauth/authorize**"));
+        this.cache.setRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher("/oauth/authorize**"));
     }
 
     public PasswordChangeUiRequiredFilter(UaaSavedRequestCache cache) {
         this.cache = cache;
-        this.matchPath = new AntPathRequestMatcher(MATCH_PATH);
-        this.completedPath = new AntPathRequestMatcher(COMPLETED_PATH);
+        this.matchPath = PathPatternRequestMatcher.withDefaults().matcher(MATCH_PATH);
+        this.completedPath = PathPatternRequestMatcher.withDefaults().matcher(COMPLETED_PATH);
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginSecurityConfiguration.java
@@ -61,8 +61,8 @@ import org.springframework.security.web.context.SecurityContextPersistenceFilter
 import org.springframework.security.web.csrf.CsrfFilter;
 import org.springframework.security.web.csrf.CsrfLogoutHandler;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.session.DisableEncodeUrlFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.io.IOException;
@@ -511,7 +511,7 @@ class LoginSecurityConfiguration {
     ) throws Exception {
         ReAuthenticationRequiredFilter reAuthenticationRequiredFilter = new ReAuthenticationRequiredFilter(samlEntityID);
         var clientRedirectStateCache = new UaaSavedRequestCache();
-        clientRedirectStateCache.setRequestMatcher(new AntPathRequestMatcher("/oauth/authorize**"));
+        clientRedirectStateCache.setRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher("/oauth/authorize**"));
 
         // See: https://docs.spring.io/spring-security/reference/servlet/exploits/csrf.html#migrating-to-spring-security-6
         var csrfRequestHandler = new CsrfTokenRequestAttributeHandler();
@@ -581,7 +581,7 @@ class LoginSecurityConfiguration {
                 csrfLogoutHandler,
                 cookieClearingLogoutHandlerWithHandler
         );
-        logoutFilter.setLogoutRequestMatcher(new AntPathRequestMatcher("/logout.do"));
+        logoutFilter.setLogoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher("/logout.do"));
         FilterRegistrationBean<LogoutFilter> bean = new FilterRegistrationBean<>(logoutFilter);
         bean.setEnabled(false);
         return bean;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/metrics/UaaMetricsFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/metrics/UaaMetricsFilter.java
@@ -9,7 +9,8 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.jmx.export.notification.NotificationPublisher;
 import org.springframework.jmx.export.notification.NotificationPublisherAware;
 import org.springframework.lang.NonNull;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.yaml.snakeyaml.Yaml;
 
@@ -41,7 +42,7 @@ public class UaaMetricsFilter extends OncePerRequestFilter implements UaaMetrics
     private final TimeService timeService;
     private final IdleTimer inflight;
     private final Map<String, MetricsQueue> perUriMetrics;
-    private final LinkedHashMap<AntPathRequestMatcher, UrlGroup> urlGroups;
+    private final LinkedHashMap<RequestMatcher, UrlGroup> urlGroups;
     private boolean enabled = true;
     private boolean perRequestMetrics;
 
@@ -60,7 +61,7 @@ public class UaaMetricsFilter extends OncePerRequestFilter implements UaaMetrics
         this.urlGroups = new LinkedHashMap<>();
         List<UrlGroup> groups = getUrlGroups();
         groups.forEach(
-                group -> urlGroups.put(new AntPathRequestMatcher(group.getPattern()), group)
+                group -> urlGroups.put(PathPatternRequestMatcher.withDefaults().matcher(group.getPattern()), group)
         );
         this.inflight = new IdleTimer();
     }
@@ -115,7 +116,7 @@ public class UaaMetricsFilter extends OncePerRequestFilter implements UaaMetrics
     protected UrlGroup getUriGroup(final HttpServletRequest request) {
         if (urlGroups != null) {
             String uri = request.getRequestURI();
-            for (Map.Entry<AntPathRequestMatcher, UrlGroup> entry : urlGroups.entrySet()) {
+            for (Map.Entry<RequestMatcher, UrlGroup> entry : urlGroups.entrySet()) {
                 if (entry.getKey().matches(request)) {
                     UrlGroup group = entry.getValue();
                     if (logger.isDebugEnabled()) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlAuthenticationFilterConfig.java
@@ -36,8 +36,7 @@ import org.springframework.security.web.authentication.logout.SecurityContextLog
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CsrfLogoutHandler;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import jakarta.servlet.Filter;
 
 /**
@@ -178,7 +177,7 @@ public class SamlAuthenticationFilterConfig {
         Saml2LogoutResponseValidator openSamlLogoutResponseValidator = new SamlLogoutResponseValidator();
 
         Saml2LogoutResponseFilter filter = new Saml2LogoutResponseFilter(relyingPartyRegistrationResolver, openSamlLogoutResponseValidator, successHandler);
-        filter.setLogoutRequestMatcher(new AntPathRequestMatcher("/saml/SingleLogout/alias/{registrationId}"));
+        filter.setLogoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher("/saml/SingleLogout/alias/{registrationId}"));
 
         FilterRegistrationBean<Saml2LogoutResponseFilter> bean = new FilterRegistrationBean<>(filter);
         bean.setEnabled(false);
@@ -205,7 +204,7 @@ public class SamlAuthenticationFilterConfig {
                 logoutRequestValidator, logoutResponseResolver,
                 authenticationFailureHandler, securityContextLogoutHandlerWithHandler, csrfLogoutHandler,
                 cookieClearingLogoutHandlerWithHandler);
-        filter.setLogoutRequestMatcher(new AntPathRequestMatcher("/saml/SingleLogout/alias/*"));
+        filter.setLogoutRequestMatcher(PathPatternRequestMatcher.withDefaults().matcher("/saml/SingleLogout/alias/*"));
         FilterRegistrationBean<Saml2LogoutRequestFilter> bean = new FilterRegistrationBean<>(filter);
         bean.setEnabled(false);
         return bean;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolver.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolver.java
@@ -20,8 +20,8 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.security.web.util.UrlUtils;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -46,7 +46,7 @@ public final class UaaRelyingPartyRegistrationResolver implements Converter<Http
     private final String entityBaseURL;
     private final String uaaWideSamlEntityIDAlias;
     private final RelyingPartyRegistrationRepository relyingPartyRegistrationRepository;
-    private final RequestMatcher registrationRequestMatcher = new AntPathRequestMatcher("/**/{registrationId}");
+    private final RequestMatcher registrationRequestMatcher = PathPatternRequestMatcher.withDefaults().matcher("/**/{registrationId}");
 
     public UaaRelyingPartyRegistrationResolver(RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
             String uaaWideSamlEntityIDAlias,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/LimitedModeUaaFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/LimitedModeUaaFilter.java
@@ -9,7 +9,7 @@ import org.cloudfoundry.identity.uaa.util.TimeServiceImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.lang.NonNull;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import jakarta.servlet.FilterChain;
@@ -37,7 +37,7 @@ public class LimitedModeUaaFilter extends OncePerRequestFilter {
     public static final long STATUS_INTERVAL_MS = 5000;
 
     private Set<String> permittedMethods = emptySet();
-    private List<AntPathRequestMatcher> endpoints = emptyList();
+    private List<PathPatternRequestMatcher> endpoints = emptyList();
     private volatile boolean enabled;
     @Getter
     private File statusFile;
@@ -96,7 +96,7 @@ public class LimitedModeUaaFilter extends OncePerRequestFilter {
         this.endpoints = ofNullable(permittedEndpoints)
                 .orElse(emptySet())
                 .stream()
-                .map(AntPathRequestMatcher::new)
+                .map(pattern -> PathPatternRequestMatcher.withDefaults().matcher(pattern))
                 .toList();
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilterTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/PasswordChangeUiRequiredFilterTest.java
@@ -93,7 +93,7 @@ class PasswordChangeUiRequiredFilterTest {
 
     @Test
     void loadingChangePasswordPage() throws Exception {
-        mockHttpServletRequest.setPathInfo("/force_password_change");
+        mockHttpServletRequest.setRequestURI("/force_password_change");
         mockHttpServletRequest.setMethod(HttpMethod.GET.name());
         SecurityContextHolder.getContext().setAuthentication(mockUaaAuthentication);
         when(mockUaaAuthentication.isAuthenticated()).thenReturn(true);
@@ -105,7 +105,7 @@ class PasswordChangeUiRequiredFilterTest {
 
     @Test
     void submitChangePassword() throws Exception {
-        mockHttpServletRequest.setPathInfo("/force_password_change");
+        mockHttpServletRequest.setRequestURI("/force_password_change");
         mockHttpServletRequest.setMethod(HttpMethod.POST.name());
         SecurityContextHolder.getContext().setAuthentication(mockUaaAuthentication);
         when(mockUaaAuthentication.isAuthenticated()).thenReturn(true);
@@ -117,7 +117,7 @@ class PasswordChangeUiRequiredFilterTest {
 
     @Test
     void followCompletedRedirect() throws Exception {
-        mockHttpServletRequest.setPathInfo("/force_password_change_completed");
+        mockHttpServletRequest.setRequestURI("/force_password_change_completed");
         mockHttpServletRequest.setMethod(HttpMethod.POST.name());
         SecurityContextHolder.getContext().setAuthentication(mockUaaAuthentication);
         when(mockUaaAuthentication.isAuthenticated()).thenReturn(true);
@@ -132,7 +132,7 @@ class PasswordChangeUiRequiredFilterTest {
         String location = "/oauth/authorize";
         SavedRequest savedRequest = getSavedRequest(location);
         when(mockRequestCache.getRequest(any(), any())).thenReturn(savedRequest);
-        mockHttpServletRequest.setPathInfo("/force_password_change_completed");
+        mockHttpServletRequest.setRequestURI("/force_password_change_completed");
         mockHttpServletRequest.setMethod(HttpMethod.POST.name());
         SecurityContextHolder.getContext().setAuthentication(mockUaaAuthentication);
         when(mockUaaAuthentication.isAuthenticated()).thenReturn(true);
@@ -144,7 +144,7 @@ class PasswordChangeUiRequiredFilterTest {
 
     @Test
     void tryingAccessForcePasswordPage() throws Exception {
-        mockHttpServletRequest.setPathInfo("/force_password_change");
+        mockHttpServletRequest.setRequestURI("/force_password_change");
         SecurityContextHolder.getContext().setAuthentication(mockUaaAuthentication);
         when(mockUaaAuthentication.isAuthenticated()).thenReturn(true);
         setRequiresPasswordChange(mockHttpServletRequest, false);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/metrics/UaaMetricsFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/metrics/UaaMetricsFilterTests.java
@@ -9,7 +9,8 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.jmx.export.notification.NotificationPublisher;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.servlet.util.matcher.PathPatternRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -198,9 +199,7 @@ class UaaMetricsFilterTests {
     @Test
     void url_groups() {
         request.setServerName("localhost:8080");
-        setRequestData("/uaa/authenticate");
-        request.setPathInfo("/authenticate");
-        request.setContextPath("/uaa");
+        setRequestData("/authenticate");
         assertThat(filter.getUriGroup(request).getGroup()).isEqualTo("/api");
     }
 
@@ -251,7 +250,7 @@ class UaaMetricsFilterTests {
     void validate_matcher() {
         //validates that patterns that end with /** still match at parent level
         setRequestData("/some/path");
-        AntPathRequestMatcher matcher = new AntPathRequestMatcher("/some/path/**");
+        RequestMatcher matcher = PathPatternRequestMatcher.withDefaults().matcher("/some/path/**");
         assertThat(matcher.matches(request)).isTrue();
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolverTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolverTests.java
@@ -65,14 +65,14 @@ class UaaRelyingPartyRegistrationResolverTests {
     @Test
     void resolveWhenRequestContainsRegistrationIdThenResolves() {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setPathInfo("/some/path/" + this.registration.getRegistrationId());
+        request.setRequestURI("/some/path/" + this.registration.getRegistrationId());
         assertThat(resolver.convert(request)).isNull();
     }
 
     @Test
     void resolveWhenRequestContainsInvalidRegistrationIdThenNull() {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setPathInfo("/some/path/not-" + this.registration.getRegistrationId());
+        request.setRequestURI("/some/path/not-" + this.registration.getRegistrationId());
         assertThat(resolver.convert(request)).isNull();
     }
 
@@ -85,7 +85,7 @@ class UaaRelyingPartyRegistrationResolverTests {
     @Test
     void resolveWhenRequestIsWithInvalidSamlResponse() {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setPathInfo("/some/path/cloudfoundry-saml-login");
+        request.setRequestURI("/some/path/cloudfoundry-saml-login");
         request.setMethod("POST");
         request.setParameter("SAMLResponse", "PGJhc2U2ND4=");
         assertThatExceptionOfType(Saml2AuthenticationException.class).isThrownBy(() -> resolver.resolve(request, null));
@@ -94,7 +94,7 @@ class UaaRelyingPartyRegistrationResolverTests {
     @Test
     void resolveWhenRequestIsWithValiddSamlResponseFromSimplySamlButNoTrust() {
         MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setPathInfo("/some/path/cloudfoundry-saml-login");
+        request.setRequestURI("/some/path/cloudfoundry-saml-login");
         request.setMethod("POST");
         request.setParameter("SAMLResponse", SIMPLE_SAML_RESPONSE);
         assertThat(resolver.resolve(request, null)).isNull();
@@ -115,7 +115,7 @@ class UaaRelyingPartyRegistrationResolverTests {
         doReturn(mock(Saml2MessageBinding.class)).when(details).getSingleSignOnServiceBinding();
         doReturn(mock(Saml2MessageBinding.class)).when(newMock).getAssertionConsumerServiceBinding();
         doReturn(newMock).when(repository).findByRegistrationId("http://uaa-acceptance.cf-app.com/saml-idp");
-        request.setPathInfo("/some/path/cloudfoundry-saml-login");
+        request.setRequestURI("/some/path/cloudfoundry-saml-login");
         request.setMethod("POST");
         request.setParameter("SAMLResponse", SIMPLE_SAML_RESPONSE);
         assertThat(resolver.resolve(request, null).getEntityId()).isEqualTo("simpleEndityID");


### PR DESCRIPTION
`AntPathRequestMatcher` was deprecated in Spring Security 6.x and later removed in Spring Security 7.x