### PR TITLE
Remove unused dependency: aspectjrt

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,7 +56,6 @@ velocity = { module = "org.apache.velocity:velocity-engine-core", version.ref = 
 xmlSecurity = { module = "org.apache.santuario:xmlsec", version.ref = "xmlSecurity" }
 
 # AspectJ
-aspectJRt = { module = "org.aspectj:aspectjrt" }
 aspectJWeaver = { module = "org.aspectj:aspectjweaver" }
 
 # Awaitility

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -42,10 +42,6 @@ dependencies {
 
     implementation(libs.guava)
 
-    // OpenAPI documentation
-    implementation(libs.springDocOpenapi)
-
-    implementation(libs.aspectJRt)
     implementation(libs.aspectJWeaver)
 
     implementation(libs.thymeLeaf) {


### PR DESCRIPTION
⏺ **aspectjrt** (the runtime) contains only what's needed to execute already-woven code: the annotations (@Aspect, @Before, etc.), the JoinPoint interfaces, and the runtime error types.

  **aspectjweaver** (the weaver) contains everything in aspectjrt plus the bytecode weaving engine itself. It's physically a superset — if you unjar both, every class in aspectjrt.jar also exists in
  aspectjweaver.jar.

  UAA uses Spring AOP with compile-time/load-time weaving, which requires the weaver on the classpath at runtime. Since the weaver is already there, declaring aspectjrt separately just adds a redundant JAR
  with duplicate classes. Removing it changes nothing at runtime.


Note: springDocOpenapi is unused in server, removed from build file. But it is still included in uaa itself