### PR TITLE
ensure that the clock doesn't move  when we calculate exp and iat

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenValidityResolver.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/TokenValidityResolver.java
@@ -22,6 +22,10 @@ public class TokenValidityResolver {
     }
 
     public Date resolve(String clientId) {
+        return resolve(clientId, timeService.getCurrentTimeMillis());
+    }
+
+    public Date resolve(String clientId, long epochMillis) {
         Integer tokenValiditySeconds = ofNullable(
                 clientTokenValidity.getValiditySeconds(clientId)
         ).orElse(
@@ -32,7 +36,7 @@ public class TokenValidityResolver {
             tokenValiditySeconds = globalTokenValiditySeconds;
         }
 
-        return new DateTime(timeService.getCurrentTimeMillis()).plusSeconds(tokenValiditySeconds).toDate();
+        return new DateTime(epochMillis).plusSeconds(tokenValiditySeconds).toDate();
     }
 
     public void setTimeService(TimeService timeService) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -424,7 +424,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             boolean isRevocable,
             UserAuthenticationData userAuthenticationData) throws AuthenticationException {
         CompositeToken compositeToken = new CompositeToken(tokenId);
-        compositeToken.setExpiration(accessTokenValidityResolver.resolve(clientId));
+        long issuedAtMillis = timeService.getCurrentTimeMillis();
+        compositeToken.setExpiration(accessTokenValidityResolver.resolve(clientId, issuedAtMillis));
         compositeToken.setRefreshToken(refreshToken == null ? null : new DefaultOAuth2RefreshToken(refreshToken));
 
         Set<String> requestedScopes = userAuthenticationData.scopes;
@@ -469,7 +470,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 grantType,
                 revocableHashSignature,
                 isRevocable,
-                additionalRootClaims);
+                additionalRootClaims,
+                issuedAtMillis);
         String token = JwtHelper.encode(jwtAccessToken, getActiveKeyInfo()).getEncoded();
         compositeToken.setValue(token);
         UaaClientDetails clientDetails = (UaaClientDetails) clientDetailsService.loadClientByClientId(clientId);
@@ -512,7 +514,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             String grantType,
             String revocableHashSignature,
             boolean isRevocable,
-            Map<String, Object> additionalRootClaims) {
+            Map<String, Object> additionalRootClaims,
+            long issuedAtEpochMillis) {
 
         Map<String, Object> claims = new LinkedHashMap<>();
 
@@ -543,7 +546,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             claims.put(REVOCATION_SIGNATURE, revocableHashSignature);
         }
 
-        claims.put(IAT, timeService.getCurrentTimeMillis() / MILLIS_PER_SECOND);
+        claims.put(IAT, issuedAtEpochMillis / MILLIS_PER_SECOND);
         claims.put(EXPIRY_IN_SECONDS, token.getExpiration().getTime() / MILLIS_PER_SECOND);
 
         if (tokenEndpointBuilder.getTokenEndpoint(IdentityZoneHolder.get()) != null) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
@@ -129,10 +129,12 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
 import static org.junit.jupiter.api.Named.named;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -283,6 +285,7 @@ class DeprecatedUaaTokenServicesTests {
 
         TokenValidityResolver tokenValidityResolver = mock(TokenValidityResolver.class);
         when(tokenValidityResolver.resolve(TokenTestSupport.CLIENT_ID)).thenReturn(new Date());
+        when(tokenValidityResolver.resolve(eq(TokenTestSupport.CLIENT_ID), anyLong())).thenReturn(new Date());
 
         JwtTokenSignedByThisUAA jwtToken = mock(JwtTokenSignedByThisUAA.class);
         TokenValidationService tokenValidationService = mock(TokenValidationService.class);
@@ -1270,7 +1273,7 @@ class DeprecatedUaaTokenServicesTests {
         this.assertCommonUserAccessTokenProperties(accessToken, CLIENT_ID);
         assertThat(accessToken).is(matching(issuerUri(is(ISSUER_URI))))
                 .is(matching(scope(is(scopesThatDontExist))))
-                .is(matching(validFor(greaterThan(60 * 60 * 12))));
+                .is(matching(validFor(greaterThanOrEqualTo(60 * 60 * 12))));
         assertThat(accessToken.getRefreshToken()).isNull();
 
         this.assertCommonEventProperties(accessToken, tokenSupport.userId, buildJsonString(scopesThatDontExist));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenValidityResolverTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/TokenValidityResolverTest.java
@@ -35,6 +35,13 @@ class TokenValidityResolverTest {
     }
 
     @Test
+    void whenEpochMillisProvided_usesItInsteadOfTimeService() {
+        Date validity = resolver.resolve("clientId", 2000L);
+
+        assertThat(validity.getTime()).isEqualTo(102_000L);
+    }
+
+    @Test
     void whenClientValidityNotConfigured_fallsBackToZoneConfiguration() {
         when(clientTokenValidity.getZoneValiditySeconds()).thenReturn(50);
         when(clientTokenValidity.getValiditySeconds("clientId")).thenReturn(null);


### PR DESCRIPTION
Prevents the following error

DeprecatedUaaTokenServicesTests > createAccessTokenPasswordGrant(TestTokenEnhancer) > 2: using enhancer FAILED
    java.lang.AssertionError:
    Expecting actual:
      eyJqa3UiOiJodHRwczovL3VhYS51cmwvdG9rZW5fa2V5cyIsImtpZCI6InRlc3RLZXkiLCJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSIsImV4X3Byb3AiOnsiY291bnRyeSI6Im56In0sInVzZXJfbmFtZSI6Impkc2EiLCJvcmlnaW4iOiJ1YWEiLCJpc3MiOiJodHRwOi8vbG9jYWxob3N0OjgwODAvdWFhL29hdXRoL3Rva2VuIiwiY2xpZW50X2lkIjoiY2xpZW50IiwiYXVkIjpbInNjaW0iLCJjbGllbnRzIl0sImV4dF9hdHRyIjp7InB1cnBvc2UiOiJ0ZXN0In0sInppZCI6InVhYSIsImdyYW50X3R5cGUiOiJwYXNzd29yZCIsInVzZXJfaWQiOiIxMjM0NSIsImF6cCI6ImNsaWVudCIsInNjb3BlIjpbInJlYWQiLCJ3cml0ZSIsIm9wZW5pZCJdLCJleF9ncm91cHMiOlsiYWRtaW4iLCJlZGl0b3IiXSwiZXhwIjoxNzc2OTEwNzExLCJpYXQiOjE3NzY4Njc1MTIsImp0aSI6IjVjZmUxN2I1OTcyNTRjYjM4YzZkNDJiYWEwZmY2ZTA2IiwiZW1haWwiOiJqZHNhQHZtd2FyZS5jb20iLCJyZXZfc2lnIjoiMzMxNGRjOTgiLCJjaWQiOiJjbGllbnQifQ.vvrLkDSNhqNBhXluZQDRRFTRpUbksVeBPYCKn1tjmS0
    to be should be valid for <is <43200>>
        at org.cloudfoundry.identity.uaa.oauth.DeprecatedUaaTokenServicesTests.validateAccessTokenOnly(DeprecatedUaaTokenServicesTests.java:2182)
        at org.cloudfoundry.identity.uaa.oauth.DeprecatedUaaTokenServicesTests.validateAccessAndRefreshToken(DeprecatedUaaTokenServicesTests.java:2187)
        at org.cloudfoundry.identity.uaa.oauth.DeprecatedUaaTokenServicesTests.createAccessTokenPasswordGrant(DeprecatedUaaTokenServicesTests.java:707)