### PR TITLE
Fix DuplicateKeyException on concurrent JDBC session writes

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/HsqldbJdbcIndexedSessionRepositoryCustomizer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/HsqldbJdbcIndexedSessionRepositoryCustomizer.java
@@ -1,0 +1,30 @@
+package org.cloudfoundry.identity.uaa.web.beans;
+
+import org.springframework.session.config.SessionRepositoryCustomizer;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+
+/**
+ * HSQLDB counterpart to {@link org.springframework.session.jdbc.PostgreSqlJdbcIndexedSessionRepositoryCustomizer}
+ * and {@link org.springframework.session.jdbc.MySqlJdbcIndexedSessionRepositoryCustomizer}: swaps the
+ * default {@code INSERT} for {@code SPRING_SESSION_ATTRIBUTES} with an idempotent {@code MERGE}, so that
+ * two concurrent requests both inserting a new attribute for the same session resolve as last-write-wins
+ * instead of failing with {@link org.springframework.dao.DuplicateKeyException}.
+ */
+public class HsqldbJdbcIndexedSessionRepositoryCustomizer
+        implements SessionRepositoryCustomizer<JdbcIndexedSessionRepository> {
+
+    private static final String CREATE_SESSION_ATTRIBUTE_QUERY = """
+            MERGE INTO %TABLE_NAME%_ATTRIBUTES AS T
+            USING (VALUES (CAST(? AS CHAR(36)), CAST(? AS VARCHAR(200)), CAST(? AS BLOB)))
+                AS S(SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+            ON T.SESSION_PRIMARY_ID = S.SESSION_PRIMARY_ID AND T.ATTRIBUTE_NAME = S.ATTRIBUTE_NAME
+            WHEN MATCHED THEN UPDATE SET T.ATTRIBUTE_BYTES = S.ATTRIBUTE_BYTES
+            WHEN NOT MATCHED THEN INSERT (SESSION_PRIMARY_ID, ATTRIBUTE_NAME, ATTRIBUTE_BYTES)
+                VALUES (S.SESSION_PRIMARY_ID, S.ATTRIBUTE_NAME, S.ATTRIBUTE_BYTES)
+            """;
+
+    @Override
+    public void customize(JdbcIndexedSessionRepository sessionRepository) {
+        sessionRepository.setCreateSessionAttributeQuery(CREATE_SESSION_ATTRIBUTE_QUERY);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaJdbcSessionConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/beans/UaaJdbcSessionConfig.java
@@ -1,16 +1,22 @@
 package org.cloudfoundry.identity.uaa.web.beans;
 
 import org.cloudfoundry.identity.uaa.UaaProperties;
+import org.cloudfoundry.identity.uaa.db.DatabasePlatform;
+import org.cloudfoundry.identity.uaa.db.beans.DatabaseProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.lang.NonNull;
+import org.springframework.session.config.SessionRepositoryCustomizer;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.session.jdbc.MySqlJdbcIndexedSessionRepositoryCustomizer;
+import org.springframework.session.jdbc.PostgreSqlJdbcIndexedSessionRepositoryCustomizer;
 import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
 import org.springframework.session.jdbc.config.annotation.web.http.JdbcHttpSessionConfiguration;
 
@@ -35,6 +41,25 @@ public class UaaJdbcSessionConfig extends UaaSessionConfig {
             final JdbcHttpSessionConfiguration jdbcHttpSessionConfiguration,
             UaaProperties.Servlet servlet) {
         jdbcHttpSessionConfiguration.setMaxInactiveIntervalInSeconds(servlet.idleTimeout());
+    }
+
+    /**
+     * Makes the {@code SPRING_SESSION_ATTRIBUTES} insert idempotent (upsert) per DB vendor.
+     * <p>
+     * Without this, two concurrent requests sharing a JSESSIONID both see an attribute as
+     * new (each {@code JdbcSession} loaded the row before either committed), both mark their
+     * delta as {@code ADDED}, and the second {@code INSERT} fails with {@code DuplicateKeyException}.
+     * Spring Session ships ready-made customizers for Postgres and MySQL; HSQLDB needs a MERGE.
+     */
+    @Bean
+    public static SessionRepositoryCustomizer<JdbcIndexedSessionRepository> sessionAttributeUpsertCustomizer(
+            DatabaseProperties databaseProperties) {
+        DatabasePlatform platform = databaseProperties.getDatabasePlatform();
+        return switch (platform) {
+            case POSTGRESQL -> new PostgreSqlJdbcIndexedSessionRepositoryCustomizer();
+            case MYSQL -> new MySqlJdbcIndexedSessionRepositoryCustomizer();
+            case HSQLDB -> new HsqldbJdbcIndexedSessionRepositoryCustomizer();
+        };
     }
 
     @Autowired

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/JdbcSessionConcurrentWriteTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/JdbcSessionConcurrentWriteTest.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import javax.sql.DataSource;
 
 import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
+import org.cloudfoundry.identity.uaa.db.beans.DatabaseProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,10 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextImpl;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
+import org.springframework.session.config.SessionRepositoryCustomizer;
 import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.session.jdbc.MySqlJdbcIndexedSessionRepositoryCustomizer;
+import org.springframework.session.jdbc.PostgreSqlJdbcIndexedSessionRepositoryCustomizer;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,9 +35,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
  * {@code MapSession} delegate, populated only at {@code findById} time), so no
  * threads are required to reproduce it.
  *
- * <p>Currently fails. Will pass once the {@code createSessionAttributeQuery} is
- * customized to upsert (e.g. via {@code PostgreSqlJdbcIndexedSessionRepositoryCustomizer}
- * on Postgres, or an equivalent {@code MERGE} on HSQLDB).
+ * <p>Runs against whichever DB the CI matrix selects via {@code spring.profiles.active}
+ * (hsqldb, mysql, postgresql) and applies the matching upsert customizer — the same one
+ * {@link UaaJdbcSessionConfig} wires up in production — so all three SQL dialects are
+ * covered.
  */
 @WithDatabaseContext
 class JdbcSessionConcurrentWriteTest {
@@ -45,6 +50,9 @@ class JdbcSessionConcurrentWriteTest {
 
     @Autowired
     private DataSource dataSource;
+
+    @Autowired
+    private DatabaseProperties databaseProperties;
 
     @SuppressWarnings("rawtypes")
     private SessionRepository repository;
@@ -58,10 +66,20 @@ class JdbcSessionConcurrentWriteTest {
         // Disable the background cleanup scheduler — we never call afterPropertiesSet,
         // but be explicit so future changes don't accidentally start it.
         jdbcRepository.setCleanupCron("-");
-        // Apply the same upsert SQL the production config wires up for HSQLDB,
-        // so this test exercises the actual fix rather than the default INSERT.
-        new HsqldbJdbcIndexedSessionRepositoryCustomizer().customize(jdbcRepository);
+        // Apply the same upsert SQL that UaaJdbcSessionConfig wires up in production,
+        // chosen by the active DB platform so this test exercises the real fix on
+        // whichever database the CI matrix is running against (hsqldb/mysql/postgresql).
+        customizerFor(databaseProperties).customize(jdbcRepository);
         this.repository = jdbcRepository;
+    }
+
+    private static SessionRepositoryCustomizer<JdbcIndexedSessionRepository> customizerFor(
+            DatabaseProperties databaseProperties) {
+        return switch (databaseProperties.getDatabasePlatform()) {
+            case POSTGRESQL -> new PostgreSqlJdbcIndexedSessionRepositoryCustomizer();
+            case MYSQL -> new MySqlJdbcIndexedSessionRepositoryCustomizer();
+            case HSQLDB -> new HsqldbJdbcIndexedSessionRepositoryCustomizer();
+        };
     }
 
     /**

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/JdbcSessionConcurrentWriteTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/JdbcSessionConcurrentWriteTest.java
@@ -1,10 +1,8 @@
 package org.cloudfoundry.identity.uaa.web.beans;
 
-import java.util.Collections;
-import javax.sql.DataSource;
-
 import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
 import org.cloudfoundry.identity.uaa.db.beans.DatabaseProperties;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +18,9 @@ import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
 import org.springframework.session.jdbc.MySqlJdbcIndexedSessionRepositoryCustomizer;
 import org.springframework.session.jdbc.PostgreSqlJdbcIndexedSessionRepositoryCustomizer;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -57,6 +58,15 @@ class JdbcSessionConcurrentWriteTest {
     @SuppressWarnings("rawtypes")
     private SessionRepository repository;
 
+    private String createdSessionId;
+
+    @AfterEach
+    void tearDown() {
+        if (createdSessionId != null) {
+            repository.deleteById(createdSessionId);
+            createdSessionId = null;
+        }
+    }
     @BeforeEach
     void setUp() {
         TransactionTemplate transactionTemplate =
@@ -88,8 +98,8 @@ class JdbcSessionConcurrentWriteTest {
      *   <li>Both call {@code findById} before either has written — neither delegate
      *       has {@code SPRING_SECURITY_CONTEXT}, so each marks its delta as {@code ADDED}.</li>
      *   <li>Request A's {@code save()} inserts the attribute row — succeeds.</li>
-     *   <li>Request B's {@code save()} insert the same attribute row — currently
-     *       throws {@code DuplicateKeyException}.</li>
+     *   <li>Request B's {@code save()} inserts the same attribute row — with the upsert customizer,
+     *       it resolves as last-write-wins instead of throwing {@code DuplicateKeyException}.</li>
      * </ol>
      */
     @Test
@@ -98,7 +108,7 @@ class JdbcSessionConcurrentWriteTest {
         Session created = repository.createSession();
         repository.save(created);
         String sessionId = created.getId();
-
+        createdSessionId = sessionId;
         Session requestA = repository.findById(sessionId);
         Session requestB = repository.findById(sessionId);
         assertThat(requestA).as("Session A should load").isNotNull();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/JdbcSessionConcurrentWriteTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/beans/JdbcSessionConcurrentWriteTest.java
@@ -1,0 +1,112 @@
+package org.cloudfoundry.identity.uaa.web.beans;
+
+import java.util.Collections;
+import javax.sql.DataSource;
+
+import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Reproduces the production race where two concurrent requests sharing the same
+ * JSESSIONID both see a session attribute as new, both mark their delta as {@code ADDED},
+ * and both call {@code save()} — the second {@code INSERT INTO SPRING_SESSION_ATTRIBUTES}
+ * fails with {@link org.springframework.dao.DuplicateKeyException}.
+ *
+ * <p>The race is fully deterministic at the repository level (the delta {@code ADDED}
+ * vs {@code UPDATED} decision is taken purely from each {@code JdbcSession}'s local
+ * {@code MapSession} delegate, populated only at {@code findById} time), so no
+ * threads are required to reproduce it.
+ *
+ * <p>Currently fails. Will pass once the {@code createSessionAttributeQuery} is
+ * customized to upsert (e.g. via {@code PostgreSqlJdbcIndexedSessionRepositoryCustomizer}
+ * on Postgres, or an equivalent {@code MERGE} on HSQLDB).
+ */
+@WithDatabaseContext
+class JdbcSessionConcurrentWriteTest {
+
+    private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DataSource dataSource;
+
+    @SuppressWarnings("rawtypes")
+    private SessionRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        TransactionTemplate transactionTemplate =
+                new TransactionTemplate(new DataSourceTransactionManager(dataSource));
+        JdbcIndexedSessionRepository jdbcRepository =
+                new JdbcIndexedSessionRepository(jdbcTemplate, transactionTemplate);
+        // Disable the background cleanup scheduler — we never call afterPropertiesSet,
+        // but be explicit so future changes don't accidentally start it.
+        jdbcRepository.setCleanupCron("-");
+        // Apply the same upsert SQL the production config wires up for HSQLDB,
+        // so this test exercises the actual fix rather than the default INSERT.
+        new HsqldbJdbcIndexedSessionRepositoryCustomizer().customize(jdbcRepository);
+        this.repository = jdbcRepository;
+    }
+
+    /**
+     * Two requests share one JSESSIONID:
+     * <ol>
+     *   <li>Both call {@code findById} before either has written — neither delegate
+     *       has {@code SPRING_SECURITY_CONTEXT}, so each marks its delta as {@code ADDED}.</li>
+     *   <li>Request A's {@code save()} inserts the attribute row — succeeds.</li>
+     *   <li>Request B's {@code save()} insert the same attribute row — currently
+     *       throws {@code DuplicateKeyException}.</li>
+     * </ol>
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    void concurrentRequestsAddingSameAttributeShouldNotCollide() {
+        Session created = repository.createSession();
+        repository.save(created);
+        String sessionId = created.getId();
+
+        Session requestA = repository.findById(sessionId);
+        Session requestB = repository.findById(sessionId);
+        assertThat(requestA).as("Session A should load").isNotNull();
+        assertThat(requestB).as("Session B should load").isNotNull();
+
+        requestA.setAttribute(SPRING_SECURITY_CONTEXT, securityContextFor("user-A"));
+        requestB.setAttribute(SPRING_SECURITY_CONTEXT, securityContextFor("user-B"));
+
+        repository.save(requestA);
+
+        assertThatCode(() -> repository.save(requestB))
+                .as("Concurrent INSERTs for the same (session_primary_id, attribute_name) "
+                        + "should resolve as an UPSERT (last write wins), not fail with DuplicateKeyException")
+                .doesNotThrowAnyException();
+
+        Session reloaded = repository.findById(sessionId);
+        assertThat(reloaded).isNotNull();
+        SecurityContext stored = reloaded.getAttribute(SPRING_SECURITY_CONTEXT);
+        assertThat(stored).isNotNull();
+        assertThat(stored.getAuthentication().getName())
+                .as("Last write should win")
+                .isEqualTo("user-B");
+    }
+
+    private static SecurityContext securityContextFor(String username) {
+        return new SecurityContextImpl(
+                new UsernamePasswordAuthenticationToken(username, "pw", Collections.emptyList()));
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/db/JdbcSessionConcurrentWriteMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/db/JdbcSessionConcurrentWriteMockMvcTest.java
@@ -1,0 +1,111 @@
+package org.cloudfoundry.identity.uaa.db;
+
+import java.util.Collections;
+
+import org.cloudfoundry.identity.uaa.DefaultTestContext;
+import org.cloudfoundry.identity.uaa.web.beans.UaaJdbcSessionConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextImpl;
+import org.springframework.session.Session;
+import org.springframework.session.SessionRepository;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Reproduces the production race where two concurrent requests sharing the same
+ * JSESSIONID both see a session attribute as new, both mark their delta as {@code ADDED},
+ * and both call {@code save()} — the second {@code INSERT INTO SPRING_SESSION_ATTRIBUTES}
+ * fails with {@link org.springframework.dao.DuplicateKeyException}.
+ *
+ * <p>Loads the real UAA Spring context with {@code servlet.session-store=database}, so the
+ * {@link JdbcIndexedSessionRepository} under test is the one wired up by
+ * {@link UaaJdbcSessionConfig} — including the vendor-specific upsert customizer. The CI
+ * matrix runs this test against hsqldb, mysql, and postgresql, exercising all three SQL
+ * dialects of the fix.
+ *
+ * <p>The race is fully deterministic at the repository level (the delta {@code ADDED}
+ * vs {@code UPDATED} decision is taken purely from each {@code JdbcSession}'s local
+ * {@code MapSession} delegate, populated only at {@code findById} time), so no threads
+ * are required to reproduce it.
+ */
+@DefaultTestContext
+@TestPropertySource(properties = "servlet.session-store=database")
+class JdbcSessionConcurrentWriteMockMvcTest {
+
+    private static final String SPRING_SECURITY_CONTEXT = "SPRING_SECURITY_CONTEXT";
+
+    @Autowired
+    private SessionRepository<?> sessionRepository;
+
+    private String createdSessionId;
+
+    @AfterEach
+    void cleanUp() {
+        if (createdSessionId != null) {
+            sessionRepository.deleteById(createdSessionId);
+        }
+    }
+
+    /**
+     * Two requests share one JSESSIONID:
+     * <ol>
+     *   <li>Both call {@code findById} before either has written — neither delegate
+     *       has {@code SPRING_SECURITY_CONTEXT}, so each marks its delta as {@code ADDED}.</li>
+     *   <li>Request A's {@code save()} inserts the attribute row — succeeds.</li>
+     *   <li>Request B's {@code save()} inserts the same attribute row — before the fix,
+     *       this threw {@code DuplicateKeyException}; with the per-vendor upsert customizer
+     *       wired in, it resolves as last-write-wins.</li>
+     * </ol>
+     */
+    @Test
+    void concurrentInsertsForSameAttributeAreIdempotent() {
+        runRace(sessionRepository);
+    }
+
+    /**
+     * Wildcard-capture helper. {@link SessionRepository} is wired in as
+     * {@code SessionRepository<?>} (the concrete session type is package-private), so we
+     * capture the wildcard as a method type parameter to keep {@code createSession}/
+     * {@code save}/{@code findById} type-aligned.
+     */
+    private <S extends Session> void runRace(SessionRepository<S> repo) {
+        S created = repo.createSession();
+        repo.save(created);
+        createdSessionId = created.getId();
+
+        S requestA = repo.findById(createdSessionId);
+        S requestB = repo.findById(createdSessionId);
+        assertThat(requestA).as("Session A should load").isNotNull();
+        assertThat(requestB).as("Session B should load").isNotNull();
+
+        requestA.setAttribute(SPRING_SECURITY_CONTEXT, securityContextFor("user-A"));
+        requestB.setAttribute(SPRING_SECURITY_CONTEXT, securityContextFor("user-B"));
+
+        repo.save(requestA);
+
+        assertThatCode(() -> repo.save(requestB))
+                .as("Concurrent INSERTs for the same (session_primary_id, attribute_name) "
+                        + "should resolve as an UPSERT (last write wins), not fail with DuplicateKeyException")
+                .doesNotThrowAnyException();
+
+        S reloaded = repo.findById(createdSessionId);
+        assertThat(reloaded).isNotNull();
+        SecurityContext stored = reloaded.getAttribute(SPRING_SECURITY_CONTEXT);
+        assertThat(stored).isNotNull();
+        assertThat(stored.getAuthentication().getName())
+                .as("Last write should win")
+                .isEqualTo("user-B");
+    }
+
+    private static SecurityContext securityContextFor(String username) {
+        return new SecurityContextImpl(
+                new UsernamePasswordAuthenticationToken(username, "pw", Collections.emptyList()));
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/db/JdbcSessionConcurrentWriteMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/db/JdbcSessionConcurrentWriteMockMvcTest.java
@@ -1,7 +1,5 @@
 package org.cloudfoundry.identity.uaa.db;
 
-import java.util.Collections;
-
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.web.beans.UaaJdbcSessionConfig;
 import org.junit.jupiter.api.AfterEach;
@@ -14,6 +12,8 @@ import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
 import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
 import org.springframework.test.context.TestPropertySource;
+
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;


### PR DESCRIPTION
Two concurrent requests sharing a JSESSIONID can both load the session before either commits, both mark a new attribute as ADDED, and the second INSERT into SPRING_SESSION_ATTRIBUTES fails with DuplicateKeyException. Wire up a SessionRepositoryCustomizer per DB vendor so the attribute insert is idempotent: PostgreSqlJdbcIndexedSessionRepositoryCustomizer and MySqlJdbcIndexedSessionRepositoryCustomizer ship with Spring Session; add an HSQLDB counterpart using MERGE.