### PR TITLE
Migrate DaoAuthenticationProvider from deprecated no-arg constructor

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ClientDetailsAuthenticationProvider.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/ClientDetailsAuthenticationProvider.java
@@ -52,8 +52,7 @@ public class ClientDetailsAuthenticationProvider extends DaoAuthenticationProvid
     private final JwtClientAuthentication jwtClientAuthentication;
 
     public ClientDetailsAuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder encoder, JwtClientAuthentication jwtClientAuthentication) {
-        super();
-        setUserDetailsService(userDetailsService);
+        super(userDetailsService);
         setPasswordEncoder(encoder);
         this.jwtClientAuthentication = jwtClientAuthentication;
     }


### PR DESCRIPTION
Default constructor was deprecated in spring-security 6.5.x and later removed in spring 7. Recommendation from deprecation notice is: `
Please provide the UserDetailsService in the constructor followed by setPasswordEncoder(PasswordEncoder) instead`:

https://github.com/spring-projects/spring-security/blob/6343002b326cea8806d93ebc449340cc54617901/core/src/main/java/org/springframework/security/authentication/dao/DaoAuthenticationProvider.java#L71-L92
