### PR TITLE
refactor: allow multiple UaaTokenEnhancers

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -143,7 +143,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     private final TokenPolicy tokenPolicy;
     private final RevocableTokenProvisioning tokenProvisioning;
     private Set<String> excludedClaims;
-    private UaaTokenEnhancer uaaTokenEnhancer;
+    private List<UaaTokenEnhancer> uaaTokenEnhancers = new ArrayList<>();
     private final IdTokenCreator idTokenCreator;
     private final RefreshTokenCreator refreshTokenCreator;
     private TokenEndpointBuilder tokenEndpointBuilder;
@@ -192,8 +192,14 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     }
 
     @Autowired(required = false)
+    public void setUaaTokenEnhancers(List<UaaTokenEnhancer> uaaTokenEnhancers) {
+        if (uaaTokenEnhancers != null) {
+            this.uaaTokenEnhancers = new ArrayList<>(uaaTokenEnhancers);
+        }
+    }
+
     public void setUaaTokenEnhancer(UaaTokenEnhancer uaaTokenEnhancer) {
-        this.uaaTokenEnhancer = uaaTokenEnhancer;
+        this.uaaTokenEnhancers.add(uaaTokenEnhancer);
     }
 
     @Override
@@ -349,7 +355,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
     private Map<String, Object> getAdditionalRootClaims(Map<String, Object> refreshTokenClaims) {
         Map<String, Object> additionalRootClaims = new HashMap<>();
-        if (uaaTokenEnhancer != null) {
+        if (!uaaTokenEnhancers.isEmpty()) {
             refreshTokenClaims.entrySet()
                     .stream()
                     .filter(entry -> !NON_ADDITIONAL_ROOT_CLAIMS.contains(entry.getKey()))
@@ -625,8 +631,16 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         boolean isRefreshTokenRevocable = isAccessTokenRevocable || OPAQUE.getStringValue().equals(getActiveTokenPolicy().getRefreshTokenFormat());
 
         Map<String, Object> additionalRootClaims = null;
-        if (uaaTokenEnhancer != null) {
-            additionalRootClaims = new HashMap<>(uaaTokenEnhancer.enhance(emptyMap(), authentication));
+        if (!uaaTokenEnhancers.isEmpty()) {
+            additionalRootClaims = new HashMap<>();
+            for (UaaTokenEnhancer enhancer : uaaTokenEnhancers) {
+                if (enhancer != null) {
+                    Map<String, Object> claims = enhancer.enhance(emptyMap(), authentication);
+                    if (claims != null) {
+                        additionalRootClaims.putAll(claims);
+                    }
+                }
+            }
         }
 
         String clientAuthentication = getAuthenticationMethod(oAuth2Request);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
@@ -584,6 +584,51 @@ class DeprecatedUaaTokenServicesTests {
 
     @MethodSource("data")
     @ParameterizedTest(name = "{index}: {0}")
+    void multipleTokenEnhancersAreSupported(TestTokenEnhancer enhancer) {
+        initDeprecatedUaaTokenServicesTests(enhancer);
+        UaaTokenEnhancer enhancer1 = new UaaTokenEnhancer() {
+            @Override
+            public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                return Map.of("claim1", "value1");
+            }
+        };
+
+        UaaTokenEnhancer enhancer2 = new UaaTokenEnhancer() {
+            @Override
+            public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                return Map.of("claim2", "value2");
+            }
+        };
+
+        tokenServices.setUaaTokenEnhancers(java.util.Arrays.asList(enhancer1, enhancer2));
+
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest(CLIENT_ID, tokenSupport.clientScopes);
+        authorizationRequest.setResourceIds(new java.util.HashSet<>(tokenSupport.resourceIds));
+        authorizationRequest.setRequestParameters(new java.util.HashMap<>());
+        OAuth2Authentication authentication = new OAuth2Authentication(authorizationRequest.createOAuth2Request(), null);
+
+        OAuth2AccessToken accessToken = tokenServices.createAccessToken(authentication);
+
+        String jwt = accessToken.getValue();
+        org.cloudfoundry.identity.uaa.oauth.jwt.Jwt parsedToken = org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper.decode(jwt);
+        Map<String, Object> claims = org.cloudfoundry.identity.uaa.util.JsonUtils.readValue(parsedToken.getClaims(), new com.fasterxml.jackson.core.type.TypeReference<Map<String, Object>>() {});
+
+        assertThat(claims).containsEntry("claim1", "value1");
+        assertThat(claims).containsEntry("claim2", "value2");
+    }
+
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: {0}")
     void createAccessTokenForAClientInAnotherIdentityZone(TestTokenEnhancer enhancer) {
         initDeprecatedUaaTokenServicesTests(enhancer);
         String subdomain = "test-zone-subdomain";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -225,6 +225,60 @@ class UaaTokenServicesTests {
         }
 
         @Nested
+        @DisplayName("when multiple token enhancers are provided")
+        @DefaultTestContext
+        @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa"})
+        class WhenMultipleTokenEnhancersAreProvided {
+
+            @DisplayName("claims from all enhancers are merged into the token")
+            @ParameterizedTest
+            @ValueSource(strings = {GRANT_TYPE_PASSWORD, GRANT_TYPE_AUTHORIZATION_CODE})
+            void claimsAreMerged(String grantType) {
+                UaaTokenEnhancer enhancer1 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("claim1", "value1");
+                    }
+                };
+
+                UaaTokenEnhancer enhancer2 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("claim2", "value2");
+                    }
+                };
+
+                tokenServices.setUaaTokenEnhancers(Arrays.asList(enhancer1, enhancer2));
+
+                try {
+                    AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, grantType, "openid", "user_attributes");
+                    OAuth2Authentication auth2Authentication = constructUserAuthenticationFromAuthzRequest(authorizationRequest, "admin", "uaa");
+
+                    CompositeToken accessToken = (CompositeToken) tokenServices.createAccessToken(auth2Authentication);
+                    
+                    String jwt = accessToken.getValue();
+                    Jwt parsedToken = JwtHelper.decode(jwt);
+                    Map<String, Object> claims = JsonUtils.readValue(parsedToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+
+                    assertThat(claims).containsEntry("claim1", "value1");
+                    assertThat(claims).containsEntry("claim2", "value2");
+                } finally {
+                    tokenServices.setUaaTokenEnhancers(new ArrayList<>());
+                }
+            }
+        }
+
+        @Nested
         @DisplayName("when the hasn't approved the 'openid' scope")
         @DefaultTestContext
         @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa"})


### PR DESCRIPTION
- previously, only one is allowed
- add `setUaaTokenEnhancers` function to allow adding multiple UaaTokenEnhancers
- for now, keep `setUaaTokenEnhancer` function intact (it just adds a UaaTokenEnhancer now) for backward compatibility; even though the naming of this function is a little misleading now, it functions the same as before.
  - If backward compatibility is not a concern (aka there is no external code relying on `setUaaTokenEnhancer`, neither explicitly nor implicitly via spring), we could remove this function (and migrate to `setUaaTokenEnhancers`).