### PR TITLE
refactor: allow multiple UaaTokenEnhancers

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -90,6 +90,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -195,7 +196,13 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
     @Autowired(required = false)
     public void setUaaTokenEnhancers(List<UaaTokenEnhancer> uaaTokenEnhancers) {
-        this.uaaTokenEnhancers = new ArrayList<>(uaaTokenEnhancers == null ? emptyList() : uaaTokenEnhancers);
+        if (uaaTokenEnhancers != null) {
+            this.uaaTokenEnhancers = uaaTokenEnhancers.stream()
+                    .filter(Objects::nonNull)
+                    .toList();
+        } else {
+            this.uaaTokenEnhancers = new ArrayList<>();
+        }
     }
 
     @Deprecated
@@ -635,11 +642,9 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         if (!uaaTokenEnhancers.isEmpty()) {
             additionalRootClaims = new HashMap<>();
             for (UaaTokenEnhancer enhancer : uaaTokenEnhancers) {
-                if (enhancer != null) {
-                    Map<String, Object> claims = enhancer.enhance(additionalRootClaims, authentication);
-                    if (claims != null) {
-                        additionalRootClaims.putAll(claims);
-                    }
+                Map<String, Object> claims = enhancer.enhance(additionalRootClaims, authentication);
+                if (claims != null) {
+                    additionalRootClaims.putAll(claims);
                 }
             }
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -95,8 +95,10 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
 import static org.cloudfoundry.identity.uaa.oauth.client.ClientConstants.REQUIRED_USER_GROUPS;
 import static org.cloudfoundry.identity.uaa.oauth.openid.IdToken.ACR_VALUES_KEY;
@@ -143,7 +145,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     private final TokenPolicy tokenPolicy;
     private final RevocableTokenProvisioning tokenProvisioning;
     private Set<String> excludedClaims;
-    private UaaTokenEnhancer uaaTokenEnhancer;
+    private List<UaaTokenEnhancer> uaaTokenEnhancers = new ArrayList<>();
     private final IdTokenCreator idTokenCreator;
     private final RefreshTokenCreator refreshTokenCreator;
     private TokenEndpointBuilder tokenEndpointBuilder;
@@ -192,8 +194,13 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     }
 
     @Autowired(required = false)
+    public void setUaaTokenEnhancers(List<UaaTokenEnhancer> uaaTokenEnhancers) {
+        this.uaaTokenEnhancers = new ArrayList<>(uaaTokenEnhancers == null ? emptyList() : uaaTokenEnhancers);
+    }
+
+    @Deprecated
     public void setUaaTokenEnhancer(UaaTokenEnhancer uaaTokenEnhancer) {
-        this.uaaTokenEnhancer = uaaTokenEnhancer;
+        this.setUaaTokenEnhancers(uaaTokenEnhancer == null ? emptyList() : singletonList(uaaTokenEnhancer));
     }
 
     @Override
@@ -349,7 +356,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
     private Map<String, Object> getAdditionalRootClaims(Map<String, Object> refreshTokenClaims) {
         Map<String, Object> additionalRootClaims = new HashMap<>();
-        if (uaaTokenEnhancer != null) {
+        if (!uaaTokenEnhancers.isEmpty()) {
             refreshTokenClaims.entrySet()
                     .stream()
                     .filter(entry -> !NON_ADDITIONAL_ROOT_CLAIMS.contains(entry.getKey()))
@@ -625,8 +632,16 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         boolean isRefreshTokenRevocable = isAccessTokenRevocable || OPAQUE.getStringValue().equals(getActiveTokenPolicy().getRefreshTokenFormat());
 
         Map<String, Object> additionalRootClaims = null;
-        if (uaaTokenEnhancer != null) {
-            additionalRootClaims = new HashMap<>(uaaTokenEnhancer.enhance(emptyMap(), authentication));
+        if (!uaaTokenEnhancers.isEmpty()) {
+            additionalRootClaims = new HashMap<>();
+            for (UaaTokenEnhancer enhancer : uaaTokenEnhancers) {
+                if (enhancer != null) {
+                    Map<String, Object> claims = enhancer.enhance(emptyMap(), authentication);
+                    if (claims != null) {
+                        additionalRootClaims.putAll(claims);
+                    }
+                }
+            }
         }
 
         String clientAuthentication = getAuthenticationMethod(oAuth2Request);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -636,7 +636,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             additionalRootClaims = new HashMap<>();
             for (UaaTokenEnhancer enhancer : uaaTokenEnhancers) {
                 if (enhancer != null) {
-                    Map<String, Object> claims = enhancer.enhance(emptyMap(), authentication);
+                    Map<String, Object> claims = enhancer.enhance(additionalRootClaims, authentication);
                     if (claims != null) {
                         additionalRootClaims.putAll(claims);
                     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
@@ -584,6 +584,51 @@ class DeprecatedUaaTokenServicesTests {
 
     @MethodSource("data")
     @ParameterizedTest(name = "{index}: {0}")
+    void multipleTokenEnhancersAreSupported(TestTokenEnhancer enhancer) {
+        initDeprecatedUaaTokenServicesTests(enhancer);
+        UaaTokenEnhancer enhancer1 = new UaaTokenEnhancer() {
+            @Override
+            public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                return Map.of("claim1", "value1");
+            }
+        };
+
+        UaaTokenEnhancer enhancer2 = new UaaTokenEnhancer() {
+            @Override
+            public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                return Map.of();
+            }
+
+            @Override
+            public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                return Map.of("claim2", "value2");
+            }
+        };
+
+        tokenServices.setUaaTokenEnhancers(Arrays.asList(enhancer1, enhancer2));
+
+        AuthorizationRequest authorizationRequest = new AuthorizationRequest(CLIENT_ID, tokenSupport.clientScopes);
+        authorizationRequest.setResourceIds(new HashSet<>(tokenSupport.resourceIds));
+        authorizationRequest.setRequestParameters(new HashMap<>());
+        OAuth2Authentication authentication = new OAuth2Authentication(authorizationRequest.createOAuth2Request(), null);
+
+        OAuth2AccessToken accessToken = tokenServices.createAccessToken(authentication);
+
+        String jwt = accessToken.getValue();
+        Jwt parsedToken = JwtHelper.decode(jwt);
+        Map<String, Object> claims = JsonUtils.readValue(parsedToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+
+        assertThat(claims).containsEntry("claim1", "value1");
+        assertThat(claims).containsEntry("claim2", "value2");
+    }
+
+    @MethodSource("data")
+    @ParameterizedTest(name = "{index}: {0}")
     void createAccessTokenForAClientInAnotherIdentityZone(TestTokenEnhancer enhancer) {
         initDeprecatedUaaTokenServicesTests(enhancer);
         String subdomain = "test-zone-subdomain";

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/DeprecatedUaaTokenServicesTests.java
@@ -606,6 +606,9 @@ class DeprecatedUaaTokenServicesTests {
 
             @Override
             public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                if (claims.containsKey("claim1")) {
+                    return Map.of("claim2", claims.get("claim1") + "_modified");
+                }
                 return Map.of("claim2", "value2");
             }
         };
@@ -624,7 +627,7 @@ class DeprecatedUaaTokenServicesTests {
         Map<String, Object> claims = JsonUtils.readValue(parsedToken.getClaims(), new TypeReference<Map<String, Object>>() {});
 
         assertThat(claims).containsEntry("claim1", "value1");
-        assertThat(claims).containsEntry("claim2", "value2");
+        assertThat(claims).containsEntry("claim2", "value1_modified");
     }
 
     @MethodSource("data")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -225,6 +225,60 @@ class UaaTokenServicesTests {
         }
 
         @Nested
+        @DisplayName("when multiple token enhancers are provided")
+        @DefaultTestContext
+        @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa"})
+        class WhenMultipleTokenEnhancersAreProvided {
+
+            @DisplayName("claims from all enhancers are merged into the token")
+            @ParameterizedTest
+            @ValueSource(strings = {GRANT_TYPE_PASSWORD, GRANT_TYPE_AUTHORIZATION_CODE})
+            void claimsAreMerged(String grantType) {
+                UaaTokenEnhancer enhancer1 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("claim1", "value1");
+                    }
+                };
+
+                UaaTokenEnhancer enhancer2 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("claim2", "value2");
+                    }
+                };
+
+                tokenServices.setUaaTokenEnhancers(Arrays.asList(enhancer1, enhancer2));
+
+                try {
+                    AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, grantType, "openid", "user_attributes");
+                    OAuth2Authentication auth2Authentication = constructUserAuthenticationFromAuthzRequest(authorizationRequest, "admin", "uaa");
+
+                    CompositeToken accessToken = (CompositeToken) tokenServices.createAccessToken(auth2Authentication);
+                    
+                    String jwt = accessToken.getValue();
+                    Jwt parsedToken = JwtHelper.decode(jwt);
+                    Map<String, Object> claims = JsonUtils.readValue(parsedToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+
+                    assertThat(claims).containsEntry("claim1", "value1");
+                    assertThat(claims).containsEntry("claim2", "value2");
+                } finally {
+                    tokenServices.setUaaTokenEnhancers(new ArrayList<>());
+                }
+            }
+        }
+
+        @Nested
         @DisplayName("when the hasn't approved the 'openid' scope")
         @DefaultTestContext
         @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa"})

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -276,6 +276,56 @@ class UaaTokenServicesTests {
                     tokenServices.setUaaTokenEnhancers(new ArrayList<>());
                 }
             }
+
+            @DisplayName("claims are passed to subsequent enhancers")
+            @ParameterizedTest
+            @ValueSource(strings = {GRANT_TYPE_PASSWORD, GRANT_TYPE_AUTHORIZATION_CODE})
+            void claimsArePassedToSubsequentEnhancers(String grantType) {
+                UaaTokenEnhancer enhancer1 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("claim1", "value1");
+                    }
+                };
+
+                UaaTokenEnhancer enhancer2 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        if (claims.containsKey("claim1")) {
+                            return Map.of("claim2", claims.get("claim1") + "_modified");
+                        }
+                        return Map.of("claim2", "value2");
+                    }
+                };
+
+                tokenServices.setUaaTokenEnhancers(Arrays.asList(enhancer1, enhancer2));
+
+                try {
+                    AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, grantType, "openid", "user_attributes");
+                    OAuth2Authentication auth2Authentication = constructUserAuthenticationFromAuthzRequest(authorizationRequest, "admin", "uaa");
+
+                    CompositeToken accessToken = (CompositeToken) tokenServices.createAccessToken(auth2Authentication);
+
+                    String jwt = accessToken.getValue();
+                    Jwt parsedToken = JwtHelper.decode(jwt);
+                    Map<String, Object> claims = JsonUtils.readValue(parsedToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+
+                    assertThat(claims).containsEntry("claim1", "value1");
+                    assertThat(claims).containsEntry("claim2", "value1_modified");
+                } finally {
+                    tokenServices.setUaaTokenEnhancers(new ArrayList<>());
+                }
+            }
         }
 
         @Nested

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -326,6 +326,52 @@ class UaaTokenServicesTests {
                     tokenServices.setUaaTokenEnhancers(new ArrayList<>());
                 }
             }
+
+            @DisplayName("claims from later enhancers override claims from earlier enhancers")
+            @ParameterizedTest
+            @ValueSource(strings = {GRANT_TYPE_PASSWORD, GRANT_TYPE_AUTHORIZATION_CODE})
+            void claimsAreOverriddenBySubsequentEnhancers(String grantType) {
+                UaaTokenEnhancer enhancer1 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("shared_claim", "original_value");
+                    }
+                };
+
+                UaaTokenEnhancer enhancer2 = new UaaTokenEnhancer() {
+                    @Override
+                    public Map<String, String> getExternalAttributes(OAuth2Authentication authentication) {
+                        return Map.of();
+                    }
+
+                    @Override
+                    public Map<String, Object> enhance(Map<String, Object> claims, OAuth2Authentication authentication) {
+                        return Map.of("shared_claim", "overridden_value");
+                    }
+                };
+
+                tokenServices.setUaaTokenEnhancers(Arrays.asList(enhancer1, enhancer2));
+
+                try {
+                    AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, grantType, "openid", "user_attributes");
+                    OAuth2Authentication auth2Authentication = constructUserAuthenticationFromAuthzRequest(authorizationRequest, "admin", "uaa");
+
+                    CompositeToken accessToken = (CompositeToken) tokenServices.createAccessToken(auth2Authentication);
+
+                    String jwt = accessToken.getValue();
+                    Jwt parsedToken = JwtHelper.decode(jwt);
+                    Map<String, Object> claims = JsonUtils.readValue(parsedToken.getClaims(), new TypeReference<Map<String, Object>>() {});
+
+                    assertThat(claims).containsEntry("shared_claim", "overridden_value");
+                } finally {
+                    tokenServices.setUaaTokenEnhancers(new ArrayList<>());
+                }
+            }
         }
 
         @Nested


### PR DESCRIPTION
- previously, only one is allowed
- add setUaaTokenEnhancers function to allow adding multiple UaaTokenEnhancers (this func will be implicitly called
when UaaTokenEnhancer bean/beans are supplied)
- refactor setUaaTokenEnhancer function (but keep same general business logic as before) for backward compatibility; mark as deprecated

---
incorporated feedback from earlier PR: https://github.com/cloudfoundry/uaa/pull/3899