### PR TITLE
Replace deprecated check() with authorize() in AuthorizationManager

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtils.java
@@ -14,6 +14,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authorization.AuthenticatedAuthorizationManager;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 
@@ -44,13 +45,20 @@ public class AuthorizationManagersUtils {
         private Set<String> missingScopes = new LinkedHashSet<>();
 
         @Override
+        @Deprecated
         public AuthorizationDecision check(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
+            AuthorizationResult result = authorize(authentication, object);
+            return (result instanceof AuthorizationDecision) ? (AuthorizationDecision) result : new AuthorizationDecision(result != null && result.isGranted());
+        }
+
+        @Override
+        public AuthorizationResult authorize(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
             for (var authorizationManager : this.delegateAuthorizationManagers) {
-                AuthorizationDecision decision = authorizationManager.check(authentication, object);
-                if (decision != null) {
-                    if (decision.isGranted()) {
-                        return decision;
-                    } else if (decision instanceof ScopeTrackingAuthorizationDecision scopeDecision) {
+                AuthorizationResult result = authorizationManager.authorize(authentication, object);
+                if (result != null) {
+                    if (result.isGranted()) {
+                        return result;
+                    } else if (result instanceof ScopeTrackingAuthorizationDecision scopeDecision) {
                         missingScopes.addAll(scopeDecision.getScopes());
                     }
                 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/SelfCheckAuthorizationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/SelfCheckAuthorizationManager.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.cloudfoundry.identity.uaa.security.IsSelfCheck;
 import org.springframework.security.authorization.AuthorizationDecision;
 import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 
@@ -68,7 +69,14 @@ public class SelfCheckAuthorizationManager  implements AuthorizationManager<Requ
     }
 
     @Override
+    @Deprecated
     public AuthorizationDecision check(Supplier<Authentication> authentication, RequestAuthorizationContext context) {
+        AuthorizationResult result = authorize(authentication, context);
+        return (result instanceof AuthorizationDecision) ? (AuthorizationDecision) result : new AuthorizationDecision(result != null && result.isGranted());
+    }
+
+    @Override
+    public AuthorizationResult authorize(Supplier<Authentication> authentication, RequestAuthorizationContext context) {
         HttpServletRequest request = context.getRequest();
         switch (type) {
             case USER -> {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtilsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/AuthorizationManagersUtilsTests.java
@@ -43,7 +43,7 @@ class AuthorizationManagersUtilsTests {
     void noAuthenticationManager() {
         AuthorizationManager<RequestAuthorizationContext> authManager = AuthorizationManagersUtils.anyOf();
 
-        var authorizationDecision = authManager.check(() -> FULLY_AUTHENTICATED, null);
+        var authorizationDecision = authManager.authorize(() -> FULLY_AUTHENTICATED, null);
 
         assertThat(authorizationDecision.isGranted()).isFalse();
     }
@@ -53,11 +53,11 @@ class AuthorizationManagersUtilsTests {
         var granted = granted();
         var notGranted = notGranted();
         var unknown = unknown();
-        assertThat(AuthorizationManagersUtils.anyOf().or(granted).check(() -> FULLY_AUTHENTICATED, null).isGranted()).isTrue();
+        assertThat(AuthorizationManagersUtils.anyOf().or(granted).authorize(() -> FULLY_AUTHENTICATED, null).isGranted()).isTrue();
         assertThat(granted.called).isTrue();
-        assertThat(AuthorizationManagersUtils.anyOf().or(notGranted).check(() -> FULLY_AUTHENTICATED, null).isGranted()).isFalse();
+        assertThat(AuthorizationManagersUtils.anyOf().or(notGranted).authorize(() -> FULLY_AUTHENTICATED, null).isGranted()).isFalse();
         assertThat(notGranted.called).isTrue();
-        assertThat(AuthorizationManagersUtils.anyOf().or(unknown).check(() -> FULLY_AUTHENTICATED, null).isGranted()).isFalse();
+        assertThat(AuthorizationManagersUtils.anyOf().or(unknown).authorize(() -> FULLY_AUTHENTICATED, null).isGranted()).isFalse();
         assertThat(unknown.called).isTrue();
     }
 
@@ -71,7 +71,7 @@ class AuthorizationManagersUtilsTests {
                 .or(granted)
                 .or(unknown);
 
-        assertThat(authorizationManager.check(() -> FULLY_AUTHENTICATED, null).isGranted()).isTrue();
+        assertThat(authorizationManager.authorize(() -> FULLY_AUTHENTICATED, null).isGranted()).isTrue();
         assertThat(notGranted.called).isTrue();
         assertThat(granted.called).isTrue();
         assertThat(unknown.called).isFalse();
@@ -82,10 +82,10 @@ class AuthorizationManagersUtilsTests {
         AuthorizationManager<RequestAuthorizationContext> authManager = AuthorizationManagersUtils.anyOf()
                 .anonymous();
 
-        assertThat(authManager.check(() -> ANONYMOUS, null).isGranted()).isTrue();
-        assertThat(authManager.check(() -> NOT_AUTHENTICATED, null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> FULLY_AUTHENTICATED, null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> REMEMBER_ME, null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> ANONYMOUS, null).isGranted()).isTrue();
+        assertThat(authManager.authorize(() -> NOT_AUTHENTICATED, null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> FULLY_AUTHENTICATED, null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> REMEMBER_ME, null).isGranted()).isFalse();
     }
 
     @Test
@@ -93,26 +93,26 @@ class AuthorizationManagersUtilsTests {
         AuthorizationManager<RequestAuthorizationContext> authManager = AuthorizationManagersUtils.anyOf()
                 .fullyAuthenticated();
 
-        assertThat(authManager.check(() -> ANONYMOUS, null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> NOT_AUTHENTICATED, null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> FULLY_AUTHENTICATED, null).isGranted()).isTrue();
-        assertThat(authManager.check(() -> REMEMBER_ME, null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> ANONYMOUS, null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> NOT_AUTHENTICATED, null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> FULLY_AUTHENTICATED, null).isGranted()).isTrue();
+        assertThat(authManager.authorize(() -> REMEMBER_ME, null).isGranted()).isFalse();
     }
 
     @Test
     void uaaAdmin() {
         AuthorizationManager<RequestAuthorizationContext> authManager = AuthorizationManagersUtils.anyOf().isUaaAdmin();
 
-        assertThat(authManager.check(() -> withScopes("foo.bar"), null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> withScopes("uaa.admin"), null).isGranted()).isTrue();
+        assertThat(authManager.authorize(() -> withScopes("foo.bar"), null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> withScopes("uaa.admin"), null).isGranted()).isTrue();
     }
 
     @Test
     void hasScope() {
         AuthorizationManager<RequestAuthorizationContext> authManager = AuthorizationManagersUtils.anyOf().hasScope("foo.bar");
 
-        assertThat(authManager.check(() -> withScopes("uaa.admin"), null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> withScopes("uaa.admin", "foo.bar"), null).isGranted()).isTrue();
+        assertThat(authManager.authorize(() -> withScopes("uaa.admin"), null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> withScopes("uaa.admin", "foo.bar"), null).isGranted()).isTrue();
     }
 
     @Test
@@ -120,7 +120,7 @@ class AuthorizationManagersUtilsTests {
         AuthorizationManager<RequestAuthorizationContext> authManager = AuthorizationManagersUtils.anyOf(true).hasScope("foo.bar");
 
         assertThatThrownBy(
-                () -> {authManager.check(() -> withScopes("uaa.admin"), null);}
+                () -> {authManager.authorize(() -> withScopes("uaa.admin"), null);}
         ).getCause().isInstanceOf(InsufficientScopeException.class);
 
     }
@@ -131,8 +131,8 @@ class AuthorizationManagersUtilsTests {
 
         IdentityZoneHolder.set(ModelTestUtils.identityZone("someZoneId", "some-domain"));
 
-        assertThat(authManager.check(() -> withScopes("foo.bar"), null).isGranted()).isFalse();
-        assertThat(authManager.check(() -> withScopes("zones.someZoneId.admin"), null).isGranted()).isTrue();
+        assertThat(authManager.authorize(() -> withScopes("foo.bar"), null).isGranted()).isFalse();
+        assertThat(authManager.authorize(() -> withScopes("zones.someZoneId.admin"), null).isGranted()).isTrue();
     }
 
     static class TestAuthManager implements AuthorizationManager<RequestAuthorizationContext> {
@@ -161,7 +161,13 @@ class AuthorizationManagersUtilsTests {
         }
 
         @Override
+        @Deprecated
         public AuthorizationDecision check(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
+            return authorize(authentication, object);
+        }
+
+        @Override
+        public AuthorizationDecision authorize(Supplier<Authentication> authentication, RequestAuthorizationContext object) {
             called = true;
             return authorizationDecision;
         }


### PR DESCRIPTION
`AuthorizationManager.check()` was deprecated in Spring Security 6.5.x in favor of `authorize()` and later got removed in Spring Security 7.x.