### PR TITLE
Always set connection and socket timeouts to preserve zero-means-disa…

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -81,9 +81,9 @@ public abstract class UaaHttpRequestUtils {
         return createRequestFactory(getClientBuilder(skipSslValidation, restTemplateConfig.maxTotal, restTemplateConfig.maxPerRoute, restTemplateConfig.maxKeepAlive, restTemplateConfig.validateAfterInactivity, restTemplateConfig.retryCount, timeout, readTimeout), timeout);
     }
 
-    protected static ClientHttpRequestFactory createRequestFactory(HttpClientBuilder builder, int timeoutInMs) {
+    protected static ClientHttpRequestFactory createRequestFactory(HttpClientBuilder builder, int connectionRequestTimeoutInMs) {
         HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory(builder.build());
-        factory.setConnectionRequestTimeout(timeoutInMs);
+        factory.setConnectionRequestTimeout(connectionRequestTimeoutInMs);
         return factory;
     }
 
@@ -111,16 +111,12 @@ public abstract class UaaHttpRequestUtils {
         cm.setDefaultMaxPerRoute(defaultMaxPerRoute);
         cm.setValidateAfterInactivity(TimeValue.of(validateAfterInactivity, TimeUnit.MILLISECONDS));
 
-        if (connectTimeoutInMs > 0) {
-            cm.setDefaultConnectionConfig(ConnectionConfig.custom()
-                    .setConnectTimeout(Timeout.ofMilliseconds(connectTimeoutInMs))
-                    .build());
-        }
-        if (readTimeoutInMs > 0) {
-            cm.setDefaultSocketConfig(SocketConfig.custom()
-                    .setSoTimeout(Timeout.ofMilliseconds(readTimeoutInMs))
-                    .build());
-        }
+        cm.setDefaultConnectionConfig(ConnectionConfig.custom()
+                .setConnectTimeout(Timeout.ofMilliseconds(connectTimeoutInMs))
+                .build());
+        cm.setDefaultSocketConfig(SocketConfig.custom()
+                .setSoTimeout(Timeout.ofMilliseconds(readTimeoutInMs))
+                .build());
 
         builder.setConnectionManager(cm);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
@@ -166,6 +166,17 @@ class UaaHttpRequestUtilsTest {
     }
 
     @Test
+    void clientBuilderWithZeroTimeoutsDisablesTimeouts() {
+        HttpClientBuilder builder = UaaHttpRequestUtils.getClientBuilder(false, 10, 5, 0, 2000, 0, 0, 0);
+        PoolingHttpClientConnectionManager cm = (PoolingHttpClientConnectionManager) ReflectionTestUtils.getField(builder, "connManager");
+        HttpRoute route = new HttpRoute(new HttpHost("localhost", 80));
+        ConnectionConfig connectionConfig = (ConnectionConfig) ReflectionTestUtils.invokeMethod(cm, "resolveConnectionConfig", route);
+        SocketConfig socketConfig = (SocketConfig) ReflectionTestUtils.invokeMethod(cm, "resolveSocketConfig", route);
+        assertThat(connectionConfig.getConnectTimeout()).isEqualTo(Timeout.ofMilliseconds(0));
+        assertThat(socketConfig.getSoTimeout()).isEqualTo(Timeout.ofMilliseconds(0));
+    }
+
+    @Test
     void trustedOnly() {
         RestTemplate restTemplate = new RestTemplate(UaaHttpRequestUtils.createRequestFactory(false, 10_000));
         try {


### PR DESCRIPTION
…bled semantics

Previously, the `> 0` guards skipped timeout configuration when callers passed 0, changing behavior from the old factory-level setters where 0 explicitly disabled timeouts. Now ConnectionConfig and SocketConfig are always applied unconditionally, and Timeout.ofMilliseconds(0) correctly maps to a disabled timeout.

Also rename the ambiguous `timeoutInMs` parameter to `connectionRequestTimeoutInMs` to clarify it is the pool lease timeout.