### PR TITLE
Remove deprecated setters in SpringServletXmlBeansConfiguration

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
@@ -101,7 +101,6 @@ public class SpringServletXmlBeansConfiguration {
     @Primary
     ContentNegotiationManagerFactoryBean contentNegotiationManager() {
         ContentNegotiationManagerFactoryBean bean = new ContentNegotiationManagerFactoryBean();
-        bean.setFavorPathExtension(false);
         bean.setFavorParameter(true);
         bean.addMediaType("json", MediaType.APPLICATION_JSON);
         bean.addMediaType("xml", MediaType.APPLICATION_XML);
@@ -115,7 +114,6 @@ public class SpringServletXmlBeansConfiguration {
     ) {
         RequestMappingHandlerMapping bean = new RequestMappingHandlerMapping();
         bean.setContentNegotiationManager(contentNegotiationManagerFactoryBean.build());
-        bean.setUseSuffixPatternMatch(false);
         bean.setOrder(1);
         return bean;
     }


### PR DESCRIPTION
ContentNegotiationManagerFactoryBean:
Deprecation Note: As of 5.2.4, favorPathExtension and ignoreUnknownPathExtensions are deprecated in order to discourage using path extensions for content negotiation and for request mapping with similar deprecations on RequestMappingHandlerMapping. For further context, please read issue #24719  .

RequestMappingHandlerMapping:
In 5.2.4, useSuffixPatternMatch and useRegisteredSuffixPatternMatch were deprecated in order to discourage use of path extensions for request mapping and for content negotiation (with similar deprecations in ContentNegotiationManagerFactoryBean). For further context, please read issue #24179

These setters were removed in Spring 7.