### PR TITLE
Remove deprecated setIgnoreDefaultModelOnRedirect

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
@@ -52,6 +52,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -244,6 +245,7 @@ public class InvitationsController {
             @RequestParam("code") String code,
             @RequestParam(value = "does_user_consent", required = false) boolean doesUserConsent,
             Model model,
+            RedirectAttributes redirectAttributes,
             HttpServletResponse response) {
 
         PasswordConfirmationValidation validation = new PasswordConfirmationValidation(password, passwordConfirmation);
@@ -268,15 +270,15 @@ public class InvitationsController {
         final String newCode = expiringCodeStore.generateCode(expiringCode.getData(), new Timestamp(System.currentTimeMillis() + (10 * 60 * 1000)), expiringCode.getIntent(), identityZoneManager.getCurrentIdentityZoneId()).getCode();
         BrandingInformation zoneBranding = identityZoneManager.getCurrentIdentityZone().getConfig().getBranding();
         if (zoneBranding != null && zoneBranding.getConsent() != null && !doesUserConsent) {
-            return processErrorReload(newCode, model, response, "error_message_code", "missing_consent");
+            return processErrorReload(newCode, model, redirectAttributes, response, "error_message_code", "missing_consent");
         }
         if (!validation.valid()) {
-            return processErrorReload(newCode, model, response, "error_message_code", validation.getMessageCode());
+            return processErrorReload(newCode, model, redirectAttributes, response, "error_message_code", validation.getMessageCode());
         }
         try {
             passwordValidator.validate(password);
         } catch (InvalidPasswordException e) {
-            return processErrorReload(newCode, model, response, "error_message", e.getMessagesAsOneString());
+            return processErrorReload(newCode, model, redirectAttributes, response, "error_message", e.getMessagesAsOneString());
         }
         AcceptedInvitation invitation;
         try {
@@ -291,15 +293,15 @@ public class InvitationsController {
         return res;
     }
 
-    private String processErrorReload(String code, Model model, HttpServletResponse response, String errorCode, String error) {
+    private String processErrorReload(String code, Model model, RedirectAttributes redirectAttributes, HttpServletResponse response, String errorCode, String error) {
         ExpiringCode expiringCode = expiringCodeStore.retrieveCode(code, identityZoneManager.getCurrentIdentityZoneId());
         Map<String, String> codeData = JsonUtils.readValue(expiringCode.getData(), new TypeReference<>() {
         });
         try {
             String newCode = expiringCodeStore.generateCode(expiringCode.getData(), new Timestamp(System.currentTimeMillis() + (10 * 60 * 1000)), expiringCode.getIntent(), identityZoneManager.getCurrentIdentityZoneId()).getCode();
 
-            model.addAttribute(errorCode, error);
-            model.addAttribute("code", newCode);
+            redirectAttributes.addAttribute(errorCode, error);
+            redirectAttributes.addAttribute("code", newCode);
             //return an absolute, within the app, link
             return "redirect:/invitations/accept";
         } catch (EmptyResultDataAccessException noProviderFound) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -60,6 +60,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.http.Cookie;
@@ -837,7 +838,7 @@ public class LoginInfoEndpoint {
     }
 
     @PostMapping(value = "/login/idp_discovery")
-    public String discoverIdentityProvider(@RequestParam String email, @RequestParam(required = false) String skipDiscovery, @RequestParam(required = false, name = LOGIN_HINT_ATTRIBUTE) String loginHint, @RequestParam(required = false, name = USERNAME_PARAMETER) String username, Model model, HttpSession session, HttpServletRequest request) {
+    public String discoverIdentityProvider(@RequestParam String email, @RequestParam(required = false) String skipDiscovery, @RequestParam(required = false, name = LOGIN_HINT_ATTRIBUTE) String loginHint, @RequestParam(required = false, name = USERNAME_PARAMETER) String username, Model model, RedirectAttributes redirectAttributes, HttpSession session, HttpServletRequest request) {
         ClientDetails clientDetails = null;
         if (hasSavedOauthAuthorizeRequest(session)) {
             SavedRequest savedRequest = SessionUtils.getSavedRequestSession(session);
@@ -866,13 +867,17 @@ public class LoginInfoEndpoint {
             }
         }
 
+        redirectAttributes.addAttribute("discoveryPerformed", true);
         if (StringUtils.hasText(email)) {
-            model.addAttribute(EMAIL_ATTRIBUTE, email);
+            redirectAttributes.addAttribute(EMAIL_ATTRIBUTE, email);
         }
         if (StringUtils.hasText(username)) {
-            model.addAttribute(USERNAME_PARAMETER, username);
+            redirectAttributes.addAttribute(USERNAME_PARAMETER, username);
         }
-        return "redirect:/login?discoveryPerformed=true";
+        if (StringUtils.hasText(loginHint)) {
+            redirectAttributes.addAttribute(LOGIN_HINT_ATTRIBUTE, loginHint);
+        }
+        return "redirect:/login";
     }
 
     private String goToPasswordPage(String email, Model model) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -854,9 +854,6 @@ public class LoginInfoEndpoint {
         if (!StringUtils.hasText(skipDiscovery) && identityProviders.size() == 1) {
             IdentityProvider matchedIdp = identityProviders.getFirst();
             if (matchedIdp.getType().equals(UAA)) {
-                if (StringUtils.hasText(loginHint)) {
-                    model.addAttribute(LOGIN_HINT_ATTRIBUTE, loginHint);
-                }
                 model.addAttribute(LOGIN_HINT_ATTRIBUTE, new UaaLoginHint("uaa").toString());
                 return goToPasswordPage(email, model);
             } else {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -867,17 +867,16 @@ public class LoginInfoEndpoint {
             }
         }
 
-        redirectAttributes.addAttribute("discoveryPerformed", true);
+        if (StringUtils.hasText(loginHint)) {
+            redirectAttributes.addAttribute(LOGIN_HINT_ATTRIBUTE, loginHint);
+        }
         if (StringUtils.hasText(email)) {
             redirectAttributes.addAttribute(EMAIL_ATTRIBUTE, email);
         }
         if (StringUtils.hasText(username)) {
             redirectAttributes.addAttribute(USERNAME_PARAMETER, username);
         }
-        if (StringUtils.hasText(loginHint)) {
-            redirectAttributes.addAttribute(LOGIN_HINT_ATTRIBUTE, loginHint);
-        }
-        return "redirect:/login";
+        return "redirect:/login?discoveryPerformed=true";
     }
 
     private String goToPasswordPage(String email, Model model) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpoint.java
@@ -849,14 +849,14 @@ public class LoginInfoEndpoint {
                 // ignore
             }
         }
-        if (StringUtils.hasText(loginHint)) {
-            model.addAttribute(LOGIN_HINT_ATTRIBUTE, loginHint);
-        }
         List<IdentityProvider> identityProviders = DomainFilter.filter(providerProvisioning.retrieveActive(IdentityZoneHolder.get().getId()), clientDetails, email, false);
 
         if (!StringUtils.hasText(skipDiscovery) && identityProviders.size() == 1) {
             IdentityProvider matchedIdp = identityProviders.getFirst();
             if (matchedIdp.getType().equals(UAA)) {
+                if (StringUtils.hasText(loginHint)) {
+                    model.addAttribute(LOGIN_HINT_ATTRIBUTE, loginHint);
+                }
                 model.addAttribute(LOGIN_HINT_ATTRIBUTE, new UaaLoginHint("uaa").toString());
                 return goToPasswordPage(email, model);
             } else {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/WebConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/WebConfig.java
@@ -1,15 +1,12 @@
 package org.cloudfoundry.identity.uaa.web;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.authentication.manager.AutologinRequestConverter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.util.List;
 
@@ -25,13 +22,5 @@ class WebConfig implements WebMvcConfigurer {
     @Override
     public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(new AutologinRequestConverter());
-    }
-
-    @Autowired
-    private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-    @PostConstruct
-    public void init() {
-        requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/account/AccountsControllerViewZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/account/AccountsControllerViewZonePathTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.account;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.home.BuildInfo;
@@ -10,9 +9,7 @@ import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.util.ZoneRequestPathMode;
 import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
-import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
-import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +32,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -138,14 +134,6 @@ class AccountsControllerViewZonePathTests extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/account/ChangeEmailControllerViewZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/account/ChangeEmailControllerViewZonePathTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.account;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
@@ -14,7 +13,6 @@ import org.cloudfoundry.identity.uaa.util.ZoneRequestPathMode;
 import org.cloudfoundry.identity.uaa.util.beans.TestBuildInfo;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
-import org.cloudfoundry.identity.uaa.zone.MultitenancyFixture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,7 +33,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 
 import java.util.Collections;
@@ -117,14 +114,6 @@ class ChangeEmailControllerViewZonePathTests extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/account/ChangePasswordControllerViewZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/account/ChangePasswordControllerViewZonePathTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.account;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.cloudfoundry.identity.uaa.home.BuildInfo;
@@ -29,7 +28,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -98,14 +96,6 @@ class ChangePasswordControllerViewZonePathTests extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.invitations;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.authentication.manager.DynamicLdapAuthenticationManager;
 import org.cloudfoundry.identity.uaa.authentication.manager.DynamicZoneAwareAuthenticationManager;
@@ -58,7 +57,6 @@ import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.net.URI;
 import java.sql.Timestamp;
@@ -773,14 +771,6 @@ class InvitationsControllerTest {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerZonePathTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsControllerZonePathTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.invitations;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.authentication.manager.DynamicLdapAuthenticationManager;
 import org.cloudfoundry.identity.uaa.authentication.manager.DynamicZoneAwareAuthenticationManager;
@@ -34,7 +33,6 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManagerImpl;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.ArgumentCaptor;
@@ -63,7 +61,6 @@ import org.springframework.web.context.ConfigurableWebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 
 import java.net.URI;
@@ -855,14 +852,6 @@ class InvitationsControllerZonePathTest {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/AccountsControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/AccountsControllerTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.account.AccountCreationService;
 import org.cloudfoundry.identity.uaa.account.AccountsController;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -35,7 +34,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -236,14 +234,6 @@ class AccountsControllerTest {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangeEmailControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ChangeEmailControllerTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.account.ChangeEmailController;
 import org.cloudfoundry.identity.uaa.account.ChangeEmailService;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
@@ -37,7 +36,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -376,14 +374,6 @@ class ChangeEmailControllerTest {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.servlet.RequestDispatcher;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.client.ClientMetadata;
@@ -41,7 +40,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -251,14 +249,6 @@ class HomeControllerViewTests extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewZonePathTests.java
@@ -1,8 +1,6 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import jakarta.servlet.RequestDispatcher;
-import jakarta.servlet.http.HttpServletRequest;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.client.ClientMetadata;
 import org.cloudfoundry.identity.uaa.client.JdbcClientMetadataProvisioning;
@@ -28,7 +26,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.saml2.Saml2Exception;
@@ -46,7 +43,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 
 import java.net.MalformedURLException;
@@ -368,14 +364,6 @@ class HomeControllerViewZonePathTests extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -386,6 +386,29 @@ class LoginInfoEndpointTests {
     }
 
     @Test
+    void discoverIdentityProvider_addsAllRedirectAttributesOnFallthrough() {
+        LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
+        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+        String loginHint = "{\"origin\":\"my-OIDC-idp1\"}";
+
+        String redirect = endpoint.discoverIdentityProvider(
+                "testuser@fake.com",
+                "true",
+                loginHint,
+                "testuser",
+                extendedModelMap,
+                redirectAttributes,
+                new MockHttpSession(),
+                new MockHttpServletRequest()
+        );
+
+        assertThat(redirect).isEqualTo("redirect:/login?discoveryPerformed=true");
+        verify(redirectAttributes).addAttribute("email", "testuser@fake.com");
+        verify(redirectAttributes).addAttribute("username", "testuser");
+        verify(redirectAttributes).addAttribute("login_hint", loginHint);
+    }
+
+    @Test
     void discoverIdentityProviderCarriesUsername() throws MalformedURLException {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
         MockHttpServletRequest request = new MockHttpServletRequest();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -47,6 +47,7 @@ import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.ui.ExtendedModelMap;
 import org.springframework.ui.Model;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpSession;
@@ -366,9 +367,10 @@ class LoginInfoEndpointTests {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpSession session = new MockHttpSession();
-        endpoint.discoverIdentityProvider("testuser@fake.com", "true", null, null, extendedModelMap, session, request);
+        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+        endpoint.discoverIdentityProvider("testuser@fake.com", "true", null, null, extendedModelMap, redirectAttributes, session, request);
 
-        assertThat(extendedModelMap).containsEntry("email", "testuser@fake.com");
+        verify(redirectAttributes).addAttribute("email", "testuser@fake.com");
     }
 
     @Test
@@ -377,7 +379,8 @@ class LoginInfoEndpointTests {
         MockHttpServletRequest request = new MockHttpServletRequest();
         MockHttpSession session = new MockHttpSession();
         String loginHint = "{\"origin\":\"my-OIDC-idp1\"}";
-        endpoint.discoverIdentityProvider("testuser@fake.com", "true", loginHint, null, extendedModelMap, session, request);
+        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+        endpoint.discoverIdentityProvider("testuser@fake.com", "true", loginHint, null, extendedModelMap, redirectAttributes, session, request);
 
         assertThat(extendedModelMap).containsEntry("login_hint", loginHint);
     }
@@ -402,7 +405,8 @@ class LoginInfoEndpointTests {
         when(idp.getConfig()).thenReturn(idpConfig);
         when(mockIdentityProviderProvisioning.retrieveActive("uaa")).thenReturn(Collections.singletonList(idp));
 
-        String redirect = endpoint.discoverIdentityProvider("testuser@fake.com", null, loginHint, "testuser@fake.com", extendedModelMap, session, request);
+        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+        String redirect = endpoint.discoverIdentityProvider("testuser@fake.com", null, loginHint, "testuser@fake.com", extendedModelMap, redirectAttributes, session, request);
 
         assertThat(redirect).contains("username=testuser@fake.com");
     }
@@ -418,7 +422,8 @@ class LoginInfoEndpointTests {
         uaaIdentityProvider.setType(OriginKeys.UAA);
         when(mockIdentityProviderProvisioning.retrieveActive("uaa")).thenReturn(singletonList(uaaIdentityProvider));
 
-        endpoint.discoverIdentityProvider("testuser@fake.com", null, null, null, extendedModelMap, session, request);
+        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
+        endpoint.discoverIdentityProvider("testuser@fake.com", null, null, null, extendedModelMap, redirectAttributes, session, request);
 
         String loginHint = "{\"origin\":\"uaa\"}";
         assertThat(extendedModelMap).containsEntry("login_hint", loginHint);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -363,7 +363,7 @@ class LoginInfoEndpointTests {
     }
 
     @Test
-    void discoverIdentityProvider_addsAllRedirectAttributesOnFallthrough() {
+    void discoverIdentityProvider_carriesAllParametersOnRedirect() {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
         RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
         String loginHint = "{\"origin\":\"my-OIDC-idp1\"}";
@@ -386,7 +386,7 @@ class LoginInfoEndpointTests {
     }
 
     @Test
-    void discoverIdentityProviderCarriesUsername() throws MalformedURLException {
+    void discoverIdentityProvider_propagatesUsernameToExternalOidcProvider() throws MalformedURLException {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.setParameter("username", "testuser@fake.com");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -363,17 +363,6 @@ class LoginInfoEndpointTests {
     }
 
     @Test
-    void discoverIdentityProviderCarriesEmailIfProvided() {
-        LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpSession session = new MockHttpSession();
-        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
-        endpoint.discoverIdentityProvider("testuser@fake.com", "true", null, null, extendedModelMap, redirectAttributes, session, request);
-
-        verify(redirectAttributes).addAttribute("email", "testuser@fake.com");
-    }
-
-    @Test
     void discoverIdentityProvider_addsAllRedirectAttributesOnFallthrough() {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
         RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -380,9 +380,10 @@ class LoginInfoEndpointTests {
         MockHttpSession session = new MockHttpSession();
         String loginHint = "{\"origin\":\"my-OIDC-idp1\"}";
         RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
-        endpoint.discoverIdentityProvider("testuser@fake.com", "true", loginHint, null, extendedModelMap, redirectAttributes, session, request);
+        String redirect = endpoint.discoverIdentityProvider("testuser@fake.com", "true", loginHint, null, extendedModelMap, redirectAttributes, session, request);
 
-        assertThat(extendedModelMap).containsEntry("login_hint", loginHint);
+        assertThat(redirect).isEqualTo("redirect:/login?discoveryPerformed=true");
+        verify(redirectAttributes).addAttribute("login_hint", loginHint);
     }
 
     @Test
@@ -446,8 +447,9 @@ class LoginInfoEndpointTests {
         when(mockIdentityProviderProvisioning.retrieveActive("uaa")).thenReturn(singletonList(uaaIdentityProvider));
 
         RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
-        endpoint.discoverIdentityProvider("testuser@fake.com", null, null, null, extendedModelMap, redirectAttributes, session, request);
+        String redirect = endpoint.discoverIdentityProvider("testuser@fake.com", null, null, null, extendedModelMap, redirectAttributes, session, request);
 
+        assertThat(redirect).isEqualTo("idp_discovery/password");
         String loginHint = "{\"origin\":\"uaa\"}";
         assertThat(extendedModelMap).containsEntry("login_hint", loginHint);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/LoginInfoEndpointTests.java
@@ -374,19 +374,6 @@ class LoginInfoEndpointTests {
     }
 
     @Test
-    void discoverIdentityProviderCarriesLoginHintIfProvided() {
-        LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpSession session = new MockHttpSession();
-        String loginHint = "{\"origin\":\"my-OIDC-idp1\"}";
-        RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);
-        String redirect = endpoint.discoverIdentityProvider("testuser@fake.com", "true", loginHint, null, extendedModelMap, redirectAttributes, session, request);
-
-        assertThat(redirect).isEqualTo("redirect:/login?discoveryPerformed=true");
-        verify(redirectAttributes).addAttribute("login_hint", loginHint);
-    }
-
-    @Test
     void discoverIdentityProvider_addsAllRedirectAttributesOnFallthrough() {
         LoginInfoEndpoint endpoint = getEndpoint(IdentityZoneHolder.get());
         RedirectAttributes redirectAttributes = mock(RedirectAttributes.class);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.account.ProfileController;
 import org.cloudfoundry.identity.uaa.approval.Approval;
 import org.cloudfoundry.identity.uaa.approval.ApprovalStore;
@@ -37,7 +36,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -75,14 +73,6 @@ class ProfileControllerMockMvcTests {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ProfileControllerMockMvcZonePathTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.account.ProfileController;
 import org.cloudfoundry.identity.uaa.approval.Approval;
 import org.cloudfoundry.identity.uaa.approval.ApprovalStore;
@@ -43,7 +42,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,14 +83,6 @@ class ProfileControllerMockMvcZonePathTests {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.account.ConflictException;
 import org.cloudfoundry.identity.uaa.account.ForgotPasswordInfo;
@@ -46,7 +45,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.thymeleaf.TemplateEngine;
 
 import java.sql.Timestamp;
@@ -340,14 +338,6 @@ class ResetPasswordControllerTest extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerViewZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerViewZonePathTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import jakarta.annotation.PostConstruct;
 import org.cloudfoundry.identity.uaa.TestClassNullifier;
 import org.cloudfoundry.identity.uaa.account.ResetPasswordController;
 import org.cloudfoundry.identity.uaa.account.ResetPasswordService;
@@ -38,7 +37,6 @@ import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 import org.thymeleaf.TemplateEngine;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 
@@ -112,14 +110,6 @@ class ResetPasswordControllerViewZonePathTests extends TestClassNullifier {
     @EnableWebMvc
     @Import(ThymeleafConfig.class)
     static class ContextConfiguration implements WebMvcConfigurer {
-
-        @Autowired
-        private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
-
-        @PostConstruct
-        public void init() {
-            requestMappingHandlerAdapter.setIgnoreDefaultModelOnRedirect(false);
-        }
 
         @Override
         public void configureDefaultServletHandling(DefaultServletHandlerConfigurer configurer) {


### PR DESCRIPTION
This method was deprecated in Spring Framework 6.x without replacement. The default model is now always ignored on redirect. The method was removed in Spring Framework 7.x.

This requires changes to some controllers where `model.addAttribute()` was used that now won't be delegated. We need to use `redirectAttributes.addAttribute()`

https://github.com/spring-projects/spring-framework/blob/cf727bd7c80881864a941933fa6fb890b37de470/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java#L488-L503