### PR TITLE
Unsigned SAML logout message validation

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
@@ -1,11 +1,13 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
 import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.saml2.provider.service.authentication.logout.OpenSaml5LogoutRequestValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequestValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequestValidatorParameters;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutValidatorResult;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 
 import java.util.Collection;
 
@@ -28,10 +30,16 @@ public class SamlLogoutRequestValidator implements Saml2LogoutRequestValidator {
     @Override
     public Saml2LogoutValidatorResult validate(Saml2LogoutRequestValidatorParameters parameters) {
         // Spring Security 7.1.0 throws NPE in RedirectParameters when SigAlg is absent (unsigned
-        // redirect-binding logout request). When no signature is present, we skip the delegate
-        // (which would throw) and run only the non-signature checks directly, bypassing signature
-        // verification but still ensuring issuer and destination are validated.
-        if (parameters != null && parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
+        // redirect-binding logout request). Restrict bypass to REDIRECT binding only — POST binding
+        // uses XML signatures (not HTTP params) and must go through the delegate unchanged.
+        if (parameters != null
+                && parameters.getLogoutRequest().getBinding() == Saml2MessageBinding.REDIRECT
+                && parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
+            // Signature present without SigAlg is malformed — reject rather than bypass.
+            if (parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIGNATURE) != null) {
+                return Saml2LogoutValidatorResult.withErrors(new Saml2Error(
+                        Saml2ErrorCodes.INVALID_SIGNATURE, "Signature present without SigAlg")).build();
+            }
             return SamlUnsignedMessageValidator.validateLogoutRequest(
                     parameters.getLogoutRequest().getSamlRequest(),
                     parameters.getLogoutRequest().getBinding(),

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
@@ -28,10 +28,14 @@ public class SamlLogoutRequestValidator implements Saml2LogoutRequestValidator {
     @Override
     public Saml2LogoutValidatorResult validate(Saml2LogoutRequestValidatorParameters parameters) {
         // Spring Security 7.1.0 throws NPE in RedirectParameters when SigAlg is absent (unsigned
-        // redirect-binding logout request). Treat the absence of a signature as acceptable — consistent
-        // with this validator's policy of not requiring signatures on logout messages.
+        // redirect-binding logout request). When no signature is present, we skip the delegate
+        // (which would throw) and run only the non-signature checks directly, bypassing signature
+        // verification but still ensuring issuer and destination are validated.
         if (parameters != null && parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
-            return Saml2LogoutValidatorResult.success();
+            return SamlUnsignedMessageValidator.validateLogoutRequest(
+                    parameters.getLogoutRequest().getSamlRequest(),
+                    parameters.getLogoutRequest().getBinding(),
+                    parameters.getRelyingPartyRegistration());
         }
 
         Saml2LogoutValidatorResult result = delegate.validate(parameters);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidator.java
@@ -13,7 +13,6 @@ import java.util.Collection;
  * Delegates SAML logout responses validation to {@link OpenSaml5LogoutResponseValidator}
  * but ignores errors due to missing signatures.
  */
-
 public class SamlLogoutResponseValidator implements Saml2LogoutResponseValidator {
 
     private final Saml2LogoutResponseValidator delegate;
@@ -29,10 +28,14 @@ public class SamlLogoutResponseValidator implements Saml2LogoutResponseValidator
     @Override
     public Saml2LogoutValidatorResult validate(Saml2LogoutResponseValidatorParameters parameters) {
         // Spring Security 7.1.0 throws NPE in RedirectParameters when SigAlg is absent (unsigned
-        // redirect-binding logout response). Treat the absence of a signature as acceptable — consistent
-        // with this validator's policy of not requiring signatures on logout messages.
+        // redirect-binding logout response). When no signature is present, we skip the delegate
+        // (which would throw) and run only the non-signature checks directly, bypassing signature
+        // verification but still ensuring issuer and destination are validated.
         if (parameters != null && parameters.getLogoutResponse().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
-            return Saml2LogoutValidatorResult.success();
+            return SamlUnsignedMessageValidator.validateLogoutResponse(
+                    parameters.getLogoutResponse().getSamlResponse(),
+                    parameters.getLogoutResponse().getBinding(),
+                    parameters.getRelyingPartyRegistration());
         }
 
         Saml2LogoutValidatorResult result = delegate.validate(parameters);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidator.java
@@ -1,11 +1,13 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
 import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.core.Saml2ErrorCodes;
 import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.saml2.provider.service.authentication.logout.OpenSaml5LogoutResponseValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutResponseValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutResponseValidatorParameters;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutValidatorResult;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 
 import java.util.Collection;
 
@@ -28,10 +30,16 @@ public class SamlLogoutResponseValidator implements Saml2LogoutResponseValidator
     @Override
     public Saml2LogoutValidatorResult validate(Saml2LogoutResponseValidatorParameters parameters) {
         // Spring Security 7.1.0 throws NPE in RedirectParameters when SigAlg is absent (unsigned
-        // redirect-binding logout response). When no signature is present, we skip the delegate
-        // (which would throw) and run only the non-signature checks directly, bypassing signature
-        // verification but still ensuring issuer and destination are validated.
-        if (parameters != null && parameters.getLogoutResponse().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
+        // redirect-binding logout response). Restrict bypass to REDIRECT binding only — POST binding
+        // uses XML signatures (not HTTP params) and must go through the delegate unchanged.
+        if (parameters != null
+                && parameters.getLogoutResponse().getBinding() == Saml2MessageBinding.REDIRECT
+                && parameters.getLogoutResponse().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
+            // Signature present without SigAlg is malformed — reject rather than bypass.
+            if (parameters.getLogoutResponse().getParameters().get(Saml2ParameterNames.SIGNATURE) != null) {
+                return Saml2LogoutValidatorResult.withErrors(new Saml2Error(
+                        Saml2ErrorCodes.INVALID_SIGNATURE, "Signature present without SigAlg")).build();
+            }
             return SamlUnsignedMessageValidator.validateLogoutResponse(
                     parameters.getLogoutResponse().getSamlResponse(),
                     parameters.getLogoutResponse().getBinding(),

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlUnsignedMessageValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlUnsignedMessageValidator.java
@@ -76,12 +76,12 @@ final class SamlUnsignedMessageValidator {
 
         String xml = decodeSaml(encodedSaml, binding);
         if (xml == null) {
-            return failure(Saml2ErrorCodes.MALFORMED_RESPONSE_DATA, "Failed to decode LogoutRequest");
+            return failure(Saml2ErrorCodes.MALFORMED_REQUEST_DATA, "Failed to decode LogoutRequest");
         }
 
         Document doc = parseXml(xml);
         if (doc == null) {
-            return failure(Saml2ErrorCodes.MALFORMED_RESPONSE_DATA, "Failed to parse LogoutRequest XML");
+            return failure(Saml2ErrorCodes.MALFORMED_REQUEST_DATA, "Failed to parse LogoutRequest XML");
         }
 
         List<Saml2Error> errors = new ArrayList<>();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlUnsignedMessageValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlUnsignedMessageValidator.java
@@ -1,0 +1,153 @@
+package org.cloudfoundry.identity.uaa.authentication;
+
+import org.cloudfoundry.identity.uaa.provider.saml.Saml2Utils;
+import org.springframework.security.saml2.core.Saml2Error;
+import org.springframework.security.saml2.core.Saml2ErrorCodes;
+import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutValidatorResult;
+import org.springframework.security.saml2.provider.service.registration.AssertingPartyMetadata;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Non-signature validation for unsigned SAML logout messages.
+ * <p>
+ * Spring Security 7.1.0 throws NPE in {@code RedirectParameters} when {@code SigAlg}
+ * is absent, so the standard validators cannot be called for unsigned messages.
+ * This class replicates the issuer/destination/status checks that
+ * {@code BaseOpenSamlLogoutResponseValidator.validateRequest()} would have run in 7.0.x.
+ */
+final class SamlUnsignedMessageValidator {
+
+    private SamlUnsignedMessageValidator() {
+    }
+
+    /**
+     * Validates a SAML LogoutResponse that arrived without a redirect-binding signature.
+     * Checks issuer, destination, and status code.
+     */
+    static Saml2LogoutValidatorResult validateLogoutResponse(
+            String encodedSaml, Saml2MessageBinding binding, RelyingPartyRegistration registration) {
+
+        String xml = decodeSaml(encodedSaml, binding);
+        if (xml == null) {
+            return failure(Saml2ErrorCodes.MALFORMED_RESPONSE_DATA, "Failed to decode LogoutResponse");
+        }
+
+        Document doc = parseXml(xml);
+        if (doc == null) {
+            return failure(Saml2ErrorCodes.MALFORMED_RESPONSE_DATA, "Failed to parse LogoutResponse XML");
+        }
+
+        List<Saml2Error> errors = new ArrayList<>();
+        AssertingPartyMetadata party = registration.getAssertingPartyMetadata();
+
+        validateDestination(doc, registration.getSingleLogoutServiceResponseLocation(), errors);
+        validateIssuer(doc, party.getEntityId(), "LogoutResponse", errors);
+
+        NodeList statusCodes = doc.getElementsByTagNameNS("urn:oasis:names:tc:SAML:2.0:protocol", "StatusCode");
+        if (statusCodes.getLength() > 0) {
+            String statusValue = ((org.w3c.dom.Element) statusCodes.item(0)).getAttribute("Value");
+            boolean ok = "urn:oasis:names:tc:SAML:2.0:status:Success".equals(statusValue)
+                    || "urn:oasis:names:tc:SAML:2.0:status:PartialLogout".equals(statusValue);
+            if (!ok) {
+                errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_RESPONSE,
+                        "Logout response status was not successful: " + statusValue));
+            }
+        }
+
+        return toResult(errors);
+    }
+
+    /**
+     * Validates a SAML LogoutRequest that arrived without a redirect-binding signature.
+     * Checks issuer and destination.
+     */
+    static Saml2LogoutValidatorResult validateLogoutRequest(
+            String encodedSaml, Saml2MessageBinding binding, RelyingPartyRegistration registration) {
+
+        String xml = decodeSaml(encodedSaml, binding);
+        if (xml == null) {
+            return failure(Saml2ErrorCodes.MALFORMED_RESPONSE_DATA, "Failed to decode LogoutRequest");
+        }
+
+        Document doc = parseXml(xml);
+        if (doc == null) {
+            return failure(Saml2ErrorCodes.MALFORMED_RESPONSE_DATA, "Failed to parse LogoutRequest XML");
+        }
+
+        List<Saml2Error> errors = new ArrayList<>();
+        AssertingPartyMetadata party = registration.getAssertingPartyMetadata();
+
+        validateDestination(doc, registration.getSingleLogoutServiceLocation(), errors);
+        validateIssuer(doc, party.getEntityId(), "LogoutRequest", errors);
+
+        return toResult(errors);
+    }
+
+    private static String decodeSaml(String encoded, Saml2MessageBinding binding) {
+        try {
+            return (binding == Saml2MessageBinding.REDIRECT)
+                    ? Saml2Utils.samlDecodeAndInflate(encoded)
+                    : new String(Saml2Utils.samlDecode(encoded), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static Document parseXml(String xml) {
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            return factory.newDocumentBuilder().parse(new InputSource(new StringReader(xml)));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static void validateDestination(Document doc, String expected, List<Saml2Error> errors) {
+        if (expected == null) {
+            return;
+        }
+        String destination = doc.getDocumentElement().getAttribute("Destination");
+        if (!expected.equals(destination)) {
+            errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_DESTINATION,
+                    "Failed to match destination to configured destination"));
+        }
+    }
+
+    private static void validateIssuer(Document doc, String expected, String messageType, List<Saml2Error> errors) {
+        NodeList issuers = doc.getElementsByTagNameNS("urn:oasis:names:tc:SAML:2.0:assertion", "Issuer");
+        if (issuers.getLength() == 0) {
+            errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER,
+                    "Failed to find issuer in " + messageType));
+            return;
+        }
+        String issuer = issuers.item(0).getTextContent();
+        if (!expected.equals(issuer)) {
+            errors.add(new Saml2Error(Saml2ErrorCodes.INVALID_ISSUER,
+                    "Failed to match issuer to configured issuer"));
+        }
+    }
+
+    private static Saml2LogoutValidatorResult toResult(List<Saml2Error> errors) {
+        return errors.isEmpty()
+                ? Saml2LogoutValidatorResult.success()
+                : Saml2LogoutValidatorResult.withErrors().errors(c -> c.addAll(errors)).build();
+    }
+
+    private static Saml2LogoutValidatorResult failure(String code, String description) {
+        return Saml2LogoutValidatorResult.withErrors(new Saml2Error(code, description)).build();
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
@@ -1,6 +1,8 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
+import org.cloudfoundry.identity.uaa.provider.saml.Saml2Utils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -16,11 +18,8 @@ import org.springframework.security.saml2.provider.service.registration.Assertin
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
-
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,33 +43,41 @@ class SamlLogoutRequestValidatorTest {
     @BeforeEach
     void setUp() {
         validator = new SamlLogoutRequestValidator(delegate);
-        // Simulate a signed request so tests exercise the delegate path
         when(parameters.getLogoutRequest()).thenReturn(logoutRequest);
-        when(logoutRequest.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIG_ALG, "rsa-sha256"));
+    }
+
+    @Nested
+    class SignedRedirectViaDelegate {
+
+        @BeforeEach
+        void setUp() {
+            when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
+            when(logoutRequest.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIG_ALG, "rsa-sha256"));
+        }
+
+        @Test
+        void validatePassesThruSuccess() {
+            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
+            assertThat(validator.validate(parameters).hasErrors()).isFalse();
+        }
+
+        @Test
+        void validateRemovesMissingSignatureError() {
+            Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
+            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
+            assertThat(validator.validate(parameters).hasErrors()).isFalse();
+        }
+
+        @Test
+        void validateDifferentErrorIsPassedThru() {
+            Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
+            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
+            assertThat(validator.validate(parameters).hasErrors()).isTrue();
+        }
     }
 
     @Test
-    void validatePassesThruSuccess() {
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
-        assertThat(validator.validate(parameters).hasErrors()).isFalse();
-    }
-
-    @Test
-    void validateRemovesMissingSignatureError() {
-        Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-        assertThat(validator.validate(parameters).hasErrors()).isFalse();
-    }
-
-    @Test
-    void validateDifferentErrorIsPassedThru() {
-        Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
-        assertThat(validator.validate(parameters).hasErrors()).isTrue();
-    }
-
-    @Test
-    void unsignedRequestBypassesDelegateAndValidatesIssuerAndDestination() {
+    void unsignedRedirectRequestBypassesDelegateAndValidatesIssuerAndDestination() {
         String destination = "http://sp.example.com/saml/SingleLogout";
         String issuer = "http://idp.example.com";
         String xml = """
@@ -83,10 +90,9 @@ class SamlLogoutRequestValidatorTest {
                 </samlp:LogoutRequest>
                 """.formatted(destination, issuer);
 
+        when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
         when(logoutRequest.getParameters()).thenReturn(Collections.emptyMap()); // no SigAlg
-        when(logoutRequest.getSamlRequest())
-                .thenReturn(Base64.getEncoder().encodeToString(xml.getBytes()));
-        when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.POST);
+        when(logoutRequest.getSamlRequest()).thenReturn(Saml2Utils.samlEncode(Saml2Utils.samlDeflate(xml)));
 
         AssertingPartyMetadata party = mock(AssertingPartyMetadata.class);
         when(party.getEntityId()).thenReturn(issuer);
@@ -98,6 +104,27 @@ class SamlLogoutRequestValidatorTest {
         Saml2LogoutValidatorResult result = validator.validate(parameters);
 
         assertThat(result.hasErrors()).isFalse();
+        verify(delegate, never()).validate(any());
+    }
+
+    @Test
+    void postBindingRequestUsesDelegate() {
+        when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.POST);
+        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
+
+        assertThat(validator.validate(parameters).hasErrors()).isFalse();
+        verify(delegate).validate(parameters);
+    }
+
+    @Test
+    void redirectRequestWithSignatureButNoSigAlgIsRejected() {
+        when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
+        when(logoutRequest.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIGNATURE, "somesig")); // Signature but no SigAlg
+
+        Saml2LogoutValidatorResult result = validator.validate(parameters);
+
+        assertThat(result.hasErrors()).isTrue();
+        assertThat(result.getErrors()).anyMatch(e -> e.getErrorCode().equals(Saml2ErrorCodes.INVALID_SIGNATURE));
         verify(delegate, never()).validate(any());
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
@@ -7,10 +7,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
+import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequest;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequestValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutRequestValidatorParameters;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutValidatorResult;
+import org.springframework.security.saml2.provider.service.registration.AssertingPartyMetadata;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
 
 import java.util.Collections;
 
@@ -26,43 +34,66 @@ class SamlLogoutRequestValidatorTest {
 
     @Mock
     private Saml2LogoutRequestValidator delegate;
+    @Mock
+    private Saml2LogoutRequestValidatorParameters parameters;
+    @Mock
+    private Saml2LogoutRequest logoutRequest;
+
     private SamlLogoutRequestValidator validator;
 
     @BeforeEach
     void setUp() {
         validator = new SamlLogoutRequestValidator(delegate);
+        // Simulate a signed request so tests exercise the delegate path
+        when(parameters.getLogoutRequest()).thenReturn(logoutRequest);
+        when(logoutRequest.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIG_ALG, "rsa-sha256"));
     }
 
     @Test
     void validatePassesThruSuccess() {
-        Saml2LogoutValidatorResult success = Saml2LogoutValidatorResult.success();
-        when(delegate.validate(any())).thenReturn(success);
-        Saml2LogoutValidatorResult result = validator.validate(null);
-        assertThat(result.hasErrors()).isFalse();
+        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
+        assertThat(validator.validate(parameters).hasErrors()).isFalse();
     }
 
     @Test
     void validateRemovesMissingSignatureError() {
         Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
         when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-        Saml2LogoutValidatorResult result = validator.validate(null);
-        assertThat(result.hasErrors()).isFalse();
+        assertThat(validator.validate(parameters).hasErrors()).isFalse();
     }
 
     @Test
     void validateDifferentErrorIsPassedThru() {
-        Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-        Saml2LogoutValidatorResult result = validator.validate(null);
-        assertThat(result.hasErrors()).isTrue();
+        Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
+        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
+        assertThat(validator.validate(parameters).hasErrors()).isTrue();
     }
 
     @Test
-    void unsignedRequestSucceedsWithoutCallingDelegate() {
-        Saml2LogoutRequest logoutRequest = mock(Saml2LogoutRequest.class);
-        when(logoutRequest.getParameters()).thenReturn(Collections.emptyMap());
-        Saml2LogoutRequestValidatorParameters parameters = mock(Saml2LogoutRequestValidatorParameters.class);
-        when(parameters.getLogoutRequest()).thenReturn(logoutRequest);
+    void unsignedRequestBypassesDelegateAndValidatesIssuerAndDestination() {
+        String destination = "http://sp.example.com/saml/SingleLogout";
+        String issuer = "http://idp.example.com";
+        String xml = """
+                <samlp:LogoutRequest
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    Destination="%s">
+                  <saml:Issuer>%s</saml:Issuer>
+                  <saml:NameID>user@example.com</saml:NameID>
+                </samlp:LogoutRequest>
+                """.formatted(destination, issuer);
+
+        when(logoutRequest.getParameters()).thenReturn(Collections.emptyMap()); // no SigAlg
+        when(logoutRequest.getSamlRequest())
+                .thenReturn(Base64.getEncoder().encodeToString(xml.getBytes()));
+        when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.POST);
+
+        AssertingPartyMetadata party = mock(AssertingPartyMetadata.class);
+        when(party.getEntityId()).thenReturn(issuer);
+        RelyingPartyRegistration reg = mock(RelyingPartyRegistration.class);
+        when(reg.getAssertingPartyMetadata()).thenReturn(party);
+        when(reg.getSingleLogoutServiceLocation()).thenReturn(destination);
+        when(parameters.getRelyingPartyRegistration()).thenReturn(reg);
 
         Saml2LogoutValidatorResult result = validator.validate(parameters);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidatorTest.java
@@ -7,10 +7,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.saml2.core.Saml2Error;
 import org.springframework.security.saml2.core.Saml2ErrorCodes;
+import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutResponse;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutResponseValidator;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutResponseValidatorParameters;
 import org.springframework.security.saml2.provider.service.authentication.logout.Saml2LogoutValidatorResult;
+import org.springframework.security.saml2.provider.service.registration.AssertingPartyMetadata;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
+import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
+
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Map;
 
 import java.util.Collections;
 
@@ -26,43 +34,68 @@ class SamlLogoutResponseValidatorTest {
 
     @Mock
     private Saml2LogoutResponseValidator delegate;
+    @Mock
+    private Saml2LogoutResponseValidatorParameters parameters;
+    @Mock
+    private Saml2LogoutResponse logoutResponse;
+
     private SamlLogoutResponseValidator validator;
 
     @BeforeEach
     void setUp() {
         validator = new SamlLogoutResponseValidator(delegate);
+        // Simulate a signed response so tests exercise the delegate path
+        when(parameters.getLogoutResponse()).thenReturn(logoutResponse);
+        when(logoutResponse.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIG_ALG, "rsa-sha256"));
     }
 
     @Test
     void validatePassesThruSuccess() {
-        Saml2LogoutValidatorResult success = Saml2LogoutValidatorResult.success();
-        when(delegate.validate(any())).thenReturn(success);
-        Saml2LogoutValidatorResult result = validator.validate(null);
-        assertThat(result.hasErrors()).isFalse();
+        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
+        assertThat(validator.validate(parameters).hasErrors()).isFalse();
     }
 
     @Test
     void validateRemovesMissingSignatureErrors() {
         Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
         when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-        Saml2LogoutValidatorResult result = validator.validate(null);
-        assertThat(result.hasErrors()).isFalse();
+        assertThat(validator.validate(parameters).hasErrors()).isFalse();
     }
 
     @Test
     void validateDifferentErrorIsPassedThru() {
-        Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-        Saml2LogoutValidatorResult result = validator.validate(null);
-        assertThat(result.hasErrors()).isTrue();
+        Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
+        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
+        assertThat(validator.validate(parameters).hasErrors()).isTrue();
     }
 
     @Test
-    void unsignedResponseSucceedsWithoutCallingDelegate() {
-        Saml2LogoutResponse logoutResponse = mock(Saml2LogoutResponse.class);
-        when(logoutResponse.getParameters()).thenReturn(Collections.emptyMap());
-        Saml2LogoutResponseValidatorParameters parameters = mock(Saml2LogoutResponseValidatorParameters.class);
-        when(parameters.getLogoutResponse()).thenReturn(logoutResponse);
+    void unsignedResponseBypassesDelegateAndValidatesIssuerDestinationAndStatus() {
+        String destination = "http://sp.example.com/saml/SingleLogout";
+        String issuer = "http://idp.example.com";
+        String xml = """
+                <samlp:LogoutResponse
+                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                    Destination="%s">
+                  <saml:Issuer>%s</saml:Issuer>
+                  <samlp:Status>
+                    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+                  </samlp:Status>
+                </samlp:LogoutResponse>
+                """.formatted(destination, issuer);
+
+        when(logoutResponse.getParameters()).thenReturn(Collections.emptyMap()); // no SigAlg
+        when(logoutResponse.getSamlResponse())
+                .thenReturn(Base64.getEncoder().encodeToString(xml.getBytes()));
+        when(logoutResponse.getBinding()).thenReturn(Saml2MessageBinding.POST);
+
+        AssertingPartyMetadata party = mock(AssertingPartyMetadata.class);
+        when(party.getEntityId()).thenReturn(issuer);
+        RelyingPartyRegistration reg = mock(RelyingPartyRegistration.class);
+        when(reg.getAssertingPartyMetadata()).thenReturn(party);
+        when(reg.getSingleLogoutServiceResponseLocation()).thenReturn(destination);
+        when(parameters.getRelyingPartyRegistration()).thenReturn(reg);
 
         Saml2LogoutValidatorResult result = validator.validate(parameters);
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutResponseValidatorTest.java
@@ -1,6 +1,8 @@
 package org.cloudfoundry.identity.uaa.authentication;
 
+import org.cloudfoundry.identity.uaa.provider.saml.Saml2Utils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -16,11 +18,8 @@ import org.springframework.security.saml2.provider.service.registration.Assertin
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
-
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,33 +43,41 @@ class SamlLogoutResponseValidatorTest {
     @BeforeEach
     void setUp() {
         validator = new SamlLogoutResponseValidator(delegate);
-        // Simulate a signed response so tests exercise the delegate path
         when(parameters.getLogoutResponse()).thenReturn(logoutResponse);
-        when(logoutResponse.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIG_ALG, "rsa-sha256"));
+    }
+
+    @Nested
+    class SignedRedirectViaDelegate {
+
+        @BeforeEach
+        void setUp() {
+            when(logoutResponse.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
+            when(logoutResponse.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIG_ALG, "rsa-sha256"));
+        }
+
+        @Test
+        void validatePassesThruSuccess() {
+            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
+            assertThat(validator.validate(parameters).hasErrors()).isFalse();
+        }
+
+        @Test
+        void validateRemovesMissingSignatureErrors() {
+            Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
+            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
+            assertThat(validator.validate(parameters).hasErrors()).isFalse();
+        }
+
+        @Test
+        void validateDifferentErrorIsPassedThru() {
+            Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
+            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
+            assertThat(validator.validate(parameters).hasErrors()).isTrue();
+        }
     }
 
     @Test
-    void validatePassesThruSuccess() {
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
-        assertThat(validator.validate(parameters).hasErrors()).isFalse();
-    }
-
-    @Test
-    void validateRemovesMissingSignatureErrors() {
-        Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-        assertThat(validator.validate(parameters).hasErrors()).isFalse();
-    }
-
-    @Test
-    void validateDifferentErrorIsPassedThru() {
-        Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
-        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
-        assertThat(validator.validate(parameters).hasErrors()).isTrue();
-    }
-
-    @Test
-    void unsignedResponseBypassesDelegateAndValidatesIssuerDestinationAndStatus() {
+    void unsignedRedirectResponseBypassesDelegateAndValidatesIssuerDestinationAndStatus() {
         String destination = "http://sp.example.com/saml/SingleLogout";
         String issuer = "http://idp.example.com";
         String xml = """
@@ -85,10 +92,9 @@ class SamlLogoutResponseValidatorTest {
                 </samlp:LogoutResponse>
                 """.formatted(destination, issuer);
 
+        when(logoutResponse.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
         when(logoutResponse.getParameters()).thenReturn(Collections.emptyMap()); // no SigAlg
-        when(logoutResponse.getSamlResponse())
-                .thenReturn(Base64.getEncoder().encodeToString(xml.getBytes()));
-        when(logoutResponse.getBinding()).thenReturn(Saml2MessageBinding.POST);
+        when(logoutResponse.getSamlResponse()).thenReturn(Saml2Utils.samlEncode(Saml2Utils.samlDeflate(xml)));
 
         AssertingPartyMetadata party = mock(AssertingPartyMetadata.class);
         when(party.getEntityId()).thenReturn(issuer);
@@ -100,6 +106,27 @@ class SamlLogoutResponseValidatorTest {
         Saml2LogoutValidatorResult result = validator.validate(parameters);
 
         assertThat(result.hasErrors()).isFalse();
+        verify(delegate, never()).validate(any());
+    }
+
+    @Test
+    void postBindingResponseUsesDelegate() {
+        when(logoutResponse.getBinding()).thenReturn(Saml2MessageBinding.POST);
+        when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.success());
+
+        assertThat(validator.validate(parameters).hasErrors()).isFalse();
+        verify(delegate).validate(parameters);
+    }
+
+    @Test
+    void redirectResponseWithSignatureButNoSigAlgIsRejected() {
+        when(logoutResponse.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
+        when(logoutResponse.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIGNATURE, "somesig")); // Signature but no SigAlg
+
+        Saml2LogoutValidatorResult result = validator.validate(parameters);
+
+        assertThat(result.hasErrors()).isTrue();
+        assertThat(result.getErrors()).anyMatch(e -> e.getErrorCode().equals(Saml2ErrorCodes.INVALID_SIGNATURE));
         verify(delegate, never()).validate(any());
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlAuthenticationMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlAuthenticationMockMvcTests.java
@@ -85,8 +85,15 @@ class SamlAuthenticationMockMvcTests {
     private JdbcIdentityProviderProvisioning jdbcIdentityProviderProvisioning;
 
     private static String extractSamlRequestFromPostForm(String html) {
-        int nameIdx = html.indexOf("name=\"SAMLRequest\"");
-        int valueStart = html.indexOf("value=\"", nameIdx) + "value=\"".length();
+        int nameIdx = html.indexOf("name=\"" + SAML_REQUEST + "\"");
+        if (nameIdx < 0) {
+            throw new IllegalArgumentException("SAMLRequest field not found in HTML form");
+        }
+        int valueStart = html.indexOf("value=\"", nameIdx);
+        if (valueStart < 0) {
+            throw new IllegalArgumentException("value attribute not found after SAMLRequest name");
+        }
+        valueStart += "value=\"".length();
         return html.substring(valueStart, html.indexOf("\"", valueStart));
     }
 


### PR DESCRIPTION

Introduce `SamlUnsignedMessageValidator` for unsigned SAML logout message validation.

Decodes and validates unsigned SAML requests and responses while ensuring issuer, destination, and status are checked correctly.