### PR TITLE
Add an extra subject_token verification to protect token extensions 

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/config/xml/OAuth2FilterConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/config/xml/OAuth2FilterConfig.java
@@ -98,8 +98,9 @@ public class OAuth2FilterConfig {
             @Qualifier("tokenServices") AuthorizationServerTokenServices tokenServices,
             @Qualifier("jdbcClientDetailsService") MultitenantClientServices clientDetailsService,
             @Qualifier("authorizationRequestManager") OAuth2RequestFactory requestFactory,
-            @Qualifier("revocableTokenProvisioning") RevocableTokenProvisioning revocableTokenProvisioning) {
-        TokenExchangeGranter tokenExchangeGranter = new TokenExchangeGranter(tokenServices, clientDetailsService, requestFactory, revocableTokenProvisioning);
+            @Qualifier("revocableTokenProvisioning") RevocableTokenProvisioning revocableTokenProvisioning,
+            @Qualifier("externalOAuthAuthenticationManager") ExternalOAuthAuthenticationManager externalOAuthAuthenticationManager) {
+        TokenExchangeGranter tokenExchangeGranter = new TokenExchangeGranter(tokenServices, clientDetailsService, requestFactory, revocableTokenProvisioning, externalOAuthAuthenticationManager);
         compositeTokenGranter.addTokenGranter(tokenExchangeGranter);
         return tokenExchangeGranter;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranter.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.identity.uaa.oauth.token;
 import com.nimbusds.jwt.JWTClaimsSet;
 import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidGrantException;
-import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
+import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenException;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Request;
@@ -12,6 +12,7 @@ import org.cloudfoundry.identity.uaa.oauth.provider.TokenRequest;
 import org.cloudfoundry.identity.uaa.oauth.provider.token.AbstractTokenGranter;
 import org.cloudfoundry.identity.uaa.oauth.provider.token.AuthorizationServerTokenServices;
 import org.cloudfoundry.identity.uaa.provider.ClientRegistrationException;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager;
 import org.cloudfoundry.identity.uaa.provider.oauth.TokenActor;
 import org.cloudfoundry.identity.uaa.security.beans.DefaultSecurityContextAccessor;
 import org.cloudfoundry.identity.uaa.util.UaaTokenUtils;
@@ -19,6 +20,7 @@ import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.text.ParseException;
@@ -35,15 +37,18 @@ public class TokenExchangeGranter extends AbstractTokenGranter {
 
     private final MultitenantClientServices clientDetailsService;
     private final RevocableTokenProvisioning revocableTokenProvisioning;
+    private final ExternalOAuthAuthenticationManager externalOAuthAuthenticationManager;
 
     public TokenExchangeGranter(AuthorizationServerTokenServices tokenServices,
                                 MultitenantClientServices clientDetailsService,
                                 OAuth2RequestFactory requestFactory,
-                                RevocableTokenProvisioning revocableTokenProvisioning) {
+                                RevocableTokenProvisioning revocableTokenProvisioning,
+                                ExternalOAuthAuthenticationManager externalOAuthAuthenticationManager) {
         super(tokenServices, clientDetailsService, requestFactory, GRANT_TYPE_TOKEN_EXCHANGE);
         defaultSecurityContextAccessor = new DefaultSecurityContextAccessor();
         this.clientDetailsService = clientDetailsService;
         this.revocableTokenProvisioning = revocableTokenProvisioning;
+        this.externalOAuthAuthenticationManager = externalOAuthAuthenticationManager;
     }
 
     protected Authentication validateRequest(TokenRequest request) {
@@ -143,7 +148,13 @@ public class TokenExchangeGranter extends AbstractTokenGranter {
                 throw new InvalidGrantException("Invalid subject_token: not a JWT and not found in the revocable token store");
             }
         }
-        JWTClaimsSet claims = JwtHelper.decode(subjectToken).getClaimSet();
+        JWTClaimsSet claims;
+        try {
+            claims = externalOAuthAuthenticationManager.verifySubjectToken(subjectToken);
+        } catch (AuthenticationException | InvalidTokenException e) {
+            logger.debug("subject_token signature verification failed", e);
+            throw new InvalidGrantException("Invalid subject_token: " + e.getMessage());
+        }
         String clientId = tokenRequest.getClientId();
         try {
             return new TokenActor(

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranter.java
@@ -153,7 +153,7 @@ public class TokenExchangeGranter extends AbstractTokenGranter {
             claims = externalOAuthAuthenticationManager.verifySubjectToken(subjectToken);
         } catch (AuthenticationException | InvalidTokenException e) {
             logger.debug("subject_token signature verification failed", e);
-            throw new InvalidGrantException("Invalid subject_token: " + e.getMessage());
+            throw new InvalidGrantException("Invalid subject_token");
         }
         String clientId = tokenRequest.getClientId();
         try {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -18,6 +18,7 @@ import tools.jackson.core.type.TypeReference;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -717,6 +718,26 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         } catch (JOSEException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    /**
+     * Resolves the registered identity provider from the token's {@code iss} claim,
+     * verifies the JWT signature against that provider's keys, and checks expiry.
+     *
+     * <p>Intended for callers (e.g. {@code TokenExchangeGranter}) that need independent
+     * verification of a {@code subject_token} without going through the full authentication
+     * pipeline.
+     *
+     * @param idToken the JWT to verify
+     * @return the verified and expiry-checked {@link JWTClaimsSet}
+     * @throws InsufficientAuthenticationException if the issuer cannot be mapped to a registered provider
+     * @throws InvalidTokenException               if the signature or expiry checks fail
+     */
+    public JWTClaimsSet verifySubjectToken(String idToken) {
+        IdentityProvider provider = resolveOriginProvider(idToken);
+        AbstractExternalOAuthIdentityProviderDefinition config =
+                (AbstractExternalOAuthIdentityProviderDefinition) provider.getConfig();
+        return validateToken(idToken, config).getJwt().getClaimSet();
     }
 
     private JwtTokenSignedByThisUAA validateToken(String idToken, AbstractExternalOAuthIdentityProviderDefinition config) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -781,9 +781,16 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
      */
     public JWTClaimsSet verifySubjectToken(String idToken) {
         IdentityProvider provider = resolveOriginProvider(idToken);
-        AbstractExternalOAuthIdentityProviderDefinition config =
-                (AbstractExternalOAuthIdentityProviderDefinition) provider.getConfig();
-        return validateToken(idToken, config).getJwt().getClaimSet();
+        if (!(provider.getConfig() instanceof AbstractExternalOAuthIdentityProviderDefinition config)) {
+            throw new InsufficientAuthenticationException("Unable to map issuer to a registered OAuth/OIDC provider");
+        }
+        try {
+            return validateToken(idToken, config).getJwt().getClaimSet();
+        } catch (InvalidTokenException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new InvalidTokenException("Unable to verify subject_token", e);
+        }
     }
 
     private JwtTokenSignedByThisUAA validateToken(String idToken, AbstractExternalOAuthIdentityProviderDefinition config) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -18,6 +18,7 @@ import tools.jackson.core.type.TypeReference;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jwt.JWTClaimsSet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import lombok.Data;
@@ -763,6 +764,26 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         } catch (JOSEException e) {
             throw new IllegalArgumentException(e);
         }
+    }
+
+    /**
+     * Resolves the registered identity provider from the token's {@code iss} claim,
+     * verifies the JWT signature against that provider's keys, and checks expiry.
+     *
+     * <p>Intended for callers (e.g. {@code TokenExchangeGranter}) that need independent
+     * verification of a {@code subject_token} without going through the full authentication
+     * pipeline.
+     *
+     * @param idToken the JWT to verify
+     * @return the verified and expiry-checked {@link JWTClaimsSet}
+     * @throws InsufficientAuthenticationException if the issuer cannot be mapped to a registered provider
+     * @throws InvalidTokenException               if the signature or expiry checks fail
+     */
+    public JWTClaimsSet verifySubjectToken(String idToken) {
+        IdentityProvider provider = resolveOriginProvider(idToken);
+        AbstractExternalOAuthIdentityProviderDefinition config =
+                (AbstractExternalOAuthIdentityProviderDefinition) provider.getConfig();
+        return validateToken(idToken, config).getJwt().getClaimSet();
     }
 
     private JwtTokenSignedByThisUAA validateToken(String idToken, AbstractExternalOAuthIdentityProviderDefinition config) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranterTests.java
@@ -8,22 +8,28 @@ import org.cloudfoundry.identity.uaa.oauth.TokenTestSupport;
 import org.cloudfoundry.identity.uaa.oauth.UaaOauth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidGrantException;
 import org.cloudfoundry.identity.uaa.oauth.common.util.OAuth2Utils;
+import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Request;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2RequestFactory;
 import org.cloudfoundry.identity.uaa.oauth.provider.TokenRequest;
 import org.cloudfoundry.identity.uaa.oauth.provider.token.AuthorizationServerTokenServices;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager;
 import org.cloudfoundry.identity.uaa.provider.oauth.TokenActor;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -40,6 +46,7 @@ import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.TOKEN_TYP
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -58,6 +65,7 @@ class TokenExchangeGranterTests {
     private MultitenantClientServices clientDetailsService;
     private OAuth2RequestFactory requestFactory;
     private RevocableTokenProvisioning revocableTokenProvisioning;
+    private ExternalOAuthAuthenticationManager externalOAuthAuthenticationManager;
     private Map<String, String> requestParameters;
 
     @BeforeEach
@@ -66,7 +74,13 @@ class TokenExchangeGranterTests {
         clientDetailsService = mock(MultitenantClientServices.class);
         requestFactory = mock(OAuth2RequestFactory.class);
         revocableTokenProvisioning = mock(RevocableTokenProvisioning.class);
-        granter = spy(new TokenExchangeGranter(tokenServices, clientDetailsService, requestFactory, revocableTokenProvisioning));
+        externalOAuthAuthenticationManager = mock(ExternalOAuthAuthenticationManager.class);
+        // Default: parse-only (mirrors the pre-fix behaviour for tests that don't need
+        // signature checking). Individual tests that want verification to fail should
+        // override this stub to throw InsufficientAuthenticationException.
+        lenient().when(externalOAuthAuthenticationManager.verifySubjectToken(anyString()))
+                .thenAnswer(inv -> JwtHelper.decode(inv.getArgument(0, String.class)).getClaimSet());
+        granter = spy(new TokenExchangeGranter(tokenServices, clientDetailsService, requestFactory, revocableTokenProvisioning, externalOAuthAuthenticationManager));
         tokenRequest = new TokenRequest(Collections.emptyMap(), "client_ID", Collections.emptySet(), GRANT_TYPE_TOKEN_EXCHANGE);
 
         authentication = mock(UaaOauth2Authentication.class);
@@ -271,6 +285,93 @@ class TokenExchangeGranterTests {
             verify(revocableTokenProvisioning, never()).retrieve(anyString(), anyString());
         } finally {
             support.clear();
+        }
+    }
+
+    /**
+     * Verifies that {@link TokenExchangeGranter#getTokenActor} rejects a {@code subject_token}
+     * whose signature cannot be verified against the registered identity provider.
+     *
+     * <p>Provider resolution is driven by the token's {@code iss} claim: the granter looks up
+     * the registered IdP whose configured issuer matches the {@code iss} value, then verifies
+     * the JWT signature against that IdP's published keys. Any failure — unknown issuer, bad
+     * signature, or expired token — must be propagated as {@link InvalidGrantException}.
+     */
+    @Nested
+    class SubjectTokenSignatureVerification {
+
+        private String forgeSelfSignedJwt(String payloadJson) {
+            Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+            String header = enc.encodeToString(
+                    "{\"alg\":\"RS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
+            String payload = enc.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
+            // A real RS256 signature would be ~342 base64url chars derived from a private RSA key.
+            // This is plaintext gibberish — it cannot pass verification for any RSA public key.
+            String bogusSignature = enc.encodeToString(
+                    "FORGED-NOT-A-REAL-RSA-SIGNATURE".getBytes(StandardCharsets.UTF_8));
+            return header + "." + payload + "." + bogusSignature;
+        }
+
+        @Test
+        void getTokenActor_whenSubjectTokenHasBogusSignature_throwsInvalidGrant() {
+            // A JWT with a completely fabricated signature and an issuer that has no
+            // corresponding registered IdP.  resolveOriginProvider() looks up by iss,
+            // finds nothing, and throws InsufficientAuthenticationException.
+            String forgedJwt = forgeSelfSignedJwt(
+                    "{\"sub\":\"forged-privileged-user\"" +
+                    ",\"iss\":\"https://not-a-registered-idp.example.com\"" +
+                    ",\"user_name\":\"forged-admin\"" +
+                    ",\"user_id\":\"forged-user-id\"" +
+                    ",\"origin\":\"uaa\"}");
+
+            when(externalOAuthAuthenticationManager.verifySubjectToken(forgedJwt))
+                    .thenThrow(new InsufficientAuthenticationException("Unable to map issuer to a registered provider"));
+
+            requestParameters.put("subject_token", forgedJwt);
+            requestParameters.put("subject_token_type", TOKEN_TYPE_ACCESS);
+            tokenRequest.setRequestParameters(requestParameters);
+
+            assertThatThrownBy(() -> granter.getTokenActor(tokenRequest))
+                    .isInstanceOf(InvalidGrantException.class);
+        }
+
+        @Test
+        void getTokenActor_whenSubjectTokenPayloadIsTamperedAfterSigning_throwsInvalidGrant()
+                throws Exception {
+            // Start with a legitimately signed JWT from this UAA instance.
+            TokenTestSupport support = new TokenTestSupport(null, null);
+            try {
+                String legitimateJwt = support.getIdTokenAsString(Collections.singletonList(OPENID));
+
+                // Replace the payload with attacker-controlled claims while keeping the
+                // original header and signature.  The signature now covers different bytes
+                // than the new payload, so validateToken() must reject it.
+                String[] parts = legitimateJwt.split("\\.");
+                String originalHeader    = parts[0];
+                String originalSignature = parts[2];
+
+                Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
+                String tamperedPayload = enc.encodeToString(
+                        ("{\"sub\":\"tampered-admin-user\"" +
+                         ",\"iss\":\"https://not-a-registered-idp.example.com\"" +
+                         ",\"user_name\":\"tampered-admin\"" +
+                         ",\"user_id\":\"tampered-user-id\"" +
+                         ",\"origin\":\"uaa\"}").getBytes(StandardCharsets.UTF_8));
+
+                String tamperedJwt = originalHeader + "." + tamperedPayload + "." + originalSignature;
+
+                when(externalOAuthAuthenticationManager.verifySubjectToken(tamperedJwt))
+                        .thenThrow(new InsufficientAuthenticationException("Signature verification failed"));
+
+                requestParameters.put("subject_token", tamperedJwt);
+                requestParameters.put("subject_token_type", TOKEN_TYPE_ACCESS);
+                tokenRequest.setRequestParameters(requestParameters);
+
+                assertThatThrownBy(() -> granter.getTokenActor(tokenRequest))
+                        .isInstanceOf(InvalidGrantException.class);
+            } finally {
+                support.clear();
+            }
         }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/TokenExchangeGranterTests.java
@@ -7,6 +7,7 @@ import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.oauth.TokenTestSupport;
 import org.cloudfoundry.identity.uaa.oauth.UaaOauth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidGrantException;
+import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenException;
 import org.cloudfoundry.identity.uaa.oauth.common.util.OAuth2Utils;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
@@ -28,8 +29,6 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -46,6 +45,7 @@ import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.TOKEN_TYP
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -289,89 +289,54 @@ class TokenExchangeGranterTests {
     }
 
     /**
-     * Verifies that {@link TokenExchangeGranter#getTokenActor} rejects a {@code subject_token}
-     * whose signature cannot be verified against the registered identity provider.
+     * Verifies that {@link TokenExchangeGranter#getTokenActor} translates every failure mode of
+     * {@link ExternalOAuthAuthenticationManager#verifySubjectToken} into {@link InvalidGrantException}.
      *
-     * <p>Provider resolution is driven by the token's {@code iss} claim: the granter looks up
-     * the registered IdP whose configured issuer matches the {@code iss} value, then verifies
-     * the JWT signature against that IdP's published keys. Any failure — unknown issuer, bad
-     * signature, or expired token — must be propagated as {@link InvalidGrantException}.
+     * <p>These are unit tests of the granter's contract with its collaborator, so
+     * {@code verifySubjectToken} is mocked. The granter catches two unrelated exception
+     * hierarchies — Spring Security's {@link org.springframework.security.core.AuthenticationException}
+     * (thrown by issuer resolution, e.g. when the {@code iss} claim maps to no registered IdP) and
+     * UAA's {@link InvalidTokenException} (thrown by signature/expiry/audience checks in
+     * {@code validateToken}) — and must map both to {@code invalid_grant} without leaking detail.
+     *
+     * <p>End-to-end cryptographic verification against real provider keys is covered by the
+     * MockMvc tests ({@code TokenExchangeDefaultConfigMockMvcTests} and
+     * {@code TokenExchangeSubjectTokenSignatureBypassMockMvcTests}).
      */
     @Nested
     class SubjectTokenSignatureVerification {
 
-        private String forgeSelfSignedJwt(String payloadJson) {
-            Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
-            String header = enc.encodeToString(
-                    "{\"alg\":\"RS256\",\"typ\":\"JWT\"}".getBytes(StandardCharsets.UTF_8));
-            String payload = enc.encodeToString(payloadJson.getBytes(StandardCharsets.UTF_8));
-            // A real RS256 signature would be ~342 base64url chars derived from a private RSA key.
-            // This is plaintext gibberish — it cannot pass verification for any RSA public key.
-            String bogusSignature = enc.encodeToString(
-                    "FORGED-NOT-A-REAL-RSA-SIGNATURE".getBytes(StandardCharsets.UTF_8));
-            return header + "." + payload + "." + bogusSignature;
-        }
+        // Structurally valid JWT (matches UaaTokenUtils.isJwtToken) so the granter does not divert
+        // to the revocable-token store. The contents are irrelevant: verifySubjectToken is mocked.
+        private static final String SUBJECT_TOKEN = "header.payload.signature";
 
-        @Test
-        void getTokenActor_whenSubjectTokenHasBogusSignature_throwsInvalidGrant() {
-            // A JWT with a completely fabricated signature and an issuer that has no
-            // corresponding registered IdP.  resolveOriginProvider() looks up by iss,
-            // finds nothing, and throws InsufficientAuthenticationException.
-            String forgedJwt = forgeSelfSignedJwt(
-                    "{\"sub\":\"forged-privileged-user\"" +
-                    ",\"iss\":\"https://not-a-registered-idp.example.com\"" +
-                    ",\"user_name\":\"forged-admin\"" +
-                    ",\"user_id\":\"forged-user-id\"" +
-                    ",\"origin\":\"uaa\"}");
-
-            when(externalOAuthAuthenticationManager.verifySubjectToken(forgedJwt))
-                    .thenThrow(new InsufficientAuthenticationException("Unable to map issuer to a registered provider"));
-
-            requestParameters.put("subject_token", forgedJwt);
+        @BeforeEach
+        void setUpSubjectToken() {
+            requestParameters.put("subject_token", SUBJECT_TOKEN);
             requestParameters.put("subject_token_type", TOKEN_TYPE_ACCESS);
             tokenRequest.setRequestParameters(requestParameters);
-
-            assertThatThrownBy(() -> granter.getTokenActor(tokenRequest))
-                    .isInstanceOf(InvalidGrantException.class);
         }
 
         @Test
-        void getTokenActor_whenSubjectTokenPayloadIsTamperedAfterSigning_throwsInvalidGrant()
-                throws Exception {
-            // Start with a legitimately signed JWT from this UAA instance.
-            TokenTestSupport support = new TokenTestSupport(null, null);
-            try {
-                String legitimateJwt = support.getIdTokenAsString(Collections.singletonList(OPENID));
+        void getTokenActor_whenIssuerCannotBeResolved_throwsInvalidGrant() {
+            doThrow(new InsufficientAuthenticationException("Unable to map issuer to a registered provider"))
+                    .when(externalOAuthAuthenticationManager).verifySubjectToken(SUBJECT_TOKEN);
 
-                // Replace the payload with attacker-controlled claims while keeping the
-                // original header and signature.  The signature now covers different bytes
-                // than the new payload, so validateToken() must reject it.
-                String[] parts = legitimateJwt.split("\\.");
-                String originalHeader    = parts[0];
-                String originalSignature = parts[2];
+            assertThatThrownBy(() -> granter.getTokenActor(tokenRequest))
+                    .isInstanceOf(InvalidGrantException.class)
+                    .hasMessage("Invalid subject_token");
+        }
 
-                Base64.Encoder enc = Base64.getUrlEncoder().withoutPadding();
-                String tamperedPayload = enc.encodeToString(
-                        ("{\"sub\":\"tampered-admin-user\"" +
-                         ",\"iss\":\"https://not-a-registered-idp.example.com\"" +
-                         ",\"user_name\":\"tampered-admin\"" +
-                         ",\"user_id\":\"tampered-user-id\"" +
-                         ",\"origin\":\"uaa\"}").getBytes(StandardCharsets.UTF_8));
+        @Test
+        void getTokenActor_whenSignatureOrExpiryCheckFails_throwsInvalidGrant() {
+            // validateToken() reports signature/expiry/audience failures as InvalidTokenException,
+            // which is NOT a Spring AuthenticationException — this exercises the second catch branch.
+            doThrow(new InvalidTokenException("Could not verify token signature."))
+                    .when(externalOAuthAuthenticationManager).verifySubjectToken(SUBJECT_TOKEN);
 
-                String tamperedJwt = originalHeader + "." + tamperedPayload + "." + originalSignature;
-
-                when(externalOAuthAuthenticationManager.verifySubjectToken(tamperedJwt))
-                        .thenThrow(new InsufficientAuthenticationException("Signature verification failed"));
-
-                requestParameters.put("subject_token", tamperedJwt);
-                requestParameters.put("subject_token_type", TOKEN_TYPE_ACCESS);
-                tokenRequest.setRequestParameters(requestParameters);
-
-                assertThatThrownBy(() -> granter.getTokenActor(tokenRequest))
-                        .isInstanceOf(InvalidGrantException.class);
-            } finally {
-                support.clear();
-            }
+            assertThatThrownBy(() -> granter.getTokenActor(tokenRequest))
+                    .isInstanceOf(InvalidGrantException.class)
+                    .hasMessage("Invalid subject_token");
         }
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerTest.java
@@ -21,6 +21,8 @@ import org.cloudfoundry.identity.uaa.login.Prompt;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfo;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
 import org.cloudfoundry.identity.uaa.oauth.TokenEndpointBuilder;
+import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey;
+import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKeySet;
 import org.cloudfoundry.identity.uaa.oauth.client.ClientConstants;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenException;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtClientAuthentication;
@@ -31,6 +33,7 @@ import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.OIDCIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.provider.RawExternalOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.scim.ScimGroupExternalMember;
 import org.cloudfoundry.identity.uaa.scim.jdbc.JdbcScimGroupExternalMembershipManager;
 import org.cloudfoundry.identity.uaa.user.UaaUser;
@@ -57,6 +60,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.AuthorityUtils;
@@ -1161,6 +1165,49 @@ class ExternalOAuthAuthenticationManagerTest {
         assertThat(codeToken.getIdToken()).isNull();
         assertThat(codeToken.getAccessToken()).isEqualTo("opaque-access-token");
 
+    }
+
+    @Test
+    void verifySubjectToken_whenProviderConfigIsNotOAuthType_throwsInsufficientAuthenticationException() {
+        final IdentityProvider<SamlIdentityProviderDefinition> nonOAuthProvider = new IdentityProvider<>();
+        nonOAuthProvider.setConfig(new SamlIdentityProviderDefinition());
+        final ExternalOAuthAuthenticationManager manager = new ExternalOAuthAuthenticationManager(
+                identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(),
+                tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), oidcMetadataFetcher, false) {
+            @Override
+            public IdentityProvider resolveOriginProvider(String idToken) {
+                return nonOAuthProvider;
+            }
+        };
+
+        assertThatThrownBy(() -> manager.verifySubjectToken("subject-token"))
+                .isInstanceOf(InsufficientAuthenticationException.class);
+    }
+
+    @Test
+    void verifySubjectToken_whenValidateTokenThrowsUnexpectedRuntimeException_throwsInvalidTokenException() {
+        // reuse the beforeEach-configured provider (issuer != UAA's own token endpoint, so
+        // validateToken resolves signing keys via getTokenKeyFromOAuth()); simulate some
+        // unrelated internal failure there to prove verifySubjectToken still honors its
+        // documented contract of only ever throwing InsufficientAuthenticationException or
+        // InvalidTokenException, instead of letting an arbitrary RuntimeException escape.
+        final ExternalOAuthAuthenticationManager manager = new ExternalOAuthAuthenticationManager(
+                identityProviderProvisioning, new IdentityZoneManagerImpl(), new RestTemplate(), new RestTemplate(),
+                tokenEndpointBuilder, new KeyInfoService(UAA_ISSUER_BASE_URL), oidcMetadataFetcher, false) {
+            @Override
+            public IdentityProvider resolveOriginProvider(String idToken) {
+                return provider;
+            }
+
+            @Override
+            public JsonWebKeySet<JsonWebKey> getTokenKeyFromOAuth(AbstractExternalOAuthIdentityProviderDefinition config) {
+                throw new NullPointerException("simulated unexpected failure while resolving signing keys");
+            }
+        };
+
+        assertThatThrownBy(() -> manager.verifySubjectToken("subject-token"))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasCauseInstanceOf(NullPointerException.class);
     }
 
     private static void assertAuthorizationHeaderIsSetAndStartsWithBasic(final HttpHeaders headers) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeDefaultConfigMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeDefaultConfigMockMvcTests.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 
@@ -261,6 +263,56 @@ class TokenExchangeDefaultConfigMockMvcTests extends TokenExchangeMockMvcBase {
                 .containsEntry(ClaimConstants.USER_NAME, subjectTokenClaims.get(ClaimConstants.USER_NAME))
                 .containsEntry(ClaimConstants.USER_ID, subjectTokenClaims.get(ClaimConstants.USER_ID))
                 .containsEntry(ClaimConstants.ORIGIN, subjectTokenClaims.get(ClaimConstants.ORIGIN));
+    }
+
+    /**
+     * Confirms that a {@code subject_token} with a tampered payload is rejected in the
+     * default configuration (no bean overrides).
+     *
+     * <p>Takes a legitimately signed access token from the control server, replaces its
+     * {@code sub} and {@code user_id} claims, and submits the result as {@code subject_token}.
+     * The {@code iss} claim is left intact so that the registered IdP can be resolved;
+     * the signature is now cryptographically invalid for the modified payload.
+     *
+     * <p>The default {@code tokenExchangeAuthenticationManager} wraps
+     * {@link org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager},
+     * which resolves the IdP by the token's {@code iss} claim and then verifies the
+     * signature against that IdP's published keys.  The mismatch is caught at the filter
+     * layer, before {@code TokenExchangeGranter.getTokenActor()} is reached, and translated
+     * to HTTP 401.
+     */
+    @Test
+    void forged_subject_token_is_blocked_by_filter_in_default_configuration() throws Exception {
+        ThreeWayUAASetup setup = getThreeWayUaaSetUp();
+        AuthorizationServer workerServer = setup.workerServer();
+
+        String legitimateJwt = (String) setup.controlServerTokens().get("access_token");
+
+        // Tamper sub and user_id; leave iss intact so the registered IdP can be resolved.
+        String[] parts = legitimateJwt.split("\\.");
+        Map<String, Object> claims = JsonUtils.readValueAsMap(
+                new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8));
+        claims.put(ClaimConstants.SUB,     "FORGED-" + claims.get(ClaimConstants.SUB));
+        claims.put(ClaimConstants.USER_ID, "FORGED-" + claims.get(ClaimConstants.USER_ID));
+        String tamperedPayload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(JsonUtils.writeValueAsString(claims).getBytes(StandardCharsets.UTF_8));
+
+        // Original header · tampered payload · original signature (now invalid).
+        String tamperedJwt = parts[0] + "." + tamperedPayload + "." + parts[2];
+
+        ResultActions result = performTokenExchangeGrantForJWT(
+                workerServer.zone().getIdentityZone(),
+                tamperedJwt,
+                TokenConstants.TOKEN_TYPE_ACCESS,
+                TokenConstants.TOKEN_TYPE_ACCESS,
+                null, null,
+                workerServer.client(),
+                ClientAuthType.FORM,
+                null
+        );
+
+        // The filter's validateToken() catches the invalid signature → 401.
+        result.andExpect(status().isUnauthorized());
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeSubjectTokenSignatureBypassMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeSubjectTokenSignatureBypassMockMvcTests.java
@@ -1,0 +1,195 @@
+package org.cloudfoundry.identity.uaa.mock.token;
+
+import tools.jackson.core.type.TypeReference;
+import org.cloudfoundry.identity.uaa.DefaultTestContext;
+import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
+import org.cloudfoundry.identity.uaa.oauth.TokenEndpointBuilder;
+import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
+import org.cloudfoundry.identity.uaa.provider.AbstractExternalOAuthIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
+import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthAuthenticationManager;
+import org.cloudfoundry.identity.uaa.provider.oauth.ExternalOAuthCodeToken;
+import org.cloudfoundry.identity.uaa.provider.oauth.OidcMetadataFetcher;
+import org.cloudfoundry.identity.uaa.provider.oauth.TokenExchangeData;
+import org.cloudfoundry.identity.uaa.scim.ScimGroupExternalMembershipManager;
+import org.cloudfoundry.identity.uaa.user.UaaUserDatabase;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.cloudfoundry.identity.uaa.oauth.token.TokenConstants.TOKEN_TYPE_ACCESS;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests that verify {@link TokenExchangeGranter} performs its own
+ * {@code subject_token} signature verification, independently of the filter layer.
+ *
+ * <p>The default {@code tokenExchangeAuthenticationManager} is marked
+ * {@code @ConditionalOnMissingBean}, so operators and extensions can supply a
+ * replacement.  If that replacement weakens or omits signature verification, the
+ * granter must still reject tokens whose signatures do not match the keys published
+ * by the registered identity provider.
+ *
+ * <p>This test class registers such a replacement — one that skips
+ * {@code validateToken()} in the filter layer — then submits a tampered
+ * {@code subject_token}.  The granter's independent verification (via
+ * {@code ExternalOAuthAuthenticationManager#verifySubjectToken}) must catch the
+ * invalid signature and return HTTP 400 {@code invalid_grant}.
+ */
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Import(TokenExchangeSubjectTokenSignatureBypassMockMvcTests.NoSignatureVerificationConfig.class)
+@DefaultTestContext
+class TokenExchangeSubjectTokenSignatureBypassMockMvcTests extends TokenExchangeMockMvcBase {
+
+    /**
+     * Replaces the default {@code tokenExchangeAuthenticationManager} with a subclass
+     * that skips signature verification in the filter layer.
+     *
+     * <p>Only {@code getClaimsFromToken(String, IdentityProvider)} is overridden: it
+     * decodes the JWT payload directly without calling {@code validateToken()}, so any
+     * token — including one with a tampered payload — is accepted at the filter.  All
+     * other behaviour (user lookup, shadow-user creation, issuer-based IdP resolution)
+     * is inherited from the base class unchanged.
+     *
+     * <p>Note that {@code verifySubjectToken()} is NOT overridden, so the granter's
+     * call to that method still runs the real {@code validateToken()} and detects the
+     * invalid signature.
+     */
+    static class NoSignatureVerificationConfig {
+
+        @Bean("tokenExchangeAuthenticationManager")
+        ExternalOAuthAuthenticationManager tokenExchangeAuthenticationManager(
+                @Qualifier("externalOAuthProviderConfigurator") IdentityProviderProvisioning providerProvisioning,
+                @Qualifier("identityZoneManager") org.cloudfoundry.identity.uaa.zone.beans.IdentityZoneManager identityZoneManager,
+                @Qualifier("trustingRestTemplate") RestTemplate trustingRestTemplate,
+                @Qualifier("nonTrustingRestTemplate") RestTemplate nonTrustingRestTemplate,
+                @Qualifier("tokenEndpointBuilder") TokenEndpointBuilder tokenEndpointBuilder,
+                @Qualifier("keyInfoService") KeyInfoService keyInfoService,
+                @Qualifier("oidcMetadataFetcher") OidcMetadataFetcher oidcMetadataFetcher,
+                @Qualifier("userDatabase") UaaUserDatabase userDatabase,
+                @Qualifier("externalGroupMembershipManager") ScimGroupExternalMembershipManager externalMembershipManager
+        ) {
+            ExternalOAuthAuthenticationManager bean = new ExternalOAuthAuthenticationManager(
+                    providerProvisioning,
+                    identityZoneManager,
+                    trustingRestTemplate,
+                    nonTrustingRestTemplate,
+                    tokenEndpointBuilder,
+                    keyInfoService,
+                    oidcMetadataFetcher,
+                    false
+            ) {
+                /**
+                 * Simulates a filter-layer implementation that skips {@code validateToken()}.
+                 * Decodes the JWT payload directly and returns the claims map without any
+                 * cryptographic check.
+                 */
+                @Override
+                protected <T extends AbstractExternalOAuthIdentityProviderDefinition<T>>
+                Map<String, Object> getClaimsFromToken(String idToken, IdentityProvider<T> identityProvider) {
+                    String[] parts = idToken.split("\\.");
+                    String json = new String(
+                            Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+                    return JsonUtils.readValue(json, new TypeReference<>() {});
+                }
+
+                /**
+                 * Mirrors the access-token → id-token field swap that the default
+                 * {@link org.cloudfoundry.identity.uaa.provider.oauth.TokenExchangeWrapperForExternalOauth}
+                 * performs, ensuring the token string is available for {@code iss}-based
+                 * IdP resolution regardless of {@code subject_token_type}.
+                 */
+                @Override
+                public Authentication authenticate(Authentication authentication) {
+                    ExternalOAuthCodeToken token = (ExternalOAuthCodeToken) authentication;
+                    if (token.getIdToken() == null) {
+                        token = new TokenExchangeData(
+                                token.getCode(),
+                                token.getOrigin(),
+                                token.getRedirectUrl(),
+                                token.getAccessToken(),
+                                token.getAccessToken(),
+                                token.getSignedRequest(),
+                                token.getUaaAuthenticationDetails()
+                        );
+                    }
+                    return super.authenticate(token);
+                }
+            };
+            bean.setUserDatabase(userDatabase);
+            bean.setExternalMembershipManager(externalMembershipManager);
+            return bean;
+        }
+    }
+
+    /**
+     * Verifies that {@code TokenExchangeGranter} independently validates the
+     * {@code subject_token} signature even when the filter layer skipped that check.
+     *
+     * <p>Steps:
+     * <ol>
+     *   <li>Obtain a legitimately signed {@code access_token} from the control server.</li>
+     *   <li>Replace its {@code sub} and {@code user_id} claims while keeping the original
+     *       {@code iss} and signature.  The {@code iss} is left intact so that the registered
+     *       IdP can be resolved by the granter; the signature is now cryptographically invalid
+     *       for the modified payload.</li>
+     *   <li>Submit the tampered JWT as {@code subject_token}.  The filter-layer auth manager
+     *       ({@code NoSignatureVerificationConfig}) accepts it without a signature check.</li>
+     *   <li>The granter calls {@code ExternalOAuthAuthenticationManager#verifySubjectToken},
+     *       which resolves the IdP by {@code iss} and verifies the signature against the
+     *       IdP's published keys.  The mismatch must produce HTTP 400 {@code invalid_grant}.</li>
+     * </ol>
+     */
+    @Test
+    void tampered_subject_token_is_rejected_by_granter_even_when_filter_skips_sig_check()
+            throws Exception {
+        ThreeWayUAASetup setup = getThreeWayUaaSetUp();
+        AuthorizationServer workerServer = setup.workerServer();
+
+        String legitimateJwt = (String) setup.controlServerTokens().get("access_token");
+
+        // Tamper sub and user_id; leave iss intact so the IdP is resolved by issuer.
+        String[] parts = legitimateJwt.split("\\.");
+        Map<String, Object> originalClaims = JsonUtils.readValueAsMap(
+                new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8));
+
+        originalClaims.put(ClaimConstants.SUB,     "FORGED-" + originalClaims.get(ClaimConstants.SUB));
+        originalClaims.put(ClaimConstants.USER_ID, "FORGED-" + originalClaims.get(ClaimConstants.USER_ID));
+
+        // Re-encode the tampered payload; the original signature no longer covers it.
+        String tamperedPayload = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(JsonUtils.writeValueAsString(originalClaims)
+                        .getBytes(StandardCharsets.UTF_8));
+
+        // Original header · tampered payload · original (now-invalid) signature.
+        String tamperedJwt = parts[0] + "." + tamperedPayload + "." + parts[2];
+
+        ResultActions result = performTokenExchangeGrantForJWT(
+                workerServer.zone().getIdentityZone(),
+                tamperedJwt,
+                TOKEN_TYPE_ACCESS,
+                TOKEN_TYPE_ACCESS,
+                null, null,
+                workerServer.client(),
+                ClientAuthType.FORM,
+                null
+        );
+
+        // The granter's verifySubjectToken() resolves the IdP by iss and detects the
+        // invalid signature → HTTP 400 invalid_grant.
+        result.andExpect(status().isBadRequest())
+              .andExpect(jsonPath("$.error").value("invalid_grant"));
+    }
+}


### PR DESCRIPTION
## Summary

- `TokenExchangeGranter.getTokenActor()` now calls
  `ExternalOAuthAuthenticationManager.verifySubjectToken()` instead of the
  parse-only `JwtHelper.decode()`. The new method resolves the registered
  identity provider by the token's `iss` claim, verifies the JWT signature
  against that provider's published keys, and checks expiry — reusing logic
  already present in `ExternalOAuthAuthenticationManager`.
- `OAuth2FilterConfig` wires the existing `externalOAuthAuthenticationManager`
  bean into `TokenExchangeGranter` as a new constructor parameter.
- Two new MockMvc tests cover the granter-level check end-to-end:
  `TokenExchangeDefaultConfigMockMvcTests` confirms the default configuration
  rejects a tampered token at the filter layer (HTTP 401); the new
  `TokenExchangeSubjectTokenSignatureBypassMockMvcTests` confirms the granter
  independently rejects it (HTTP 400 `invalid_grant`) even when the filter
  layer is replaced by a custom bean that skips signature checking.
