### PR TITLE
Consolidate JWT keys usage stored in Clients for client authentication

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/client/UaaClientDetails.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/client/UaaClientDetails.java
@@ -99,6 +99,9 @@ public class UaaClientDetails implements ClientDetails {
         this.setScope(prototype.getScope());
         this.setResourceIds(prototype.getResourceIds());
         this.setAdditionalInformation(prototype.getAdditionalInformation());
+        if (prototype instanceof UaaClientDetails uaa) {
+            this.setClientJwtConfig(uaa.getClientJwtConfig());
+        }
     }
 
     public UaaClientDetails(String clientId, String resourceIds,

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpoints.java
@@ -22,6 +22,7 @@ import org.cloudfoundry.identity.uaa.oauth.client.ClientConstants;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientDetailsCreation;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientDetailsModification;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientJwtChangeRequest;
+import org.cloudfoundry.identity.uaa.oauth.client.ClientJwtCredential;
 import org.cloudfoundry.identity.uaa.oauth.client.SecretChangeRequest;
 import org.cloudfoundry.identity.uaa.provider.ClientAlreadyExistsException;
 import org.cloudfoundry.identity.uaa.provider.NoSuchClientException;
@@ -32,6 +33,7 @@ import org.cloudfoundry.identity.uaa.resources.ResourceMonitor;
 import org.cloudfoundry.identity.uaa.resources.SearchResults;
 import org.cloudfoundry.identity.uaa.resources.SearchResultsFactory;
 import org.cloudfoundry.identity.uaa.resources.SimpleAttributeNameMapper;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.security.beans.SecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.util.UaaPagingUtils;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
@@ -84,6 +86,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -740,9 +743,60 @@ public class ClientAdminEndpoints implements ApplicationEventPublisherAware {
         if (Boolean.FALSE.equals(additionalInformation.get(ClientConstants.ALLOW_PUBLIC))) {
             additionalInformation.remove(ClientConstants.ALLOW_PUBLIC);
         }
+
+        if (existing instanceof UaaClientDetails existingUaa && input instanceof UaaClientDetails inputUaa && details instanceof UaaClientDetails detailsUaa) {
+            UaaClient existingAsClient = new UaaClient(
+                    existingUaa.getClientId(),
+                    existingUaa.getClientSecret(),
+                    existingUaa.getAuthorities(),
+                    new HashMap<>(Optional.ofNullable(existingUaa.getAdditionalInformation()).orElseGet(Collections::emptyMap)),
+                    existingUaa.getClientJwtConfig()
+            );
+            UaaClient inputAsClient = new UaaClient(
+                    inputUaa.getClientId(),
+                    inputUaa.getClientSecret(),
+                    inputUaa.getAuthorities(),
+                    new HashMap<>(Optional.ofNullable(inputUaa.getAdditionalInformation()).orElseGet(Collections::emptyMap)),
+                    inputUaa.getClientJwtConfig()
+            );
+            ClientJwtConfiguration existingJwt = existingAsClient.getClientJwtConfiguration();
+            ClientJwtConfiguration inputJwt = inputAsClient.getClientJwtConfiguration();
+            inputJwt = ensureJwtCredsFromAdditionalInfoMap(additionalInformation, inputJwt);
+            ClientJwtConfiguration mergedJwtConfig = ClientJwtConfiguration.merge(existingJwt, inputJwt, false);
+            if (mergedJwtConfig != null && mergedJwtConfig.hasConfiguration()) {
+                mergedJwtConfig.writeValue(detailsUaa);
+            }
+        }
+
+        additionalInformation.remove(ClientJwtConfiguration.JWT_CREDS);
+        additionalInformation.remove("client_jwt_config");
         details.setAdditionalInformation(additionalInformation);
 
         return details;
+    }
+
+    private ClientJwtConfiguration ensureJwtCredsFromAdditionalInfoMap(Map<String, Object> addl, ClientJwtConfiguration inputJwt) {
+        if (addl == null) {
+            return inputJwt;
+        }
+        Object v = addl.get(ClientJwtConfiguration.JWT_CREDS);
+        if (v == null) {
+            return inputJwt;
+        }
+        try {
+            ClientJwtConfiguration extra = new ClientJwtConfiguration();
+            if (v instanceof String s) {
+                extra.addJwtCredentials(ClientJwtCredential.parse(s));
+            } else if (v instanceof List<?> list) {
+                extra.addJwtCredentials(ClientJwtCredential.parse(JsonUtils.writeValueAsString(list)));
+            } else {
+                return inputJwt;
+            }
+            return ClientJwtConfiguration.merge(inputJwt, extra, false);
+        } catch (Exception e) {
+            logger.warn("Failed to read jwt_creds from client update request", e);
+            return inputJwt;
+        }
     }
 
     public void publish(ApplicationEvent event) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsValidator.java
@@ -269,10 +269,14 @@ public class ClientAdminEndpointsValidator implements InitializingBean, ClientDe
             // Fold jwt_creds and client_jwt_config from additional information into the persisted client_jwt_config string
             Object jwtCredsValue = client.getAdditionalInformation().get(ClientJwtConfiguration.JWT_CREDS);
             if (jwtCredsValue instanceof String jwtCredential) {
-                ClientJwtConfiguration newKeyConfig = Optional.ofNullable(ClientJwtConfiguration.readValue(client))
-                        .orElseGet(ClientJwtConfiguration::new);
-                newKeyConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredential));
-                newKeyConfig.writeValue(client);
+                try {
+                    ClientJwtConfiguration newKeyConfig = Optional.ofNullable(ClientJwtConfiguration.readValue(client))
+                            .orElseGet(ClientJwtConfiguration::new);
+                    newKeyConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredential));
+                    newKeyConfig.writeValue(client);
+                } catch (Exception e) {
+                    throw new InvalidClientDetailsException("Invalid jwt_creds format in additionalInformation", e);
+                }
             } else if (jwtCredsValue instanceof List<?> jwtCredsList) {
                 try {
                     String jwtCredsJson = JsonUtils.writeValueAsString(jwtCredsList);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsValidator.java
@@ -15,6 +15,8 @@ package org.cloudfoundry.identity.uaa.client;
 
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientDetailsCreation;
+import org.cloudfoundry.identity.uaa.oauth.client.ClientJwtCredential;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.resources.QueryableResourceManager;
 import org.cloudfoundry.identity.uaa.security.beans.SecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
@@ -32,6 +34,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.GRANT_TYPE_AUTHORIZATION_CODE;
@@ -259,10 +265,53 @@ public class ClientAdminEndpointsValidator implements InitializingBean, ClientDe
                     }
                 }
             }
+            
+            // Fold jwt_creds and client_jwt_config from additional information into the persisted client_jwt_config string
+            Object jwtCredsValue = client.getAdditionalInformation().get(ClientJwtConfiguration.JWT_CREDS);
+            if (jwtCredsValue instanceof String jwtCredential) {
+                ClientJwtConfiguration newKeyConfig = Optional.ofNullable(ClientJwtConfiguration.readValue(client))
+                        .orElseGet(ClientJwtConfiguration::new);
+                newKeyConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredential));
+                newKeyConfig.writeValue(client);
+            } else if (jwtCredsValue instanceof List<?> jwtCredsList) {
+                try {
+                    String jwtCredsJson = JsonUtils.writeValueAsString(jwtCredsList);
+                    ClientJwtConfiguration newKeyConfig = Optional.ofNullable(ClientJwtConfiguration.readValue(client))
+                            .orElseGet(ClientJwtConfiguration::new);
+                    newKeyConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredsJson));
+                    newKeyConfig.writeValue(client);
+                } catch (Exception e) {
+                    throw new InvalidClientDetailsException("Invalid jwt_creds format in additionalInformation", e);
+                }
+            }
+
+            Object cjc = client.getAdditionalInformation().get("client_jwt_config");
+            if (cjc != null) {
+                try {
+                    ClientJwtConfiguration fromNested;
+                    if (cjc instanceof String s) {
+                        fromNested = ClientJwtConfiguration.readValue(s);
+                    } else {
+                        fromNested = JsonUtils.readValue(JsonUtils.writeValueAsString(cjc), ClientJwtConfiguration.class);
+                    }
+                    if (fromNested != null) {
+                        ClientJwtConfiguration current = Optional.ofNullable(ClientJwtConfiguration.readValue(client))
+                                .orElseGet(ClientJwtConfiguration::new);
+                        current = ClientJwtConfiguration.merge(current, fromNested, false);
+                        current.writeValue(client);
+                    }
+                } catch (Exception e) {
+                    throw new InvalidClientDetailsException("Invalid client_jwt_config in additionalInformation", e);
+                }
+            }
+
+            LinkedHashMap<String, Object> withoutDuplicateJwt = new LinkedHashMap<>(client.getAdditionalInformation());
+            withoutDuplicateJwt.remove(ClientJwtConfiguration.JWT_CREDS);
+            withoutDuplicateJwt.remove("client_jwt_config");
+            client.setAdditionalInformation(withoutDuplicateJwt);
         }
 
         return client;
-
     }
 
     public void validateClientRedirectUri(ClientDetails client) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
@@ -348,6 +348,9 @@ public class ClientJwtConfiguration implements Cloneable {
                 result.addJwtCredentials(newConfig.clientJwtCredentials);
             }
         }
+        if (result == null) {
+            return existingConfig;
+        }
         return result;
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/UaaClient.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/UaaClient.java
@@ -1,6 +1,8 @@
 package org.cloudfoundry.identity.uaa.client;
 
 import org.cloudfoundry.identity.uaa.oauth.client.ClientConstants;
+import org.cloudfoundry.identity.uaa.oauth.client.ClientJwtCredential;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.core.userdetails.User;
@@ -9,6 +11,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.io.Serial;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -51,7 +54,52 @@ public class UaaClient extends User {
     }
 
     public ClientJwtConfiguration getClientJwtConfiguration() {
-        return Optional.ofNullable(clientJwtConfig).map(ClientJwtConfiguration::readValue).orElse(new ClientJwtConfiguration());
+        // Start with configuration from clientJwtConfig field
+        ClientJwtConfiguration result = Optional.ofNullable(clientJwtConfig)
+                .map(ClientJwtConfiguration::readValue)
+                .orElse(new ClientJwtConfiguration());
+        
+        // For backward compatibility, also check for JWT credentials in additionalInformation
+        if (additionalInformation != null) {
+            // Check for top-level jwt_creds in additionalInformation
+            Object jwtCredsValue = additionalInformation.get(ClientJwtConfiguration.JWT_CREDS);
+            if (jwtCredsValue != null) {
+                try {
+                    ClientJwtConfiguration additionalConfig = new ClientJwtConfiguration();
+                    if (jwtCredsValue instanceof String jwtCredential) {
+                        additionalConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredential));
+                    } else if (jwtCredsValue instanceof List<?> jwtCredsList) {
+                        String jwtCredsJson = JsonUtils.writeValueAsString(jwtCredsList);
+                        additionalConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredsJson));
+                    }
+                    result = ClientJwtConfiguration.merge(result, additionalConfig, false);
+                } catch (Exception e) {
+                    // Log but don't fail - graceful degradation for backward compatibility
+                }
+            }
+            
+            // Check for nested client_jwt_config.jwt_creds in additionalInformation
+            Object clientJwtCredsValue = additionalInformation.get("client_jwt_config");
+            if (clientJwtCredsValue instanceof Map clientJwtCredsMap) {
+                Object nestedJwtCreds = clientJwtCredsMap.get(ClientJwtConfiguration.JWT_CREDS);
+                if (nestedJwtCreds != null) {
+                    try {
+                        ClientJwtConfiguration nestedConfig = new ClientJwtConfiguration();
+                        if (nestedJwtCreds instanceof String jwtCredential) {
+                            nestedConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredential));
+                        } else if (nestedJwtCreds instanceof List<?> jwtCredsList) {
+                            String jwtCredsJson = JsonUtils.writeValueAsString(jwtCredsList);
+                            nestedConfig.addJwtCredentials(ClientJwtCredential.parse(jwtCredsJson));
+                        }
+                        result = ClientJwtConfiguration.merge(result, nestedConfig, false);
+                    } catch (Exception e) {
+                        // Log but don't fail - graceful degradation for backward compatibility
+                    }
+                }
+            }
+        }
+        
+        return result != null ? result : new ClientJwtConfiguration();
     }
 
     /**

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientDetailsModification.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/client/ClientDetailsModification.java
@@ -7,12 +7,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import org.cloudfoundry.identity.uaa.client.ClientJwtConfiguration;
+import org.cloudfoundry.identity.uaa.client.UaaClient;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey;
 import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKeySet;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -44,16 +47,27 @@ public class ClientDetailsModification extends UaaClientDetails {
     public ClientDetailsModification(ClientDetails prototype) {
         super(prototype);
         if (prototype instanceof UaaClientDetails baseClientDetails) {
-            this.setAdditionalInformation(baseClientDetails.getAdditionalInformation());
+            this.setAdditionalInformation(new LinkedHashMap<>(baseClientDetails.getAdditionalInformation()));
             if (baseClientDetails.getAutoApproveScopes() != null) {
                 this.setAutoApproveScopes(baseClientDetails.getAutoApproveScopes());
             }
-            if (baseClientDetails.getClientJwtConfig() instanceof String ) {
-                ClientJwtConfiguration clientJwtConfiguration = ClientJwtConfiguration.readValue(baseClientDetails);
-                this.setJwksUri(clientJwtConfiguration.getJwksUri());
-                this.setJwkSet(clientJwtConfiguration.getJwkSet());
-                this.setClientJwtCredentials(clientJwtConfiguration.getClientJwtCredentials());
+            UaaClient asUaaClient = new UaaClient(
+                    baseClientDetails.getClientId(),
+                    baseClientDetails.getClientSecret(),
+                    baseClientDetails.getAuthorities(),
+                    new LinkedHashMap<>(this.getAdditionalInformation()),
+                    baseClientDetails.getClientJwtConfig()
+            );
+            ClientJwtConfiguration configuration = asUaaClient.getClientJwtConfiguration();
+            if (configuration != null && configuration.hasConfiguration()) {
+                this.setJwksUri(configuration.getJwksUri());
+                this.setJwkSet(configuration.getJwkSet());
+                this.setClientJwtCredentials(configuration.getClientJwtCredentials());
             }
+            Map<String, Object> forResponse = new LinkedHashMap<>(getAdditionalInformation());
+            forResponse.remove(ClientJwtConfiguration.JWT_CREDS);
+            forResponse.remove("client_jwt_config");
+            this.setAdditionalInformation(forResponse);
         }
         if (prototype instanceof ClientDetailsModification modification) {
             this.action = modification.getAction();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsService.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsService.java
@@ -63,12 +63,15 @@ public class MultitenantJdbcClientDetailsService extends MultitenantClientServic
     private static final String GET_CREATED_BY_SQL =
             "select created_by from oauth_client_details where client_id=? and identity_zone_id=?";
 
-    private static final String CLIENT_FIELDS_FOR_UPDATE =
+    /** DB columns for client row after {@code client_jwt_config} (insert/update share this tail). */
+    private static final String CLIENT_DATA_FIELDS =
             "resource_ids, scope, " +
                     "authorized_grant_types, web_server_redirect_uri, authorities, access_token_validity, " +
                     "refresh_token_validity, additional_information, autoapprove, lastmodified, required_user_groups";
 
-    private static final String CLIENT_FIELDS = "client_secret, client_jwt_config, " + CLIENT_FIELDS_FOR_UPDATE;
+    private static final String CLIENT_FIELDS_FOR_UPDATE = "client_jwt_config, " + CLIENT_DATA_FIELDS;
+
+    private static final String CLIENT_FIELDS = "client_secret, client_jwt_config, " + CLIENT_DATA_FIELDS;
 
     private static final String BASE_FIND_STATEMENT =
             "select client_id, " + CLIENT_FIELDS + " from oauth_client_details";
@@ -186,9 +189,9 @@ public class MultitenantJdbcClientDetailsService extends MultitenantClientServic
     }
 
     private Object[] getInsertClientDetailsFields(ClientDetails clientDetails, String zoneId) {
-        Object[] fieldsForUpdate = getFieldsForUpdate(clientDetails, zoneId);
-        Object[] clientDetailFieldsForUpdate = new Object[fieldsForUpdate.length + 3];
-        System.arraycopy(fieldsForUpdate, 0, clientDetailFieldsForUpdate, 2, fieldsForUpdate.length);
+        Object[] fieldValues = getClientRowFieldValues(clientDetails, zoneId);
+        Object[] clientDetailFieldsForUpdate = new Object[fieldValues.length + 3];
+        System.arraycopy(fieldValues, 0, clientDetailFieldsForUpdate, 2, fieldValues.length);
         clientDetailFieldsForUpdate[0] =
                 clientDetails.getClientSecret() != null ?
                         passwordEncoder.encode(clientDetails.getClientSecret()) :
@@ -199,6 +202,16 @@ public class MultitenantJdbcClientDetailsService extends MultitenantClientServic
     }
 
     private Object[] getFieldsForUpdate(ClientDetails clientDetails, String zoneId) {
+        String clientJwt = clientDetails instanceof UaaClientDetails ucd ? ucd.getClientJwtConfig() : null;
+        Object[] withoutJwt = getClientRowFieldValues(clientDetails, zoneId);
+        Object[] withClientJwt = new Object[withoutJwt.length + 1];
+        withClientJwt[0] = clientJwt;
+        System.arraycopy(withoutJwt, 0, withClientJwt, 1, withoutJwt.length);
+        return withClientJwt;
+    }
+
+    /** resource_ids through required_user_groups plus client_id, zone_id (update prepends client_jwt_config). */
+    private Object[] getClientRowFieldValues(ClientDetails clientDetails, String zoneId) {
 
         Map<String, Object> additionalInformation = new HashMap<>(clientDetails.getAdditionalInformation());
         Collection<String> requiredGroups = (Collection<String>) additionalInformation.remove(REQUIRED_USER_GROUPS);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminEndpointsValidatorTests.java
@@ -17,6 +17,7 @@ package org.cloudfoundry.identity.uaa.client;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.cloudfoundry.identity.uaa.resources.QueryableResourceManager;
 import org.cloudfoundry.identity.uaa.security.beans.SecurityContextAccessor;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.zone.ClientSecretPolicy;
 import org.cloudfoundry.identity.uaa.zone.ClientSecretValidator;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
@@ -31,8 +32,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
@@ -278,5 +281,40 @@ class ClientAdminEndpointsValidatorTests {
         }
 
         return httpsUrls;
+    }
+
+    @Test
+    void validate_create_foldsTopLevelJwtCredsListIntoClientJwtConfigAndStripsAdditional() {
+        client.setScope(Collections.singletonList(caller.getClientId() + ".read"));
+        client.addAdditionalInformation(ClientJwtConfiguration.JWT_CREDS,
+                JsonUtils.readValue("[{\"iss\":\"http://localhost/uaa/oauth/token\",\"sub\":\"subj\",\"aud\":\"aud\"}]", List.class));
+
+        UaaClientDetails result = (UaaClientDetails) validator.validate(client, true, true);
+
+        assertThat(result.getClientJwtConfig()).isNotBlank();
+        assertThat(ClientJwtConfiguration.readValue(result).getClientJwtCredentials()).hasSize(1);
+        assertThat(result.getAdditionalInformation()).doesNotContainKey(ClientJwtConfiguration.JWT_CREDS);
+    }
+
+    @Test
+    void validate_create_foldsNestedClientJwtConfigMapAndStripsFromAdditional() {
+        client.setScope(Collections.singletonList(caller.getClientId() + ".read"));
+        Map<String, Object> nested = new java.util.HashMap<>();
+        nested.put(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue("[{\"iss\":\"http://issuer\",\"sub\":\"subj\"}]", List.class));
+        client.addAdditionalInformation("client_jwt_config", nested);
+
+        UaaClientDetails result = (UaaClientDetails) validator.validate(client, true, true);
+
+        assertThat(result.getClientJwtConfig()).isNotBlank();
+        assertThat(result.getAdditionalInformation()).doesNotContainKey("client_jwt_config");
+    }
+
+    @Test
+    void validate_create_invalidJwtCredsList_throws() {
+        client.setScope(Collections.singletonList(caller.getClientId() + ".read"));
+        client.addAdditionalInformation(ClientJwtConfiguration.JWT_CREDS, List.of(Map.of("not", "valid")));
+
+        assertThatThrownBy(() -> validator.validate(client, true, true))
+                .isInstanceOf(InvalidClientDetailsException.class);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/UaaClientTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/UaaClientTest.java
@@ -1,0 +1,59 @@
+package org.cloudfoundry.identity.uaa.client;
+
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UaaClientTest {
+
+    @Test
+    void getClientJwtConfiguration_includesTopLevelJwtCredsFromAdditionalInformation() {
+        Map<String, Object> addl = new HashMap<>();
+        addl.put(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue(
+                "[{\"iss\":\"http://localhost/uaa/oauth/token\",\"sub\":\"c1\",\"aud\":\"c1\"}]", List.class));
+        UaaClient c = new UaaClient("cid", "sec", List.of(new SimpleGrantedAuthority("uaa.none")), addl, null);
+        ClientJwtConfiguration j = c.getClientJwtConfiguration();
+        assertThat(j.getClientJwtCredentials()).isNotNull().hasSize(1);
+        assertThat(j.getClientJwtCredentials().get(0).getIssuer()).isEqualTo("http://localhost/uaa/oauth/token");
+    }
+
+    @Test
+    void getClientJwtConfiguration_mergesClientJwtConfigStringWithAdditionalJwtCreds() {
+        String cfg = "{\"jwt_creds\":[{\"iss\":\"http://a\",\"sub\":\"b\"}]}";
+        Map<String, Object> addl = new HashMap<>();
+        addl.put(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue(
+                "[{\"iss\":\"http://c\",\"sub\":\"d\"}]", List.class));
+        UaaClient c = new UaaClient("cid", "sec", List.of(new SimpleGrantedAuthority("uaa.none")), addl, cfg);
+        ClientJwtConfiguration j = c.getClientJwtConfiguration();
+        assertThat(j.getClientJwtCredentials()).hasSize(2);
+    }
+
+    @Test
+    void getClientJwtConfiguration_includesNestedClientJwtConfigInAdditional() {
+        Map<String, Object> inner = new HashMap<>();
+        inner.put(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue("[{\"iss\":\"http://n\",\"sub\":\"n\"}]", List.class));
+        Map<String, Object> addl = new HashMap<>();
+        addl.put("client_jwt_config", inner);
+        UaaClient c = new UaaClient("cid", "sec", List.of(new SimpleGrantedAuthority("uaa.none")), addl, null);
+        assertThat(c.getClientJwtConfiguration().getClientJwtCredentials()).hasSize(1);
+    }
+
+    @Test
+    void mergeMatchesSyncWithExisting_twoDistinctCredentials() {
+        String iss = "http://localhost:8080/uaa/oauth/token";
+        UaaClient existing = new UaaClient("id", "s", List.of(new SimpleGrantedAuthority("uaa.none")),
+                new HashMap<>(), "{\"jwt_creds\":[{\"iss\":\"" + iss + "\",\"sub\":\"first\"}]}");
+        UaaClient input = new UaaClient("id", "s", List.of(new SimpleGrantedAuthority("uaa.none")),
+                new HashMap<>(Map.of(ClientJwtConfiguration.JWT_CREDS, "[{\"iss\":\"" + iss + "\",\"sub\":\"second\"}]")),
+                null);
+        ClientJwtConfiguration merged = ClientJwtConfiguration.merge(
+                existing.getClientJwtConfiguration(), input.getClientJwtConfiguration(), false);
+        assertThat(merged.getClientJwtCredentials()).hasSize(2);
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/ClientDetailsModificationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/ClientDetailsModificationTest.java
@@ -1,0 +1,31 @@
+package org.cloudfoundry.identity.uaa.oauth.client;
+
+import org.cloudfoundry.identity.uaa.client.ClientJwtConfiguration;
+import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ClientDetailsModificationTest {
+
+    @Test
+    void constructor_exposesMergedJwtCredsAndOmitsRawAdditionalKeys() {
+        UaaClientDetails d = new UaaClientDetails();
+        d.setClientId("x");
+        d.setClientSecret("s");
+        d.setAuthorizedGrantTypes(List.of("client_credentials"));
+        d.setAuthorities(List.of(new SimpleGrantedAuthority("uaa.none")));
+        d.addAdditionalInformation(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue(
+                "[{\"iss\":\"http://u\",\"sub\":\"s\"}]", List.class));
+
+        ClientDetailsModification m = new ClientDetailsModification(d);
+        assertThat(m.getClientJwtCredentials()).isNotNull().hasSize(1);
+        assertThat(m.getAdditionalInformation()).doesNotContainKey(ClientJwtConfiguration.JWT_CREDS);
+        assertThat(m.getAdditionalInformation()).doesNotContainKey("client_jwt_config");
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/ClientDetailsModificationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/client/ClientDetailsModificationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtClientAuthenticationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwt/JwtClientAuthenticationTest.java
@@ -554,6 +554,56 @@ class JwtClientAuthenticationTest {
         ).isFalse();
     }
 
+    /**
+     * When a client is configured with multiple {@code jwt_creds} (e.g. merged trust from column + legacy
+     * additional information), a {@code private_key_jwt} assertion is accepted if it successfully verifies
+     * and its iss/sub/aud <strong>match</strong> <em>one</em> of those entries (RFC 7523 federated path, not
+     * OIDC client_id=iss=sub). UAA then resolves signing keys for that entry’s issuer and performs signature
+     * verification. This is the predictable behavior for “two configurations”: evaluate each known trust
+     * until one matches, then validate.
+     */
+    @Test
+    void privateKeyJwt_federatedAcceptsAssertionForEachOfMultipleConfiguredJwtCreds() throws Exception {
+        jwtClientAuthentication = new JwtClientAuthentication(keyInfoService, oidcMetadataFetcher, externalOAuthAuthenticationManager);
+        mockKeyInfoService(KEY_ID, JwtHelperX5tTest.CERTIFICATE_1, JwtHelperX5tTest.SIGNING_KEY_1);
+        ClientJwtCredential c1 = new ClientJwtCredential("assertion-one", issuer, "aud-one");
+        ClientJwtCredential c2 = new ClientJwtCredential("assertion-two", issuer, "aud-two");
+        ClientJwtConfiguration withBothCreds = new ClientJwtConfiguration(List.of(c1, c2));
+        when(externalOAuthAuthenticationManager.idTokenWasIssuedByTheUaa(issuer)).thenReturn(true);
+        mockOIDCDefinition(c1);
+        String assertion1 = jwtClientAuthentication.getClientAssertion(config);
+        assertThat(jwtClientAuthentication.validateClientJwt(
+                getMockedRequestParameter(null, assertion1), withBothCreds, "own_client_id_1")
+        ).isTrue();
+        mockOIDCDefinition(c2);
+        String assertion2 = jwtClientAuthentication.getClientAssertion(config);
+        assertThat(jwtClientAuthentication.validateClientJwt(
+                getMockedRequestParameter(null, assertion2), withBothCreds, "own_client_id_2")
+        ).isTrue();
+    }
+
+    /**
+     * A presentation that does not match <em>any</em> configured trust entry must fail, even if other
+     * entries are configured, so a wrong (unregistered) key / subject is never accepted in place of a
+     * registered one.
+     */
+    @Test
+    void privateKeyJwt_federatedRejectsWhenAssertionSubjectDoesNotMatchAnyJwtCred() throws Exception {
+        jwtClientAuthentication = new JwtClientAuthentication(keyInfoService, oidcMetadataFetcher, externalOAuthAuthenticationManager);
+        mockKeyInfoService(KEY_ID, JwtHelperX5tTest.CERTIFICATE_1, JwtHelperX5tTest.SIGNING_KEY_1);
+        ClientJwtCredential c1 = new ClientJwtCredential("allowed-one", issuer, "a");
+        ClientJwtCredential c2 = new ClientJwtCredential("allowed-two", issuer, "b");
+        ClientJwtConfiguration withBothCreds = new ClientJwtConfiguration(List.of(c1, c2));
+        when(externalOAuthAuthenticationManager.idTokenWasIssuedByTheUaa(issuer)).thenReturn(true);
+        ClientJwtCredential notListed = new ClientJwtCredential("not-listed", issuer, "a");
+        mockOIDCDefinition(notListed);
+        String untrusted = jwtClientAuthentication.getClientAssertion(config);
+        assertThatThrownBy(() -> jwtClientAuthentication.validateClientJwt(
+                getMockedRequestParameter(null, untrusted), withBothCreds, "x"))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessage("Wrong client_assertion");
+    }
+
     private void mockKeyInfoService(String keyId, String x509Certificate) throws JOSEException {
         mockKeyInfoService(keyId, x509Certificate, null);
     }

--- a/uaa/slateCustomizations/source/index.html.md.erb
+++ b/uaa/slateCustomizations/source/index.html.md.erb
@@ -2461,6 +2461,8 @@ _Response Fields_
 
 # Clients
 
+A client can carry JWT trust for `private_key_jwt` (client assertion) in several shapes. The **preferred** approach is a single top-level `client_jwt_config` string (one JSON value in the `client_jwt_config` column) that can contain `jwks`, `jwks_uri`, and/or an embedded `jwt_creds` array, as needed. For **backward compatibility**, a separate top-level `jwt_creds` field is still accepted and is **merged** with `client_jwt_config` to form the effective `ClientJwtConfiguration` the UAA uses for `private_key_jwt` and for the admin **GET** response. **At authentication time** (`private_key_jwt`), a client assertion is accepted if it **matches and verifies** against the merged trust (e.g. federated claims match a configured credential, or OIDC-style keys verify against the configured JWKS). A nested `client_jwt_config` object under extra keys may also be merged; **still prefer** one `client_jwt_config` string at the top level for clarity. The **decomposed** top-level `jwks` / `jwks_uri` / `jwt_creds` fields in **responses** (retrieve/list) are a convenience view derived from the stored `client_jwt_config` JSON.
+
 ## Create
 
 <%= render('ClientAdminEndpointDocs/createClient/curl-request.md') %>

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointDocs.java
@@ -69,6 +69,14 @@ class ClientAdminEndpointDocs extends AdminClientCreator {
             fieldWithPath(ClientConstants.CREATED_WITH).optional(null).type(STRING).description("What scope the bearer token had when client was created"),
             fieldWithPath(ClientConstants.APPROVALS_DELETED).optional(null).type(BOOLEAN).description("Were the approvals deleted for the client, and an audit event sent"),
             fieldWithPath(ClientConstants.REQUIRED_USER_GROUPS).optional(null).type(ARRAY).description("A list of group names. If a user doesn't belong to all the required groups, the user will not be authenticated and no tokens will be issued to this client for that user. If this field is not set, authentication and token issuance will proceed normally."),
+            fieldWithPath("client_jwt_config").optional(null).type(STRING)
+                    .description("**Preferred (top-level).** JSON string of the client's JWT trust for `private_key_jwt` client authentication, using the `ClientJwtConfiguration` shape: optional `jwks` (JWK set), `jwks_uri` (per OpenID `jwks_uri` semantics), and/or `jwt_creds` (array of `iss`/`sub`/`aud` objects for federated RFC 7523). Stored in the `client_jwt_config` column, merged on create/update, and re-read for token validation. For new work, set trust only here, not in duplicate legacy fields."),
+            fieldWithPath("jwt_creds").optional(null).type(ARRAY)
+                    .description("**Not preferred (legacy, backward compatibility).** A `jwt_creds` array in the same JSON object as the other top-level client fields. It is merged with `client_jwt_config` to form the effective `ClientJwtConfiguration` for the client, then normalized for responses. For new work, **prefer** placing `jwt_creds` (if required) only inside the `client_jwt_config` JSON string, with `client_jwt_config` as the only top-level field that carries JWT policy."),
+            fieldWithPath("jwks_uri").optional(null).type(STRING)
+                    .description("**Primarily returned** on get/list/retrieve when the response is a `ClientDetailsModification` with JWT trust: the trust can be decomposed to a top-level `jwks_uri` (OIDC) for readability. It is derived from the stored `client_jwt_config`. For **new write operations**, do not rely on sending a standalone `jwks_uri`; **prefer** the full `client_jwt_config` string or the client-JWT change endpoint, so the column is the source of truth."),
+            fieldWithPath("jwks").optional(null).type(OBJECT)
+                    .description("**Primarily returned** on get/list/retrieve as a decomposed inline JWK set when trust is present. It is derived from `client_jwt_config`. For **new configuration input**, **prefer** `client_jwt_config` over sending raw `jwks` alongside other client data."),
     };
 
     private static final FieldDescriptor[] secretChangeFields = new FieldDescriptor[]{

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientJwtCredentialsEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientJwtCredentialsEndpointMockMvcTests.java
@@ -1,0 +1,172 @@
+package org.cloudfoundry.identity.uaa.mock.clients;
+
+import org.cloudfoundry.identity.uaa.DefaultTestContext;
+import org.cloudfoundry.identity.uaa.client.ClientJwtConfiguration;
+import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
+import org.cloudfoundry.identity.uaa.oauth.client.ClientDetailsModification;
+import org.cloudfoundry.identity.uaa.test.TestClient;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * MockMvc tests for jwt_creds and client_jwt_config handling on create/update/get.
+ */
+@DefaultTestContext
+class ClientJwtCredentialsEndpointMockMvcTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestClient testClient;
+
+    private String adminToken;
+
+    private static final String ISSUER = "http://localhost:8080/uaa/oauth/token";
+
+    @BeforeEach
+    void setUp() throws Exception {
+        adminToken = testClient.getClientCredentialsOAuthAccessToken("admin", "adminsecret", "clients.admin");
+    }
+
+    @Test
+    void createWithTopLevelJwtCreds_getReturnsCredsAndStripsAdditionalKeys() throws Exception {
+        String clientId = "jwt-top-" + UUID.randomUUID().toString().substring(0, 8);
+        String credsJson = "[{\"iss\":\"" + ISSUER + "\",\"sub\":\"" + clientId + "\",\"aud\":\"" + clientId + "\"}]";
+
+        UaaClientDetails client = new UaaClientDetails();
+        client.setClientId(clientId);
+        client.setClientSecret("secret");
+        client.setAuthorizedGrantTypes(List.of("client_credentials"));
+        client.setAuthorities(Collections.singletonList(new org.springframework.security.core.authority.SimpleGrantedAuthority("uaa.none")));
+        client.addAdditionalInformation(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue(credsJson, List.class));
+
+        mockMvc.perform(post("/oauth/clients")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(JsonUtils.writeValueAsString(client)))
+                .andExpect(status().isCreated());
+
+        ClientDetailsModification retrieved = getClient(clientId);
+        assertThat(retrieved.getClientJwtCredentials()).isNotNull().isNotEmpty();
+        assertThat(retrieved.getAdditionalInformation()).doesNotContainKey(ClientJwtConfiguration.JWT_CREDS);
+        assertThat(retrieved.getAdditionalInformation()).doesNotContainKey("client_jwt_config");
+    }
+
+    @Test
+    void createWithNestedClientJwtConfig_getReturnsCredsAndStripsAdditionalKeys() throws Exception {
+        String clientId = "jwt-nested-" + UUID.randomUUID().toString().substring(0, 8);
+        String credsJson = "[{\"iss\":\"" + ISSUER + "\",\"sub\":\"" + clientId + "\"}]";
+        // client_jwt_config is a String field; a JSON object would not deserialize to String
+        String clientJwtString = "{\"jwt_creds\":" + credsJson + "}";
+
+        UaaClientDetails client = new UaaClientDetails();
+        client.setClientId(clientId);
+        client.setClientSecret("secret");
+        client.setAuthorizedGrantTypes(List.of("client_credentials"));
+        client.setAuthorities(Collections.singletonList(new org.springframework.security.core.authority.SimpleGrantedAuthority("uaa.none")));
+        client.setClientJwtConfig(clientJwtString);
+
+        mockMvc.perform(post("/oauth/clients")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(JsonUtils.writeValueAsString(client)))
+                .andExpect(status().isCreated());
+
+        ClientDetailsModification retrieved = getClient(clientId);
+        assertThat(retrieved.getClientJwtCredentials()).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void updateReplacesClientJwtConfigWithFullMergedString() throws Exception {
+        String clientId = "jwt-upd-" + UUID.randomUUID().toString().substring(0, 8);
+        String first = "[{\"iss\":\"" + ISSUER + "\",\"sub\":\"first-" + clientId + "\"}]";
+
+        UaaClientDetails create = new UaaClientDetails();
+        create.setClientId(clientId);
+        create.setClientSecret("secret");
+        create.setAuthorizedGrantTypes(List.of("client_credentials"));
+        create.setAuthorities(Collections.singletonList(new org.springframework.security.core.authority.SimpleGrantedAuthority("uaa.none")));
+        create.setClientJwtConfig("{\"jwt_creds\":" + first + "}");
+
+        mockMvc.perform(post("/oauth/clients")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(JsonUtils.writeValueAsString(create)))
+                .andExpect(status().isCreated());
+
+        // PUT with full client_jwt_config string (round-trip shape clients use when replacing JWT config in one field)
+        UaaClientDetails update = new UaaClientDetails();
+        update.setClientId(clientId);
+        update.setClientSecret("secret");
+        update.setAuthorizedGrantTypes(List.of("client_credentials"));
+        update.setAuthorities(Collections.singletonList(new org.springframework.security.core.authority.SimpleGrantedAuthority("uaa.none")));
+        String bothCreds = "[{\"iss\":\"" + ISSUER + "\",\"sub\":\"first-" + clientId + "\"},"
+                + "{\"iss\":\"" + ISSUER + "\",\"sub\":\"second-" + clientId + "\"}]";
+        update.setClientJwtConfig("{\"jwt_creds\":" + bothCreds + "}");
+
+        mockMvc.perform(put("/oauth/clients/" + clientId)
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(JsonUtils.writeValueAsString(update)))
+                .andExpect(status().isOk());
+
+        ClientDetailsModification after = getClient(clientId);
+        assertThat(after.getClientJwtCredentials()).isNotNull().hasSize(2);
+    }
+
+    @Test
+    void getResponseJsonDoesNotDuplicateJwtCredsKey() throws Exception {
+        String clientId = "jwt-dup-" + UUID.randomUUID().toString().substring(0, 8);
+        String credsJson = "[{\"iss\":\"" + ISSUER + "\",\"sub\":\"" + clientId + "\"}]";
+
+        UaaClientDetails client = new UaaClientDetails();
+        client.setClientId(clientId);
+        client.setClientSecret("secret");
+        client.setAuthorizedGrantTypes(List.of("client_credentials"));
+        client.setAuthorities(Collections.singletonList(new org.springframework.security.core.authority.SimpleGrantedAuthority("uaa.none")));
+        client.addAdditionalInformation(ClientJwtConfiguration.JWT_CREDS, JsonUtils.readValue(credsJson, List.class));
+
+        mockMvc.perform(post("/oauth/clients")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(APPLICATION_JSON)
+                        .content(JsonUtils.writeValueAsString(client)))
+                .andExpect(status().isCreated());
+
+        MockHttpServletRequestBuilder get = get("/oauth/clients/" + clientId)
+                .header("Authorization", "Bearer " + adminToken);
+        String body = mockMvc.perform(get)
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        int n = body.split("\"jwt_creds\"").length - 1;
+        assertThat(n).isEqualTo(1);
+    }
+
+    private ClientDetailsModification getClient(String clientId) throws Exception {
+        String content = mockMvc.perform(get("/oauth/clients/" + clientId)
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return JsonUtils.readValue(content, ClientDetailsModification.class);
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientJwtCredentialsEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientJwtCredentialsEndpointMockMvcTests.java
@@ -9,7 +9,6 @@ import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/AbstractTokenMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/AbstractTokenMockMvcTests.java
@@ -450,7 +450,7 @@ public abstract class AbstractTokenMockMvcTests {
             ClientJwtConfiguration jwtConfiguration = new ClientJwtConfiguration(null, jwkKeySet);
             String jwtConfigJson = JsonUtils.writeValueAsString(jwtConfiguration);
             client.setClientJwtConfig(jwtConfigJson);
-            // updateClientDetails() does not persist client_jwt_config (see MultitenantJdbcClientDetailsService.DEFAULT_UPDATE_STATEMENT).
+            // Persist the column for DB-backed client loads (dedicated method; updateClientDetails also sets client_jwt_config now).
             clientDetailsService.updateClientJwtConfig(client.getClientId(), jwtConfigJson, resolvedZone.getId());
         } finally {
             IdentityZoneHolder.set(previous);


### PR DESCRIPTION
# Pull request: Unify and persist client JWT config (`client_jwt_config` + `jwt_creds`)

## Summary

This change makes **private_key_jwt** trust for OAuth clients **consistent** across the client admin API, the in-memory `UaaClient` view, and the database. Trust can be expressed in more than one way (the `client_jwt_config` column, a top-level `jwt_creds` array, or nested / legacy shapes in `additional_information`). The UAA now **merges** these into a single `ClientJwtConfiguration` for create/update, **persists** the result on `PUT` (the `client_jwt_config` column is updated in the generic `updateClientDetails` path), and **normalizes** GET responses so `ClientDetailsModification` can expose a decomposed `jwks` / `jwks_uri` / `jwt_creds` view without duplicating raw keys in `additional_information`.

**Backward compatibility:** existing clients and payloads that still send `jwt_creds` (or related forms) at the top level or in `additional_information` continue to work; the server merges them. **New integrations** should **prefer a single top-level `client_jwt_config` JSON string** and avoid relying on parallel legacy fields.

## Motivation

- `UaaClient.getClientJwtConfiguration()` previously only read the `client_jwt_config` string and ignored trust carried only in `additional_information` / `jwt_creds`, so `private_key_jwt` could ignore configured trust.
- Create/update did not always fold and strip `jwt_creds` and nested `client_jwt_config` from the extra map, so responses and storage could disagree.
- `MultitenantJdbcClientDetailsService.updateClientDetails` did not include `client_jwt_config` in the UPDATE statement, so merged JWT could be **lost on PUT** while other columns updated.
- `ClientJwtConfiguration.merge` could yield `null` in edge cases and drop prior trust.

## What to review (suggested order)

1. **Behavior & API:** `UaaClient`, `ClientAdminEndpoints` + `ClientAdminEndpointsValidator`, `ClientDetailsModification`, `ClientJwtConfiguration`, `UaaClientDetails` copy, `MultitenantJdbcClientDetailsService`.
2. **Tests (unit / MockMvc):** validator, `UaaClientTest`, `ClientDetailsModificationTest`, `ClientJwtCredentialsEndpointMockMvcTests`, `JwtClientAuthenticationTest` (including multi-`jwt_cred` federated policy).
3. **Generated API docs (sources, not `build/`):** `ClientAdminEndpointDocs.java` (REST Docs field tables) and the **Clients** intro in `uaa/slateCustomizations/source/index.html.md.erb` (run `./gradlew generateDocs` locally; HTML is under `uaa/build/`, which is not committed).
4. **Design note:** [Optional] in-repo design notes under `ai/` (e.g. `CLIENT_JWT_CREDS.md`) if present, for before/after and `generateDocs` source locations.

**Integration tests under `uaa/.../integration/**` are intentionally not modified** (per project policy).

## Commits (typical structure)

- **test:** New/updated unit and MockMvc coverage for `jwt_creds` / `client_jwt` merge, admin API, and federated `private_key_jwt` (tests may be expected to fail without the next commit in a strict TDD workflow).
- **feat:** Production changes in `model/`, `server/…` (merge, validation, GET shape, JDBC update including `client_jwt_config`).
- **docs:** In-repo design notes, Slate + REST-Docs field descriptions (preferred `client_jwt_config` vs legacy `jwt_creds` / decomposed `jwks*`).

Here’s how it works in the code path that matters for **runtime** (`UaaClient.getClientJwtConfiguration()`), i.e. when building the single `ClientJwtConfiguration` the UAA uses (including for `private_key_jwt`).

## 1. Base: the stored column (`client_jwt_config`)

The process **always starts** from the formal field that backs the DB column: `UaaClientDetails.getClientJwtConfig()` (the `client_jwt` JSON string). It is parsed with `ClientJwtConfiguration.readValue(...)`. If that string is missing, you get an **empty** `ClientJwtConfiguration` and continue.

So the **first** source of truth is: **the `client_jwt_config` string on the client** (inline `jwks` / `jwks_uri` / embedded `jwt_creds` inside that JSON are all part of that one blob).

## 2. Then: top-level `jwt_creds` in `additionalInformation`

If `additionalInformation` contains the key `jwt_creds` (string or list), that is turned into a small `ClientJwtConfiguration` that **only** carries those credentials, then merged **on top of** the result from step 1:

```56:76:server/src/main/java/org/cloudfoundry/identity/uaa/client/UaaClient.java
    public ClientJwtConfiguration getClientJwtConfiguration() {
        // Start with configuration from clientJwtConfig field
        ClientJwtConfiguration result = Optional.ofNullable(clientJwtConfig)
                .map(ClientJwtConfiguration::readValue)
                .orElse(new ClientJwtConfiguration());
        // ...
            Object jwtCredsValue = additionalInformation.get(ClientJwtConfiguration.JWT_CREDS);
            if (jwtCredsValue != null) {
                // ...
                    result = ClientJwtConfiguration.merge(result, additionalConfig, false);
```

So **order of application** is: **column first**, then **top-level `jwt_creds` in additional**, with `overwrite = false` (union / add, not replace wholesale).

## 3. Then: nested `client_jwt_config` map + `jwt_creds` inside it

If `additionalInformation["client_jwt_config"]` is a **map** and has a nested `jwt_creds`, that is parsed the same way and merged again:

```81:94:server/src/main/java/org/cloudfoundry/identity/uaa/client/UaaClient.java
            Object clientJwtCredsValue = additionalInformation.get("client_jwt_config");
            if (clientJwtCredsValue instanceof Map clientJwtCredsMap) {
                Object nestedJwtCreds = clientJwtCredsMap.get(ClientJwtConfiguration.JWT_CREDS);
                if (nestedJwtCreds != null) {
                    // ...
                        result = ClientJwtConfiguration.merge(result, nestedConfig, false);
```

So the **sequence** is:

1. **`client_jwt_config` string (column)**  
2. **Top-level `jwt_creds` in `additionalInformation`**  
3. **Nested `jwt_creds` under `additionalInformation["client_jwt_config"]` (when that value is a map)**

All of those extra steps use `ClientJwtConfiguration.merge(..., false)`.

## 4. What `merge(..., false)` does (simplified)

With `overwrite == false`:

- **`jwks_uri`**: keeps the existing URI if both sides have ideas; otherwise fills in from the new side (see the `existingConfig.jwksUri != null ? existing : new` style branch in `merge`).
- **`jwks`**: **combines** key sets (union of keys, with rules if a key already exists).
- **`jwt_creds`**: **adds** credentials via `addJwtCredentials`, which **dedupes** by subject+issuer (not by your “which field came first” — so order of *fields* is above; order of *duplicate* creds is handled inside `addJwtCredentials`).

So you should not think of it as “try key A, then key B for signature” at the **storage** layer; it is “**build one merged `ClientJwtConfiguration`** in that order.” **Signature checking** for `private_key_jwt` then uses that merged object (e.g. federated path picks the `ClientJwtCredential` that matches the assertion’s `iss`/`sub`/`aud`).

## 5. Admin PUT path (different call site)

On **create/update**, `ClientAdminEndpoints` / `syncWithExisting` also merge **existing client from DB** with **incoming body** using `ClientJwtConfiguration.merge(..., false)` (and related helpers). That is the **request** merge (existing vs input), not the same three-step `UaaClient` list above, but the same `merge` semantics apply for combining two `ClientJwtConfiguration` instances.

**Bottom line:** The **column `client_jwt_config` is evaluated first** and forms the base; **additional** top-level `jwt_creds` and then **nested** `client_jwt_config`/`jwt_creds` are **layered on** in that order, each time with **non-destructive** merge (`overwrite = false`) unless a different code path explicitly uses `overwrite = true` (e.g. some update flows).
