### PR TITLE
Fix CodeQL finding - regex

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -115,7 +115,7 @@ public abstract class UaaUrlUtils {
     /**
      * Maximum length accepted for a registered redirect URI. Inputs longer than this are rejected
      * before regex evaluation as a defence against polynomial backtracking on pathological inputs.
-     * RFC 7230 limizd max URI is 8000.
+     * RFC 7230 recommends support for request-line lengths of at least 8000 octets.
      */
     private static final int MAX_REDIRECT_URI_LENGTH = 8000;
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -112,9 +112,15 @@ public abstract class UaaUrlUtils {
         return false;
     }
 
+    /**
+     * Maximum length accepted for a registered redirect URI. Inputs longer than this are rejected
+     * before regex evaluation as a defence against polynomial backtracking on pathological inputs.
+     */
+    private static final int MAX_REDIRECT_URI_LENGTH = 2048;
+
     private static final Pattern allowedRedirectUriPattern = Pattern.compile(
             "^([a-zA-Z][a-zA-Z0-9+\\*\\-.]*)://" + //URL starts with 'some-scheme://' or 'https://' or 'http*://
-                    "(.*:.*@)?" +                    //username/password in URL
+                    "([^:/@]{0,255}:[^/@]{0,255}@)?" + //username/password in URL — bounded, no `/`/`@` to avoid ReDoS
                     "(([a-zA-Z0-9\\-\\*\\_]+\\.){0,255}" + //subdomains (RFC1035) limited, regex backtracking disabled
                     "[a-zA-Z0-9\\-\\_]+\\.)?" +      //hostname
                     "[a-zA-Z0-9\\-]+" +              //tld
@@ -122,7 +128,7 @@ public abstract class UaaUrlUtils {
     );
 
     public static boolean isValidRegisteredRedirectUrl(String url) {
-        if (hasText(url)) {
+        if (hasText(url) && url.length() <= MAX_REDIRECT_URI_LENGTH) {
             return allowedRedirectUriPattern.matcher(url).matches();
         }
         return false;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java
@@ -115,8 +115,9 @@ public abstract class UaaUrlUtils {
     /**
      * Maximum length accepted for a registered redirect URI. Inputs longer than this are rejected
      * before regex evaluation as a defence against polynomial backtracking on pathological inputs.
+     * RFC 7230 limizd max URI is 8000.
      */
-    private static final int MAX_REDIRECT_URI_LENGTH = 2048;
+    private static final int MAX_REDIRECT_URI_LENGTH = 8000;
 
     private static final Pattern allowedRedirectUriPattern = Pattern.compile(
             "^([a-zA-Z][a-zA-Z0-9+\\*\\-.]*)://" + //URL starts with 'some-scheme://' or 'https://' or 'http*://

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java
@@ -656,6 +656,20 @@ class UaaUrlUtilsTest {
     }
 
     @Test
+    void isValidRegisteredRedirectUrlRejectsOverlongInputQuickly() {
+        // Defence against polynomial regex backtracking (CWE-1333). A long pathological input
+        // that does not contain "://" should be rejected by the length cap before regex matching,
+        // and must complete well under the 1 s budget even on a slow CI box.
+        String pathological = "a".repeat(100_000);
+        long start = System.nanoTime();
+        boolean result = UaaUrlUtils.isValidRegisteredRedirectUrl(pathological);
+        long elapsedMillis = (System.nanoTime() - start) / 1_000_000L;
+
+        assertThat(result).isFalse();
+        assertThat(elapsedMillis).as("regex evaluation time in ms").isLessThan(1000);
+    }
+
+    @Test
     void invalidUrlExceptionIsThrown() {
         assertThatExceptionOfType(InvalidUrlException.class).isThrownBy(
                 () -> UaaUrlUtils.fromUriString("invalid-url")


### PR DESCRIPTION
Changes:

  - server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtils.java:115-134
    - Replaced the unbounded userinfo group (.*:.*@)? with ([^:/@]{0,255}:[^/@]{0,255}@)? — character classes that exclude the surrounding delimiters, so the regex engine has only one way to match each character (no quadratic backtracking) and is hard-bounded at 255 chars per part.
    - Added a MAX_REDIRECT_URI_LENGTH = 8000 length cap in isValidRegisteredRedirectUrl so pathological inputs are rejected before the regex ever runs.
  - server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaUrlUtilsTest.java:649-672
    - New isValidRegisteredRedirectUrlRejectsOverlongInputQuickly test: feeds 100 000 a's, asserts false and that the call returns in under 1 second. This guards against future regressions reintroducing polynomial behaviour.

  Test results: 172 tests in UaaUrlUtilsTest pass, 92 tests across ClientAdminEndpointsValidatorTests and LegacyRedirectResolverTest pass — all existing redirect-URI semantics (including userinfo
  edge cases like http://username:password@some.server.com, http://*:*@some.server.com, and the http://AAA@@attacker.com host-confusion rejections) are preserved.

  The CodeQL alert at line 126 should now clear: the regex is no longer polynomial, and the input is length-bounded before evaluation.