### PR TITLE
fix: restore X-Frame-Options: none on /session and /session_management

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlSecurityConfiguration.java
@@ -41,7 +41,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 @EnableWebSecurity
@@ -69,7 +68,7 @@ public class SpringServletXmlSecurityConfiguration {
             "/.well-known/openid-configuration",
             // OpenAPI documentation endpoints
             "/v3/api-docs/**",
-            "/v3/api-docs", 
+            "/v3/api-docs",
             "/v3/api-docs.yaml",
             "/swagger-ui/**",
             "/swagger-ui.html",
@@ -122,7 +121,7 @@ public class SpringServletXmlSecurityConfiguration {
     @Order(FilterChainOrder.NO_SECURITY)
     UaaFilterChain noSecurityFilters(HttpSecurity http) throws Exception {
         SecurityFilterChain chain = http
-                .headers(headers -> headers.frameOptions(withDefaults()))
+                .headers(headers -> headers.frameOptions(c -> c.disable()))
                 .securityMatcher(noSecurityEndpoints)
                 .authorizeHttpRequests(requests -> requests.anyRequest().permitAll())
                 .anonymous(AnonymousConfigurer::disable)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlSecurityConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlSecurityConfiguration.java
@@ -46,6 +46,18 @@ import java.util.Map;
 @EnableWebSecurity
 public class SpringServletXmlSecurityConfiguration {
 
+    /**
+     * These endpoints are loaded by the uaa-singular library inside a hidden cross-origin iframe
+     * (opFrame) to drive OIDC Session Management via postMessage. They must never send
+     * X-Frame-Options: DENY, which is handled by the dedicated sessionManagementFilters chain below.
+     * Keeping them in a separate chain prevents the frameOptions override from accidentally
+     * spreading to the rest of the no-security endpoints in a future refactor.
+     */
+    private final String[] sessionManagementEndpoints = {
+            "/session",
+            "/session_management"
+    };
+
     private final String[] noSecurityEndpoints = {
             "/error**",
             "/error/**",
@@ -62,8 +74,6 @@ public class SpringServletXmlSecurityConfiguration {
             "/saml_error",
             "/favicon.ico",
             "/oauth_error",
-            "/session",
-            "/session_management",
             "/oauth/token/.well-known/openid-configuration",
             "/.well-known/openid-configuration",
             // OpenAPI documentation endpoints
@@ -118,10 +128,27 @@ public class SpringServletXmlSecurityConfiguration {
     }
 
     @Bean
+    @Order(FilterChainOrder.SESSION_MANAGEMENT)
+    UaaFilterChain sessionManagementFilters(HttpSecurity http) throws Exception {
+        SecurityFilterChain chain = http
+                .headers(headers -> headers.frameOptions(c -> c.disable()))
+                .securityMatcher(sessionManagementEndpoints)
+                .authorizeHttpRequests(requests -> requests.anyRequest().permitAll())
+                .anonymous(AnonymousConfigurer::disable)
+                .csrf(csrf -> csrf.ignoringRequestMatchers(sessionManagementEndpoints))
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .securityContext(sc -> sc.requireExplicitSave(false))
+                .build();
+
+        return new UaaFilterChain(chain, "sessionManagementFilters");
+    }
+
+    @Bean
     @Order(FilterChainOrder.NO_SECURITY)
     UaaFilterChain noSecurityFilters(HttpSecurity http) throws Exception {
         SecurityFilterChain chain = http
-                .headers(headers -> headers.frameOptions(c -> c.disable()))
                 .securityMatcher(noSecurityEndpoints)
                 .authorizeHttpRequests(requests -> requests.anyRequest().permitAll())
                 .anonymous(AnonymousConfigurer::disable)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/FilterChainOrder.java
@@ -12,6 +12,7 @@ public class FilterChainOrder {
 
     // spring-servlet.xml: 0
     public static final int NO_SECURITY = 1;
+    public static final int SESSION_MANAGEMENT = 2;
 
     // login-server-security.xml: 100
     public static final int AUTHENTICATE_BEARER = 100;

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/SessionControllerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/SessionControllerMockMvcTests.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
@@ -35,5 +36,32 @@ class SessionControllerMockMvcTests {
                         .param("messageOrigin", "origin"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("session_management"));
+    }
+
+    /**
+     * The /session and /session_management endpoints are loaded by the uaa-singular library
+     * inside a cross-origin iframe (opFrame) to implement OIDC session management via postMessage.
+     * Browsers refuse to render pages in iframes when X-Frame-Options: DENY is set, which would
+     * prevent the logout callback from ever firing. These endpoints must not send that header.
+     *
+     * Regression: introduced by the Spring Boot 3.4.6 upgrade (9954ddaba) which accidentally
+     * changed frameOptions().disable() to frameOptions(withDefaults()) — the latter means DENY.
+     */
+    @Test
+    void sessionEndpointMustNotSendXFrameOptionsDeny() throws Exception {
+        mockMvc.perform(get("/session")
+                        .param("clientId", "1")
+                        .param("messageOrigin", "origin"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("X-Frame-Options"));
+    }
+
+    @Test
+    void sessionManagementEndpointMustNotSendXFrameOptionsDeny() throws Exception {
+        mockMvc.perform(get("/session_management")
+                        .param("clientId", "1")
+                        .param("messageOrigin", "origin"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("X-Frame-Options"));
     }
 }


### PR DESCRIPTION
Green test run at https://bosh.ci.cloudfoundry.org/teams/uaa/pipelines/pull-requests/jobs/uaa-singular-tests/builds/259


**fix: restore X-Frame-Options: none on /session and /session\_management**

The uaa-singular OIDC Session Management library implements logout detection by loading `/session_management` (and the legacy `/session`) inside a hidden cross-origin iframe called the *opFrame*. The embedded page posts the user's current session state back to the RP via `window.postMessage`. When the browser sees `X-Frame-Options: DENY` it refuses to render the iframe, so the `postMessage` handler never fires and the `onLogout` callback is never invoked — breaking silent logout for every application that integrates uaa-singular.

The regression was introduced by commit 9954ddaba ("Upgrade to Spring Boot 3.4.6"). The `noSecurityFilters` `SecurityFilterChain`, which covers the no-auth endpoints including `/session` and `/session_management`, previously called `.frameOptions().disable()` to suppress the header on those paths. During the Spring Boot 3.4 migration the call was rewritten as `.frameOptions(withDefaults())`, which resolves to `DENY` — the opposite of the intended behaviour.

The two new `SessionControllerMockMvcTests` assertions (`header().doesNotExist("X-Frame-Options")`) guard against this class of regression recurring.