### PR TITLE
Align and lock library versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,26 +21,22 @@ allprojects {
     apply(plugin: "io.spring.dependency-management")
     apply(plugin: "org.barfuin.gradle.jacocolog")
     apply(plugin: "org.sonarqube")
+    
+    // Override Spring Boot managed dependency versions using ext properties
+    // See: https://docs.spring.io/spring-boot/appendix/dependency-versions/properties.html
+    ext['tomcat.version'] = libs.versions.tomcat.get()
+    ext['commons-codec.version'] = libs.versions.commonsCodec.get()
+    ext['selenium.version'] = libs.versions.selenium.get()
 
     dependencyManagement {
         imports {
             mavenBom(libs.springBootBom.get().toString())
         }
         
-        // Libraries that have version conflicts
+        // Libraries that have version conflicts (not managed by BOMs above)
         dependencies {
-            // Selenium - modules were at mixed versions (4.43.0 vs 4.31.0)
-            dependency "org.seleniumhq.selenium:selenium-java:${libs.versions.selenium.get()}"
-            dependency "org.seleniumhq.selenium:selenium-api:${libs.versions.selenium.get()}"
-            dependency "org.seleniumhq.selenium:selenium-chrome-driver:${libs.versions.selenium.get()}"
-            dependency "org.seleniumhq.selenium:selenium-remote-driver:${libs.versions.selenium.get()}"
-            dependency "org.seleniumhq.selenium:selenium-http:${libs.versions.selenium.get()}"
-            
             // Guava - multiple versions from different transitive deps
             dependency "com.google.guava:guava:${libs.versions.guava.get()}"
-
-            // Commons Codec - OpenSAML/Shibboleth dependencies bring in older versions
-            dependency "commons-codec:commons-codec:${libs.versions.commonsCodec.get()}"
         }
     }
 
@@ -85,25 +81,16 @@ subprojects {
 
         resolutionStrategy {
             resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                // Dependencies not managed by any BOM
                 // OpenSAML modules - align for migration
                 if (details.requested.group == 'org.opensaml' && details.requested.name.startsWith("opensaml-")) {
                     details.useVersion "${libs.versions.opensaml.get()}"
                     details.because 'Pinning all opensaml modules to the same version for OpenSAML 5 migration.'
                 }
-                // Cryptacular - avoid regressions  
+                // Cryptacular - avoid regressions, explicit downgrade to 1.2.6
                 else if (details.requested.group == 'org.cryptacular' && details.requested.name == 'cryptacular') {
                     details.useVersion "${libs.versions.cryptacular.get()}"
                     details.because 'Pinning cryptacular to 1.2.6 to avoid regressions from newer OpenSAML versions.'
-                }
-                // Selenium - force all modules to same version
-                else if (details.requested.group == 'org.seleniumhq.selenium') {
-                    details.useVersion "${libs.versions.selenium.get()}"
-                    details.because 'Force Selenium modules to consistent version'
-                }
-                // Tomcat - force consistent version across all tomcat modules
-                else if (details.requested.group == 'org.apache.tomcat' || details.requested.group == 'org.apache.tomcat.embed') {
-                    details.useVersion "${libs.versions.tomcat.get()}"
-                    details.because 'Force Tomcat modules to consistent version'
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,11 @@ subprojects {
                     details.useVersion "${libs.versions.selenium.get()}"
                     details.because 'Force Selenium modules to consistent version'
                 }
+                // Tomcat - force consistent version across all tomcat modules
+                else if (details.requested.group == 'org.apache.tomcat' || details.requested.group == 'org.apache.tomcat.embed') {
+                    details.useVersion "${libs.versions.tomcat.get()}"
+                    details.because 'Force Tomcat modules to consistent version'
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ allprojects {
             
             // Guava - multiple versions from different transitive deps
             dependency "com.google.guava:guava:${libs.versions.guava.get()}"
+
+            // Commons Codec - OpenSAML/Shibboleth dependencies bring in older versions
+            dependency "commons-codec:commons-codec:${libs.versions.commonsCodec.get()}"
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ springBoot = "3.5.14"
 springDependencyManagement = "1.1.7"
 springDocOpenapi = "2.8.17"
 statsdClient = "3.1.0"
+tomcat = "10.1.55"
 unboundIdScimSdk = "2.0.0"
 velocity = "2.4.1"
 xmlSecurity = "4.0.4"
@@ -43,10 +44,10 @@ log4jCore = { module = "org.apache.logging.log4j:log4j-core" }
 slf4jImpl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl" }
 
 # Apache Tomcat
-tomcatElApi = { module = "org.apache.tomcat.embed:tomcat-embed-el" }
-tomcatEmbed = { module = "org.apache.tomcat.embed:tomcat-embed-core" }
-tomcatJasperEl = { module = "org.apache.tomcat.embed:tomcat-embed-jasper" }
-tomcatJdbc = { module = "org.apache.tomcat:tomcat-jdbc" }
+tomcatElApi = { module = "org.apache.tomcat.embed:tomcat-embed-el", version.ref = "tomcat" }
+tomcatEmbed = { module = "org.apache.tomcat.embed:tomcat-embed-core", version.ref = "tomcat" }
+tomcatJasperEl = { module = "org.apache.tomcat.embed:tomcat-embed-jasper", version.ref = "tomcat" }
+tomcatJdbc = { module = "org.apache.tomcat:tomcat-jdbc", version.ref = "tomcat" }
 
 # Apache Velocity
 velocity = { module = "org.apache.velocity:velocity-engine-core", version.ref = "velocity" }


### PR DESCRIPTION
Multiple transitive dependencies (OpenSAML, Shibboleth, Apache LDAP, Apache XML Security) were bringing in older versions that overrode your catalog specification

Fix tomcat versions, since there are many CVEs and allows flexibility to upgrade before spring boot releases