### PR TITLE
Fix missing leading slash in requestMatcher pattern

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientAdminSecurityConfiguration.java
@@ -47,7 +47,7 @@ class ClientAdminSecurityConfiguration {
                     auth.requestMatchers(HttpMethod.PUT, "/oauth/clients/tx/**").access(isAdminOrHasScopes());
                     auth.requestMatchers(HttpMethod.DELETE, "/oauth/clients/tx/**").access(isAdminOrHasScopes());
 
-                    auth.requestMatchers(HttpMethod.GET, "oauth/clients/meta", "/oauth/clients/*/meta").fullyAuthenticated();
+                    auth.requestMatchers(HttpMethod.GET, "/oauth/clients/meta", "/oauth/clients/*/meta").fullyAuthenticated();
 
                     auth.requestMatchers(HttpMethod.GET, "/oauth/clients/**").access(isAdminOrHasScopes("clients.read"));
 


### PR DESCRIPTION
Spring Security 7 enforces that patterns passed to requestMatchers() must start with a /. The pattern "oauth/clients/meta" was missing the leading slash.