### PR TITLE
Remove ApacheDS dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,8 +61,6 @@ subprojects {
         exclude(group: "org.hamcrest", module: "hamcrest-core")
         exclude(group: "org.hamcrest", module: "hamcrest-library")
         exclude(group: "org.springframework.boot", module: "spring-boot-starter-logging")
-        exclude(group: "org.apache.directory.server", module: "apacheds-core")
-        exclude(group: "org.apache.directory.server", module: "apacheds-protocol-ldap")
         exclude(group: "org.skyscreamer", module: "jsonassert")
         exclude(group: "com.vaadin.external.google", module: "android-json")
         exclude(group: "com.unboundid.components", module: "json")

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,6 @@ ext {
 }
 
 // Versions shared between multiple dependencies
-versions.apacheDsVersion = "2.0.0.AM27"
 versions.bouncyCastleFipsVersion = "2.1.2"
 versions.bouncyCastlePkixFipsVersion = "2.1.11"
 versions.bouncyCastleTlsFipsVersion = "2.1.23"
@@ -18,7 +17,6 @@ versions.opensaml = "4.3.2"
 ext["selenium.version"] = "${versions.seleniumVersion}" // Selenium for integration tests only
 
 // Dependencies (some rely on shared versions, some are shared between projects)
-libraries.apacheDsProtocolLdap = "org.apache.directory.server:apacheds-protocol-ldap:${versions.apacheDsVersion}"
 libraries.apacheHttpClient = "org.apache.httpcomponents.client5:httpclient5"
 libraries.aspectJRt = "org.aspectj:aspectjrt"
 libraries.apacheLdapApi = "org.apache.directory.api:api-ldap-model:2.1.7"

--- a/uaa/build.gradle
+++ b/uaa/build.gradle
@@ -73,11 +73,6 @@ dependencies {
 
     testImplementation(project(":cloudfoundry-identity-model"))
     testImplementation(project(":cloudfoundry-identity-metrics-data"))
-    testImplementation(libraries.apacheDsProtocolLdap) {
-        exclude(module: "bcprov-jdk15")
-        exclude(module: "slf4j-api")
-        exclude(module: "slf4j-log4j12")
-    }
     testImplementation(libraries.apacheLdapApi) {
         exclude(module: "slf4j-api")
     }


### PR DESCRIPTION
* api-ldap-model:2.1.7 (actively used in production) has zero org.apache.directory.server transitive dependencies — the global excludes are not suppressing anything real
* apacheds-protocol-ldap is declared as testImplementation in uaa/build.gradle and simultaneously excluded by configurations.configureEach in build.gradle — a direct self-contradiction; it can never be resolved
* The global exclude lines for both apacheds-core and apacheds-protocol-ldap are themselves dead — nothing in the current dependency graph pulls them in