### PR TITLE
Migrate to scim2-sdk-common

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ springDependencyManagement = "1.1.7"
 springDocOpenapi = "3.0.3"
 statsdClient = "3.1.0"
 tomcat = "11.0.22"
-unboundIdScimSdk = "2.0.0"
+scim2Sdk = "6.0.0"
 velocity = "2.4.1"
 xmlSecurity = "4.0.4"
 
@@ -204,7 +204,7 @@ thymeleafSpring = { module = "org.thymeleaf:thymeleaf-spring6" }
 
 # UnboundID
 unboundIdLdapSdk = { module = "com.unboundid:unboundid-ldapsdk" }
-unboundIdScimSdk = { module = "com.unboundid.product.scim:scim-sdk", version.ref = "unboundIdScimSdk" }
+scim2SdkCommon = { module = "com.unboundid.product.scim2:scim2-sdk-common", version.ref = "scim2Sdk" }
 
 # XMLUnit
 xmlUnit = { module = "org.xmlunit:xmlunit-assertj" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -57,13 +57,7 @@ dependencies {
         exclude(module = "ognl")
     }
 
-    implementation(libs.unboundIdScimSdk) {
-        exclude(module = "servlet-api")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "wink-client-apache-httpclient")
-        exclude(module = "json")
-    }
+    implementation(libs.scim2SdkCommon)
 
     implementation(libs.hibernateValidator)
     implementation(libs.flywayHsqlDb)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -1,9 +1,10 @@
 package org.cloudfoundry.identity.uaa.resources.jdbc;
 
-import com.unboundid.scim.sdk.AttributePath;
-import com.unboundid.scim.sdk.InvalidResourceException;
-import com.unboundid.scim.sdk.SCIMException;
-import com.unboundid.scim.sdk.SCIMFilter;
+import com.unboundid.scim2.common.exceptions.BadRequestException;
+import com.unboundid.scim2.common.exceptions.ScimException;
+import com.unboundid.scim2.common.filters.Filter;
+import com.unboundid.scim2.common.filters.FilterType;
+import tools.jackson.databind.node.ValueNode;
 import org.cloudfoundry.identity.uaa.resources.AttributeNameMapper;
 import org.cloudfoundry.identity.uaa.resources.JoinAttributeNameMapper;
 import org.cloudfoundry.identity.uaa.resources.SimpleAttributeNameMapper;
@@ -25,7 +26,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import static com.unboundid.scim.sdk.SCIMException.createException;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
@@ -143,12 +143,10 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
             final String zoneId) {
 
         try {
-            final SCIMFilter zoneIdFilter = SCIMFilter.createEqualityFilter(
-                    AttributePath.parse("identity_zone_id"),
-                    zoneId);
-            SCIMFilter fullFilter;
+            final Filter zoneIdFilter = Filter.eq("identity_zone_id", zoneId);
+            Filter fullFilter;
             if (hasText(filter)) {
-                fullFilter = SCIMFilter.createAndFilter(asList(scimFilter(filter), zoneIdFilter));
+                fullFilter = Filter.and(asList(scimFilter(filter), zoneIdFilter));
             } else {
                 fullFilter = zoneIdFilter;
             }
@@ -162,7 +160,7 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
             }
 
             return whereClause;
-        } catch (SCIMException e) {
+        } catch (ScimException e) {
             logger.debug("Unable to parse {}", filter, e);
             throw new IllegalArgumentException("Invalid SCIM Filter: " + filter + "; Message: " + e.getMessage());
         }
@@ -171,117 +169,127 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
     @Override
     public MultiValueMap<String, Object> getFilterValues(String filter, List<String> validAttributes) throws IllegalArgumentException {
         try {
-            SCIMFilter scimFilter = SCIMFilter.parse(filter);
+            Filter scimFilter = Filter.fromString(filter);
             validateFilterAttributes(scimFilter, validAttributes);
             MultiValueMap<String, Object> result = new LinkedMultiValueMap<>();
             extractValues(scimFilter, result);
             return result;
-        } catch (SCIMException x) {
+        } catch (ScimException x) {
             throw new IllegalArgumentException(x.getMessage());
         }
     }
 
-    private SCIMFilter scimFilter(String filter) throws SCIMException {
-        SCIMFilter scimFilter;
+    private Filter scimFilter(String filter) throws ScimException {
+        Filter scimFilter;
         try {
-            scimFilter = SCIMFilter.parse(filter);
-        } catch (SCIMException e) {
+            scimFilter = Filter.fromString(filter);
+        } catch (ScimException e) {
             logger.debug("Attempting legacy scim filter conversion for [{}]", filter, e);
-            filter = filter.replaceAll("'", "\"");
-            scimFilter = SCIMFilter.parse(filter);
+            filter = filter.replace("'", "\"");
+            scimFilter = Filter.fromString(filter);
         }
         validateFilterAttributes(scimFilter, VALID_ATTRIBUTE_NAMES);
         return scimFilter;
     }
 
-    private void validateFilterAttributes(SCIMFilter filter, List<String> validAttributeNames) throws SCIMException {
+    private void validateFilterAttributes(Filter filter, List<String> validAttributeNames) throws ScimException {
         List<String> invalidAttributes = new LinkedList<>();
         validateFilterAttributes(filter, invalidAttributes, validAttributeNames, 0);
         if (!invalidAttributes.isEmpty()) {
-            throw new InvalidResourceException("Invalid filter attributes:" + StringUtils.collectionToCommaDelimitedString(invalidAttributes));
+            throw new BadRequestException("Invalid filter attributes:" + StringUtils.collectionToCommaDelimitedString(invalidAttributes));
         }
     }
 
-    private void validateFilterAttributes(SCIMFilter filter, List<String> invalidAttribues, List<String> validAttributeNames, int depth) {
+    private void validateFilterAttributes(Filter filter, List<String> invalidAttribues, List<String> validAttributeNames, int depth) {
         if (depth > MAX_FILTER_DEPTH) {
             throw new IllegalArgumentException("Filter too deeply nested");
         }
-        if (filter.getFilterAttribute() != null && filter.getFilterAttribute().getAttributeName() != null) {
-            String name = filter.getFilterAttribute().getAttributeName();
-            if (filter.getFilterAttribute().getSubAttributeName() != null) {
-                name = name + "." + filter.getFilterAttribute().getSubAttributeName();
-            }
+        if (filter.getAttributePath() != null) {
+            String name = filter.getAttributePath().toString();
             if (!validAttributeNames.contains(name.toLowerCase())) {
                 invalidAttribues.add(name);
             }
         }
-        for (SCIMFilter subfilter : ofNullable(filter.getFilterComponents()).orElse(emptyList())) {
+        for (Filter subfilter : ofNullable(filter.getCombinedFilters()).orElse(emptyList())) {
             validateFilterAttributes(subfilter, invalidAttribues, validAttributeNames, depth + 1);
         }
     }
 
-    private void extractValues(SCIMFilter filter, MultiValueMap<String, Object> values) throws SCIMException {
+    private void extractValues(Filter filter, MultiValueMap<String, Object> values) throws ScimException {
         extractValues(filter, values, 0);
     }
 
-    private void extractValues(SCIMFilter filter, MultiValueMap<String, Object> values, int depth) throws SCIMException {
+    private void extractValues(Filter filter, MultiValueMap<String, Object> values, int depth) throws ScimException {
         if (depth > MAX_FILTER_DEPTH) {
-            throw createException(400, "Filter too deeply nested");
+            throw new BadRequestException("Filter too deeply nested");
         }
         switch (filter.getFilterType()) {
             case AND:
-                extractValues(filter.getFilterComponents().getFirst(), values, depth + 1);
-                extractValues(filter.getFilterComponents().get(1), values, depth + 1);
+                for (Filter component : filter.getCombinedFilters()) {
+                    extractValues(component, values, depth + 1);
+                }
                 break;
             case OR:
-                throw createException(400, "[or] operator is not supported.");
-            case EQUALITY:
-                Object value = getStringOrDate(filter.getFilterValue());
-                String key = filter.getFilterAttribute().getAttributeName();
+                throw new BadRequestException("[or] operator is not supported.");
+            case EQUAL:
+                Object value = getStringOrDate(filter.getComparisonValue().asString());
+                String key = filter.getAttributePath().toString();
                 values.add(key, value);
                 break;
             case CONTAINS:
-                throw createException(400, "[co] operator is not supported.");
+                throw new BadRequestException("[co] operator is not supported.");
             case STARTS_WITH:
-                throw createException(400, "[sw] operator is not supported.");
-            case PRESENCE:
-                throw createException(400, "[pr] operator is not supported.");
+                throw new BadRequestException("[sw] operator is not supported.");
+            case PRESENT:
+                throw new BadRequestException("[pr] operator is not supported.");
             case GREATER_THAN:
-                throw createException(400, "[gt] operator is not supported.");
+                throw new BadRequestException("[gt] operator is not supported.");
             case GREATER_OR_EQUAL:
-                throw createException(400, "[ge] operator is not supported.");
+                throw new BadRequestException("[ge] operator is not supported.");
             case LESS_THAN:
-                throw createException(400, "[lt] operator is not supported.");
+                throw new BadRequestException("[lt] operator is not supported.");
             case LESS_OR_EQUAL:
-                throw createException(400, "[le] operator is not supported.");
+                throw new BadRequestException("[le] operator is not supported.");
             default:
-                throw createException(400, "Unknown filter operator:" + filter.getFilterType());
+                throw new BadRequestException("Unknown filter operator:" + filter.getFilterType());
         }
     }
 
-    private String whereClauseFromFilter(SCIMFilter filter, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix) {
+    private String buildCombiningClause(Filter filter, String operator, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix, int depth) {
+        StringBuilder sb = new StringBuilder("(");
+        List<Filter> components = filter.getCombinedFilters();
+        sb.append(whereClauseFromFilter(components.getFirst(), values, mapper, paramPrefix, depth + 1));
+        for (int i = 1; i < components.size(); i++) {
+            sb.append(operator).append(whereClauseFromFilter(components.get(i), values, mapper, paramPrefix, depth + 1));
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    private String whereClauseFromFilter(Filter filter, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix) {
         return whereClauseFromFilter(filter, values, mapper, paramPrefix, 0);
     }
 
-    private String whereClauseFromFilter(SCIMFilter filter, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix, int depth) {
+    private String whereClauseFromFilter(Filter filter, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix, int depth) {
         if (depth > MAX_FILTER_DEPTH) {
             throw new IllegalArgumentException("Filter too deeply nested");
         }
         return switch (filter.getFilterType()) {
-            case AND -> "(" + whereClauseFromFilter(filter.getFilterComponents().getFirst(), values, mapper, paramPrefix, depth + 1) + " AND " + whereClauseFromFilter(filter.getFilterComponents().get(1), values, mapper, paramPrefix, depth + 1) + ")";
-            case OR -> "(" + whereClauseFromFilter(filter.getFilterComponents().getFirst(), values, mapper, paramPrefix, depth + 1) + " OR " + whereClauseFromFilter(filter.getFilterComponents().get(1), values, mapper, paramPrefix, depth + 1) + ")";
-            case EQUALITY -> comparisonClause(filter, "=", values, "", "", paramPrefix);
+            case AND -> buildCombiningClause(filter, " AND ", values, mapper, paramPrefix, depth);
+            case OR -> buildCombiningClause(filter, " OR ", values, mapper, paramPrefix, depth);
+            case EQUAL -> comparisonClause(filter, "=", values, "", "", paramPrefix);
             case CONTAINS -> comparisonClause(filter, "LIKE", values, "%", "%", paramPrefix);
             case STARTS_WITH -> comparisonClause(filter, "LIKE", values, "", "%", paramPrefix);
-            case PRESENCE -> getAttributeName(filter, mapper) + " IS NOT NULL";
+            case PRESENT -> getAttributeName(filter, mapper) + " IS NOT NULL";
             case GREATER_THAN -> comparisonClause(filter, ">", values, "", "", paramPrefix);
             case GREATER_OR_EQUAL -> comparisonClause(filter, ">=", values, "", "", paramPrefix);
             case LESS_THAN -> comparisonClause(filter, "<", values, "", "", paramPrefix);
             case LESS_OR_EQUAL -> comparisonClause(filter, "<=", values, "", "", paramPrefix);
+            default -> throw new IllegalArgumentException("Unsupported filter type: " + filter.getFilterType());
         };
     }
 
-    private String comparisonClause(SCIMFilter filter,
+    private String comparisonClause(Filter filter,
             String comparator,
             Map<String, Object> values,
             String valuePrefix,
@@ -289,13 +297,14 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
             String paramPrefix) {
         String pName = getParamName(values, paramPrefix);
         String paramName = ":" + pName;
-        if (filter.getFilterValue() == null) {
+        ValueNode compValue = filter.getComparisonValue();
+        if (compValue == null || compValue.isNull()) {
             return getAttributeName(filter, mapper) + " IS NULL";
-        } else if (filter.isQuoteFilterValue()) {
-            Object value = getStringOrDate(filter.getFilterValue());
+        } else if (compValue.isString()) {
+            Object value = getStringOrDate(compValue.asString());
             if (value instanceof String) {
                 //lower is used to satisfy the requirement that all quoted values are compared case insensitive
-                switch (filter.getFilterAttribute().getAttributeName().toLowerCase()) {
+                switch (filter.getAttributePath().toString().toLowerCase()) {
                     case "client_secret":
                     case "password":
                     case "salt":
@@ -306,7 +315,7 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
                 }
                 values.put(pName, valuePrefix + value + valueSuffix);
                 if (isDbCaseInsensitive()) {
-                    return "" + getAttributeName(filter, mapper) + " " + comparator + " " + paramName + "";
+                    return getAttributeName(filter, mapper) + " " + comparator + " " + paramName;
                 } else {
                     return "LOWER(" + getAttributeName(filter, mapper) + ") " + comparator + " LOWER(" + paramName + ")";
                 }
@@ -314,29 +323,20 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
                 values.put(pName, value);
                 return getAttributeName(filter, mapper) + " " + comparator + " " + paramName;
             }
-        } else {
-            try {
-                values.put(pName, Double.parseDouble(filter.getFilterValue()));
-            } catch (NumberFormatException _) {
-                if ("true".equalsIgnoreCase(filter.getFilterValue())) {
-                    values.put(pName, Boolean.TRUE);
-                } else if ("false".equalsIgnoreCase(filter.getFilterValue())) {
-                    values.put(pName, Boolean.FALSE);
-                } else {
-                    throw new IllegalArgumentException("Invalid non quoted value [" + filter.getFilterAttribute() +
-                            " : " + filter.getFilterValue() + "]");
-                }
-            }
+        } else if (compValue.isBoolean()) {
+            values.put(pName, compValue.booleanValue());
             return getAttributeName(filter, mapper) + " " + comparator + " " + paramName;
+        } else if (compValue.isNumber()) {
+            values.put(pName, compValue.doubleValue());
+            return getAttributeName(filter, mapper) + " " + comparator + " " + paramName;
+        } else {
+            throw new IllegalArgumentException("Invalid non-quoted value [" + filter.getAttributePath() +
+                    " : " + compValue + "]");
         }
     }
 
-    private String getAttributeName(SCIMFilter filter, AttributeNameMapper mapper) {
-        String name = filter.getFilterAttribute().getAttributeName();
-        String subName = filter.getFilterAttribute().getSubAttributeName();
-        if (hasText(subName)) {
-            name = name + "." + subName;
-        }
+    private String getAttributeName(Filter filter, AttributeNameMapper mapper) {
+        String name = filter.getAttributePath().toString();
         name = mapper.mapToInternal(name);
         return name.replace("meta.", "");
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -3,7 +3,6 @@ package org.cloudfoundry.identity.uaa.resources.jdbc;
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.exceptions.ScimException;
 import com.unboundid.scim2.common.filters.Filter;
-import com.unboundid.scim2.common.filters.FilterType;
 import tools.jackson.databind.node.ValueNode;
 import org.cloudfoundry.identity.uaa.resources.AttributeNameMapper;
 import org.cloudfoundry.identity.uaa.resources.JoinAttributeNameMapper;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -34,6 +34,8 @@ import static org.springframework.util.StringUtils.hasText;
 
 public class SimpleSearchQueryConverter implements SearchQueryConverter {
 
+    private static final int MAX_FILTER_DEPTH = 20;
+
     //LOWER
     private static final List<String> VALID_ATTRIBUTE_NAMES = List.of(
             "id",
@@ -194,13 +196,16 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
 
     private void validateFilterAttributes(SCIMFilter filter, List<String> validAttributeNames) throws SCIMException {
         List<String> invalidAttributes = new LinkedList<>();
-        validateFilterAttributes(filter, invalidAttributes, validAttributeNames);
+        validateFilterAttributes(filter, invalidAttributes, validAttributeNames, 0);
         if (!invalidAttributes.isEmpty()) {
             throw new InvalidResourceException("Invalid filter attributes:" + StringUtils.collectionToCommaDelimitedString(invalidAttributes));
         }
     }
 
-    private void validateFilterAttributes(SCIMFilter filter, List<String> invalidAttribues, List<String> validAttributeNames) {
+    private void validateFilterAttributes(SCIMFilter filter, List<String> invalidAttribues, List<String> validAttributeNames, int depth) {
+        if (depth > MAX_FILTER_DEPTH) {
+            throw new IllegalArgumentException("Filter too deeply nested");
+        }
         if (filter.getFilterAttribute() != null && filter.getFilterAttribute().getAttributeName() != null) {
             String name = filter.getFilterAttribute().getAttributeName();
             if (filter.getFilterAttribute().getSubAttributeName() != null) {
@@ -211,15 +216,22 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
             }
         }
         for (SCIMFilter subfilter : ofNullable(filter.getFilterComponents()).orElse(emptyList())) {
-            validateFilterAttributes(subfilter, invalidAttribues, validAttributeNames);
+            validateFilterAttributes(subfilter, invalidAttribues, validAttributeNames, depth + 1);
         }
     }
 
     private void extractValues(SCIMFilter filter, MultiValueMap<String, Object> values) throws SCIMException {
+        extractValues(filter, values, 0);
+    }
+
+    private void extractValues(SCIMFilter filter, MultiValueMap<String, Object> values, int depth) throws SCIMException {
+        if (depth > MAX_FILTER_DEPTH) {
+            throw createException(400, "Filter too deeply nested");
+        }
         switch (filter.getFilterType()) {
             case AND:
-                extractValues(filter.getFilterComponents().getFirst(), values);
-                extractValues(filter.getFilterComponents().get(1), values);
+                extractValues(filter.getFilterComponents().getFirst(), values, depth + 1);
+                extractValues(filter.getFilterComponents().get(1), values, depth + 1);
                 break;
             case OR:
                 throw createException(400, "[or] operator is not supported.");
@@ -248,9 +260,16 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
     }
 
     private String whereClauseFromFilter(SCIMFilter filter, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix) {
+        return whereClauseFromFilter(filter, values, mapper, paramPrefix, 0);
+    }
+
+    private String whereClauseFromFilter(SCIMFilter filter, Map<String, Object> values, AttributeNameMapper mapper, String paramPrefix, int depth) {
+        if (depth > MAX_FILTER_DEPTH) {
+            throw new IllegalArgumentException("Filter too deeply nested");
+        }
         return switch (filter.getFilterType()) {
-            case AND -> "(" + whereClauseFromFilter(filter.getFilterComponents().getFirst(), values, mapper, paramPrefix) + " AND " + whereClauseFromFilter(filter.getFilterComponents().get(1), values, mapper, paramPrefix) + ")";
-            case OR -> "(" + whereClauseFromFilter(filter.getFilterComponents().getFirst(), values, mapper, paramPrefix) + " OR " + whereClauseFromFilter(filter.getFilterComponents().get(1), values, mapper, paramPrefix) + ")";
+            case AND -> "(" + whereClauseFromFilter(filter.getFilterComponents().getFirst(), values, mapper, paramPrefix, depth + 1) + " AND " + whereClauseFromFilter(filter.getFilterComponents().get(1), values, mapper, paramPrefix, depth + 1) + ")";
+            case OR -> "(" + whereClauseFromFilter(filter.getFilterComponents().getFirst(), values, mapper, paramPrefix, depth + 1) + " OR " + whereClauseFromFilter(filter.getFilterComponents().get(1), values, mapper, paramPrefix, depth + 1) + ")";
             case EQUALITY -> comparisonClause(filter, "=", values, "", "", paramPrefix);
             case CONTAINS -> comparisonClause(filter, "LIKE", values, "%", "%", paramPrefix);
             case STARTS_WITH -> comparisonClause(filter, "LIKE", values, "", "%", paramPrefix);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
@@ -32,8 +32,9 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.View;
 import org.springframework.web.util.HtmlUtils;
 
-import com.unboundid.scim.sdk.SCIMException;
-import com.unboundid.scim.sdk.SCIMFilter;
+import com.unboundid.scim2.common.exceptions.BadRequestException;
+import com.unboundid.scim2.common.filters.Filter;
+import com.unboundid.scim2.common.filters.FilterType;
 
 @Controller
 public class UserIdConversionEndpoints implements InitializingBean {
@@ -142,13 +143,13 @@ public class UserIdConversionEndpoints implements InitializingBean {
         if (filter.isEmpty()) {
             throw new ScimException("a 'filter' parameter is required", HttpStatus.BAD_REQUEST);
         }
-        SCIMFilter scimFilter;
+        Filter scimFilter;
         try {
-            scimFilter = SCIMFilter.parse(filter);
+            scimFilter = Filter.fromString(filter);
             if (!containsIdOrUserNameClause(scimFilter, 0)) {
                 throw new ScimException("Invalid filter attribute.", HttpStatus.BAD_REQUEST);
             }
-        } catch (SCIMException e) {
+        } catch (BadRequestException e) {
             logger.debug("/ids/Users received an invalid filter [{}]", filter, e);
             throw new ScimException("Invalid filter '" + HtmlUtils.htmlEscape(filter) + "'", HttpStatus.BAD_REQUEST);
         }
@@ -157,17 +158,23 @@ public class UserIdConversionEndpoints implements InitializingBean {
     /**
      * Check if the given SCIM filter contains at least one clause involving either the "id" or "userName" property.
      */
-    private boolean containsIdOrUserNameClause(SCIMFilter filter, int depth) {
+    private boolean containsIdOrUserNameClause(Filter filter, int depth) {
         if (depth > MAX_FILTER_DEPTH) {
             throw new ScimException("Filter too deeply nested", HttpStatus.BAD_REQUEST);
         }
         switch (filter.getFilterType()) {
             case AND, OR:
-                // one of the operands must contain a comparison with the "id" or "userName" property
-                final boolean resultLeftOperand = containsIdOrUserNameClause(filter.getFilterComponents().getFirst(), depth + 1);
-                return containsIdOrUserNameClause(filter.getFilterComponents().get(1), depth + 1) || resultLeftOperand;
-            case EQUALITY:
-                String name = filter.getFilterAttribute().getAttributeName();
+                // at least one operand must contain a comparison with the "id" or "userName" property;
+                // iterate all components to validate each one (may throw for invalid operators)
+                boolean foundIdOrUserName = false;
+                for (Filter component : filter.getCombinedFilters()) {
+                    if (containsIdOrUserNameClause(component, depth + 1)) {
+                        foundIdOrUserName = true;
+                    }
+                }
+                return foundIdOrUserName;
+            case EQUAL:
+                String name = filter.getAttributePath().toString();
                 if (FIELD_ID.equalsIgnoreCase(name) ||
                         FIELD_USERNAME.equalsIgnoreCase(name)) {
                     return true;
@@ -176,12 +183,13 @@ public class UserIdConversionEndpoints implements InitializingBean {
                 } else {
                     throw new ScimException("Invalid filter attribute.", HttpStatus.BAD_REQUEST);
                 }
-            case PRESENCE, STARTS_WITH, CONTAINS:
+            case PRESENT, STARTS_WITH, CONTAINS:
                 throw new ScimException("Wildcards are not allowed in filter.", HttpStatus.BAD_REQUEST);
             case GREATER_THAN, GREATER_OR_EQUAL, LESS_THAN, LESS_OR_EQUAL:
                 throw new ScimException("Invalid operator.", HttpStatus.BAD_REQUEST);
+            default:
+                throw new ScimException("Unsupported filter type.", HttpStatus.BAD_REQUEST);
         }
-        return false;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
@@ -34,7 +34,6 @@ import org.springframework.web.util.HtmlUtils;
 
 import com.unboundid.scim2.common.exceptions.BadRequestException;
 import com.unboundid.scim2.common.filters.Filter;
-import com.unboundid.scim2.common.filters.FilterType;
 
 @Controller
 public class UserIdConversionEndpoints implements InitializingBean {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
@@ -136,6 +136,8 @@ public class UserIdConversionEndpoints implements InitializingBean {
     public void handleException() {
     }
 
+    private static final int MAX_FILTER_DEPTH = 20;
+
     private void checkFilter(String filter) {
         if (filter.isEmpty()) {
             throw new ScimException("a 'filter' parameter is required", HttpStatus.BAD_REQUEST);
@@ -143,7 +145,7 @@ public class UserIdConversionEndpoints implements InitializingBean {
         SCIMFilter scimFilter;
         try {
             scimFilter = SCIMFilter.parse(filter);
-            if (!containsIdOrUserNameClause(scimFilter)) {
+            if (!containsIdOrUserNameClause(scimFilter, 0)) {
                 throw new ScimException("Invalid filter attribute.", HttpStatus.BAD_REQUEST);
             }
         } catch (SCIMException e) {
@@ -155,12 +157,15 @@ public class UserIdConversionEndpoints implements InitializingBean {
     /**
      * Check if the given SCIM filter contains at least one clause involving either the "id" or "userName" property.
      */
-    private boolean containsIdOrUserNameClause(SCIMFilter filter) {
+    private boolean containsIdOrUserNameClause(SCIMFilter filter, int depth) {
+        if (depth > MAX_FILTER_DEPTH) {
+            throw new ScimException("Filter too deeply nested", HttpStatus.BAD_REQUEST);
+        }
         switch (filter.getFilterType()) {
             case AND, OR:
                 // one of the operands must contain a comparison with the "id" or "userName" property
-                final boolean resultLeftOperand = containsIdOrUserNameClause(filter.getFilterComponents().getFirst());
-                return containsIdOrUserNameClause(filter.getFilterComponents().get(1)) || resultLeftOperand;
+                final boolean resultLeftOperand = containsIdOrUserNameClause(filter.getFilterComponents().getFirst(), depth + 1);
+                return containsIdOrUserNameClause(filter.getFilterComponents().get(1), depth + 1) || resultLeftOperand;
             case EQUALITY:
                 String name = filter.getFilterAttribute().getAttributeName();
                 if (FIELD_ID.equalsIgnoreCase(name) ||

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpointsTests.java
@@ -1,8 +1,6 @@
 package org.cloudfoundry.identity.uaa.oauth.approval;
 
 import tools.jackson.core.type.TypeReference;
-import com.unboundid.scim.sdk.AttributePath;
-import com.unboundid.scim.sdk.SCIMFilter;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
 import org.cloudfoundry.identity.uaa.approval.Approval;
@@ -358,6 +356,7 @@ class ApprovalsAdminEndpointsTests {
     }
 
     private static String userIdFilter(String userId) {
-        return SCIMFilter.createEqualityFilter(AttributePath.parse("user_id"), userId).getFilterValue();
+        // getApprovals ignores the filter param; return userId as a passthrough value
+        return userId;
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/approval/ApprovalsAdminEndpointsTests.java
@@ -156,7 +156,7 @@ class ApprovalsAdminEndpointsTests {
                 .setScope("scope")
                 .setExpiresAt(new Date())
                 .setStatus(ApprovalStatus.APPROVED));
-        Set<Approval> deserializedApprovals = JsonUtils.readValue("[{\"userid\":\"test-user-id\",\"clientid\":\"testclientid\",\"scope\":\"scope\",\"status\":\"APPROVED\",\"expiresat\":\"2015-08-25T14:35:42.512Z\",\"lastupdatedat\":\"2015-08-25T14:35:42.512Z\"}]", new TypeReference<Set<Approval>>() {
+        Set<Approval> deserializedApprovals = JsonUtils.readValue("[{\"userid\":\"test-user-id\",\"clientid\":\"testclientid\",\"scope\":\"scope\",\"status\":\"APPROVED\",\"expiresat\":\"2015-08-25T14:35:42.512Z\",\"lastupdatedat\":\"2015-08-25T14:35:42.512Z\"}]", new TypeReference<>() {
         });
         assertThat(deserializedApprovals).hasSameElementsAs(approvals);
     }
@@ -341,7 +341,8 @@ class ApprovalsAdminEndpointsTests {
                 .setExpiresAt(Approval.timeFromNow(2000))
                 .setStatus(APPROVED)};
 
-        assertThatThrownBy(() -> endpoints.updateApprovals(approvals)).asInstanceOf(InstanceOfAssertFactories.throwable(UaaException.class));
+        assertThatThrownBy(() -> endpoints.updateApprovals(approvals))
+                .isInstanceOf(UaaException.class);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
@@ -10,8 +10,6 @@ import org.springframework.util.MultiValueMap;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -107,11 +105,11 @@ class SimpleSearchQueryConverterTests {
     void deeplyNestedFilterIsRejected() {
         // SCIM 2 parser creates flat n-ary AND for chains; explicit parentheses create actual tree depth.
         // Build: ((...((a and a) and a)...) and a) with 22 nestings → depth 22 > MAX_FILTER_DEPTH(20)
-        String filter = "username eq \"joe\" and username eq \"joe\"";
+        StringBuilder filter = new StringBuilder("username eq \"joe\" and username eq \"joe\"");
         for (int i = 0; i < 22; i++) {
-            filter = "(" + filter + ") and username eq \"joe\"";
+            filter = new StringBuilder("(" + filter + ") and username eq \"joe\"");
         }
-        final String deepFilter = filter;
+        final String deepFilter = filter.toString();
         assertThatThrownBy(() -> converter.convert(deepFilter, null, false, "zone"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
@@ -119,22 +117,22 @@ class SimpleSearchQueryConverterTests {
     @Test
     void moderatelyNestedFilterIsAccepted() {
         // 5 explicit nestings → depth 5, well within MAX_FILTER_DEPTH(20)
-        String filter = "username eq \"joe\" and username eq \"joe\"";
+        StringBuilder filter = new StringBuilder("username eq \"joe\" and username eq \"joe\"");
         for (int i = 0; i < 5; i++) {
-            filter = "(" + filter + ") and username eq \"joe\"";
+            filter = new StringBuilder("(" + filter + ") and username eq \"joe\"");
         }
-        final String shallowFilter = filter;
+        final String shallowFilter = filter.toString();
         assertThatNoException().isThrownBy(() -> converter.convert(shallowFilter, null, false, "zone"));
     }
 
     @Test
     void deeplyNestedGetFilterValuesIsRejected() {
         // Same depth limit applies to getFilterValues
-        String filter = "origin eq \"uaa\" and origin eq \"uaa\"";
+        StringBuilder filter = new StringBuilder("origin eq \"uaa\" and origin eq \"uaa\"");
         for (int i = 0; i < 22; i++) {
-            filter = "(" + filter + ") and origin eq \"uaa\"";
+            filter = new StringBuilder("(" + filter + ") and origin eq \"uaa\"");
         }
-        final String deepFilter = filter;
+        final String deepFilter = filter.toString();
         assertThatThrownBy(() -> converter.getFilterValues(deepFilter, List.of("origin")))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
@@ -28,14 +28,14 @@ class SimpleSearchQueryConverterTests {
 
     @Test
     void query() {
+        // The SCIM 2.0 parser rejects the injection payload at parse time (stricter syntax check
+        // for '/' in attribute names), so the error comes from the parser rather than the attribute
+        // whitelist. The important property is that the filter is rejected as an IllegalArgumentException.
         String query = ModelTestUtils.getResourceAsString(this.getClass(), "testQuery.scimFilter");
 
         assertThatThrownBy(() -> converter.convert(query, null, false, "foo"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Message: Invalid filter attributes")
-                .hasMessageContaining("an/**/invalid/**/attribute/**/and/**/1")
-                .hasMessageContaining("1")
-                .hasMessageContaining("\"1\"");
+                .hasMessageContaining("Invalid SCIM Filter");
     }
 
     @ParameterizedTest
@@ -105,29 +105,36 @@ class SimpleSearchQueryConverterTests {
 
     @Test
     void deeplyNestedFilterIsRejected() {
-        // 26 terms → 25 ANDs → depth 24 at deepest node, exceeds MAX_FILTER_DEPTH(20)
-        String deepFilter = IntStream.range(0, 26)
-                .mapToObj(_ -> "username eq \"joe\"")
-                .collect(Collectors.joining(" and "));
+        // SCIM 2 parser creates flat n-ary AND for chains; explicit parentheses create actual tree depth.
+        // Build: ((...((a and a) and a)...) and a) with 22 nestings → depth 22 > MAX_FILTER_DEPTH(20)
+        String filter = "username eq \"joe\" and username eq \"joe\"";
+        for (int i = 0; i < 22; i++) {
+            filter = "(" + filter + ") and username eq \"joe\"";
+        }
+        final String deepFilter = filter;
         assertThatThrownBy(() -> converter.convert(deepFilter, null, false, "zone"))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     void moderatelyNestedFilterIsAccepted() {
-        // 5 terms → 4 ANDs → depth 3, well within MAX_FILTER_DEPTH(20)
-        String filter = IntStream.range(0, 5)
-                .mapToObj(_ -> "username eq \"joe\"")
-                .collect(Collectors.joining(" and "));
-        assertThatNoException().isThrownBy(() -> converter.convert(filter, null, false, "zone"));
+        // 5 explicit nestings → depth 5, well within MAX_FILTER_DEPTH(20)
+        String filter = "username eq \"joe\" and username eq \"joe\"";
+        for (int i = 0; i < 5; i++) {
+            filter = "(" + filter + ") and username eq \"joe\"";
+        }
+        final String shallowFilter = filter;
+        assertThatNoException().isThrownBy(() -> converter.convert(shallowFilter, null, false, "zone"));
     }
 
     @Test
     void deeplyNestedGetFilterValuesIsRejected() {
         // Same depth limit applies to getFilterValues
-        String deepFilter = IntStream.range(0, 26)
-                .mapToObj(_ -> "origin eq \"uaa\"")
-                .collect(Collectors.joining(" and "));
+        String filter = "origin eq \"uaa\" and origin eq \"uaa\"";
+        for (int i = 0; i < 22; i++) {
+            filter = "(" + filter + ") and origin eq \"uaa\"";
+        }
+        final String deepFilter = filter;
         assertThatThrownBy(() -> converter.getFilterValues(deepFilter, List.of("origin")))
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
@@ -10,8 +10,11 @@ import org.springframework.util.MultiValueMap;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SimpleSearchQueryConverterTests {
@@ -98,6 +101,35 @@ class SimpleSearchQueryConverterTests {
         assertThat(converter.getJoinName()).isEmpty();
         converter.setAttributeNameMapper(new JoinAttributeNameMapper("myTable"));
         assertThat(converter.getJoinName()).isEqualTo("myTable");
+    }
+
+    @Test
+    void deeplyNestedFilterIsRejected() {
+        // 26 terms → 25 ANDs → depth 24 at deepest node, exceeds MAX_FILTER_DEPTH(20)
+        String deepFilter = IntStream.range(0, 26)
+                .mapToObj(_ -> "username eq \"joe\"")
+                .collect(Collectors.joining(" and "));
+        assertThatThrownBy(() -> converter.convert(deepFilter, null, false, "zone"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void moderatelyNestedFilterIsAccepted() {
+        // 5 terms → 4 ANDs → depth 3, well within MAX_FILTER_DEPTH(20)
+        String filter = IntStream.range(0, 5)
+                .mapToObj(_ -> "username eq \"joe\"")
+                .collect(Collectors.joining(" and "));
+        assertThatNoException().isThrownBy(() -> converter.convert(filter, null, false, "zone"));
+    }
+
+    @Test
+    void deeplyNestedGetFilterValuesIsRejected() {
+        // Same depth limit applies to getFilterValues
+        String deepFilter = IntStream.range(0, 26)
+                .mapToObj(_ -> "origin eq \"uaa\"")
+                .collect(Collectors.joining(" and "));
+        assertThatThrownBy(() -> converter.getFilterValues(deepFilter, List.of("origin")))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.scim.jdbc;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.cloudfoundry.identity.uaa.resources.SimpleAttributeNameMapper;
 import org.cloudfoundry.identity.uaa.resources.jdbc.SearchQueryConverter.ProcessedFilter;
 import org.cloudfoundry.identity.uaa.resources.jdbc.SimpleSearchQueryConverter;
@@ -149,7 +148,8 @@ class ScimSearchQueryConverterTests {
 
     @Test
     void illegalUnquotedValueInFilter() {
-        assertThatThrownBy(() -> filterProcessor.convert("username eq joe", null, false, zoneId)).asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class));
+        assertThatThrownBy(() -> filterProcessor.convert("username eq joe", null, false, zoneId))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
@@ -6,12 +6,15 @@ import org.cloudfoundry.identity.uaa.resources.jdbc.SearchQueryConverter.Process
 import org.cloudfoundry.identity.uaa.resources.jdbc.SimpleSearchQueryConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ScimSearchQueryConverterTests {
@@ -115,6 +118,33 @@ class ScimSearchQueryConverterTests {
         validate(filterProcessor.convert("displayName pr", "displayName", false, zoneId), "displayName IS NOT NULL", "ORDER BY displayName DESC", 0);
         validate(filterProcessor.convert("username pr and emails.value co '.com'", null, false, zoneId), "(username IS NOT NULL AND LOWER(email) LIKE LOWER(:__value_0))", null, 1);
         validate(filterProcessor.convert("username eq 'joe' or emails.value co '.com'", null, false, zoneId), "(LOWER(username) = LOWER(:__value_0) OR LOWER(email) LIKE LOWER(:__value_1))", null, 2);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Unbalanced parentheses — SCIM parser must reject these
+            "id pr ) or identity_zone_id pr or ( id pr",
+            "username eq \"joe\" )",
+            "( username eq \"joe\"",
+            // Injection patterns in attribute names — attribute whitelist rejects these
+            "id/**/pr/**/or/**/1=1 pr",
+            "username/**/eq/**/\"a\"",
+    })
+    void malformedOrInjectionFiltersAreRejected(String filter) {
+        assertThatThrownBy(() -> filterProcessor.convert(filter, null, false, zoneId))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // Values with SQL-injection content — the value is a bound parameter, not raw SQL
+            "username eq \"joe'; select * from users; --\"",
+            "username eq \"' or '1'='1\"",
+            "username eq \"\\\" or \\\"1\\\"=\\\"1\"",
+    })
+    void sqlInjectionInFilterValueIsBoundSafely(String filter) {
+        // Must parse and produce SQL with a bound parameter — not throw, not inject raw SQL
+        assertThatNoException().isThrownBy(() -> filterProcessor.convert(filter, null, false, zoneId));
     }
 
     @Test

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -105,12 +105,7 @@ dependencies {
     testImplementation(libs.orgJson)
     testImplementation(libs.jsonAssert)
     testImplementation(libs.jsonPathAssert)
-    testImplementation(libs.unboundIdScimSdk) {
-        exclude(module = "servlet-api")
-        exclude(module = "commons-logging")
-        exclude(module = "httpclient")
-        exclude(module = "wink-client-apache-httpclient")
-    }
+    testImplementation(libs.scim2SdkCommon)
     testImplementation(libs.springBootStarterLog4j2)
     testImplementation(libs.springContextSupport)
     testImplementation(libs.springSessionJdbc)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -1,7 +1,5 @@
 package org.cloudfoundry.identity.uaa.scim.endpoints;
 
-import com.unboundid.scim.sdk.AttributePath;
-import com.unboundid.scim.sdk.SCIMFilter;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.account.UserAccountStatus;
@@ -578,9 +576,7 @@ class ScimUserEndpointsTests {
 
     @Test
     void findGroupsAndApprovals() {
-        String isJoelOrDaleFilter = SCIMFilter.createOrFilter(asList(
-                SCIMFilter.createEqualityFilter(AttributePath.parse("id"), joel.getId()),
-                SCIMFilter.createEqualityFilter(AttributePath.parse("id"), dale.getId()))).toString();
+        String isJoelOrDaleFilter = "id eq \"" + joel.getId() + "\" or id eq \"" + dale.getId() + "\"";
 
         SearchResults<?> results = scimUserEndpoints.findUsers("id,groups,approvals", isJoelOrDaleFilter, null, "ascending", 1, 100);
         assertThat(results.getTotalResults()).isEqualTo(2);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsTests.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.scim.endpoints;
 
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.account.UserAccountStatus;
 import org.cloudfoundry.identity.uaa.approval.Approval;
@@ -407,7 +406,8 @@ class ScimUserEndpointsTests {
 
     @Test
     void create_uaa_user_when_internal_user_management_is_disabled() {
-        assertThatThrownBy(() -> createUserWhenInternalUserManagementIsDisabled(OriginKeys.UAA)).asInstanceOf(InstanceOfAssertFactories.throwable(InternalUserManagementDisabledException.class));
+        assertThatThrownBy(() -> createUserWhenInternalUserManagementIsDisabled(OriginKeys.UAA))
+                .isInstanceOf(InternalUserManagementDisabledException.class);
     }
 
     @Test
@@ -427,8 +427,8 @@ class ScimUserEndpointsTests {
         verify(user, atLeastOnce()).setPassword(passwords.capture());
 
         //1. this method, 2. user scimUserEndpoints, 3. user provisioning
-        assertThat(passwords.getAllValues()).hasSize(3);
-        assertThat(passwords.getAllValues()).first().isEqualTo("bla bla");
+        assertThat(passwords.getAllValues()).hasSize(3)
+                .first().isEqualTo("bla bla");
         assertThat(passwords.getAllValues().get(1)).isEmpty();
     }
 
@@ -503,7 +503,8 @@ class ScimUserEndpointsTests {
 
     @Test
     void deleteIs_Not_Allowed_For_UAA_When_InternalUserManagement_Is_Disabled() {
-        assertThatThrownBy(() -> deleteWhenInternalUserManagementIsDisabled(OriginKeys.UAA)).asInstanceOf(InstanceOfAssertFactories.throwable(InternalUserManagementDisabledException.class));
+        assertThatThrownBy(() -> deleteWhenInternalUserManagementIsDisabled(OriginKeys.UAA))
+                .isInstanceOf(InternalUserManagementDisabledException.class);
     }
 
     @Test
@@ -523,7 +524,8 @@ class ScimUserEndpointsTests {
                         exGuyId,
                         Integer.toString(exGuyMeta.getVersion() + 1),
                         new MockHttpServletRequest(),
-                        new MockHttpServletResponse())).asInstanceOf(InstanceOfAssertFactories.throwable(OptimisticLockingFailureException.class));
+                        new MockHttpServletResponse()))
+                .isInstanceOf(OptimisticLockingFailureException.class);
     }
 
     @Test
@@ -875,7 +877,8 @@ class ScimUserEndpointsTests {
 
     @Test
     void updateWhenInternalUserManagementIsDisabledForUaa() {
-        assertThatThrownBy(() -> updateWhenInternalUserManagementIsDisabled(OriginKeys.UAA)).asInstanceOf(InstanceOfAssertFactories.throwable(InternalUserManagementDisabledException.class));
+        assertThatThrownBy(() -> updateWhenInternalUserManagementIsDisabled(OriginKeys.UAA))
+                .isInstanceOf(InternalUserManagementDisabledException.class);
     }
 
     @Test
@@ -1004,7 +1007,8 @@ class ScimUserEndpointsTests {
                 "0",
                 new MockHttpServletRequest(),
                 new MockHttpServletResponse(),
-                null)).asInstanceOf(InstanceOfAssertFactories.throwable(ScimResourceNotFoundException.class));
+                null))
+            .isInstanceOf(ScimResourceNotFoundException.class);
     }
 
     @Test
@@ -1030,7 +1034,8 @@ class ScimUserEndpointsTests {
         user.addEmail("test@example.org");
         ScimUser createdUser = scimUserEndpoints.createUser(user, new MockHttpServletRequest(), new MockHttpServletResponse());
         createdUser.getMeta().setAttributes(new String[]{"attributeName"});
-        assertThatThrownBy(() -> scimUserEndpoints.patchUser(createdUser, createdUser.getId(), Integer.toString(createdUser.getVersion()), new MockHttpServletRequest(), new MockHttpServletResponse(), null)).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidScimResourceException.class));
+        assertThatThrownBy(() -> scimUserEndpoints.patchUser(createdUser, createdUser.getId(), Integer.toString(createdUser.getVersion()), new MockHttpServletRequest(), new MockHttpServletResponse(), null))
+                .isInstanceOf(InvalidScimResourceException.class);
     }
 
     @Test
@@ -1039,7 +1044,8 @@ class ScimUserEndpointsTests {
         user.setPassword("password");
         user.addEmail("test@example.org");
         ScimUser createdUser = scimUserEndpoints.createUser(user, new MockHttpServletRequest(), new MockHttpServletResponse());
-        assertThatThrownBy(() -> scimUserEndpoints.patchUser(createdUser, createdUser.getId(), Integer.toString(createdUser.getVersion() + 1), new MockHttpServletRequest(), new MockHttpServletResponse(), null)).asInstanceOf(InstanceOfAssertFactories.throwable(ScimResourceConflictException.class));
+        assertThatThrownBy(() -> scimUserEndpoints.patchUser(createdUser, createdUser.getId(), Integer.toString(createdUser.getVersion() + 1), new MockHttpServletRequest(), new MockHttpServletResponse(), null))
+                .isInstanceOf(ScimResourceConflictException.class);
     }
 
     @Test
@@ -1062,7 +1068,8 @@ class ScimUserEndpointsTests {
         ScimUser createdUser = scimUserEndpoints.createUser(user, new MockHttpServletRequest(), new MockHttpServletResponse());
         UserAccountStatus userAccountStatus = new UserAccountStatus();
         userAccountStatus.setLocked(true);
-        assertThatThrownBy(() -> scimUserEndpoints.updateAccountStatus(userAccountStatus, createdUser.getId())).asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class));
+        assertThatThrownBy(() -> scimUserEndpoints.updateAccountStatus(userAccountStatus, createdUser.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -1073,7 +1080,8 @@ class ScimUserEndpointsTests {
         ScimUser createdUser = scimUserEndpoints.createUser(user, new MockHttpServletRequest(), new MockHttpServletResponse());
         UserAccountStatus userAccountStatus = new UserAccountStatus();
         userAccountStatus.setPasswordChangeRequired(false);
-        assertThatThrownBy(() -> scimUserEndpoints.updateAccountStatus(userAccountStatus, createdUser.getId())).asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class));
+        assertThatThrownBy(() -> scimUserEndpoints.updateAccountStatus(userAccountStatus, createdUser.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -1084,7 +1092,8 @@ class ScimUserEndpointsTests {
         ScimUser createdUser = scimUserEndpoints.createUser(user, new MockHttpServletRequest(), new MockHttpServletResponse());
         UserAccountStatus userAccountStatus = new UserAccountStatus();
         userAccountStatus.setPasswordChangeRequired(true);
-        assertThatThrownBy(() -> scimUserEndpoints.updateAccountStatus(userAccountStatus, createdUser.getId())).asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class));
+        assertThatThrownBy(() -> scimUserEndpoints.updateAccountStatus(userAccountStatus, createdUser.getId()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
 com.unboundid.product.scim:scim-sdk (version 2.0.0) is deprecated — the repo is archived, last meaningful work was ~2015, and Ping Identity recommends com.unboundid:scim2-sdk-common as the replacement. The SDK is used only for SCIM filter string parsing in 2 production files and 2 test files — not for SCIM resource representation. 

The SCIM 2.0 SDK parses the same basic filter grammar (eq, co, sw, pr, gt, ge, lt, le, and, or) used in UAA, so existing clients sending filter strings are unaffected.

SCIM 1.1 SDK is used directly in server/build.gradle.kts:64 with several exclusions hinting at its age.