### PR TITLE
Remove deprecated XSS protection setter from HttpHeaderSecurityFilter

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlFiltersConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlFiltersConfiguration.java
@@ -227,7 +227,6 @@ public class SpringServletXmlFiltersConfiguration {
         filter.setHstsEnabled(false);
         filter.setAntiClickJackingEnabled(false);
         filter.setBlockContentTypeSniffingEnabled(true);
-        filter.setXssProtectionEnabled(false);
         FilterRegistrationBean<HttpHeaderSecurityFilter> bean = new FilterRegistrationBean<>(filter);
         bean.setEnabled(false);
         return bean;


### PR DESCRIPTION
This comes from tomcat-embed-core and it was deprecated. Spring 7 pulls a newer version where this setter does not exist. It seems we already have CSP header setting and this `setXssProtectionEnabled` was set to false anyway, so it seems a safe change.