### PR TITLE
Enhance flaky job rerun summary with detailed logs for failed tests

### DIFF
--- a/.github/workflows/rerun-flaky-jobs.yml
+++ b/.github/workflows/rerun-flaky-jobs.yml
@@ -65,6 +65,9 @@ jobs:
           # Build job list for summary (one line per job: name, conclusion)
           JOB_LIST=$(echo "$JOBS_JSON" | jq -r '.jobs[] | "- **\(.name)**: \(.conclusion // "pending")"')
 
+          # Always defined so the summary block can reference it unconditionally
+          FAILED_DETAILS=""
+
           # Decision: rerun only if some failed and at least one passed (flakiness)
           if [ "$FAILED_COUNT" -gt 0 ] && [ "$SUCCESS_COUNT" -gt 0 ]; then
             CONCLUSION_MSG="Flakiness detected. Rerunning failed jobs..."
@@ -81,6 +84,81 @@ jobs:
             else
               RERUN_ERROR_MSG=""
             fi
+
+            # For each failed matrix job, fetch its log and extract FAILED-block excerpts.
+            # Each block starts at a line containing FAILED and ends at the next line
+            # containing PASSED, a Gradle test-count summary, or BUILD SUCCESSFUL/FAILED —
+            # whichever comes first.  Blocks are capped at 50 lines to keep the summary
+            # readable; any remaining lines are replaced with a truncation notice.
+            while IFS=$'\t' read -r JOB_ID JOB_NAME; do
+              echo "Fetching logs for failed job: ${JOB_NAME} (id=${JOB_ID})"
+              set +e
+              # curl -L follows the 302 redirect that the logs API returns;
+              # head -c caps the download at 2 MB to guard against huge logs.
+              LOG_CONTENT=$(curl -fsL \
+                -H "Authorization: Bearer ${GH_TOKEN}" \
+                "https://api.github.com/repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" \
+                2>/dev/null | head -c 2097152)
+              CURL_STATUS=$?
+              set -e
+
+              if [ "$CURL_STATUS" -ne 0 ] || [ -z "$LOG_CONTENT" ]; then
+                EXCERPTS="_Could not fetch logs for this job (curl exit ${CURL_STATUS})._"
+              else
+                EXCERPTS=$(printf '%s' "$LOG_CONTENT" | awk '
+                  BEGIN { capturing=0; block=""; lines=0 }
+
+                  # A new FAILED line: flush any open block, then start a fresh one
+                  /FAILED/ {
+                    if (capturing && block != "") { printf "%s\n", block }
+                    block = $0 "\n"; lines = 1; capturing = 1; next
+                  }
+
+                  # Terminal line while capturing: flush block including this line
+                  capturing && (/PASSED/ || /[0-9]+ tests completed/ || /BUILD SUCCESSFUL/ || /BUILD FAILED/) {
+                    block = block $0 "\n"
+                    printf "%s\n", block
+                    block = ""; lines = 0; capturing = 0; next
+                  }
+
+                  # Still capturing and within the 50-line cap: accumulate
+                  capturing && lines < 50 { block = block $0 "\n"; lines++; next }
+
+                  # Hit the cap without finding a terminal line: truncate and flush
+                  capturing && lines >= 50 {
+                    block = block "...(truncated)\n"
+                    printf "%s\n", block
+                    block = ""; lines = 0; capturing = 0; next
+                  }
+
+                  # Flush any open block at end of file
+                  END { if (capturing && block != "") { printf "%s\n", block } }
+                ')
+
+                if [ -z "$EXCERPTS" ]; then
+                  EXCERPTS="_No FAILED output found in logs._"
+                fi
+              fi
+
+              FAILED_DETAILS="${FAILED_DETAILS}
+<details>
+<summary><b>${JOB_NAME}</b></summary>
+
+\`\`\`
+${EXCERPTS}
+\`\`\`
+
+</details>
+"
+            done < <(echo "$JOBS_JSON" | jq -r '
+              .jobs[]
+              | select(.conclusion != null and
+                  (.conclusion == "failure" or
+                   .conclusion == "cancelled" or
+                   .conclusion == "timed_out"))
+              | [(.id | tostring), .name]
+              | @tsv')
+
           else
             CONCLUSION_MSG="Flakiness not detected. Skipping auto-rerun."
             echo "$CONCLUSION_MSG"
@@ -114,5 +192,11 @@ jobs:
               echo ""
               echo "### Rerun error details"
               echo "${RERUN_ERROR_MSG}"
+            fi
+            if [ -n "${FAILED_DETAILS}" ]; then
+              echo ""
+              echo "### Failed test details"
+              echo ""
+              echo "${FAILED_DETAILS}"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rerun-flaky-jobs.yml
+++ b/.github/workflows/rerun-flaky-jobs.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Summarize failed test logs
         if: steps.check-and-rerun.outputs.flaky == 'true'
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
@@ -203,16 +204,8 @@ jobs:
             # break the <summary> tag rendering.
             ESCAPED_JOB_NAME="$(printf '%s' "$JOB_NAME" | python3 -c 'import html, sys; print(html.escape(sys.stdin.read()), end="")')"
 
-            JOB_BLOCK="
-<details>
-<summary><b>${ESCAPED_JOB_NAME}</b></summary>
-
-\`\`\`
-${EXCERPTS}
-\`\`\`
-
-</details>
-"
+            JOB_BLOCK="$(printf '\n<details>\n<summary><b>%s</b></summary>\n\n```\n%s\n```\n\n</details>\n' \
+              "${ESCAPED_JOB_NAME}" "${EXCERPTS}")"
 
             # Global size cap: keep FAILED_DETAILS under 400 KB so the overall
             # step summary stays well within GitHub's 1 MB limit.
@@ -222,14 +215,8 @@ ${EXCERPTS}
             if [ $((CURRENT_SIZE + BLOCK_SIZE)) -le $MAX_DETAILS_BYTES ]; then
               FAILED_DETAILS="${FAILED_DETAILS}${JOB_BLOCK}"
             else
-              FAILED_DETAILS="${FAILED_DETAILS}
-<details>
-<summary><b>${ESCAPED_JOB_NAME}</b> _(truncated — global size cap reached)_</summary>
-
-_Output omitted: the combined log excerpts have exceeded the 400 KB limit._
-
-</details>
-"
+              FAILED_DETAILS="${FAILED_DETAILS}$(printf '\n<details>\n<summary><b>%s</b> _(truncated — global size cap reached)_</summary>\n\n_Output omitted: the combined log excerpts have exceeded the 400 KB limit._\n\n</details>\n' \
+                "${ESCAPED_JOB_NAME}")"
               break
             fi
           done < <(echo "$JOBS_JSON" | jq -r '

--- a/.github/workflows/rerun-flaky-jobs.yml
+++ b/.github/workflows/rerun-flaky-jobs.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for flakiness and rerun failed jobs
+        id: check-and-rerun
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.event.workflow_run.id }}
@@ -65,9 +66,6 @@ jobs:
           # Build job list for summary (one line per job: name, conclusion)
           JOB_LIST=$(echo "$JOBS_JSON" | jq -r '.jobs[] | "- **\(.name)**: \(.conclusion // "pending")"')
 
-          # Always defined so the summary block can reference it unconditionally
-          FAILED_DETAILS=""
-
           # Decision: rerun only if some failed and at least one passed (flakiness)
           if [ "$FAILED_COUNT" -gt 0 ] && [ "$SUCCESS_COUNT" -gt 0 ]; then
             CONCLUSION_MSG="Flakiness detected. Rerunning failed jobs..."
@@ -84,85 +82,12 @@ jobs:
             else
               RERUN_ERROR_MSG=""
             fi
-
-            # For each failed matrix job, fetch its log and extract FAILED-block excerpts.
-            # Each block starts at a line containing FAILED and ends at the next line
-            # containing PASSED, a Gradle test-count summary, or BUILD SUCCESSFUL/FAILED —
-            # whichever comes first.  Blocks are capped at 50 lines to keep the summary
-            # readable; any remaining lines are replaced with a truncation notice.
-            while IFS=$'\t' read -r JOB_ID JOB_NAME; do
-              echo "Fetching logs for failed job: ${JOB_NAME} (id=${JOB_ID})"
-              set +e
-              # curl -L follows the 302 redirect that the logs API returns;
-              # head -c caps the download at 2 MB to guard against huge logs.
-              LOG_CONTENT=$(curl -fsL \
-                -H "Authorization: Bearer ${GH_TOKEN}" \
-                "https://api.github.com/repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" \
-                2>/dev/null | head -c 2097152)
-              CURL_STATUS=$?
-              set -e
-
-              if [ "$CURL_STATUS" -ne 0 ] || [ -z "$LOG_CONTENT" ]; then
-                EXCERPTS="_Could not fetch logs for this job (curl exit ${CURL_STATUS})._"
-              else
-                EXCERPTS=$(printf '%s' "$LOG_CONTENT" | awk '
-                  BEGIN { capturing=0; block=""; lines=0 }
-
-                  # A new FAILED line: flush any open block, then start a fresh one
-                  /FAILED/ {
-                    if (capturing && block != "") { printf "%s\n", block }
-                    block = $0 "\n"; lines = 1; capturing = 1; next
-                  }
-
-                  # Terminal line while capturing: flush block including this line
-                  capturing && (/PASSED/ || /[0-9]+ tests completed/ || /BUILD SUCCESSFUL/ || /BUILD FAILED/) {
-                    block = block $0 "\n"
-                    printf "%s\n", block
-                    block = ""; lines = 0; capturing = 0; next
-                  }
-
-                  # Still capturing and within the 50-line cap: accumulate
-                  capturing && lines < 50 { block = block $0 "\n"; lines++; next }
-
-                  # Hit the cap without finding a terminal line: truncate and flush
-                  capturing && lines >= 50 {
-                    block = block "...(truncated)\n"
-                    printf "%s\n", block
-                    block = ""; lines = 0; capturing = 0; next
-                  }
-
-                  # Flush any open block at end of file
-                  END { if (capturing && block != "") { printf "%s\n", block } }
-                ')
-
-                if [ -z "$EXCERPTS" ]; then
-                  EXCERPTS="_No FAILED output found in logs._"
-                fi
-              fi
-
-              FAILED_DETAILS="${FAILED_DETAILS}
-<details>
-<summary><b>${JOB_NAME}</b></summary>
-
-\`\`\`
-${EXCERPTS}
-\`\`\`
-
-</details>
-"
-            done < <(echo "$JOBS_JSON" | jq -r '
-              .jobs[]
-              | select(.conclusion != null and
-                  (.conclusion == "failure" or
-                   .conclusion == "cancelled" or
-                   .conclusion == "timed_out"))
-              | [(.id | tostring), .name]
-              | @tsv')
-
+            echo "flaky=true" >> "$GITHUB_OUTPUT"
           else
             CONCLUSION_MSG="Flakiness not detected. Skipping auto-rerun."
             echo "$CONCLUSION_MSG"
             RERUN_ERROR_MSG=""
+            echo "flaky=false" >> "$GITHUB_OUTPUT"
           fi
 
           # Write GITHUB_STEP_SUMMARY
@@ -193,10 +118,133 @@ ${EXCERPTS}
               echo "### Rerun error details"
               echo "${RERUN_ERROR_MSG}"
             fi
-            if [ -n "${FAILED_DETAILS}" ]; then
-              echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summarize failed test logs
+        if: steps.check-and-rerun.outputs.flaky == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+        run: |
+          set -uo pipefail
+
+          JOBS_JSON=$(gh api "repos/${{ github.repository }}/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}/jobs" 2>&1)
+          GH_STATUS=$?
+          if [ "$GH_STATUS" -ne 0 ]; then
+            echo "Error fetching jobs (exit code: $GH_STATUS)." >&2
+            echo "$JOBS_JSON" >&2
+            exit "$GH_STATUS"
+          fi
+
+          set -e
+          FAILED_DETAILS=""
+
+          # For each failed matrix job, fetch its log and extract FAILED-block excerpts.
+          # Each block starts at a line matching ") FAILED" (JUnit-style) and ends at the
+          # next line containing PASSED, a Gradle test-count summary, or BUILD SUCCESSFUL/FAILED.
+          # Blocks are capped at 30 lines; any remaining lines are replaced with a truncation notice.
+          while IFS=$'\t' read -r JOB_ID JOB_NAME; do
+            echo "Fetching logs for failed job: ${JOB_NAME} (id=${JOB_ID})"
+            set +e
+            # The job-logs endpoint redirects to a plain-text log file (unlike
+            # run-level logs which are ZIPs). -L follows the 302 redirect.
+            # --range avoids SIGPIPE issues from piping into head -c and caps
+            # the download at 2 MB to guard against very large logs.
+            LOG_CONTENT=$(curl -fsL \
+              --range 0-2097151 \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" \
+              2>/dev/null)
+            CURL_STATUS=$?
+            set -e
+
+            if [ "$CURL_STATUS" -ne 0 ] || [ -z "$LOG_CONTENT" ]; then
+              EXCERPTS="_Could not fetch logs for this job (curl exit ${CURL_STATUS})._"
+            else
+              EXCERPTS=$(printf '%s' "$LOG_CONTENT" | awk '
+                BEGIN { capturing=0; block=""; lines=0 }
+
+                # A new JUnit-style test failure line (e.g. "SomeTest > method() FAILED").
+                # Anchored to ") FAILED" at end-of-line so Gradle task/build lines like
+                # "> Task :foo FAILED" and "BUILD FAILED in …" are excluded.
+                /) FAILED$/ {
+                  if (capturing && block != "") { printf "%s\n", block }
+                  block = $0 "\n"; lines = 1; capturing = 1; next
+                }
+
+                # Terminal line while capturing: flush block including this line
+                capturing && (/PASSED/ || /[0-9]+ tests completed/ || /BUILD SUCCESSFUL/ || /BUILD FAILED/) {
+                  block = block $0 "\n"
+                  printf "%s\n", block
+                  block = ""; lines = 0; capturing = 0; next
+                }
+
+                # Still capturing and within the 30-line cap: accumulate
+                capturing && lines < 30 { block = block $0 "\n"; lines++; next }
+
+                # Hit the cap without finding a terminal line: truncate and flush
+                capturing && lines >= 30 {
+                  block = block "...(truncated)\n"
+                  printf "%s\n", block
+                  block = ""; lines = 0; capturing = 0; next
+                }
+
+                # Flush any open block at end of file
+                END { if (capturing && block != "") { printf "%s\n", block } }
+              ')
+
+              if [ -z "$EXCERPTS" ]; then
+                EXCERPTS="_No FAILED output found in logs._"
+              fi
+            fi
+
+            # HTML-escape the job name so that & < > in matrix labels don't
+            # break the <summary> tag rendering.
+            ESCAPED_JOB_NAME="$(printf '%s' "$JOB_NAME" | python3 -c 'import html, sys; print(html.escape(sys.stdin.read()), end="")')"
+
+            JOB_BLOCK="
+<details>
+<summary><b>${ESCAPED_JOB_NAME}</b></summary>
+
+\`\`\`
+${EXCERPTS}
+\`\`\`
+
+</details>
+"
+
+            # Global size cap: keep FAILED_DETAILS under 400 KB so the overall
+            # step summary stays well within GitHub's 1 MB limit.
+            CURRENT_SIZE=${#FAILED_DETAILS}
+            BLOCK_SIZE=${#JOB_BLOCK}
+            MAX_DETAILS_BYTES=409600
+            if [ $((CURRENT_SIZE + BLOCK_SIZE)) -le $MAX_DETAILS_BYTES ]; then
+              FAILED_DETAILS="${FAILED_DETAILS}${JOB_BLOCK}"
+            else
+              FAILED_DETAILS="${FAILED_DETAILS}
+<details>
+<summary><b>${ESCAPED_JOB_NAME}</b> _(truncated — global size cap reached)_</summary>
+
+_Output omitted: the combined log excerpts have exceeded the 400 KB limit._
+
+</details>
+"
+              break
+            fi
+          done < <(echo "$JOBS_JSON" | jq -r '
+            .jobs[]
+            | select(.conclusion != null and
+                (.conclusion == "failure" or
+                 .conclusion == "cancelled" or
+                 .conclusion == "timed_out"))
+            | [(.id | tostring), .name]
+            | @tsv')
+
+          if [ -n "${FAILED_DETAILS}" ]; then
+            {
               echo "### Failed test details"
               echo ""
               echo "${FAILED_DETAILS}"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/rerun-flaky-jobs.yml
+++ b/.github/workflows/rerun-flaky-jobs.yml
@@ -4,7 +4,7 @@
 name: Rerun flaky tests
 on:
   workflow_run:
-    workflows: [ "Integration tests on database", "JUnit tests on database" ]
+    workflows: [ "Integration tests on database", "JUnit tests on database", "Java CI with Gradle" ]
     types: [ completed ]
 
 permissions:


### PR DESCRIPTION
This adds the standalone tests to be monitored by the flaky job restart action. It also adds data on the tests that caused the failure. So that we can collect metrics and fix the most common issues first.