### PR TITLE
Fix: SAML metadata ACS URL ignores zone subdomain when entityBaseURL is set

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -1716,8 +1716,21 @@ When `true`, users see an account chooser UI that lets them pick from previously
 **Type:** `String`
 
 The base URL of this UAA instance for SAML SP metadata generation. This URL appears in the
-SAML metadata as the service provider's base location. When `null`, UAA uses the request URL,
-which enables automatic zone subdomain resolution.
+SAML metadata as the service provider's base location and is used to construct AssertionConsumerService (ACS) and SingleLogoutService (SLS) endpoints.
+
+**When `null` or empty:** UAA derives the base URL from the incoming HTTP request, which works for subdomain-based zones but provides automatic hostname resolution.
+
+**Important:** The behavior of `entityBaseURL` varies depending on the identity zone access pattern:
+
+| Zone Access Pattern | Behavior | Example |
+|---------------------|----------|---------|
+| **Default (UAA) zone** | Uses `entityBaseURL` as-is | `http://localhost:8080/uaa` → ACS: `http://localhost:8080/uaa/saml/SSO/alias/...` |
+| **Non-default zone, subdomain access** | Prepends zone subdomain to `entityBaseURL` host | `http://localhost:8080/uaa` + zone `myzone` → ACS: `http://myzone.localhost:8080/uaa/saml/SSO/alias/...` |
+| **Non-default zone, path access** (`zones.paths.enabled=true`) | **Ignores** `entityBaseURL`; derives from request | Request to `/z/myzone/saml/metadata` → ACS: `http://localhost/z/myzone/saml/SSO/alias/...` |
+
+**Zone Path Access Pattern:** When [`zones.paths.enabled=true`](#zonespathsenabled) and zones are accessed via `/z/{subdomain}/` URLs, `entityBaseURL` is ignored because it's a static configuration value that cannot encode the dynamic zone path. The SAML metadata URLs are derived from the incoming request, which already contains the zone path information thanks to the [`ZonePathContextRewritingFilter`](../server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilter.java).
+
+**When to set `entityBaseURL`:** Configure this when deploying behind load balancers or proxies where the internal server hostname/port differs from the externally accessible URL. This ensures SAML metadata contains stable, publicly reachable endpoints.
 
 [Back to table](#login--branding)
 
@@ -2937,6 +2950,12 @@ When `false`, only aggregate metrics are collected.
 When `true`, enables path-based identity zone routing via `/z/{subdomain}/` URL prefixes.
 This allows multiple zones to be accessed through the same hostname using different
 URL paths instead of different subdomains.
+
+**Examples:**
+- Subdomain access (default): `https://myzone.uaa.example.com/login`
+- Path access (when enabled): `https://uaa.example.com/z/myzone/login`
+
+**Important:** When path-based zone access is enabled, [`login.entityBaseURL`](#loginentitybaseurl) is ignored for SAML metadata generation in non-default zones, as the zone information is already encoded in the URL path. See the `login.entityBaseURL` documentation for details on how this affects SAML endpoint URLs.
 
 [Back to table](#zone-paths)
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolver.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolver.java
@@ -16,6 +16,10 @@
 package org.cloudfoundry.identity.uaa.provider.saml;
 
 import lombok.extern.slf4j.Slf4j;
+import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
@@ -85,7 +89,7 @@ public final class UaaRelyingPartyRegistrationResolver implements Converter<Http
             if (relyingPartyRegistration == null) {
                 return null;
             } else {
-                String baseUrl = StringUtils.hasText(entityBaseURL) ? entityBaseURL : getApplicationUri(request);
+                String baseUrl = resolveBaseUrl(entityBaseURL, request);
                 Function<String, String> templateResolver = this.templateResolver(baseUrl, relyingPartyRegistration);
                 String relyingPartyEntityId = templateResolver.apply(relyingPartyRegistration.getEntityId());
                 String assertionConsumerServiceLocation = templateResolver.apply(relyingPartyRegistration.getAssertionConsumerServiceLocation());
@@ -150,6 +154,63 @@ public final class UaaRelyingPartyRegistrationResolver implements Converter<Http
         uriVariables.put("entityId", StringUtils.hasText(entityId) ? entityId : "");
         uriVariables.put("registrationId", StringUtils.hasText(registrationId) ? registrationId : "");
         return uriVariables;
+    }
+
+    /**
+     * Determines the base URL used to expand {@code {baseUrl}} template variables in
+     * relying-party endpoint locations, accounting for both zone-access patterns:
+     *
+     * <ul>
+     *   <li><b>Subdomain-based zones</b> ({@code http://zone.host/uaa/…}): when
+     *       {@code entityBaseURL} is configured the zone subdomain is prepended to its
+     *       host, e.g. {@code http://localhost:8080/uaa} →
+     *       {@code http://zone.localhost:8080/uaa}.</li>
+     *   <li><b>Path-based zones</b> ({@code http://host/z/{subdomain}/…}):
+     *       {@link ZonePathContextRewritingFilter} has already rewritten
+     *       {@code request.getContextPath()} to include {@code /z/{subdomain}}, so
+     *       {@link #getApplicationUri} produces the correct zone-specific base URL.
+     *       {@code entityBaseURL} is a static operator setting that cannot encode the
+     *       per-zone path dynamically, therefore it is ignored for this access pattern.</li>
+     * </ul>
+     *
+     * When {@code entityBaseURL} is not configured the base URL is always derived from
+     * the incoming HTTP request, which already carries the correct zone information
+     * (subdomain in the {@code Host} header, or zone path in the rewritten context path).
+     */
+    private static String resolveBaseUrl(String entityBaseURL, HttpServletRequest request) {
+        // Path-based zone: ZonePathContextRewritingFilter has embedded /z/{subdomain}
+        // into the context path. entityBaseURL is a static value that cannot reflect this
+        // dynamically, so always derive from the request for this access pattern.
+        if (isZonePathRequest(request)) {
+            return getApplicationUri(request);
+        }
+
+        if (!StringUtils.hasText(entityBaseURL)) {
+            return getApplicationUri(request);
+        }
+
+        // Subdomain-based zone with entityBaseURL configured: prepend the zone
+        // subdomain to the host so ACS/SLO endpoints resolve to the right virtual host.
+        IdentityZone currentZone = IdentityZoneHolder.get();
+        if (!currentZone.isUaa()) {
+            return UaaUrlUtils.addSubdomainToUrl(entityBaseURL, currentZone.getSubdomain());
+        }
+        return entityBaseURL;
+    }
+
+    /**
+     * Returns {@code true} when the current request is being served under a path-based
+     * zone URL ({@code /z/{subdomain}/}), as signalled by the
+     * {@link ZonePathContextRewritingFilter#ZONE_ORIGINAL_CONTEXT_PATH} request attribute.
+     */
+    private static boolean isZonePathRequest(HttpServletRequest request) {
+        Object origAttr = request.getAttribute(ZonePathContextRewritingFilter.ZONE_ORIGINAL_CONTEXT_PATH);
+        if (origAttr instanceof String originalContextPath) {
+            String contextPath = request.getContextPath();
+            return contextPath != null
+                    && contextPath.startsWith(originalContextPath + ZonePathContextRewritingFilter.ZONE_PATH_PREFIX);
+        }
+        return false;
     }
 
     private static String getApplicationUri(HttpServletRequest request) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlMetadataEndpointKeyRotationTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlMetadataEndpointKeyRotationTests.java
@@ -84,7 +84,10 @@ public class SamlMetadataEndpointKeyRotationTests {
 
         RelyingPartyRegistrationRepository registrationRepository =
                 new DefaultRelyingPartyRegistrationRepository("entityId", "entityIdAlias", List.of(), NAME_ID_FORMAT);
-        RelyingPartyRegistrationResolver registrationResolver = new UaaRelyingPartyRegistrationResolver(registrationRepository, ENTITY_ID, "http://zone-id.localhost:8080/uaa");
+        // entityBaseURL is the UAA base URL without any zone subdomain. For non-default zones accessed
+        // via subdomain, UaaRelyingPartyRegistrationResolver prepends the zone subdomain automatically
+        // (e.g. "http://localhost:8080/uaa" → "http://zone-id.localhost:8080/uaa").
+        RelyingPartyRegistrationResolver registrationResolver = new UaaRelyingPartyRegistrationResolver(registrationRepository, ENTITY_ID, "http://localhost:8080/uaa");
         endpoint = spy(new SamlMetadataEndpoint(registrationResolver, identityZoneManager, SignatureAlgorithm.SHA256, true));
         IdentityZoneHolder.set(otherZone);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolverTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/UaaRelyingPartyRegistrationResolverTests.java
@@ -16,6 +16,10 @@
 package org.cloudfoundry.identity.uaa.provider.saml;
 
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,6 +64,11 @@ class UaaRelyingPartyRegistrationResolverTests {
         registration = mock(RelyingPartyRegistration.class);
         repository = mock(RelyingPartyRegistrationRepository.class);
         resolver = new UaaRelyingPartyRegistrationResolver(repository, "cloudfoundry-saml-login", "http://localhost:8080/uaa");
+    }
+
+    @AfterEach
+    void afterEach() {
+        IdentityZoneHolder.clear();
     }
 
     @Test
@@ -142,21 +151,7 @@ class UaaRelyingPartyRegistrationResolverTests {
 
         String expectedBaseUrl = "https://uaa.example.com/uaa-security";
 
-        RelyingPartyRegistration testRegistration = RelyingPartyRegistration.withRegistrationId("test-idp")
-                .entityId("{baseUrl}/saml/metadata")
-                .assertionConsumerServiceLocation("{baseUrl}/saml/SSO")
-                .assertionConsumerServiceBinding(Saml2MessageBinding.POST)
-                .singleLogoutServiceLocation("{baseUrl}/saml/SingleLogout")
-                .singleLogoutServiceResponseLocation("{baseUrl}/saml/SingleLogout")
-                .singleLogoutServiceBinding(Saml2MessageBinding.POST)
-                .assertingPartyMetadata(party -> party
-                        .entityId("https://idp.example.com")
-                        .singleSignOnServiceLocation("https://idp.example.com/sso")
-                        .singleSignOnServiceBinding(Saml2MessageBinding.POST)
-                        .wantAuthnRequestsSigned(false))
-                .build();
-
-        doReturn(testRegistration).when(repository).findByRegistrationId("test-idp");
+        doReturn(buildTestRegistration()).when(repository).findByRegistrationId("test-idp");
 
         RelyingPartyRegistration result = resolverWithNullOrEmptyBaseUrl.resolve(request, "test-idp");
 
@@ -181,7 +176,134 @@ class UaaRelyingPartyRegistrationResolverTests {
 
         String expectedBaseUrl = StringUtils.trimTrailingCharacter(configuredBaseUrl, '/');
 
-        RelyingPartyRegistration testRegistration = RelyingPartyRegistration.withRegistrationId("test-idp")
+        doReturn(buildTestRegistration()).when(repository).findByRegistrationId("test-idp");
+
+        RelyingPartyRegistration result = resolverWithConfiguredBaseUrl.resolve(request, "test-idp");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEntityId()).isEqualTo(expectedBaseUrl + "/saml/metadata");
+        assertThat(result.getAssertionConsumerServiceLocation()).isEqualTo(expectedBaseUrl + "/saml/SSO");
+        assertThat(result.getSingleLogoutServiceLocation()).isEqualTo(expectedBaseUrl + "/saml/SingleLogout");
+    }
+
+    @Test
+    void resolveWhenEntityBaseUrlIsSetAndNonDefaultZoneSubdomainPrependsSubdomainToHost() {
+        UaaRelyingPartyRegistrationResolver resolverWithConfiguredBaseUrl =
+                new UaaRelyingPartyRegistrationResolver(repository, "cloudfoundry-saml-login", "http://localhost:8080/uaa");
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("myzone.localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/uaa");
+        request.setRequestURI("/uaa/saml/metadata/test-idp");
+
+        IdentityZone zone = new IdentityZone();
+        zone.setId("myzone-id");
+        zone.setSubdomain("myzone");
+        IdentityZoneHolder.set(zone);
+
+        RelyingPartyRegistration testRegistration = buildTestRegistration();
+        doReturn(testRegistration).when(repository).findByRegistrationId("test-idp");
+
+        RelyingPartyRegistration result = resolverWithConfiguredBaseUrl.resolve(request, "test-idp");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEntityId()).isEqualTo("http://myzone.localhost:8080/uaa/saml/metadata");
+        assertThat(result.getAssertionConsumerServiceLocation()).isEqualTo("http://myzone.localhost:8080/uaa/saml/SSO");
+        assertThat(result.getSingleLogoutServiceLocation()).isEqualTo("http://myzone.localhost:8080/uaa/saml/SingleLogout");
+    }
+
+    /**
+     * Validates that {@code entityBaseURL} is ignored when the request is path-based zone access,
+     * regardless of whether {@code zones.paths.enabled} is set as a system property.
+     *
+     * <p>This test is intentionally NOT gated by {@code @EnabledIfZonePathsEnabled}. The companion
+     * MockMvc test ({@code nonDefaultZoneSamlMetadataXMLValidationViaZonePath}) goes through the
+     * real {@link org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter} and is
+     * annotated with {@code @EnabledIfZonePathsEnabled}, so it can be silently skipped when
+     * {@code zones.paths.enabled} is not set (e.g. running from an IDE without Gradle's system
+     * property default). This unit test runs unconditionally and is the safety net that would
+     * fail if {@link org.cloudfoundry.identity.uaa.provider.saml.UaaRelyingPartyRegistrationResolver#isZonePathRequest}
+     * were removed or returned {@code false} for all inputs.
+     *
+     * <p>Request setup mirrors what {@link org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter}
+     * actually produces in the MockMvc (no-{@code /uaa}-context-path) environment:
+     * <ul>
+     *   <li>{@code ZONE_ORIGINAL_CONTEXT_PATH = ""} — original context path before filter runs</li>
+     *   <li>{@code getContextPath() = "/z/myzone"} — context path after filter rewrites it</li>
+     * </ul>
+     * The filter would produce {@code ZONE_ORIGINAL_CONTEXT_PATH = "/uaa"} in a production deployment
+     * with a servlet context path of {@code /uaa}; that is tested separately below.
+     */
+    @Test
+    void resolveWhenEntityBaseUrlIsSetAndNonDefaultZonePathIgnoresEntityBaseUrlAndUsesRequestContextPath() {
+        UaaRelyingPartyRegistrationResolver resolverWithConfiguredBaseUrl =
+                new UaaRelyingPartyRegistrationResolver(repository, "cloudfoundry-saml-login", "http://localhost:8080/uaa");
+
+        // Realistic MockMvc scenario: no /uaa context path prefix. The filter rewrites
+        // contextPath from "" to "/z/myzone" and records ZONE_ORIGINAL_CONTEXT_PATH="".
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/z/myzone");
+        request.setRequestURI("/z/myzone/saml/metadata/test-idp");
+        request.setAttribute(ZonePathContextRewritingFilter.ZONE_ORIGINAL_CONTEXT_PATH, "");
+
+        IdentityZone zone = new IdentityZone();
+        zone.setId("myzone-id");
+        zone.setSubdomain("myzone");
+        IdentityZoneHolder.set(zone);
+
+        doReturn(buildTestRegistration()).when(repository).findByRegistrationId("test-idp");
+        RelyingPartyRegistration result = resolverWithConfiguredBaseUrl.resolve(request, "test-idp");
+
+        // entityBaseURL ("http://localhost:8080/uaa") is ignored for zone-path requests.
+        // If isZonePathRequest returned false, the subdomain path would be taken instead and
+        // the base URL would be "http://myzone.localhost:8080/uaa" — a different host/path.
+        assertThat(result).isNotNull();
+        assertThat(result.getEntityId()).isEqualTo("http://localhost:8080/z/myzone/saml/metadata");
+        assertThat(result.getAssertionConsumerServiceLocation()).isEqualTo("http://localhost:8080/z/myzone/saml/SSO");
+        assertThat(result.getSingleLogoutServiceLocation()).isEqualTo("http://localhost:8080/z/myzone/saml/SingleLogout");
+    }
+
+    /**
+     * Production-deployment variant: servlet context path is {@code /uaa}, so the filter sets
+     * {@code ZONE_ORIGINAL_CONTEXT_PATH="/uaa"} and rewrites {@code getContextPath()} to
+     * {@code /uaa/z/myzone}. entityBaseURL must still be ignored.
+     */
+    @Test
+    void resolveWhenEntityBaseUrlIsSetAndNonDefaultZonePathWithServletContextPathIgnoresEntityBaseUrl() {
+        UaaRelyingPartyRegistrationResolver resolverWithConfiguredBaseUrl =
+                new UaaRelyingPartyRegistrationResolver(repository, "cloudfoundry-saml-login", "http://localhost:8080/uaa");
+
+        // Production scenario: UAA deployed at context path /uaa; filter rewrites contextPath
+        // from "/uaa" to "/uaa/z/myzone" and sets ZONE_ORIGINAL_CONTEXT_PATH="/uaa".
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setServerName("localhost");
+        request.setServerPort(8080);
+        request.setContextPath("/uaa/z/myzone");
+        request.setRequestURI("/uaa/z/myzone/saml/metadata/test-idp");
+        request.setAttribute(ZonePathContextRewritingFilter.ZONE_ORIGINAL_CONTEXT_PATH, "/uaa");
+
+        IdentityZone zone = new IdentityZone();
+        zone.setId("myzone-id");
+        zone.setSubdomain("myzone");
+        IdentityZoneHolder.set(zone);
+
+        doReturn(buildTestRegistration()).when(repository).findByRegistrationId("test-idp");
+        RelyingPartyRegistration result = resolverWithConfiguredBaseUrl.resolve(request, "test-idp");
+
+        assertThat(result).isNotNull();
+        assertThat(result.getEntityId()).isEqualTo("http://localhost:8080/uaa/z/myzone/saml/metadata");
+        assertThat(result.getAssertionConsumerServiceLocation()).isEqualTo("http://localhost:8080/uaa/z/myzone/saml/SSO");
+        assertThat(result.getSingleLogoutServiceLocation()).isEqualTo("http://localhost:8080/uaa/z/myzone/saml/SingleLogout");
+    }
+
+    private RelyingPartyRegistration buildTestRegistration() {
+        return RelyingPartyRegistration.withRegistrationId("test-idp")
                 .entityId("{baseUrl}/saml/metadata")
                 .assertionConsumerServiceLocation("{baseUrl}/saml/SSO")
                 .assertionConsumerServiceBinding(Saml2MessageBinding.POST)
@@ -194,14 +316,5 @@ class UaaRelyingPartyRegistrationResolverTests {
                         .singleSignOnServiceBinding(Saml2MessageBinding.POST)
                         .wantAuthnRequestsSigned(false))
                 .build();
-
-        doReturn(testRegistration).when(repository).findByRegistrationId("test-idp");
-
-        RelyingPartyRegistration result = resolverWithConfiguredBaseUrl.resolve(request, "test-idp");
-
-        assertThat(result).isNotNull();
-        assertThat(result.getEntityId()).isEqualTo(expectedBaseUrl + "/saml/metadata");
-        assertThat(result.getAssertionConsumerServiceLocation()).isEqualTo(expectedBaseUrl + "/saml/SSO");
-        assertThat(result.getSingleLogoutServiceLocation()).isEqualTo(expectedBaseUrl + "/saml/SingleLogout");
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlMetadataEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlMetadataEndpointMockMvcTests.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.identity.uaa.mock.saml;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
+import org.cloudfoundry.identity.uaa.mock.util.ZoneResolutionMode;
 import org.cloudfoundry.identity.uaa.oauth.common.util.RandomValueStringGenerator;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.context.WebApplicationContext;
@@ -18,6 +20,7 @@ import org.springframework.web.context.WebApplicationContext;
 import java.net.URI;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_DIGEST_SHA256;
 import static org.opensaml.xmlsec.signature.support.SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA256;
 import static org.springframework.http.HttpHeaders.HOST;
@@ -76,7 +79,7 @@ class SamlMetadataEndpointMockMvcTests {
                         xpath("/EntityDescriptor/SPSSODescriptor/KeyDescriptor[@use='signing']/KeyInfo/X509Data/X509Certificate").string("MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEOMAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEOMAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5hcnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4HaMIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGcgBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxCKdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkKRpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0="),
                         xpath("/EntityDescriptor/SPSSODescriptor/KeyDescriptor[@use='encryption']/KeyInfo/X509Data/X509Certificate").string("MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEOMAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEOMAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5hcnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4HaMIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGcgBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxCKdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkKRpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0="),
                         xpath("/EntityDescriptor/SPSSODescriptor/AssertionConsumerService/@Location")
-                                .string(containsString("/saml/SSO/alias/integration-saml-entity-id")), // last path is the UAA-wide entity ID alias, set by login.saml.entityIDAlias; is not set, fall back to login.entityID
+                                .string(equalTo("http://localhost:8080/uaa/saml/SSO/alias/integration-saml-entity-id")), // entityBaseURL (http://localhost:8080/uaa) + /saml/SSO/alias/ + login.entityID
                         xpath("/EntityDescriptor/Signature").exists(),
                         xpath("/EntityDescriptor/Signature/SignedInfo/SignatureMethod/@Algorithm").string(containsString(ALGO_ID_SIGNATURE_RSA_SHA256)),
                         xpath("/EntityDescriptor/Signature/SignatureValue").exists(),
@@ -102,8 +105,52 @@ class SamlMetadataEndpointMockMvcTests {
                         xpath("/EntityDescriptor/SPSSODescriptor/NameIDFormat").string("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"),  // matches UAA config login.saml.NameID???
                         xpath("/EntityDescriptor/SPSSODescriptor/KeyDescriptor[@use='signing']/KeyInfo/X509Data/X509Certificate").string("MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEOMAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEOMAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5hcnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4HaMIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGcgBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxCKdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkKRpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0="),
                         xpath("/EntityDescriptor/SPSSODescriptor/KeyDescriptor[@use='encryption']/KeyInfo/X509Data/X509Certificate").string("MIIDSTCCArKgAwIBAgIBADANBgkqhkiG9w0BAQQFADB8MQswCQYDVQQGEwJhdzEOMAwGA1UECBMFYXJ1YmExDjAMBgNVBAoTBWFydWJhMQ4wDAYDVQQHEwVhcnViYTEOMAwGA1UECxMFYXJ1YmExDjAMBgNVBAMTBWFydWJhMR0wGwYJKoZIhvcNAQkBFg5hcnViYUBhcnViYS5hcjAeFw0xNTExMjAyMjI2MjdaFw0xNjExMTkyMjI2MjdaMHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDHtC5gUXxBKpEqZTLkNvFwNGnNIkggNOwOQVNbpO0WVHIivig5L39WqS9u0hnA+O7MCA/KlrAR4bXaeVVhwfUPYBKIpaaTWFQR5cTR1UFZJL/OF9vAfpOwznoD66DDCnQVpbCjtDYWX+x6imxn8HCYxhMol6ZnTbSsFW6VZjFMjQIDAQABo4HaMIHXMB0GA1UdDgQWBBTx0lDzjH/iOBnOSQaSEWQLx1syGDCBpwYDVR0jBIGfMIGcgBTx0lDzjH/iOBnOSQaSEWQLx1syGKGBgKR+MHwxCzAJBgNVBAYTAmF3MQ4wDAYDVQQIEwVhcnViYTEOMAwGA1UEChMFYXJ1YmExDjAMBgNVBAcTBWFydWJhMQ4wDAYDVQQLEwVhcnViYTEOMAwGA1UEAxMFYXJ1YmExHTAbBgkqhkiG9w0BCQEWDmFydWJhQGFydWJhLmFyggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEEBQADgYEAYvBJ0HOZbbHClXmGUjGs+GS+xC1FO/am2suCSYqNB9dyMXfOWiJ1+TLJk+o/YZt8vuxCKdcZYgl4l/L6PxJ982SRhc83ZW2dkAZI4M0/Ud3oePe84k8jm3A7EvH5wi5hvCkKRpuRBwn3Ei+jCRouxTbzKPsuCVB+1sNyxMTXzf0="),
-                        xpath("/EntityDescriptor/SPSSODescriptor/AssertionConsumerService/@Location").string(containsString("/saml/SSO/alias/%s.integration-saml-entity-id".formatted(subdomain))) // this needs to be: /saml/SSO/alias/[zone-subdomain].[UAA-wide SAML entity ID, aka UAA.yml's login.saml.entityIDAlias, or fall back on login.entityID in this case]
+                        xpath("/EntityDescriptor/SPSSODescriptor/AssertionConsumerService/@Location").string(equalTo("http://%s.localhost:8080/uaa/saml/SSO/alias/%s.integration-saml-entity-id".formatted(subdomain, subdomain))) // this needs to be: /saml/SSO/alias/[zone-subdomain].[UAA-wide SAML entity ID, aka UAA.yml's login.saml.entityIDAlias, or fall back on login.entityID in this case]
                 );
+    }
+
+    /**
+     * Zone accessed via the path prefix ({@code /z/{subdomain}/…}) instead of a subdomain.
+     * <p>
+     * {@code zones.paths.enabled=true} is set explicitly via {@link TestPropertySource} so that the
+     * {@link org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter} is wired with
+     * {@code zonePathsEnabled=true} at context startup. This makes the test run unconditionally —
+     * no {@code @EnabledIfZonePathsEnabled} gate and no reliance on a Gradle system-property default.
+     */
+    @Nested
+    @DefaultTestContext
+    @TestPropertySource(properties = {"zones.paths.enabled=true"})
+    class SamlMetadataZonePathMockMvcTests {
+        @Autowired
+        private MockMvc mockMvc;
+
+        /**
+         * {@link org.cloudfoundry.identity.uaa.zone.ZonePathContextRewritingFilter} rewrites the context
+         * path to {@code /z/{subdomain}} so {@code entityBaseURL} (a static operator config) is ignored
+         * in favour of the request-derived base URL, which already carries the zone path.
+         * The resulting ACS Location must use plain {@code localhost} (no subdomain in the host) and
+         * include the zone path prefix in the URL path.
+         */
+        @Test
+        void nonDefaultZoneSamlMetadataXMLValidationViaZonePath() throws Exception {
+            IdentityZone spZone = setupIdentityZone(true);
+            String subdomain = spZone.getSubdomain();
+
+            mockMvc.perform(ZoneResolutionMode.ZONE_PATH.createRequestBuilder(subdomain, HttpMethod.GET, "/saml/metadata"))
+                    .andDo(print())
+                    .andExpectAll(
+                            status().isOk(),
+                            header().string(HttpHeaders.CONTENT_DISPOSITION, containsString("filename=\"saml-%s-sp.xml\";".formatted(subdomain))),
+                            xpath("/EntityDescriptor/@entityID").string(spZone.getConfig().getSamlConfig().getEntityID()),
+                            xpath("/EntityDescriptor/SPSSODescriptor/@AuthnRequestsSigned").booleanValue(false),
+                            xpath("/EntityDescriptor/SPSSODescriptor/@WantAssertionsSigned").booleanValue(false),
+                            // Zone path: entityBaseURL ("http://localhost:8080/uaa") is ignored.
+                            // Base URL comes from the rewritten context path /z/{subdomain}.
+                            // MockMvc uses port 80 (default HTTP), so no port in the URL.
+                            xpath("/EntityDescriptor/SPSSODescriptor/AssertionConsumerService/@Location")
+                                    .string(equalTo("http://localhost/z/%s/saml/SSO/alias/%s.integration-saml-entity-id".formatted(subdomain, subdomain)))
+                    );
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Fix: SAML metadata ACS URL ignores zone subdomain when `entityBaseURL` is set

### Background — the regression introduced by #3739

PR #3739 ("Use entityBaseURL for URLs when generating SAML Metadata", merged 2026-02-19, commit `4123092`) changed `UaaRelyingPartyRegistrationResolver` to use the operator-configured `login.entityBaseURL` as the base for all SAML SP metadata URLs.

The intent was correct — a static, canonical base URL produces stable metadata behind proxies and load balancers. However, the implementation applied `entityBaseURL` verbatim for **all** zones, including non-default identity zones accessed via subdomain (e.g. `testzone-jnakrm.localhost`). Because `entityBaseURL` is a single static value (`http://localhost:8080/uaa`), the generated metadata for any non-default zone contained the wrong host:

```xml
<!-- Regression: host is localhost, not the zone subdomain host -->
<md:AssertionConsumerService
    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
    Location="http://localhost:8080/uaa/saml/SSO/alias/testzone-jnakrm.integration-saml-entity-id"
    index="0"
    isDefault="true"/>
```

The correct URL for a subdomain-based zone is:

```xml
<md:AssertionConsumerService
    Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
    Location="http://testzone-jnakrm.localhost:8080/uaa/saml/SSO/alias/testzone-jnakrm.integration-saml-entity-id"
    index="0"
    isDefault="true"/>
```

### Why the existing test did not catch this

`SamlMetadataEndpointMockMvcTests#nonDefaultZoneSamlMetadataXMLValidation` — the test that directly exercises non-default zone metadata — only asserted with `containsString` on the **path suffix**:

```java
// Before: only checks the alias path, not the full URL — passes even with the wrong host
xpath(".../AssertionConsumerService/@Location")
    .string(containsString("/saml/SSO/alias/testzone-jnakrm.integration-saml-entity-id"))
```

The path suffix was correct (`/saml/SSO/alias/testzone-jnakrm.integration-saml-entity-id`); only the host was wrong (`localhost` vs `testzone-jnakrm.localhost`). Because the assertion never checked the full URL, the test kept passing throughout the regression.

### What this PR fixes

**`UaaRelyingPartyRegistrationResolver`** — adds `resolveBaseUrl` which selects the correct base URL for each access pattern:

| Scenario | Behaviour |
|---|---|
| `entityBaseURL` not set | Derive base URL from the incoming `HttpServletRequest` |
| Default (UAA) zone, `entityBaseURL` set | Use `entityBaseURL` as-is |
| Non-default zone, subdomain access, `entityBaseURL` set | Prepend zone subdomain to `entityBaseURL` host via `UaaUrlUtils.addSubdomainToUrl` |
| Non-default zone, path access (`/z/{subdomain}/`), any `entityBaseURL` | Always derive from request — `entityBaseURL` is a static value that cannot encode the dynamic zone path; `ZonePathContextRewritingFilter` has already embedded the zone in the context path |

**`SamlMetadataEndpointMockMvcTests`** — three improvements:

1. The default-zone ACS Location assertion is tightened from `containsString` to `equalTo` with the full expected URL, so no future host regression can go undetected.
2. `nonDefaultZoneSamlMetadataXMLValidation` now asserts the **full** ACS Location URL (scheme + host + path), not just the path suffix.
3. A new `SamlMetadataZonePathMockMvcTests` nested class covers identity zones accessed via path (`/z/{subdomain}/`). It is placed in a `@Nested @TestPropertySource(properties = {"zones.paths.enabled=true"})` class — the same pattern the other config-variant nested classes use — so the test always runs unconditionally without relying on a Gradle system-property default.

**`UaaRelyingPartyRegistrationResolverTests`** — adds two unconditional unit tests (no `@EnabledIfZonePathsEnabled` gate) covering `resolveBaseUrl` for both zone access patterns:

- `resolveWhenEntityBaseUrlIsSetAndNonDefaultZonePathIgnoresEntityBaseUrlAndUsesRequestContextPath` — uses `ZONE_ORIGINAL_CONTEXT_PATH = ""` and `contextPath = "/z/myzone"`, which is the realistic value the filter sets in a no-servlet-context-path environment (MockMvc / embedded server). This test is the unconditional safety net: it fails immediately if `isZonePathRequest` is broken or removed, regardless of whether `zones.paths.enabled` is set as a system property.
- `resolveWhenEntityBaseUrlIsSetAndNonDefaultZonePathWithServletContextPathIgnoresEntityBaseUrl` — covers the production deployment variant (`contextPath = "/uaa/z/myzone"`, `ZONE_ORIGINAL_CONTEXT_PATH = "/uaa"`).

**`SamlMetadataEndpointKeyRotationTests`** — fixes a bug introduced by #3739 in the test itself: the resolver was constructed with `entityBaseURL = "http://zone-id.localhost:8080/uaa"` — the zone-specific URL with the subdomain already baked in. Because `resolveBaseUrl` now correctly prepends the zone subdomain, this produced a doubled subdomain (`http://zone-id.zone-id.localhost:8080/uaa`). The test is corrected to use `"http://localhost:8080/uaa"` — the UAA instance base URL, consistent with what operators configure in `login.entityBaseURL` and what `integration_test_properties.yml` contains.