### PR TITLE
Migrate from TimGroup's java-statsd-client to Datadog's java-dogstatsd-client

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ sonarqube = "7.3.1.8318"
 springBoot = "4.0.6"
 springDependencyManagement = "1.1.7"
 springDocOpenapi = "3.0.3"
-statsdClient = "3.1.0"
+statsdClient = "4.4.5"
 tomcat = "11.0.22"
 scim2Sdk = "6.0.0"
 velocity = "2.4.1"
@@ -194,7 +194,7 @@ springSecurityWeb = { module = "org.springframework.security:spring-security-web
 springSessionJdbc = { module = "org.springframework.session:spring-session-jdbc" }
 
 # StatsD
-statsdClient = { module = "com.timgroup:java-statsd-client", version.ref = "statsdClient" }
+statsdClient = { module = "com.datadoghq:java-dogstatsd-client", version.ref = "statsdClient" }
 
 # Thymeleaf
 thymeLeaf = { module = "org.thymeleaf:thymeleaf" }

--- a/statsd-lib/src/main/java/org/cloudfoundry/identity/statsd/StatsdConfiguration.java
+++ b/statsd-lib/src/main/java/org/cloudfoundry/identity/statsd/StatsdConfiguration.java
@@ -14,7 +14,7 @@
 
 package org.cloudfoundry.identity.statsd;
 
-import com.timgroup.statsd.NonBlockingStatsDClient;
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import com.timgroup.statsd.StatsDClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,7 +31,11 @@ public class StatsdConfiguration {
 
     @Bean
     public StatsDClient statsDClient() {
-        return new NonBlockingStatsDClient("uaa", "localhost", 8125);
+        return new NonBlockingStatsDClientBuilder()
+                .prefix("uaa")
+                .hostname("localhost")
+                .port(8125)
+                .build();
     }
 
     @Bean

--- a/statsd-lib/src/test/java/org/cloudfoundry/identity/statsd/UaaMetricsEmitterTest.java
+++ b/statsd-lib/src/test/java/org/cloudfoundry/identity/statsd/UaaMetricsEmitterTest.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.statsd;
 
-import com.timgroup.statsd.ConvenienceMethodProvidingStatsDClient;
 import com.timgroup.statsd.StatsDClient;
 import org.cloudfoundry.identity.uaa.metrics.UaaMetrics;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +66,7 @@ class UaaMetricsEmitterTest {
         emitter = new NotificationBroadcasterSupport();
         when(metricsUtils.getUaaMetricsSubscriber(any())).thenReturn(emitter);
 
-        statsDClient = mock(ConvenienceMethodProvidingStatsDClient.class);
+        statsDClient = mock(StatsDClient.class);
         uaaMetricsEmitter = new UaaMetricsEmitter(metricsUtils, statsDClient, server);
 
         mBeanMap1 = new MBeanMap();


### PR DESCRIPTION


### TimGroup java-statsd-client (Current):
Last update: February 19, 2015 (version 3.1.0)
Status: Effectively unmaintained for over 10 years
Update frequency: None - project is dormant

### Datadog java-dogstatsd-client (Target):
Latest version: 4.4.5 (August 21, 2025)
Status: Actively maintained and is now the canonical library
Update frequency: Regular releases (typically 3-4 per year) with bug fixes, performance improvements, and new features

**Note**: This library merged efforts from multiple upstream projects including TimGroup's original library

### Key Benefits of Migration
Active maintenance: Regular security patches and bug fixes
Performance improvements: Modern non-blocking implementation with better buffering
Enhanced features: Support for tags, sampling, client-side aggregation, telemetry
Better error handling: Improved error handling and monitoring capabilities
Future compatibility: Continued support and development
Backward Compatibility Assessment
The migration should be very low-risk because:

**Note**: UAA uses only basic StatsD operations (gauge, count, time)
The Datadog library maintains API compatibility with TimGroup's interface
