### PR TITLE
Replace UriComponentsBuilder.fromHttpUrl with fromUriString

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/client/OAuth2ClientContextFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/client/OAuth2ClientContextFilter.java
@@ -96,7 +96,7 @@ public class OAuth2ClientContextFilter implements Filter, InitializingBean {
 
         String redirectUri = e.getRedirectUri();
         UriComponentsBuilder builder = UriComponentsBuilder
-                .fromHttpUrl(redirectUri);
+                .fromUriString(redirectUri);
         Map<String, String> requestParams = e.getRequestParams();
         for (Map.Entry<String, String> param : requestParams.entrySet()) {
             builder.queryParam(param.getKey(), param.getValue());


### PR DESCRIPTION
`UriComponentsBuilder.fromHttpUrl` was deprecated in Spring 6 and later removed in Spring 7 in favor of `UriComponentsBuilder.fromUriString`