### PR TITLE
review subdomain zone selection

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/DenyAccessToUaaAdvice.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/DenyAccessToUaaAdvice.java
@@ -7,13 +7,13 @@ import org.springframework.stereotype.Component;
 public class DenyAccessToUaaAdvice {
 
     public void checkIdentityZone(IdentityZone identityZone) {
-        if (identityZone != null && identityZone.isUaa()) {
+        if (identityZone != null && IdentityZone.getUaaZoneId().equalsIgnoreCase(identityZone.getId())) {
             throw new AccessDeniedException("Access to UAA is not allowed.");
         }
     }
 
     public void checkIdentityZoneId(String identityZoneId) {
-        if (IdentityZone.getUaaZoneId().equals(identityZoneId)) {
+        if (IdentityZone.getUaaZoneId().equalsIgnoreCase(identityZoneId)) {
             throw new AccessDeniedException("Access to UAA is not allowed.");
         }
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneValidator.java
@@ -15,7 +15,7 @@ public class GeneralIdentityZoneValidator implements IdentityZoneValidator {
 
     @Override
     public IdentityZone validate(IdentityZone identityZone, Mode mode) throws InvalidIdentityZoneDetailsException {
-        if (IdentityZoneHolder.getUaaZone().getId().equals(identityZone.getId()) && !identityZone.isActive()) {
+        if (IdentityZoneHolder.getUaaZone().getId().equalsIgnoreCase(identityZone.getId()) && !identityZone.isActive()) {
             throw new InvalidIdentityZoneDetailsException("The default zone cannot be set inactive.", null);
         }
         if (DEFAULT_ZONE_SUBDOMAIN_PATH.equalsIgnoreCase(identityZone.getSubdomain())) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/DenyAccessToUaaAdviceTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/DenyAccessToUaaAdviceTest.java
@@ -3,6 +3,8 @@ package org.cloudfoundry.identity.uaa.zone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.security.access.AccessDeniedException;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -57,10 +59,44 @@ class DenyAccessToUaaAdviceTest {
         }
 
         @Test
+        void checkIdentityZone_zoneWithNullId_isNotUaa() {
+            IdentityZone zoneWithNullId = new IdentityZone();
+            assertThatNoException().isThrownBy(() -> denyAccessToUaaAdvice.checkIdentityZone(zoneWithNullId));
+        }
+
+        @Test
         void checkIdentityZoneId_isNotUaa() {
             assertThatNoException().isThrownBy(() -> denyAccessToUaaAdvice.checkIdentityZoneId(identityZone.getId()));
             assertThatNoException().isThrownBy(() -> denyAccessToUaaAdvice.checkIdentityZoneId(""));
             assertThatNoException().isThrownBy(() -> denyAccessToUaaAdvice.checkIdentityZoneId(null));
+        }
+    }
+
+    /**
+     * On case-insensitive databases (default MySQL collations), a WHERE id = 'UAA' lookup
+     * resolves to the system-zone row stored as 'uaa'. These tests verify that the advice
+     * blocks all case variants of "uaa", closing the authorization bypass reported in
+     * .agent/report.md.
+     */
+    @Nested
+    class WhenZoneIdIsCaseVariantOfUaa {
+
+        @ParameterizedTest(name = "checkIdentityZone blocks id=''{0}''")
+        @ValueSource(strings = {"UAA", "Uaa", "uAA", "uAa", "UaA", "UAa"})
+        void checkIdentityZone_deniesAccess(String caseVariant) {
+            IdentityZone zone = new IdentityZone();
+            zone.setId(caseVariant);
+            assertThatThrownBy(() -> denyAccessToUaaAdvice.checkIdentityZone(zone))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage("Access to UAA is not allowed.");
+        }
+
+        @ParameterizedTest(name = "checkIdentityZoneId blocks id=''{0}''")
+        @ValueSource(strings = {"UAA", "Uaa", "uAA", "uAa", "UaA", "UAa"})
+        void checkIdentityZoneId_deniesAccess(String caseVariant) {
+            assertThatThrownBy(() -> denyAccessToUaaAdvice.checkIdentityZoneId(caseVariant))
+                    .isInstanceOf(AccessDeniedException.class)
+                    .hasMessage("Access to UAA is not allowed.");
         }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneValidatorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/GeneralIdentityZoneValidatorTests.java
@@ -3,6 +3,8 @@ package org.cloudfoundry.identity.uaa.zone;
 import org.cloudfoundry.identity.uaa.extensions.PollutionPreventionExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -49,6 +51,29 @@ class GeneralIdentityZoneValidatorTests {
             try {
                 validator.validate(uaaZone, mode);
                 fail("");
+            } catch (InvalidIdentityZoneDetailsException e) {
+                assertThat(e.getMessage()).isEqualTo("The default zone cannot be set inactive.");
+            }
+        }
+    }
+
+    /**
+     * On case-insensitive databases (default MySQL collations), a WHERE id = 'UAA' lookup
+     * resolves to the system-zone row stored as 'uaa'. The validator must also treat all
+     * case variants of "uaa" as the system zone and refuse to deactivate them.
+     */
+    @ParameterizedTest(name = "uaaZoneInactive blocked for id=''{0}''")
+    @ValueSource(strings = {"UAA", "Uaa", "uAA", "uAa", "UaA", "UAa"})
+    void uaaZoneInactive_withCasedId_fails(String caseVariant) {
+        IdentityZone zone = new IdentityZone();
+        zone.setId(caseVariant);
+        zone.setSubdomain("");
+        zone.setName(caseVariant);
+        zone.setActive(false);
+        for (IdentityZoneValidator.Mode mode : Arrays.asList(CREATE, MODIFY, DELETE)) {
+            try {
+                validator.validate(zone, mode);
+                fail("Expected InvalidIdentityZoneDetailsException for id='" + caseVariant + "' mode=" + mode);
             } catch (InvalidIdentityZoneDetailsException e) {
                 assertThat(e.getMessage()).isEqualTo("The default zone cannot be set inactive.");
             }


### PR DESCRIPTION
Ensure case insensitivity for the UAA default zone (`id=uaa`) 