### PR TITLE
Migrate ResponseErrorHandler.handleError

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/http/OAuth2ErrorHandler.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/http/OAuth2ErrorHandler.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.identity.uaa.oauth.client.resource.OAuth2AccessDeniedExc
 import org.cloudfoundry.identity.uaa.oauth.client.resource.OAuth2ProtectedResourceDetails;
 import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.converter.HttpMessageConversionException;
@@ -21,6 +22,7 @@ import org.springframework.web.client.RestTemplate;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
@@ -70,11 +72,11 @@ public class OAuth2ErrorHandler implements ResponseErrorHandler {
                 || this.errorHandler.hasError(response);
     }
 
-    public void handleError(final ClientHttpResponse response) throws IOException {
+    public void handleError(URI url, HttpMethod method, final ClientHttpResponse response) throws IOException {
         if (!HttpStatus.Series.CLIENT_ERROR.equals(HttpStatus.resolve(response.getStatusCode().value()).series())) {
             // We should only care about 400 level errors. Ex: A 500 server error shouldn't
             // be an oauth related error.
-            errorHandler.handleError(response);
+            errorHandler.handleError(url, method, response);
         } else {
             // Need to use buffered response because input stream may need to be consumed multiple times.
             ClientHttpResponse bufferedResponse = new ClientHttpResponse() {
@@ -141,7 +143,7 @@ public class OAuth2ErrorHandler implements ResponseErrorHandler {
                 }
 
                 // then delegate to the custom handler
-                errorHandler.handleError(bufferedResponse);
+                errorHandler.handleError(url, method, bufferedResponse);
             }
             catch (InvalidTokenException ex) {
                 // Special case: an invalid token can be renewed so tell the caller what to do
@@ -155,7 +157,7 @@ public class OAuth2ErrorHandler implements ResponseErrorHandler {
                 }
                 // This is not an exception that is really understood, so allow our delegate
                 // to handle it in a non-oauth way
-                errorHandler.handleError(bufferedResponse);
+                errorHandler.handleError(url, method, bufferedResponse);
             }
         }
     }

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/OAuth2AccessTokenSupport.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/OAuth2AccessTokenSupport.java
@@ -34,6 +34,7 @@ import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -232,7 +233,7 @@ public abstract class OAuth2AccessTokenSupport {
 
         @SuppressWarnings("unchecked")
         @Override
-        public void handleError(ClientHttpResponse response) throws IOException {
+        public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
             for (HttpMessageConverter<?> converter : messageConverters) {
                 if (converter.canRead(OAuth2Exception.class, response.getHeaders().getContentType())) {
                     OAuth2Exception ex;
@@ -246,7 +247,7 @@ public abstract class OAuth2AccessTokenSupport {
                     throw ex;
                 }
             }
-            super.handleError(response);
+            super.handleError(url, method, response);
         }
 
     }

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/http/OAuth2ErrorHandlerTests.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/http/OAuth2ErrorHandlerTests.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -27,6 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -105,7 +107,7 @@ class OAuth2ErrorHandlerTests {
         HttpHeaders headers = new HttpHeaders();
         headers.set("www-authenticate", "Bearer error=foo");
         ClientHttpResponse response = new TestClientHttpResponse(headers, 401);
-        assertThatThrownBy(() -> handler.handleError(response))
+        assertThatThrownBy(() -> handler.handleError(null, null, response))
                 .isInstanceOf(HttpClientErrorException.class)
                 .hasMessageContaining("401 Unauthorized");
     }
@@ -115,7 +117,7 @@ class OAuth2ErrorHandlerTests {
         HttpHeaders headers = new HttpHeaders();
         headers.set("www-authenticate", "Bearer error=\"invalid_token\", description=\"foo\"");
         ClientHttpResponse response = new TestClientHttpResponse(headers, 401);
-        assertThatThrownBy(() -> handler.handleError(response))
+        assertThatThrownBy(() -> handler.handleError(null, null, response))
                 .isInstanceOf(AccessTokenRequiredException.class)
                 .hasMessageContaining("OAuth2 access denied");
     }
@@ -128,13 +130,13 @@ class OAuth2ErrorHandlerTests {
                 return true;
             }
 
-            public void handleError(ClientHttpResponse response) throws IOException {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
                 throw new RuntimeException("planned");
             }
         }, resource);
         HttpHeaders headers = new HttpHeaders();
         ClientHttpResponse response = new TestClientHttpResponse(headers, 401);
-        assertThatThrownBy(() -> handler.handleError(response))
+        assertThatThrownBy(() -> handler.handleError(null, null, response))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("planned");
     }
@@ -144,7 +146,7 @@ class OAuth2ErrorHandlerTests {
         HttpHeaders headers = new HttpHeaders();
         ClientHttpResponse response = new TestClientHttpResponse(headers, 500);
         assertThatExceptionOfType(HttpServerErrorException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     @Test
@@ -152,7 +154,7 @@ class OAuth2ErrorHandlerTests {
         HttpHeaders headers = new HttpHeaders();
         ClientHttpResponse response = new TestClientHttpResponse(headers, 400);
         assertThatExceptionOfType(HttpClientErrorException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     @Test
@@ -160,7 +162,7 @@ class OAuth2ErrorHandlerTests {
         HttpHeaders headers = new HttpHeaders();
         ClientHttpResponse response = new TestClientHttpResponse(headers, 403);
         assertThatExceptionOfType(HttpClientErrorException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     // See https://github.com/spring-projects/spring-security-oauth/issues/387
@@ -172,7 +174,7 @@ class OAuth2ErrorHandlerTests {
                 new ByteArrayInputStream("{}".getBytes()));
         handler = new OAuth2ErrorHandler(new DefaultResponseErrorHandler(), resource);
         assertThatExceptionOfType(HttpClientErrorException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     @Test
@@ -183,7 +185,7 @@ class OAuth2ErrorHandlerTests {
                 return true;
             }
 
-            public void handleError(ClientHttpResponse response) throws IOException {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
                 InputStream body = response.getBody();
                 byte[] buf = new byte[appSpecificBodyContent.length()];
                 int readResponse = body.read(buf);
@@ -197,7 +199,7 @@ class OAuth2ErrorHandlerTests {
         headers.set("Content-Type", "application/json");
         InputStream appSpecificErrorBody = new ByteArrayInputStream(appSpecificBodyContent.getBytes("UTF-8"));
         ClientHttpResponse response = new TestClientHttpResponse(headers, 400, appSpecificErrorBody);
-        assertThatThrownBy(() -> handler.handleError(response))
+        assertThatThrownBy(() -> handler.handleError(null, null, response))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("planned");
     }
@@ -210,7 +212,7 @@ class OAuth2ErrorHandlerTests {
         when(response.getBody()).thenReturn(new ByteArrayInputStream(new byte[0]));
         when(response.getStatusText()).thenReturn(HttpStatus.BAD_REQUEST.toString());
         assertThatExceptionOfType(HttpClientErrorException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     // gh-875
@@ -222,7 +224,7 @@ class OAuth2ErrorHandlerTests {
         headers.setContentType(MediaType.APPLICATION_JSON);
         ClientHttpResponse response = new TestClientHttpResponse(headers, 400, messageBody);
         assertThatExceptionOfType(UserDeniedAuthorizationException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     // gh-875
@@ -234,7 +236,7 @@ class OAuth2ErrorHandlerTests {
         headers.setContentType(MediaType.APPLICATION_JSON);
         ClientHttpResponse response = new TestClientHttpResponse(headers, 403, messageBody);
         assertThatExceptionOfType(OAuth2AccessDeniedException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 
     @Test
@@ -273,6 +275,6 @@ class OAuth2ErrorHandlerTests {
         InputStream appSpecificErrorBody = new ByteArrayInputStream(appSpecificBodyContent.getBytes("UTF-8"));
         ClientHttpResponse response = new TestClientHttpResponse(headers, 401, appSpecificErrorBody);
         assertThatExceptionOfType(HttpClientErrorException.class).isThrownBy(() ->
-                handler.handleError(response));
+                handler.handleError(null, null, response));
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
@@ -42,6 +42,7 @@ import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,9 +80,9 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
         ((RestTemplate) restTemplate).setErrorHandler(new DefaultResponseErrorHandler() {
             @Override
             // Ignore 400
-            public void handleError(ClientHttpResponse response) throws IOException {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
                 if (response.getStatusCode().value() != 400) {
-                    super.handleError(response);
+                    super.handleError(url, method, response);
                 }
             }
         });

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/ServerRunningExtension.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/ServerRunningExtension.java
@@ -309,7 +309,7 @@ public final class ServerRunningExtension implements BeforeAllCallback, RestTemp
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestAccountExtension.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestAccountExtension.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
@@ -43,6 +44,7 @@ import org.springframework.web.client.RestOperations;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -285,7 +287,7 @@ public final class TestAccountExtension implements BeforeAllCallback {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // do nothing
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CfUserIdTranslationEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/CfUserIdTranslationEndpointIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -112,7 +113,7 @@ class CfUserIdTranslationEndpointIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/IdentityZoneEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/IdentityZoneEndpointsIntegrationTests.java
@@ -34,6 +34,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +70,7 @@ class IdentityZoneEndpointsIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/LoginServerSecurityIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/LoginServerSecurityIntegrationTests.java
@@ -49,6 +49,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
@@ -105,7 +106,7 @@ class LoginServerSecurityIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OpenIdTokenAuthorizationWithApprovalIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/OpenIdTokenAuthorizationWithApprovalIntegrationTests.java
@@ -47,6 +47,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriUtils;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -100,7 +101,7 @@ class OpenIdTokenAuthorizationWithApprovalIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });
@@ -114,8 +115,8 @@ class OpenIdTokenAuthorizationWithApprovalIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
-                // pas through
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
+                // pass through
             }
         });
         user = createUser(new RandomValueStringGenerator().generate(), "openiduser", "openidlast", "test@openid,com", true).getBody();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/PasswordChangeEndpointIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/PasswordChangeEndpointIntegrationTests.java
@@ -39,6 +39,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.Map;
 
@@ -89,7 +90,7 @@ class PasswordChangeEndpointIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/PasswordGrantIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/PasswordGrantIntegrationTests.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
@@ -23,6 +24,7 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -140,7 +142,7 @@ class PasswordGrantIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) throws IOException {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) throws IOException {
                 //do nothing
             }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimGroupEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimGroupEndpointsIntegrationTests.java
@@ -120,7 +120,7 @@ class ScimGroupEndpointsIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimUserEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ScimUserEndpointsIntegrationTests.java
@@ -34,6 +34,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -84,7 +85,7 @@ class ScimUserEndpointsIntegrationTests {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/IdentityZoneNotAvailableIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/IdentityZoneNotAvailableIT.java
@@ -15,6 +15,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 
@@ -47,7 +48,7 @@ public class IdentityZoneNotAvailableIT {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/LoginIT.java
@@ -47,6 +47,7 @@ import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -285,7 +286,7 @@ class LoginIT {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // pass through
             }
         });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/util/IntegrationTestUtils.java
@@ -273,7 +273,7 @@ public class IntegrationTestUtils {
             }
 
             @Override
-            public void handleError(ClientHttpResponse response) {
+            public void handleError(URI url, HttpMethod method, ClientHttpResponse response) {
                 // ignore
             }
         });


### PR DESCRIPTION
In Spring 6.2.x handleError(ClientHttpResponse response) was deprecated and later removed in Spring 7.x in favor of handleError(URI url, HttpMethod method, ClientHttpResponse response)