### PR TITLE
Fix for Issue #3650

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/home/HomeController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/home/HomeController.java
@@ -120,16 +120,16 @@ public class HomeController {
     @RequestMapping("/error500")
     public String error500(Model model, HttpServletRequest request, HttpServletResponse response) {
         Throwable genericException = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
-        logger.error("Internal error", genericException);
 
-        // check for common SAML related exceptions and redirect these to external_auth_error
         Saml2Exception samlException = extractSaml2Exception(genericException);
         if (samlException != null) {
+            logger.warn("SAML authentication error", samlException);
             model.addAttribute("saml_error", samlException.getMessage());
             response.setStatus(400);
             return EXTERNAL_AUTH_ERROR;
         }
 
+        logger.error("Internal error", genericException);
         populateBuildAndLinkInfo(model);
         return ERROR;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/home/HomeController.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/home/HomeController.java
@@ -122,9 +122,9 @@ public class HomeController {
         Throwable genericException = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
         logger.error("Internal error", genericException);
 
-        // check for common SAML related exceptions and redirect these to bad_request
-        if (nonNull(genericException) &&
-                (genericException.getCause() instanceof Saml2Exception samlException)) {
+        // check for common SAML related exceptions and redirect these to external_auth_error
+        Saml2Exception samlException = extractSaml2Exception(genericException);
+        if (samlException != null) {
             model.addAttribute("saml_error", samlException.getMessage());
             response.setStatus(400);
             return EXTERNAL_AUTH_ERROR;
@@ -208,5 +208,15 @@ public class HomeController {
     }
 
     public record JsonError(String error) {
+    }
+
+    private static Saml2Exception extractSaml2Exception(Throwable throwable) {
+        if (throwable instanceof Saml2Exception saml2) {
+            return saml2;
+        }
+        if (throwable != null && throwable.getCause() instanceof Saml2Exception saml2) {
+            return saml2;
+        }
+        return null;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepository.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepository.java
@@ -33,6 +33,7 @@ public class ConfiguratorRelyingPartyRegistrationRepository extends BaseUaaRelyi
      *
      * @param registrationId the registration identifier
      * @return the {@link RelyingPartyRegistration} if found, otherwise {@code null}
+     * @throws Saml2Exception if the registration cannot be built due to invalid or unreachable metadata
      */
     @Override
     public RelyingPartyRegistration findByRegistrationId(String registrationId) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepository.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepository.java
@@ -5,6 +5,7 @@ import org.cloudfoundry.identity.uaa.provider.AbstractIdentityProviderDefinition
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.util.KeyWithCert;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.util.Assert;
 
@@ -51,7 +52,8 @@ public class ConfiguratorRelyingPartyRegistrationRepository extends BaseUaaRelyi
                 }
             }
         } catch (Exception e) {
-            log.warn("Cannot retrieve SAML trusted party.", e);
+            log.warn("Cannot retrieve SAML trusted party for registrationId: {}", registrationId, e);
+            throw new Saml2Exception("Unable to build SAML relying party registration for: " + registrationId, e);
         }
 
         return null;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/HomeControllerViewTests.java
@@ -190,6 +190,14 @@ class HomeControllerViewTests extends TestClassNullifier {
     }
 
     @Test
+    void error500WithDirectSAMLException() throws Exception {
+        mockMvc.perform(get("/error500").requestAttr(RequestDispatcher.ERROR_EXCEPTION, new Saml2Exception("metadata fetch failed")))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().string(containsString(customFooterText)))
+                .andExpect(content().string(containsString(base64ProductLogo)));
+    }
+
+    @Test
     void error500WithMetadataProviderNotFoundExceptionCause() throws Exception {
         mockMvc.perform(get("/error500").requestAttr(RequestDispatcher.ERROR_EXCEPTION, new Exception(new MetadataProviderNotFoundException("bad", new RuntimeException()))))
                 .andExpect(status().isBadRequest())

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepositoryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepositoryTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
+import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.util.FileCopyUtils;
@@ -28,7 +29,6 @@ import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.cloudfoundry.identity.uaa.provider.saml.TestCredentialObjects.keyName1;
 import static org.cloudfoundry.identity.uaa.provider.saml.TestCredentialObjects.keyName2;
@@ -305,7 +305,7 @@ class ConfiguratorRelyingPartyRegistrationRepositoryTest {
     }
 
     @Test
-    void failsWhenInvalidMetadataLocationIsStored() {
+    void throwsWhenInvalidMetadataLocationIsStored() {
         when(repository.retrieveZone()).thenReturn(identityZone);
         when(identityZone.isUaa()).thenReturn(true);
         when(identityZone.getConfig()).thenReturn(identityZoneConfiguration);
@@ -315,11 +315,13 @@ class ConfiguratorRelyingPartyRegistrationRepositoryTest {
         when(definition.getMetaDataLocation()).thenReturn("not_found_metadata.xml");
         when(configurator.getIdentityProviderDefinitionsForZone(identityZone)).thenReturn(List.of(definition));
 
-        assertThatNoException().isThrownBy(() -> repository.findByRegistrationId(REGISTRATION_ID));
+        assertThatThrownBy(() -> repository.findByRegistrationId(REGISTRATION_ID))
+                .isInstanceOf(Saml2Exception.class)
+                .hasMessageContaining(REGISTRATION_ID);
     }
 
     @Test
-    void failsWhenInvalidMetadataXmlIsStored() {
+    void throwsWhenInvalidMetadataXmlIsStored() {
         when(repository.retrieveZone()).thenReturn(identityZone);
         when(identityZone.isUaa()).thenReturn(true);
         when(identityZone.getConfig()).thenReturn(identityZoneConfiguration);
@@ -329,7 +331,9 @@ class ConfiguratorRelyingPartyRegistrationRepositoryTest {
         when(definition.getMetaDataLocation()).thenReturn("<?xml version=\"1.0\"?>\n<xml>invalid xml</xml>");
         when(configurator.getIdentityProviderDefinitionsForZone(identityZone)).thenReturn(List.of(definition));
 
-        assertThatNoException().isThrownBy(() -> repository.findByRegistrationId(REGISTRATION_ID));
+        assertThatThrownBy(() -> repository.findByRegistrationId(REGISTRATION_ID))
+                .isInstanceOf(Saml2Exception.class)
+                .hasMessageContaining(REGISTRATION_ID);
     }
 
     @Test


### PR DESCRIPTION
  Problem: When a SAML IDP's metadata endpoint is unreachable, the ConfiguratorRelyingPartyRegistrationRepository catches the exception, returns null, and the DelegatingRelyingPartyRegistrationRepository falls through to the DefaultRelyingPartyRegistrationRepository which returns a stub registration
  pointing to https://www.cloudfoundry.org. The user gets redirected there with all SAML request parameters — confusing UX and a data leak.