### PR TITLE
Update default redirect url matching to be more secure

### DIFF
--- a/scripts/boot/uaa.yml
+++ b/scripts/boot/uaa.yml
@@ -375,3 +375,8 @@ oauth:
       - roles
       - user_attributes
       - uaa.offline_token
+
+uaa:
+  oauth:
+    redirect_uri:
+      allow_unsafe_matching: true

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/RedirectResolverFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/RedirectResolverFactoryBean.java
@@ -12,7 +12,7 @@ public class RedirectResolverFactoryBean implements FactoryBean<RedirectResolver
     private final boolean allowUnsafeMatching;
 
     public RedirectResolverFactoryBean(
-            @Value("${uaa.oauth.redirect_uri.allow_unsafe_matching:true}") boolean allowUnsafeMatching
+            @Value("${uaa.oauth.redirect_uri.allow_unsafe_matching:false}") boolean allowUnsafeMatching
     ) {
         this.allowUnsafeMatching = allowUnsafeMatching;
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/beans/RedirectResolverFactoryBeanTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/beans/RedirectResolverFactoryBeanTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.oauth.beans;
 
-import org.cloudfoundry.identity.uaa.oauth.provider.endpoint.DefaultRedirectResolver;
 import org.cloudfoundry.identity.uaa.oauth.provider.endpoint.RedirectResolver;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.FactoryBean;
@@ -18,12 +17,11 @@ class RedirectResolverFactoryBeanTest {
     }
 
     @Test
-    void disallowUnsafeMatching_shouldReturnSpringSecurityOauth2RedirectResolver_withDontMatchSubdomain() throws Exception {
+    void disallowUnsafeMatching_shouldReturnRedirectResolver_withDontMatchSubdomain() throws Exception {
         FactoryBean<RedirectResolver> factory = new RedirectResolverFactoryBean(false);
 
         RedirectResolver redirectResolver = factory.getObject();
-        assertThat(redirectResolver).isInstanceOf(DefaultRedirectResolver.class);
+        assertThat(redirectResolver).isInstanceOf(NormalizedRedirectResolver.class);
         assertThat(ReflectionTestUtils.getField(redirectResolver, "matchSubdomains")).isEqualTo(false);
     }
-
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcTests.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.TestPropertySource;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -139,8 +140,14 @@ class InvitationsEndpointMockMvcTests {
 
     @Nested
     @DefaultTestContext
+    @TestPropertySource(
+            properties = "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
+    )
     @ExtendWith(ZoneSeederExtension.class)
     class WithOtherIdentityZone {
+
+        @Autowired // New mockMvc tied to the new web app context created by @TestPropertySource
+        protected MockMvc mockMvc;
 
         private ZoneSeeder zoneSeeder;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcZonePathTests.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.web.context.WebApplicationContext;
@@ -254,8 +255,14 @@ class InvitationsEndpointMockMvcZonePathTests {
 
     @Nested
     @DefaultTestContext
+    @TestPropertySource(
+            properties = "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
+    )
     @ExtendWith(ZoneSeederExtension.class)
     class WithOtherIdentityZone {
+
+        @Autowired // New mockMvc tied to the new web app context created by @TestPropertySource
+        protected MockMvc mockMvc;
 
         private ZoneSeeder zoneSeeder;
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/invitations/InvitationsEndpointMockMvcZonePathTests.java
@@ -23,7 +23,6 @@ import org.cloudfoundry.identity.uaa.zone.BrandingInformation;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
-import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
 import org.cloudfoundry.identity.uaa.zone.MultitenantJdbcClientDetailsService;
 import org.flywaydb.core.internal.util.StringUtils;
@@ -766,12 +765,6 @@ class InvitationsEndpointMockMvcZonePathTests {
                                                                              String... emails) throws Exception {
         return MockMvcUtils.sendRequestWithTokenAndReturnResponse(webApplicationContext,
                 mockMvc, token, subdomain, clientId, redirectUri, emails);
-    }
-
-    private static void sendRequestWithToken(WebApplicationContext webApplicationContext, MockMvc mockMvc, String token, String clientId, String... emails) throws Exception {
-        InvitationsResponse response = sendRequestWithTokenAndReturnResponse(webApplicationContext, mockMvc, token, null, clientId, "example.com", emails);
-        assertThat(response.getNewInvites()).hasSameSizeAs(emails);
-        assertThat(response.getFailedInvites()).isEmpty();
     }
 
     private static void assertResponseAndCodeCorrect(ExpiringCodeStore expiringCodeStore, String[] emails, String redirectUrl, IdentityZone zone, InvitationsResponse response, ClientDetails clientDetails) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/oauth/AuthorizationPromptNoneEntryPointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/oauth/AuthorizationPromptNoneEntryPointMockMvcTests.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpSession;
-import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.context.WebApplicationContext;
 
@@ -30,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@TestPropertySource(properties = "uaa.oauth.redirect_uri.allow_unsafe_matching=true")
 @DefaultTestContext
 class AuthorizationPromptNoneEntryPointMockMvcTests {
 
@@ -115,6 +116,7 @@ class AuthorizationPromptNoneEntryPointMockMvcTests {
 
             //we need to know session id when we are calculating session_state
             MockHttpSession session = new MockHttpSession(null, "12345") {
+                @Override
                 public String changeSessionId() {
                     return "12345";
                 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -161,7 +161,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
 })
 @DefaultTestContext
-@SuppressWarnings("rule:java:S5810")
 public // NOSONAR public for LimitedModeTokenMockMvcTests
 class TokenMvcMockTests extends AbstractTokenMockMvcTests {
     private static final String BAD_SECRET = "badsecret";

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -155,7 +155,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@TestPropertySource(properties = {"uaa.url=https://localhost:8080/uaa", "jwt.token.refresh.format=jwt"})
+@TestPropertySource(properties = {
+        "uaa.url=https://localhost:8080/uaa",
+        "jwt.token.refresh.format=jwt",
+        "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
+})
 @DefaultTestContext
 // public for LimitedModeTokenMockMvcTests
 public class TokenMvcMockTests extends AbstractTokenMockMvcTests {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -161,8 +161,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
 })
 @DefaultTestContext
-// public for LimitedModeTokenMockMvcTests
-public class TokenMvcMockTests extends AbstractTokenMockMvcTests {
+@SuppressWarnings("rule:java:S5810")
+public // NOSONAR public for LimitedModeTokenMockMvcTests
+class TokenMvcMockTests extends AbstractTokenMockMvcTests {
     private static final String BAD_SECRET = "badsecret";
     protected AlphanumericRandomValueStringGenerator generator = new AlphanumericRandomValueStringGenerator();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
@@ -165,10 +165,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
         "jwt.token.refresh.format=jwt",
         "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
 })
-// public for LimitedModeTokenMockMvcTests
 @EnabledIfZonePathsEnabled
 @DefaultTestContext
-public class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
+public // NOSONAR public for LimitedModeTokenMockMvcTests
+class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
     private static final String BAD_SECRET = "badsecret";
     protected AlphanumericRandomValueStringGenerator generator = new AlphanumericRandomValueStringGenerator();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
@@ -160,7 +160,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-@TestPropertySource(properties = {"uaa.url=https://localhost:8080/uaa", "jwt.token.refresh.format=jwt"})
+@TestPropertySource(properties = {
+        "uaa.url=https://localhost:8080/uaa",
+        "jwt.token.refresh.format=jwt",
+        "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
+})
 // public for LimitedModeTokenMockMvcTests
 @EnabledIfZonePathsEnabled
 @DefaultTestContext

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
@@ -1036,7 +1036,7 @@ public final class MockMvcUtils {
                 .param(TokenConstants.REQUEST_TOKEN_FORMAT, tokenFormat.getStringValue())
                 .param(OAuth2Utils.STATE, state)
                 .param(OAuth2Utils.CLIENT_ID, clientId)
-                .param(OAuth2Utils.REDIRECT_URI, "http://localhost/test");
+                .param(OAuth2Utils.REDIRECT_URI, "http://localhost:8080/test");
         if (StringUtils.hasText(scope)) {
             authRequest.param(OAuth2Utils.SCOPE, scope);
         }
@@ -1052,7 +1052,7 @@ public final class MockMvcUtils {
                 .param(OAuth2Utils.GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                 .param("code", code)
                 .param(OAuth2Utils.CLIENT_ID, clientId)
-                .param(OAuth2Utils.REDIRECT_URI, "http://localhost/test");
+                .param(OAuth2Utils.REDIRECT_URI, "http://localhost:8080/test");
         if (StringUtils.hasText(scope)) {
             authRequest.param(OAuth2Utils.SCOPE, scope);
         }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
@@ -351,8 +351,8 @@ public final class MockMvcUtils {
         return JsonUtils.readValue(result.getResponse().getContentAsString(), InvitationsResponse.class);
     }
 
-    public static URL inviteUser(ApplicationContext context, MockMvc mockMvc, String email, String userInviteToken, String subdomain, String clientId, String expectedOrigin, String REDIRECT_URI) throws Exception {
-        InvitationsResponse response = sendRequestWithTokenAndReturnResponse(context, mockMvc, userInviteToken, subdomain, clientId, REDIRECT_URI, email);
+    public static URL inviteUser(ApplicationContext context, MockMvc mockMvc, String email, String userInviteToken, String subdomain, String clientId, String expectedOrigin, String redirectUri) throws Exception {
+        InvitationsResponse response = sendRequestWithTokenAndReturnResponse(context, mockMvc, userInviteToken, subdomain, clientId, redirectUri, email);
         assertThat(response.getNewInvites()).hasSize(1);
         assertThat(context.getBean(JdbcTemplate.class).queryForObject("SELECT origin FROM users WHERE username='" + email + "'", String.class)).isEqualTo(expectedOrigin);
         return response.getNewInvites().getFirst().getInviteLink();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcTest.java
@@ -62,7 +62,13 @@ class UaaAuthorizationEndpointMockMvcTest {
 
     @Nested
     @DefaultTestContext
+    @TestPropertySource(
+            properties = "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
+    )
     class WhenRedirectUriAllowUnsafeMatchingIsEnabled {
+
+        @Autowired // New mockMvc tied to the new web app context created by @TestPropertySource
+        protected MockMvc mockMvc;
 
         @Nested
         @DefaultTestContext

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcTest.java
@@ -88,17 +88,6 @@ class UaaAuthorizationEndpointMockMvcTest {
                         .andExpect(status().isFound())
                         .andExpect(header().string("Location", startsWith("http://sample.com/a/b?code=")));
             }
-
-            @Test
-            void shouldRedirect_whenTheRequestRedirectUriIsAnExactMatch() throws Exception {
-                mockMvc.perform(implicitGrantAuthorizeRequest("http://sample.com/a/b"))
-                        .andExpect(status().isFound())
-                        .andExpect(header().string("Location", startsWith("http://sample.com/a/b#token_type=bearer&access_token=")));
-
-                mockMvc.perform(authCodeAuthorizeRequest("http://sample.com/a/b"))
-                        .andExpect(status().isFound())
-                        .andExpect(header().string("Location", startsWith("http://sample.com/a/b?code=")));
-            }
         }
 
         @Nested

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcZonePathTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcZonePathTest.java
@@ -96,17 +96,6 @@ class UaaAuthorizationEndpointMockMvcZonePathTest {
                         .andExpect(status().isFound())
                         .andExpect(header().string("Location", startsWith("http://sample.com/a/b?code=")));
             }
-
-            @Test
-            void shouldRedirect_whenTheRequestRedirectUriIsAnExactMatch() throws Exception {
-                mockMvc.perform(implicitGrantAuthorizeRequest("http://sample.com/a/b"))
-                        .andExpect(status().isFound())
-                        .andExpect(header().string("Location", startsWith("http://sample.com/a/b#token_type=bearer&access_token=")));
-
-                mockMvc.perform(authCodeAuthorizeRequest("http://sample.com/a/b"))
-                        .andExpect(status().isFound())
-                        .andExpect(header().string("Location", startsWith("http://sample.com/a/b?code=")));
-            }
         }
 
         @Nested

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcZonePathTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaAuthorizationEndpointMockMvcZonePathTest.java
@@ -70,7 +70,13 @@ class UaaAuthorizationEndpointMockMvcZonePathTest {
 
     @Nested
     @DefaultTestContext
+    @TestPropertySource(
+            properties = "uaa.oauth.redirect_uri.allow_unsafe_matching=true"
+    )
     class WhenRedirectUriAllowUnsafeMatchingIsEnabled {
+
+        @Autowired // Need a new mockMvc which is tied to the new web app context created by @TestPropertySource
+        protected MockMvc mockMvc;
 
         @Nested
         @DefaultTestContext
@@ -142,7 +148,7 @@ class UaaAuthorizationEndpointMockMvcZonePathTest {
     )
     class WhenRedirectUriAllowUnsafeMatchingIsDisabled {  // "spec-compliant" mode
 
-        @Autowired // Need a new mockMvc which is tied to the new web app context created by @TestPropertySource
+        @Autowired // New mockMvc tied to the new web app context created by @TestPropertySource
         protected MockMvc mockMvc;
 
         @Nested

--- a/uaa/src/test/resources/mockmvc_unittest_properties.yml
+++ b/uaa/src/test/resources/mockmvc_unittest_properties.yml
@@ -418,6 +418,9 @@ oauth:
       - uaa.offline_token
 
 uaa:
+  oauth:
+    redirect_uri:
+      allow_unsafe_matching: true
   # The hostname of the UAA that this login server will connect to
   url: http://localhost:8080/uaa
   token:


### PR DESCRIPTION
Changing the default value of uaa.oauth.redirect_uri.allow_unsafe_matching from true to false to make UAA use the more secure setting by default.

When uaa.oauth.redirect_uri.allow_unsafe_matching is true, UAA uses the LegacyRedirectResolver, which performs permissive subdomain matching when validating OAuth2 redirect URIs. This means that a redirect URI registered as https://app.example.com/callback will also match https://evil.app.example.com/callback.
This behavior could pose a security risk. Exact URI matching (the behavior when allow_unsafe_matching is false) is the correct and safe default.

This setting is overridden in uaa-release. So deployments using the uaa-release will notice no effect, until it also changes.

Implements #3883 