### PR TITLE
Remove deprecated PortResolver

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/invitations/InvitationsController.java
@@ -40,7 +40,6 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.stereotype.Controller;
@@ -195,7 +194,7 @@ public class InvitationsController {
         RequestContextHolder.getRequestAttributes().setAttribute("user_id", user.getId(), RequestAttributes.SCOPE_SESSION);
         HttpServletRequestWrapper wrapper = getNewCodeWrapper(request, newCode);
 
-        SavedRequest savedRequest = new DefaultSavedRequest(wrapper, new PortResolverImpl());
+        SavedRequest savedRequest = new DefaultSavedRequest(wrapper);
         RequestContextHolder.getRequestAttributes().setAttribute(SAVED_REQUEST_SESSION_ATTRIBUTE, savedRequest, RequestAttributes.SCOPE_SESSION);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestCache.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestCache.java
@@ -21,7 +21,6 @@ import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.PortResolver;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
@@ -130,7 +129,7 @@ public class UaaSavedRequestCache extends HttpSessionRequestCache implements Fil
         private final Map<String, String[]> parameters;
 
         public ClientRedirectSavedRequest(HttpServletRequest request, String redirectUrl) {
-            super(request, ServletRequest::getServerPort);
+            super(request);
             this.redirectUrl = redirectUrl;
             parameters = Collections.unmodifiableMap(UaaUrlUtils.getParameterMap(redirectUrl));
         }
@@ -180,8 +179,7 @@ public class UaaSavedRequestCache extends HttpSessionRequestCache implements Fil
             return parameters.keySet();
         }
 
-        @Override
-        public boolean doesRequestMatch(HttpServletRequest request, PortResolver portResolver) {
+        public boolean doesRequestMatch(HttpServletRequest request) {
             boolean result = UrlUtils.buildFullRequestUrl(request).equals(redirectUrl);
             String formRedirect = request.getParameter(FORM_REDIRECT_PARAMETER);
             if (!result &&

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestCacheTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestCacheTests.java
@@ -208,15 +208,15 @@ class UaaSavedRequestCacheTests {
         request.setQueryString("name=value");
         request.setServerPort(443);
         ClientRedirectSavedRequest saved = new ClientRedirectSavedRequest(request, redirectUrl);
-        assertThat(saved.doesRequestMatch(request, null)).isTrue();
+        assertThat(saved.doesRequestMatch(request)).isTrue();
 
         request.setQueryString("name=value&name2=value2");
-        assertThat(saved.doesRequestMatch(request, null)).isFalse();
+        assertThat(saved.doesRequestMatch(request)).isFalse();
         request.setQueryString("name=value");
 
         request = new MockHttpServletRequest(POST.name(), "/login.do");
         request.setParameter(FORM_REDIRECT_PARAMETER, redirectUrl);
-        assertThat(saved.doesRequestMatch(request, null)).isTrue();
+        assertThat(saved.doesRequestMatch(request)).isTrue();
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -61,7 +61,6 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
-import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.SavedRequest;
@@ -1671,7 +1670,7 @@ public class LoginMockMvcTests {
         MockMvcUtils.updateClient(webApplicationContext, zoneAdminClient, identityZone);
 
         MockHttpSession session = new MockHttpSession();
-        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest(), new PortResolverImpl()) {
+        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest()) {
             @Override
             public String getRedirectUrl() {
                 return "http://test/redirect/oauth/authorize";
@@ -2859,7 +2858,7 @@ public class LoginMockMvcTests {
     }
 
     private static SavedRequest getSavedRequest(UaaClientDetails client) {
-        return new DefaultSavedRequest(new MockHttpServletRequest(), new PortResolverImpl()) {
+        return new DefaultSavedRequest(new MockHttpServletRequest()) {
             @Override
             public String getRedirectUrl() {
                 return "http://test/redirect/oauth/authorize";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
@@ -67,7 +67,6 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
-import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.SavedRequest;
@@ -2038,7 +2037,7 @@ public class LoginMockMvcZonePathTests {
         MockMvcUtils.updateClient(webApplicationContext, zoneAdminClient, identityZone);
 
         MockHttpSession session = new MockHttpSession();
-        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest(), new PortResolverImpl()) {
+        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest()) {
             @Override
             public String getRedirectUrl() {
                 return "http://test/redirect/oauth/authorize";
@@ -3462,7 +3461,7 @@ public class LoginMockMvcZonePathTests {
     }
 
     private static SavedRequest getSavedRequest(UaaClientDetails client) {
-        return new DefaultSavedRequest(new MockHttpServletRequest(), new PortResolverImpl()) {
+        return new DefaultSavedRequest(new MockHttpServletRequest()) {
             @Override
             public String getRedirectUrl() {
                 return "http://test/redirect/oauth/authorize";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerMockMvcTests.java
@@ -29,7 +29,6 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.test.web.servlet.MockMvc;
@@ -245,7 +244,7 @@ public class ResetPasswordControllerMockMvcTests {
         user = MockMvcUtils.createUser(mockMvc, token, user);
 
         MockHttpSession session = new MockHttpSession();
-        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest(), new PortResolverImpl()) {
+        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest()) {
             @Override
             public String getRedirectUrl() {
                 return "http://test/redirect/oauth/authorize";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/ResetPasswordControllerMockMvcZonePathTests.java
@@ -36,7 +36,6 @@ import org.springframework.http.MediaType;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.savedrequest.DefaultSavedRequest;
 import org.springframework.security.web.savedrequest.SavedRequest;
 import org.springframework.test.web.servlet.MockMvc;
@@ -260,7 +259,7 @@ public class ResetPasswordControllerMockMvcZonePathTests {
         user = MockMvcUtils.createUser(mockMvc, token, user);
 
         MockHttpSession session = new MockHttpSession();
-        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest(), new PortResolverImpl()) {
+        SavedRequest savedRequest = new DefaultSavedRequest(new MockHttpServletRequest()) {
             @Override
             public String getRedirectUrl() {
                 return "http://test/redirect/oauth/authorize";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
@@ -84,7 +84,6 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextImpl;
-import org.springframework.security.web.PortResolverImpl;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRepository;
@@ -1200,7 +1199,7 @@ public final class MockMvcUtils {
     public static class MockSavedRequest extends DefaultSavedRequest {
 
         public MockSavedRequest() {
-            super(new MockHttpServletRequest(), new PortResolverImpl());
+            super(new MockHttpServletRequest());
         }
 
         @Override


### PR DESCRIPTION
It was deprecated in 6.5.x and later removed in 7.x

"Deprecated: This existed for an old IE bug and is no longer need."