### PR TITLE
Migrate deprecated RestTemplate.doExecute

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/OAuth2RestTemplate.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/OAuth2RestTemplate.java
@@ -129,12 +129,12 @@ public class OAuth2RestTemplate extends RestTemplate implements OAuth2RestOperat
     }
 
     @Override
-    protected <T> T doExecute(URI url, HttpMethod method, RequestCallback requestCallback,
+    protected <T> T doExecute(URI url, String uriTemplate, HttpMethod method, RequestCallback requestCallback,
             ResponseExtractor<T> responseExtractor) throws RestClientException {
         OAuth2AccessToken accessToken = context.getAccessToken();
         RuntimeException rethrow = null;
         try {
-            return super.doExecute(url, method, requestCallback, responseExtractor);
+            return super.doExecute(url, uriTemplate, method, requestCallback, responseExtractor);
         }
         catch (AccessTokenRequiredException | OAuth2AccessDeniedException e) {
             rethrow = e;
@@ -146,7 +146,7 @@ public class OAuth2RestTemplate extends RestTemplate implements OAuth2RestOperat
         if (accessToken != null && retryBadAccessTokens) {
             context.setAccessToken(null);
             try {
-                return super.doExecute(url, method, requestCallback, responseExtractor);
+                return super.doExecute(url, uriTemplate, method, requestCallback, responseExtractor);
             }
             catch (InvalidTokenException e) {
                 // Don't reveal the token value in case it is logged

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/OAuth2RestTemplateTests.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/OAuth2RestTemplateTests.java
@@ -165,7 +165,7 @@ class OAuth2RestTemplateTests {
             throw new AccessTokenRequiredException(resource);
         });
         assertThatExceptionOfType(AccessTokenRequiredException.class).isThrownBy(() ->
-                restTemplate.doExecute(new URI("https://foo"), HttpMethod.GET, new NullRequestCallback(),
+                restTemplate.doExecute(new URI("https://foo"), null, HttpMethod.GET, new NullRequestCallback(),
                         new SimpleResponseExtractor()));
     }
 
@@ -183,7 +183,7 @@ class OAuth2RestTemplateTests {
                 return request;
             }
         });
-        Boolean result = restTemplate.doExecute(new URI("https://foo"), HttpMethod.GET, new NullRequestCallback(),
+        Boolean result = restTemplate.doExecute(new URI("https://foo"), null, HttpMethod.GET, new NullRequestCallback(),
                 new SimpleResponseExtractor());
         assertThat(result).isTrue();
     }


### PR DESCRIPTION
This was deprecated in 6.0.x and later removed in 7.x in favor of the other doExecute that also accepts uriTemplate