### PR TITLE
Migrate from NestedServletException to ServletException

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/client/OAuth2ClientContextFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/client/OAuth2ClientContextFilter.java
@@ -8,7 +8,6 @@ import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.util.ThrowableAnalyzer;
 import org.springframework.util.Assert;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
-import org.springframework.web.util.NestedServletException;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -75,7 +74,7 @@ public class OAuth2ClientContextFilter implements Filter, InitializingBean {
                 if (ex instanceof RuntimeException runtimeException) {
                     throw runtimeException;
                 }
-                throw new NestedServletException("Unhandled exception", ex);
+                throw new ServletException("Unhandled exception", ex);
             }
         }
     }


### PR DESCRIPTION
`NestedServletException` was deprecated in Spring Framework 6.x and later removed in Spring Framework 7.x