### PR TITLE
Initial AI agent rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,26 @@
+# GitHub Copilot Instructions
+
+This repository uses a single source of truth for AI agent rules and skills located in
+`ai/rules/` and `ai/skills/`. Read all `.mdc` files in `ai/rules/` before making changes.
+
+## Rules
+
+- **`ai/rules/markdownlint.mdc`** — After creating or editing any `.md` or `.mdc` file run
+  `npx markdownlint-cli2 --fix <file>`.
+- **`ai/rules/documentation.mdc`** — Keep `docs/` in sync with all code changes:
+  configuration changes update `docs/UAA-Configuration-Reference.md`; API changes update
+  `*Docs.java` files and require `./gradlew generateDocs`.
+- **`ai/rules/java-testing.mdc`** — Use AssertJ for assertions, Awaitility for async
+  waits, `@ParameterizedTest` instead of loops, `@Nested` for grouped tests, and
+  `@DefaultTestContext` for UAA integration tests.
+  (PRs, issues, workflows).
+- **`ai/rules/shellcheck.mdc`** — Run `shellcheck <file>` after every shell script
+  create/edit.
+- **`ai/rules/ai-instructions.mdc`** — When changing `ai/rules/`, update the summary
+  in `AGENTS.md`, `CLAUDE.md`, and this file.
+
+## Working plans
+
+Write ephemeral working plans to `ai/plans/` (gitignored). Do not commit plan files.
+
+See `ai/README.md` for full documentation on the AI setup.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,8 +12,7 @@ This repository uses a single source of truth for AI agent rules and skills loca
   `*Docs.java` files and require `./gradlew generateDocs`.
 - **`ai/rules/java-testing.mdc`** — Use AssertJ for assertions, Awaitility for async
   waits, `@ParameterizedTest` instead of loops, `@Nested` for grouped tests, and
-  `@DefaultTestContext` for UAA integration tests.
-  (PRs, issues, workflows).
+  `@DefaultTestContext` for UAA integration tests. (PRs, issues, workflows).
 - **`ai/rules/shellcheck.mdc`** — Run `shellcheck <file>` after every shell script
   create/edit.
 - **`ai/rules/ai-instructions.mdc`** — When changing `ai/rules/`, update the summary

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ server/logs
 uaa/logs
 
 uaa/node_modules
+node_modules/
 # Docs
 uaa/slate/package-lock.json
 uaa/slate/node_modules
@@ -54,6 +55,10 @@ scripts/boot/tomcat/**
 
 # VS Code and Cursor
 .cursor/
+
+# AI agent working plans (ephemeral, never committed)
+ai/plans/
+
 .ruby-version
 .vscode/
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+  "MD013": {
+    "line_length": 120,
+    "tables": false
+  },
+  "MD060": {
+    "style": "consistent"
+  }
+}
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ starting work.
 | [`documentation.mdc`](ai/rules/documentation.mdc) | All code changes | Keep `docs/` in sync; update config reference, API docs, and feature docs |
 | [`java-testing.mdc`](ai/rules/java-testing.mdc) | `**/*Test*.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested`, UAA-specific patterns |
 | [`shellcheck.mdc`](ai/rules/shellcheck.mdc) | `**/*.sh` | Run `shellcheck <file>` after every shell script create/edit |
-| [`ai-instructions.mdc`](ai/rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `copilot-instructions.md` in sync |
+| [`ai-instructions.mdc`](ai/rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` in sync |
 
 See [`ai/README.md`](ai/README.md) for full documentation on the AI setup.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,133 @@ Run once after cloning to wire Cursor to `ai/rules/` and `ai/skills/`:
 ```bash
 ./scripts/setup_cursor.sh
 ```
+
+---
+
+## Codebase Overview
+
+### Architecture
+
+The CloudFoundry UAA is a multi-tenant OAuth2/OIDC identity server built on Spring Boot.
+It is a multi-module Gradle project:
+
+| Directory | Artifact | Role |
+| --- | --- | --- |
+| `model/` | `cloudfoundry-identity-model` | Shared domain objects |
+| `server/` | `cloudfoundry-identity-server` | Core REST API, SCIM, security, DB, LDAP |
+| `uaa/` | `cloudfoundry-identity-uaa` | Spring Boot executable WAR; wires everything via `UaaBootConfiguration` |
+| `statsd-lib/` + `statsd/` | `cloudfoundry-identity-statsd[-lib]` | Metrics publishing via StatsD |
+| `metrics-data/` | `cloudfoundry-identity-metrics-data` | Metric definitions |
+
+`server/` contains virtually all business logic. `uaa/` is the thin Spring Boot entry
+point; `uaa/src/main/resources/uaa.yml` is the primary configuration file (overridden at
+runtime by `$CLOUDFOUNDRY_CONFIG_PATH/uaa.yml` or `$UAA_CONFIG_PATH/uaa.yml`).
+
+### Multi-tenancy (Identity Zones)
+
+Every request runs in the context of an `IdentityZone` stored in `ThreadLocal` via
+`IdentityZoneHolder` (deprecated — prefer injecting `IdentityZoneManager`). The `uaa`
+zone is the system/default zone. Zone switching at the HTTP boundary is handled by
+`IdentityZoneSwitchingFilter` (reads `X-Identity-Zone-Id` / `X-Identity-Zone-Subdomain`
+headers; callers need `zones.<zone-id>.admin` scope).
+
+**When adding any zone-aware feature**, always query/write using the current zone ID
+(`identityZoneManager.getCurrentIdentityZoneId()`), never assume the `uaa` zone.
+
+### Database and migrations
+
+- Three supported databases: **HSQLDB** (default/in-memory), **PostgreSQL**, **MySQL**.
+- Schema migrations use **Flyway**; SQL scripts live in
+  `server/src/main/resources/org/cloudfoundry/identity/uaa/db/{hsqldb,mysql,postgresql}/`.
+- New migration files must be added to **all three** database directories.
+- Migration version format: `V<major>_<minor>__Description.sql`
+  (e.g. `V4_113__Add_group_membership_idz_origin_idx.sql`).
+- Non-FIPS BouncyCastle variants are globally excluded; use only the FIPS variants
+  (`bc-fips`, `bctls-fips`, `bcpkix-fips`).
+
+### Build and run
+
+```bash
+# Run the server (kills any existing UAA first)
+./gradlew run
+
+# Run with a real database
+./gradlew -Dspring.profiles.active=mysql run
+./gradlew -Dspring.profiles.active=postgresql run
+
+# Debug (attach on port 5005; -Pdebugs suspends until debugger connects)
+./gradlew run -Pdebug
+./gradlew run -Pdebugs -PdebugPort=5006
+
+# Build the executable WAR
+./gradlew :clean :assemble
+
+# Generate API docs (requires Ruby 3.3.8 + bundler)
+./gradlew generateDocs
+```
+
+Server starts at `http://localhost:8080/uaa`. Config for local runs lives in
+`scripts/boot/`.
+
+### Testing
+
+**Test types:**
+
+- Unit tests: `./gradlew test` (HSQLDB by default)
+- Integration tests (MockMvc / full Spring context): `./gradlew integrationTest`
+- Docker-wrapped suites: `./run-unit-tests.sh <dbtype>` /
+  `./run-integration-tests.sh <dbtype>`
+
+**Key annotations:**
+
+| Annotation | Use |
+| --- | --- |
+| `@DefaultTestContext` | Full Spring Boot context + MockMvc for `cloudfoundry-identity-uaa` tests |
+| `@WithDatabaseContext` | Lightweight DB-only context for `cloudfoundry-identity-server` tests |
+| `@EnabledIfProfile({"mysql","postgresql"})` | Run test only on specified DB profiles |
+| `@DisabledIfProfile({"mysql"})` | Skip test on specified DB profiles |
+
+Always run with `--no-daemon` when using real databases to avoid exhausting the 24
+pre-created test databases (`uaa_1`…`uaa_24`):
+
+```bash
+./gradlew test --no-daemon
+./gradlew '-Dspring.profiles.active=postgresql' test --no-daemon
+```
+
+Start real DB infrastructure first:
+
+```bash
+docker compose --file scripts/docker-compose.yml up [postgresql|mysql]
+```
+
+Run a single test class:
+
+```bash
+./gradlew :cloudfoundry-identity-server:test \
+  --tests "org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupMembershipManagerTests"
+```
+
+### Key conventions
+
+- **Lombok** everywhere for boilerplate (`@Getter`, `@Builder`, etc.); configured in
+  `lombok.config`.
+- **AssertJ** for assertions. Legacy `hamcrest-all/core/library` artifacts are globally
+  excluded.
+- **JUnit 5** with `useJUnitPlatform()`. No JUnit 4 vintage engine.
+- All dependencies declared centrally in `dependencies.gradle` as named aliases
+  (e.g. `libraries.springBeans`, `libraries.nimbusJwt`); use these in `build.gradle`
+  files, not inline coordinates.
+- Spring profiles (`hsqldb`, `mysql`, `postgresql`, `ldap`, `saml`) gate both runtime
+  behaviour and test infrastructure.
+
+### Integration points
+
+- **LDAP**: `spring_profiles: ldap` in `uaa.yml`; local dev setup in `scripts/ldap/`.
+- **SAML**: `spring_profiles: saml`; test certificates in `scripts/saml/`.
+- **SMTP**: Configurable via `smtp.host` / `smtp.port` (default `localhost:2525`); used
+  for invite/reset flows.
+- **StatsD metrics**: Enabled via `-Dstatsd.enabled=true`; implementation in
+  `statsd-lib/`.
+- **API docs**: Generated by `spring-restdocs` from tests in `uaa/src/test/java`,
+  rendered via Slate (Ruby) into `uaa/build/docs/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Guidelines
+
+This repository uses a single source of truth for AI agent rules and skills:
+
+- **Rules:** [`ai/rules/`](ai/rules/) — coding conventions, testing practices, documentation
+  requirements, and tool usage patterns.
+- **Skills:** [`ai/skills/`](ai/skills/) — reusable task patterns (added here as they are identified).
+- **Plans:** `ai/plans/` — ephemeral working plans written during a task; gitignored, never committed.
+
+All agents (OpenAI Codex, Claude Code, GitHub Copilot, Cursor) should read the files in `ai/rules/` before
+starting work.
+
+## Rules summary
+
+| File | Applies to | Summary |
+| --- | --- | --- |
+| [`markdownlint.mdc`](ai/rules/markdownlint.mdc) | All `.md`/`.mdc` files | Run `npx markdownlint-cli2 --fix <file>` after every Markdown create/edit |
+| [`documentation.mdc`](ai/rules/documentation.mdc) | All code changes | Keep `docs/` in sync; update config reference, API docs, and feature docs |
+| [`java-testing.mdc`](ai/rules/java-testing.mdc) | `**/*Test*.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested`, UAA-specific patterns |
+| [`shellcheck.mdc`](ai/rules/shellcheck.mdc) | `**/*.sh` | Run `shellcheck <file>` after every shell script create/edit |
+| [`ai-instructions.mdc`](ai/rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `copilot-instructions.md` in sync |
+
+See [`ai/README.md`](ai/README.md) for full documentation on the AI setup.
+
+## First-time setup (Cursor)
+
+Run once after cloning to wire Cursor to `ai/rules/` and `ai/skills/`:
+
+```bash
+./scripts/setup_cursor.sh
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Claude Code Guidelines
+
+This repository uses a single source of truth for AI agent rules and skills:
+
+- **Rules:** [`ai/rules/`](ai/rules/) — read all `.mdc` files here before starting any task.
+- **Skills:** [`ai/skills/`](ai/skills/) — reusable task patterns (added here as they are identified).
+- **Plans:** `ai/plans/` — write working plans here; this directory is gitignored.
+
+## Rules summary
+
+| File | Applies to | Summary |
+| --- | --- | --- |
+| [`markdownlint.mdc`](ai/rules/markdownlint.mdc) | All `.md`/`.mdc` files | Run `npx markdownlint-cli2 --fix <file>` after every Markdown create/edit |
+| [`documentation.mdc`](ai/rules/documentation.mdc) | All code changes | Keep `docs/` in sync; update config reference, API docs, and feature docs |
+| [`java-testing.mdc`](ai/rules/java-testing.mdc) | `**/*Test*.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested`, UAA-specific patterns |
+| [`shellcheck.mdc`](ai/rules/shellcheck.mdc) | `**/*.sh` | Run `shellcheck <file>` after every shell script create/edit |
+| [`ai-instructions.mdc`](ai/rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `copilot-instructions.md` in sync |
+
+See [`ai/README.md`](ai/README.md) for full documentation on the AI setup.
+
+## Key documentation files
+
+- **Configuration reference:** `docs/UAA-Configuration-Reference.md`
+- **API test/doc sources:** `uaa/src/test/java/**/*Docs.java`
+- **Feature docs:** `docs/*.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,19 @@ See [`ai/README.md`](ai/README.md) for full documentation on the AI setup.
 - **Configuration reference:** `docs/UAA-Configuration-Reference.md`
 - **API test/doc sources:** `uaa/src/test/java/**/*Docs.java`
 - **Feature docs:** `docs/*.md`
+
+## Codebase quick reference
+
+UAA is a multi-module Gradle project. `server/` holds virtually all business logic;
+`uaa/` is the thin Spring Boot entry point. See `AGENTS.md` for the full architecture
+overview, build commands, database migration conventions, and testing patterns.
+
+Key points:
+
+- Every request runs in an **IdentityZone** context — always use
+  `identityZoneManager.getCurrentIdentityZoneId()`, never hardcode the `uaa` zone.
+- DB migrations (Flyway) must be added to all three directories:
+  `hsqldb/`, `mysql/`, `postgresql/`.
+- Dependencies are declared centrally in `dependencies.gradle` as named aliases; use
+  those aliases in `build.gradle` files.
+- Use **AssertJ** for assertions, **JUnit 5** only (no JUnit 4 vintage engine).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This repository uses a single source of truth for AI agent rules and skills:
 | [`documentation.mdc`](ai/rules/documentation.mdc) | All code changes | Keep `docs/` in sync; update config reference, API docs, and feature docs |
 | [`java-testing.mdc`](ai/rules/java-testing.mdc) | `**/*Test*.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested`, UAA-specific patterns |
 | [`shellcheck.mdc`](ai/rules/shellcheck.mdc) | `**/*.sh` | Run `shellcheck <file>` after every shell script create/edit |
-| [`ai-instructions.mdc`](ai/rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `copilot-instructions.md` in sync |
+| [`ai-instructions.mdc`](ai/rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` in sync |
 
 See [`ai/README.md`](ai/README.md) for full documentation on the AI setup.
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -41,15 +41,15 @@ After cloning, run once to wire Cursor:
 | [`documentation.mdc`](rules/documentation.mdc) | Any code change | Keep `docs/`, config reference, and API docs in sync |
 | [`java-testing.mdc`](rules/java-testing.mdc) | `*Test*.java`, `*IT.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested` |
 | [`shellcheck.mdc`](rules/shellcheck.mdc) | `**/*.sh` | Run `shellcheck <file>` after every shell script edit |
-| [`ai-instructions.mdc`](rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `copilot-instructions.md` in sync |
+| [`ai-instructions.mdc`](rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `.github/copilot-instructions.md` in sync |
 
 ## Working Plans
 
 Agents may write task plans to `ai/plans/` before implementing. These files are gitignored
 and are never committed — they are ephemeral working notes only.
-``
+
 If you want to preserve a significant architectural decision, write an ADR in `docs/adrs` instead.
-``
+
 
 ## Adding a New Shared Rule
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,128 @@
+# Using AI Agents with UAA
+
+This document explains how AI coding agents are configured in this repository and how to
+work effectively with them.
+
+## How It Works
+
+All agent rules and reusable skill patterns live in a single place:
+
+```text
+ai/
+  rules/       <- coding conventions loaded by all agents
+  skills/      <- reusable task patterns (add here as identified)
+  plans/       <- ephemeral working notes (gitignored)
+```
+
+Three thin entry-point files point every supported agent at `ai/rules/`:
+
+| File | Agent |
+| --- | --- |
+| `AGENTS.md` | OpenAI Codex, Gemini CLI, and any AGENTS.md-compatible agent |
+| `CLAUDE.md` | Claude Code |
+| `.github/copilot-instructions.md` | GitHub Copilot (VS Code, JetBrains, agent mode) |
+
+Cursor is wired via `.cursor/rules → ai/rules` and `.cursor/skills → ai/skills` symlinks
+created by `scripts/setup_cursor.sh`.
+
+## First-Time Setup
+
+After cloning, run once to wire Cursor:
+
+```bash
+./scripts/setup_cursor.sh
+```
+
+## Current Rules
+
+| Rule file | Applies when | What it enforces |
+| --- | --- | --- |
+| [`markdownlint.mdc`](rules/markdownlint.mdc) | Editing any `.md` or `.mdc` file | Run `npx markdownlint-cli2 --fix <file>` after every edit |
+| [`documentation.mdc`](rules/documentation.mdc) | Any code change | Keep `docs/`, config reference, and API docs in sync |
+| [`java-testing.mdc`](rules/java-testing.mdc) | `*Test*.java`, `*IT.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested` |
+| [`shellcheck.mdc`](rules/shellcheck.mdc) | `**/*.sh` | Run `shellcheck <file>` after every shell script edit |
+| [`ai-instructions.mdc`](rules/ai-instructions.mdc) | Changing `ai/rules/` | Keep `AGENTS.md`, `CLAUDE.md`, and `copilot-instructions.md` in sync |
+
+## Working Plans
+
+Agents may write task plans to `ai/plans/` before implementing. These files are gitignored
+and are never committed — they are ephemeral working notes only.
+``
+If you want to preserve a significant architectural decision, write an ADR in `docs/adrs` instead.
+``
+
+## Adding a New Shared Rule
+
+1. Create `ai/rules/your-rule.mdc` with the appropriate frontmatter:
+
+   ```yaml
+   ---
+   description: "One-line summary"
+   globs: "optional/glob/pattern"
+   alwaysApply: false
+   ---
+   ```
+
+2. Write the rule content in Markdown below the frontmatter.
+3. Run `npx markdownlint-cli2 --fix ai/rules/your-rule.mdc`.
+4. Re-run `./scripts/setup_cursor.sh` to create the symlink in `.cursor/rules/`.
+5. Update the summary table in `AGENTS.md`, `CLAUDE.md`, and
+   `.github/copilot-instructions.md` (see `ai-instructions.mdc`).
+
+## Personal Rules (not committed to the repo)
+
+You can add your own rules that apply only to your local checkout without modifying any
+committed file.
+
+### Cursor
+
+After running `./scripts/setup_cursor.sh`, place personal `.mdc` files directly in
+`.cursor/rules/`. The setup script only creates and manages symlinks for files in
+`ai/rules/`; any real files you place there are left untouched and are gitignored.
+
+```bash
+# Example: create a personal rule
+cat > .cursor/rules/my-personal-style.mdc << 'EOF'
+---
+description: "My personal preferences"
+alwaysApply: true
+---
+# My Preferences
+Always use British English spelling in comments.
+EOF
+```
+
+Re-running `./scripts/setup_cursor.sh` will not remove or overwrite this file.
+
+### Claude Code
+
+Claude Code also reads `CLAUDE.md` files in subdirectories, and reads a global user-level
+file at `~/.claude/CLAUDE.md`. Add personal instructions there — they apply across all
+your repos and are never committed.
+
+### GitHub Copilot
+
+Copilot only reads `.github/copilot-instructions.md` and has no per-user override
+mechanism at the repository level. Personal preferences for Copilot must be configured
+via VS Code / JetBrains user settings.
+
+## Adding a New Skill
+
+Skills are reusable step-by-step patterns for common tasks (e.g. "how to add a new config
+property end-to-end"). Add `.mdc` files to `ai/skills/` following the same frontmatter
+convention as rules.
+
+## About `.github/copilot-instructions.md`
+
+This file is the standard GitHub Copilot configuration mechanism for repository-level
+instructions. GitHub Copilot reads it automatically whenever it operates inside this
+repository — there is nothing to configure.
+
+- **Location:** `.github/` is GitHub's conventional directory for repository configuration
+  (alongside `CODEOWNERS`, `PULL_REQUEST_TEMPLATE.md`, and `workflows/`). Placing it there
+  keeps the repo root clean and follows GitHub's own convention.
+- **Used by:** GitHub Copilot Chat (VS Code, JetBrains, GitHub.com), Copilot code completions
+  context, and GitHub Copilot coding agent (agentic / autonomous mode).
+- **Content:** Keep it brief — Copilot embeds this as context on every prompt, so long
+  instructions increase token usage. The file should point to `ai/rules/` rather than
+  reproducing rule content inline.

--- a/ai/plans/.gitignore
+++ b/ai/plans/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory except this file.
+*
+!.gitignore
+

--- a/ai/rules/ai-instructions.mdc
+++ b/ai/rules/ai-instructions.mdc
@@ -1,0 +1,58 @@
+---
+alwaysApply: false
+description: "Keep AGENTS.md, CLAUDE.md, and .github/copilot-instructions.md in sync"
+globs: "AGENTS.md,CLAUDE.md,.github/copilot-instructions.md,ai/rules/*.mdc"
+version: "1.1.0"
+---
+# AI Instruction File Sync Rule
+
+## Overview
+
+Three files serve as entry points for different AI agents into this repository's conventions.
+They are thin pointers to `ai/rules/` and must stay equivalent in content.
+
+| File | Read by |
+| --- | --- |
+| `AGENTS.md` | OpenAI Codex, Gemini CLI, and any agent following the Codex AGENTS.md convention |
+| `CLAUDE.md` | Claude Code (Anthropic) — loaded automatically from the repo root |
+| `.github/copilot-instructions.md` | GitHub Copilot in VS Code, JetBrains, and Copilot agent mode |
+
+## When to Update These Files
+
+You **MUST** update all three files when:
+
+- A rule file is added to `ai/rules/`
+- A rule file is removed from `ai/rules/`
+- The summary or scope of an existing rule changes significantly
+- The `scripts/setup_cursor.sh` setup process changes
+
+You do **not** need to duplicate the full rule content — keep the summaries short and
+link to the rule files.
+
+## What Must Stay in Sync
+
+Each file must contain:
+
+1. A pointer to `ai/rules/` and `ai/skills/` as the source of truth
+2. A summary table of all current rules (file, applies-to, one-line summary)
+3. A mention of `ai/plans/` as the ephemeral working-plans location
+4. The `scripts/setup_cursor.sh` first-time setup instruction (where the format allows)
+
+## Format Differences (Allowed)
+
+Minor format differences between the three files are acceptable — each tool has its own
+conventions:
+
+- `AGENTS.md` uses full GitHub Markdown including a setup section
+- `CLAUDE.md` includes a "Key documentation files" section for Claude's benefit
+- `.github/copilot-instructions.md` uses a flat bullet-list style (no heavy tables) since
+  Copilot embeds this as context in every prompt and brevity matters
+
+## Update Checklist
+
+When changing `ai/rules/` in any way:
+
+- [ ] Rule summary table updated in `AGENTS.md`
+- [ ] Rule summary table updated in `CLAUDE.md`
+- [ ] Rule bullet list updated in `.github/copilot-instructions.md`
+- [ ] `markdownlint` run on all three files after editing

--- a/ai/rules/documentation.mdc
+++ b/ai/rules/documentation.mdc
@@ -1,0 +1,158 @@
+---
+alwaysApply: false
+description: "Documentation Requirements"
+version: "1.2.0"
+---
+# Documentation Requirements
+
+## When Documentation Must Be Updated
+
+When making changes to UAA code, you MUST ensure related documentation is updated:
+
+### 1. Configuration Changes
+
+When adding, removing, or modifying configuration properties:
+
+- **MUST** update `docs/UAA-Configuration-Reference.md` with:
+  - New property descriptions
+  - Updated default values
+  - Examples and usage notes
+  - Deprecation warnings for removed properties
+
+### 2. API Changes
+
+When modifying REST endpoints, request/response formats, or API behavior:
+
+- **MUST** update corresponding `*Docs.java` files in `uaa/src/test/java/**/*Docs.java`
+- **MUST** regenerate API documentation to ensure examples are current
+- **MUST** update any affected documentation in `docs/` directory
+
+### 3. Feature Documentation
+
+When adding new features or significantly changing existing ones:
+
+- **MUST** update relevant documentation in `docs/` directory
+- **MUST** consider if changes affect:
+  - `docs/UAA-Tokens.md` (token-related changes)
+  - `docs/UAA-LDAP.md` (LDAP integration changes)
+  - `docs/UAA-Rate-Limiting.md` (rate limiting changes)
+  - `docs/testing.md` (test setup or procedures)
+  - Provider-specific docs in `docs/OIDC-Provider-Examples/`
+
+### 4. AI Rule and Instruction Files
+
+When adding, removing, or changing a rule in `ai/rules/`:
+
+- **MUST** update the rules summary table in all three AI instruction files:
+  - `AGENTS.md` (OpenAI Codex / general agents)
+  - `CLAUDE.md` (Claude Code)
+  - `.github/copilot-instructions.md` (GitHub Copilot)
+- These files must stay equivalent in content; only formatting may differ per tool.
+- See [`ai-instructions.mdc`](ai-instructions.mdc) for the full sync rule.
+
+## Documentation Quality Standards
+
+### Configuration Reference Content Requirements
+
+All configuration properties must include:
+
+- Purpose and behavior description
+- Data type and format
+- Default value (if any)
+- Example usage
+- Related properties or dependencies
+
+### API Documentation Content Requirements
+
+API documentation must include:
+
+- Complete request/response examples
+- Error scenarios and status codes
+- Authentication/authorization requirements
+- Parameter descriptions and constraints
+
+### Cross-Reference Validation
+
+- Ensure internal links use correct paths
+- Verify external links are accessible
+- Update version numbers and compatibility notes
+- Check code examples for syntax and accuracy
+
+## API Documentation Generation
+
+To regenerate API documentation after making changes to `*Docs.java` files:
+
+```bash
+# Setup Ruby environment (one-time setup)
+brew install rbenv
+rbenv install 3.3.5
+rbenv global 3.3.5
+gem install bundler
+
+# Generate API documentation
+./gradlew generateDocs
+```
+
+**Note:** The `generateDocs` task processes the `*Docs.java` test files and generates the
+corresponding API documentation.
+
+## Common Documentation Patterns
+
+### Configuration Reference Format
+
+````markdown
+## property.name
+
+**Type:** `string` | **Default:** `value` | **Required:** No
+
+Description of what this property controls and its behavior.
+
+**Example:**
+
+```yaml
+property:
+  name: example-value
+```
+
+**Related Properties:** `other.property`, `another.setting`
+````
+
+### API Documentation Updates
+
+- Update corresponding `*Docs.java` test files in `uaa/src/test/java/**/*Docs.java`
+- Ensure request/response examples are complete and accurate
+- Include error scenarios with proper HTTP status codes
+- Run `./gradlew generateDocs` to update generated documentation
+
+## Documentation Update Workflow
+
+1. **Identify affected documentation** based on code changes
+2. **Update content** following quality standards above
+3. **Apply markdownlint** to ensure formatting consistency
+   (`npx markdownlint-cli2 --fix <file>`)
+4. **Regenerate API docs** if `*Docs.java` files were modified
+5. **Verify links and references** are still valid
+6. **Test code examples** for accuracy
+
+## Checklist for Documentation Updates
+
+Before completing any change that affects documentation:
+
+- [ ] Configuration reference updated (if config properties changed)
+- [ ] API documentation updated (if endpoints/formats changed)
+- [ ] Related feature documentation updated
+- [ ] AI instruction files synced (if `ai/rules/` changed — see `ai-instructions.mdc`)
+- [ ] Markdownlint applied and issues resolved
+- [ ] Internal links verified and working
+- [ ] Code examples tested for accuracy
+- [ ] API documentation regenerated (if `*Docs.java` changed)
+- [ ] Cross-references to related properties/features updated
+
+## Key Documentation Files
+
+- **Configuration:** `docs/UAA-Configuration-Reference.md`
+- **API Tests/Docs:** `uaa/src/test/java/**/*Docs.java`
+- **Feature Docs:** `docs/*.md`
+- **Provider Examples:** `docs/OIDC-Provider-Examples/*.md`
+- **AI Rules:** `ai/rules/*.mdc`
+- **AI Instruction Files:** `AGENTS.md`, `CLAUDE.md`, `.github/copilot-instructions.md`

--- a/ai/rules/java-testing.mdc
+++ b/ai/rules/java-testing.mdc
@@ -1,0 +1,247 @@
+---
+description: "Java testing practices for UAA: JUnit 5, AssertJ, Mockito, MockMvc, Awaitility, and Selenium"
+globs: "**/*Test*.java,**/*IT.java,**/*Docs.java"
+alwaysApply: false
+---
+
+# Java Testing Best Practices
+
+## AssertJ Assertions
+
+Use AssertJ for all assertions instead of JUnit's built-in assertions:
+
+```java
+// ❌ BAD - JUnit assertions
+assertEquals(expected, actual);
+assertTrue(condition);
+assertNotNull(value);
+
+// ✅ GOOD - AssertJ assertions
+assertThat(actual).isEqualTo(expected);
+assertThat(condition).isTrue();
+assertThat(value).isNotNull();
+```
+
+### Chain Multiple Assertions
+
+When testing the same object, chain assertions instead of multiple `assertThat()` calls:
+
+```java
+// ❌ BAD - Multiple separate assertions
+assertThat(finalGroupNames).doesNotContain(groupName);
+assertThat(finalGroupNames).contains("openid");
+
+// ✅ GOOD - Chained assertions
+assertThat(finalGroupNames)
+    .doesNotContain(groupName)
+    .contains("openid");
+
+// ✅ GOOD - Use variadic methods when available
+assertThat(groupNames).contains(baseGroupName)
+    .doesNotContain(similarGroupName1, similarGroupName2, similarGroupName3);
+```
+
+### Exception Testing
+
+```java
+// ✅ GOOD - AssertJ exception testing
+assertThatThrownBy(() -> service.processInvalidInput(null))
+    .isInstanceOf(IllegalArgumentException.class)
+    .hasMessage("Input cannot be null")
+    .hasNoCause();
+```
+
+## Awaitility for Async Testing
+
+Use Awaitility instead of `Thread.sleep()` or manual polling:
+
+```java
+// ✅ GOOD - Awaitility with proper timeout and polling
+await()
+    .atMost(Duration.ofSeconds(10))
+    .pollInterval(Duration.ofMillis(100))
+    .until(() -> service.isComplete());
+```
+
+## Parameterized Tests
+
+Use `@ParameterizedTest` instead of loops within test methods:
+
+```java
+// ✅ GOOD - Simple parameterized test
+@ParameterizedTest
+@ValueSource(strings = {"valid1", "valid2", "valid3"})
+void validatesInput(String input) {
+    assertThat(validator.isValid(input)).isTrue();
+}
+
+// ✅ GOOD - Complex scenarios with method source
+@ParameterizedTest
+@MethodSource("provideTestCases")
+void calculatesCorrectly(int input, int expected) {
+    assertThat(calculator.calculate(input)).isEqualTo(expected);
+}
+```
+
+## Test Organization
+
+Use nested test classes when multiple tests share common setup or configuration:
+
+```java
+@Nested
+class WhenSslValidationEnabled {
+    @BeforeEach
+    void setUp() {
+        service.setSslValidationEnabled(true);
+        service.configure(sslProperties);
+    }
+
+    @Test
+    void authenticatesSuccessfully() { }
+
+    @Test
+    void rejectsInvalidCertificates() { }
+}
+```
+
+### Test Method Naming
+
+Use descriptive test method names that explain the scenario. Choose between two naming
+patterns based on context:
+
+#### Pattern 1: CamelCase for Simple Actions
+
+Use camelCase for straightforward test scenarios:
+
+```java
+// ✅ GOOD - Simple action tests
+@Test
+void createsUserWithValidData() { }
+
+@Test
+void throwsExceptionWhenEmailExists() { }
+
+@Test
+void returnsEmptyListWhenNoUsersFound() { }
+```
+
+#### Pattern 2: Underscores for Action_Context_ExpectedResult
+
+Use underscores to clearly separate test components, especially for complex scenarios:
+
+```java
+// ✅ GOOD - Complex scenario tests with clear structure
+@Test
+void process_whenSslValidationIsEnabled_succeeds() { }
+
+@Test
+void getAttribute_returnsValueFromContainerSession() { }
+
+@Test
+void getSession_whenNoContainerSession_returnsNull() { }
+```
+
+**Guidelines:**
+
+- Avoid "should" and "test" — redundant words
+- Use underscores for action_context_result patterns
+- Use camelCase for simpler scenarios
+- Include context that affects behavior
+
+## Selenium WebDriver
+
+Use WebDriverWait with ExpectedConditions instead of Thread.sleep():
+
+```java
+// ✅ GOOD - Explicit waits with conditions
+WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+WebElement result = wait.until(
+    ExpectedConditions.visibilityOfElementLocated(By.id("result"))
+);
+
+// ✅ GOOD - Custom wait conditions
+wait.until(driver -> driver.getPageSource().contains("Expected Content"));
+```
+
+## MockMvc
+
+Use descriptive matchers and `.andDo(print())` for debugging:
+
+```java
+// ✅ GOOD - Clear, comprehensive expectations
+mockMvc.perform(post("/users")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"name\":\"John\",\"email\":\"john@example.com\"}"))
+        .andDo(print())
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.name").value("John"))
+        .andExpect(header().string("Location", containsString("/users/")));
+```
+
+## Mockito
+
+Use ArgumentCaptor for complex arguments and explicit mock configuration:
+
+```java
+// ✅ GOOD - Capture and verify argument details
+ArgumentCaptor<EntityDeletedEvent<User>> captor =
+    ArgumentCaptor.forClass(EntityDeletedEvent.class);
+service.deleteUser("userId");
+verify(eventPublisher).publishEvent(captor.capture());
+
+// ✅ GOOD - Explicit mock configuration
+when(repository.findById("id")).thenReturn(Optional.of(existingUser));
+verify(repository).save(argThat(user ->
+    user.getId().equals("id") && user.isProcessed()));
+verifyNoMoreInteractions(repository);
+```
+
+## UAA-Specific Patterns
+
+### Integration test setup
+
+Use `@DefaultTestContext` for Spring context, `@ExtendWith(ZoneSeederExtension.class)`
+with `ZoneSeeder` for zone and client/user fixture setup:
+
+```java
+// ✅ GOOD - UAA integration test setup
+@ExtendWith(ZoneSeederExtension.class)
+@DefaultTestContext
+class UserControllerIntegrationTest {
+    @Autowired private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp(ZoneSeeder zoneSeeder) {
+        zoneSeeder.withDefaults()
+                  .withUser("user@example.com")
+                  .withClientWithImplicitAndAuthorizationCodeGrants(
+                      "my-client", "http://redirect.example.com");
+    }
+}
+```
+
+### JSON handling
+
+Use `JsonUtils` rather than raw Jackson for JSON processing in tests:
+
+```java
+// ✅ GOOD - UAA JsonUtils
+Map<String, Object> result = JsonUtils.readValueAsMap(json);
+String json = JsonUtils.writeValueAsString(object);
+```
+
+## Test Data and Lifecycle
+
+```java
+// ✅ GOOD - Test lifecycle management
+@BeforeEach
+void setUp() {
+    // Initialize test state
+}
+
+@AfterEach
+void tearDown() {
+    reset(mockDependency);
+}
+```

--- a/ai/rules/markdownlint.mdc
+++ b/ai/rules/markdownlint.mdc
@@ -1,0 +1,49 @@
+---
+globs: "**/*.md,**/*.mdc"
+alwaysApply: true
+version: "1.3.0"
+---
+# Markdownlint Auto-Fix Rules
+
+## Automatic Markdownlint Application
+
+When creating or updating any Markdown or MDC document (`.md` and `.mdc` files), you MUST:
+
+1. **After creating a new file**: Automatically run markdownlint with auto-fix to ensure the
+   file follows best practices
+2. **After updating an existing file**: Automatically run markdownlint with auto-fix to correct
+   any linting issues introduced
+
+## Implementation
+
+Run via `npx` — no `package.json` or local install required:
+
+```bash
+npx markdownlint-cli2 --fix <file>
+```
+
+Lint configuration is in `.markdownlint.json` at the repo root (120-char line limit, tables
+exempt, consistent table-pipe style).
+
+## Workflow
+
+1. Create or edit the `.md` or `.mdc` file
+2. Run `npx markdownlint-cli2 --fix <file>` to auto-fix issues
+3. Review the changes and ensure they don't alter the document's meaning
+4. If markdownlint reports unfixable issues, inform the user about them
+
+## Example Commands
+
+```bash
+# Fix a single file
+npx markdownlint-cli2 --fix path/to/file.md
+
+# Fix a Cursor/AI rule file
+npx markdownlint-cli2 --fix ai/rules/some-rule.mdc
+
+# Fix all markdown and mdc files (excluding node_modules)
+npx markdownlint-cli2 --fix "**/*.md" "**/*.mdc" "#node_modules"
+
+# Fix multiple specific files
+npx markdownlint-cli2 --fix file1.md file2.mdc file3.md
+```

--- a/ai/rules/shellcheck.mdc
+++ b/ai/rules/shellcheck.mdc
@@ -90,16 +90,44 @@ main "$@"
 - **Files:** `lower_snake_case.sh`
 - **Functions:** `lower_snake_case`
 - **Local variables:** `lower_snake_case`, declared with `local`
-- **Constants / globals:** `UPPER_SNAKE_CASE`, declared with `readonly`
+- **Script-level constants:** `lower_snake_case`, declared with `readonly`
+- **Environment variables** (exported or inherited from the shell): `UPPER_SNAKE_CASE`
+
+`UPPER_SNAKE_CASE` is only valid for true environment variables (e.g. `PATH`, `HOME`,
+`JAVA_HOME`). Script-internal variables — even `readonly` ones — use `lower_snake_case`.
 
 ```bash
-readonly MAX_RETRIES=3
+# Script-level constants — lowercase + readonly
+readonly max_retries=3
+readonly config_file="${HOME}/.config/app.conf"
+
+# Environment variable passed in by the caller — uppercase is correct
+: "${JAVA_HOME:?JAVA_HOME must be set}"
 
 process_file() {
   local -r input_file="$1"
   local result
   result="$(parse "${input_file}")"
   echo "${result}"
+}
+```
+
+### Function comments
+
+Every function must have a comment block immediately before it describing its
+purpose, arguments, outputs, and return value:
+
+```bash
+# Short description of what the function does.
+# Arguments:
+#   $1 - name : description
+#   $2 - path : absolute path to ...
+# Outputs:
+#   Writes progress lines to stdout.
+# Returns:
+#   0 on success; non-zero if ... fails.
+my_function() {
+  ...
 }
 ```
 

--- a/ai/rules/shellcheck.mdc
+++ b/ai/rules/shellcheck.mdc
@@ -1,0 +1,174 @@
+---
+alwaysApply: false
+description: "Run ShellCheck and follow Google Shell Style Guide on shell scripts"
+globs: "**/*.sh"
+---
+# ShellCheck and Shell Style Rules
+
+## Automatic ShellCheck Application
+
+After creating or editing any shell script (`.sh` file) you MUST run ShellCheck and fix
+all reported issues before considering the change complete.
+
+## Installation
+
+ShellCheck must be installed on the system:
+
+```bash
+# macOS
+brew install shellcheck
+
+# Ubuntu/Debian
+apt-get install shellcheck
+```
+
+Verify with `shellcheck --version`.
+
+## Workflow
+
+1. Create or edit the `.sh` file
+2. Run `shellcheck <file>` to check for issues
+3. Fix all reported warnings and errors
+4. Re-run until clean
+
+## Example Commands
+
+```bash
+# Check a single script
+shellcheck scripts/setup_cursor.sh
+
+# Check all scripts in the scripts/ directory
+shellcheck scripts/*.sh
+```
+
+## Script Naming Convention
+
+Use **underscores** to separate words in script filenames, not hyphens:
+
+```text
+setup_cursor.sh       ✅
+start_docker_database.sh  ✅
+setup-cursor.sh       ❌
+```
+
+## Google Shell Style Guide
+
+Follow the [Google Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+with one exception: use `#!/usr/bin/env bash` instead of `#!/bin/bash` for portability.
+
+### Script header
+
+Every script must start with:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+```
+
+### Structure
+
+Wrap all logic in functions; call `main "$@"` at the bottom:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+helper() {
+  local -r name="$1"
+  echo "Hello, ${name}"
+}
+
+main() {
+  helper "world"
+}
+
+main "$@"
+```
+
+### Naming
+
+- **Files:** `lower_snake_case.sh`
+- **Functions:** `lower_snake_case`
+- **Local variables:** `lower_snake_case`, declared with `local`
+- **Constants / globals:** `UPPER_SNAKE_CASE`, declared with `readonly`
+
+```bash
+readonly MAX_RETRIES=3
+
+process_file() {
+  local -r input_file="$1"
+  local result
+  result="$(parse "${input_file}")"
+  echo "${result}"
+}
+```
+
+### Variables
+
+- Always quote variables: `"${var}"` not `$var`
+- Use `${var}` (braces) consistently
+- Declare and assign `local` variables separately to preserve exit codes:
+
+```bash
+# ❌ Bad — hides exit code of $()
+local result=$(command)
+
+# ✅ Good
+local result
+result=$(command)
+```
+
+### Conditionals
+
+Use `[[ ]]` instead of `[ ]`:
+
+```bash
+# ❌ Bad
+if [ -f "$file" ]; then
+
+# ✅ Good
+if [[ -f "${file}" ]]; then
+```
+
+### Command substitution
+
+Use `$(...)` instead of backticks:
+
+```bash
+# ❌ Bad
+result=`command`
+
+# ✅ Good
+result=$(command)
+```
+
+### Formatting
+
+- Indent with **2 spaces** (no tabs)
+- Maximum line length: **80 characters**
+- `; then` and `; do` on the same line as the condition
+
+```bash
+for file in "${files[@]}"; do
+  process "${file}"
+done
+```
+
+### Error handling
+
+Check exit codes with `if !` rather than `$?`:
+
+```bash
+# ❌ Bad
+command
+if [[ $? -ne 0 ]]; then
+
+# ✅ Good
+if ! command; then
+```
+
+## Things to Remember
+
+- ShellCheck does not auto-fix — all fixes are manual
+- Use `# shellcheck disable=SC2034` only when a suppression is genuinely intentional
+- Use `# shellcheck source=path/to/file` for sourced files ShellCheck cannot find

--- a/scripts/setup_cursor.sh
+++ b/scripts/setup_cursor.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# setup-cursor.sh
+# Wires Cursor's rules and skills directories to the canonical ai/ directory.
+#
+# Creates per-file symlinks inside .cursor/rules/ and .cursor/skills/ so that:
+#   - Shared rules from ai/rules/ are available to Cursor automatically
+#   - .cursor/ remains a real gitignored directory, letting you add personal
+#     .mdc rule files to .cursor/rules/ without committing them to the repo
+#
+# Re-running this script is safe: it adds symlinks for new shared rules and
+# removes symlinks for deleted ones, leaving any personal files untouched.
+#
+# Run once after cloning, and again whenever shared rules are added or removed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CURSOR_DIR="$REPO_ROOT/.cursor"
+AI_DIR="$REPO_ROOT/ai"
+
+echo "==> Setting up Cursor symlinks for $(basename "$REPO_ROOT")"
+
+# If .cursor is currently a symlink (legacy setup), replace it with a directory.
+if [ -L "$CURSOR_DIR" ]; then
+  echo "    Replacing legacy .cursor symlink with a real directory..."
+  rm "$CURSOR_DIR"
+fi
+
+for subdir in rules skills; do
+  SRC_DIR="$AI_DIR/$subdir"
+  DEST_DIR="$CURSOR_DIR/$subdir"
+
+  # Ensure source and destination directories exist.
+  mkdir -p "$SRC_DIR" "$DEST_DIR"
+
+  # If the destination is still a directory symlink from older setup, replace it.
+  if [ -L "$DEST_DIR" ]; then
+    echo "    Replacing legacy .cursor/$subdir symlink with a real directory..."
+    rm "$DEST_DIR"
+    mkdir -p "$DEST_DIR"
+  fi
+
+  # Create a symlink for each .mdc file in ai/<subdir>/.
+  for src_file in "$SRC_DIR"/*.mdc; do
+    [ -e "$src_file" ] || continue   # skip if glob matched nothing
+    filename="$(basename "$src_file")"
+    dest_file="$DEST_DIR/$filename"
+    rel_target="../../ai/$subdir/$filename"
+
+    if [ -L "$dest_file" ]; then
+      current_target="$(readlink "$dest_file")"
+      if [ "$current_target" = "$rel_target" ]; then
+        echo "    .cursor/$subdir/$filename  (already correct)"
+        continue
+      fi
+      echo "    Updating stale symlink: .cursor/$subdir/$filename"
+      rm "$dest_file"
+    elif [ -e "$dest_file" ]; then
+      echo "    SKIP: .cursor/$subdir/$filename exists as a real file (personal rule?)"
+      continue
+    fi
+
+    ln -s "$rel_target" "$dest_file"
+    echo "    Created .cursor/$subdir/$filename -> ai/$subdir/$filename"
+  done
+
+  # Remove symlinks that point to ai/<subdir> files that no longer exist.
+  for dest_file in "$DEST_DIR"/*.mdc; do
+    [ -L "$dest_file" ] || continue  # only manage symlinks, never touch real files
+    filename="$(basename "$dest_file")"
+    if [ ! -e "$SRC_DIR/$filename" ]; then
+      echo "    Removing stale symlink: .cursor/$subdir/$filename (source deleted)"
+      rm "$dest_file"
+    fi
+  done
+done
+
+echo ""
+echo "Done. Cursor loads shared rules from ai/rules/ via .cursor/rules/ symlinks."
+echo "Add personal .mdc files directly to .cursor/rules/ — they are gitignored"
+echo "and will not be touched when you re-run this script."

--- a/scripts/setup_cursor.sh
+++ b/scripts/setup_cursor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup-cursor.sh
+# setup_cursor.sh
 # Wires Cursor's rules and skills directories to the canonical ai/ directory.
 #
 # Creates per-file symlinks inside .cursor/rules/ and .cursor/skills/ so that:
@@ -7,75 +7,82 @@
 #   - .cursor/ remains a real gitignored directory, letting you add personal
 #     .mdc rule files to .cursor/rules/ without committing them to the repo
 #
-# Re-running this script is safe: it adds symlinks for new shared rules and
-# removes symlinks for deleted ones, leaving any personal files untouched.
-#
-# Run once after cloning, and again whenever shared rules are added or removed.
+# Safe to re-run: adds symlinks for new shared rules, removes stale ones,
+# and leaves personal (non-symlink) files untouched.
 
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-CURSOR_DIR="$REPO_ROOT/.cursor"
-AI_DIR="$REPO_ROOT/ai"
+# Link every .mdc in <src_dir>/ into <dest_dir>/ and remove stale symlinks.
+# Arguments:
+#   $1 - subdir  : relative name used in display paths (e.g. "rules")
+#   $2 - src_dir : absolute path to the source .mdc directory (ai/<subdir>/)
+#   $3 - dest_dir: absolute path to the symlink directory (.cursor/<subdir>/)
+# Outputs:
+#   Writes progress lines to stdout.
+# Returns:
+#   0 on success; non-zero if mkdir, ln, or rm fails.
+sync_dir() {
+  local -r subdir="$1"
+  local -r src_dir="$2"
+  local -r dest_dir="$3"
+  local src_file filename dest_file rel_target
 
-echo "==> Setting up Cursor symlinks for $(basename "$REPO_ROOT")"
+  mkdir -p "${src_dir}" "${dest_dir}"
 
-# If .cursor is currently a symlink (legacy setup), replace it with a directory.
-if [ -L "$CURSOR_DIR" ]; then
-  echo "    Replacing legacy .cursor symlink with a real directory..."
-  rm "$CURSOR_DIR"
-fi
+  # Create or refresh symlinks for all shared .mdc files.
+  for src_file in "${src_dir}"/*.mdc; do
+    [[ -e "${src_file}" ]] || continue
+    filename="$(basename "${src_file}")"
+    dest_file="${dest_dir}/${filename}"
+    rel_target="../../ai/${subdir}/${filename}"
 
-for subdir in rules skills; do
-  SRC_DIR="$AI_DIR/$subdir"
-  DEST_DIR="$CURSOR_DIR/$subdir"
-
-  # Ensure source and destination directories exist.
-  mkdir -p "$SRC_DIR" "$DEST_DIR"
-
-  # If the destination is still a directory symlink from older setup, replace it.
-  if [ -L "$DEST_DIR" ]; then
-    echo "    Replacing legacy .cursor/$subdir symlink with a real directory..."
-    rm "$DEST_DIR"
-    mkdir -p "$DEST_DIR"
-  fi
-
-  # Create a symlink for each .mdc file in ai/<subdir>/.
-  for src_file in "$SRC_DIR"/*.mdc; do
-    [ -e "$src_file" ] || continue   # skip if glob matched nothing
-    filename="$(basename "$src_file")"
-    dest_file="$DEST_DIR/$filename"
-    rel_target="../../ai/$subdir/$filename"
-
-    if [ -L "$dest_file" ]; then
-      current_target="$(readlink "$dest_file")"
-      if [ "$current_target" = "$rel_target" ]; then
-        echo "    .cursor/$subdir/$filename  (already correct)"
-        continue
-      fi
-      echo "    Updating stale symlink: .cursor/$subdir/$filename"
-      rm "$dest_file"
-    elif [ -e "$dest_file" ]; then
-      echo "    SKIP: .cursor/$subdir/$filename exists as a real file (personal rule?)"
+    if [[ -L "${dest_file}" ]]; then
+      [[ "$(readlink "${dest_file}")" == "${rel_target}" ]] && continue
+      echo "    Updating: .cursor/${subdir}/${filename}"
+      rm "${dest_file}"
+    elif [[ -e "${dest_file}" ]]; then
+      echo "    Skipping: .cursor/${subdir}/${filename} (personal file)"
       continue
     fi
 
-    ln -s "$rel_target" "$dest_file"
-    echo "    Created .cursor/$subdir/$filename -> ai/$subdir/$filename"
+    ln -s "${rel_target}" "${dest_file}"
+    echo "    Linked:   .cursor/${subdir}/${filename} -> ai/${subdir}/${filename}"
   done
 
-  # Remove symlinks that point to ai/<subdir> files that no longer exist.
-  for dest_file in "$DEST_DIR"/*.mdc; do
-    [ -L "$dest_file" ] || continue  # only manage symlinks, never touch real files
-    filename="$(basename "$dest_file")"
-    if [ ! -e "$SRC_DIR/$filename" ]; then
-      echo "    Removing stale symlink: .cursor/$subdir/$filename (source deleted)"
-      rm "$dest_file"
-    fi
+  # Remove symlinks for deleted shared rules.
+  for dest_file in "${dest_dir}"/*.mdc; do
+    [[ -L "${dest_file}" ]] || continue
+    filename="$(basename "${dest_file}")"
+    [[ -e "${src_dir}/${filename}" ]] && continue
+    echo "    Removed:  .cursor/${subdir}/${filename} (source deleted)"
+    rm "${dest_file}"
   done
-done
+}
 
-echo ""
-echo "Done. Cursor loads shared rules from ai/rules/ via .cursor/rules/ symlinks."
-echo "Add personal .mdc files directly to .cursor/rules/ — they are gitignored"
-echo "and will not be touched when you re-run this script."
+# Entry point. Resolves the repo root and syncs rules and skills symlinks.
+# Arguments:
+#   None (extra arguments are accepted and ignored).
+# Outputs:
+#   Writes progress and summary lines to stdout.
+# Returns:
+#   0 on success; non-zero if any sync_dir call fails.
+main() {
+  local repo_root
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  local -r cursor_dir="${repo_root}/.cursor"
+  local -r ai_dir="${repo_root}/ai"
+
+  echo "==> Setting up Cursor symlinks for $(basename "${repo_root}")"
+
+  local subdir
+  for subdir in rules skills; do
+    sync_dir "${subdir}" "${ai_dir}/${subdir}" "${cursor_dir}/${subdir}"
+  done
+
+  echo ""
+  echo "Done. Cursor loads shared rules from ai/rules/ via .cursor/rules/ symlinks."
+  echo "Add personal .mdc files directly to .cursor/rules/ — they are gitignored"
+  echo "and will not be touched when you re-run this script."
+}
+
+main "$@"


### PR DESCRIPTION
## Add source-of-truth AI agent rules

### Intent

As the number of AI coding assistants in active use grows (Cursor, Claude Code, GitHub
Copilot, OpenAI Codex), each tool has its own mechanism for loading repository-level
instructions. Without a shared location, rules end up duplicated or drift out of sync
across tool-specific config files.

This PR introduces `ai/rules/` as the **source of truth** for all AI agent
coding conventions. A thin entry-point file for each supported agent points at that
directory — agent-specific files contain no rule content of their own.

> **Note:** This is an initial setup. The rules included here are a starting point based
> on current practices. They will need to be reviewed and updated over time as conventions
> evolve, new tools are adopted, and gaps are identified. Treat them as living documents,
> not a final specification.

### Structure

```text
ai/
  rules/    shared .mdc rule files (Markdown with YAML frontmatter)
  skills/   ← shared .mdc skill patterns (populated as patterns are identified)
  plans/    ← ephemeral agent working notes (gitignored, never committed)
```

This structure also allows developers
to add personal rules alongside the shared ones without committing them. 

### How each agent is wired

| Agent | Entry point | Mechanism |
| --- | --- | --- |
| GitHub Copilot | `.github/copilot-instructions.md` | Read automatically by Copilot in VS Code, JetBrains, and agent mode |
| Claude Code | `CLAUDE.md` | Read automatically at session start |
| OpenAI Codex / Gemini CLI | `AGENTS.md` | AGENTS.md convention |
| Cursor | `.cursor/rules/` symlinks | Created by `scripts/setup_cursor.sh` |

Cursor requires a local setup step to populate `.cursor/` which is gitignored.
 Run once after cloning:

```bash
./scripts/setup_cursor.sh
```

### Initial rules

These rules reflect current practice at the time of writing. They should be revisited
as the codebase and tooling change.

| Rule | Glob | Enforces |
| --- | --- | --- |
| `markdownlint.mdc` | `**/*.md`, `**/*.mdc` | Run `npx markdownlint-cli2 --fix <file>` after every Markdown edit |
| `documentation.mdc` | all code changes | Keep `docs/`, config reference, and API docs in sync with code |
| `java-testing.mdc` | `**/*Test*.java`, `**/*IT.java`, `**/*Docs.java` | AssertJ, Awaitility, `@ParameterizedTest`, `@Nested`, UAA-specific patterns |
| `shellcheck.mdc` | `**/*.sh` | Run `shellcheck` after every shell script edit; follow Google Shell Style Guide |
| `ai-instructions.mdc` | `AGENTS.md`, `CLAUDE.md`, `copilot-instructions.md`, `ai/rules/*.mdc` | Keep the three agent entry-point files in sync when rules change |

### Supporting files

- `.markdownlint.json` — repo-level markdownlint config (120-char line limit, consistent
  heading style) so `npx markdownlint-cli2` works without per-file overrides
- `ai/plans/.gitignore` — keeps the `ai/plans/` directory present after cloning while
  ignoring all plan files
- `ai/README.md` — full documentation: how the wiring works, first-time setup, adding
  rules and skills, and per-agent personal rule instructions