### PR TITLE
Fix: client secret re-encoding

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoder.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoder.java
@@ -1,11 +1,15 @@
 package org.cloudfoundry.identity.uaa.util.beans;
 
+import org.springframework.security.crypto.bcrypt.BCrypt;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Set;
 
 public class BackwardsCompatibleDelegatingPasswordEncoder implements PasswordEncoder {
 
     private static final String OPTIONAL_BCRYPT_PREFIX = "bcrypt";
+    private static final Set<String> BCRYPT_HASH_PREFIXES = Set.of("$2a$", "$2b$", "$2y$");
     private final BCryptPasswordEncoder defaultPasswordEncoder;
 
     public BackwardsCompatibleDelegatingPasswordEncoder(final BCryptPasswordEncoder defaultPasswordEncoder) {
@@ -27,7 +31,19 @@ public class BackwardsCompatibleDelegatingPasswordEncoder implements PasswordEnc
             return false;
         }
 
-        return defaultPasswordEncoder.matches(rawPassword, verifyPrefixAndExtractPassword(encodedPassword));
+        String extracted = verifyPrefixAndExtractPassword(encodedPassword);
+        // Spring Security 7's BCryptPasswordEncoder rejects empty rawPassword outright.
+        // UAA legitimately stores BCrypt hashes of empty strings (e.g. the `cf` CLI client
+        // has no secret), so we call BCrypt directly to preserve that behaviour.
+        if (rawPassword.isEmpty() && isBcryptHash(extracted)) {
+            try {
+                return BCrypt.checkpw("", extracted);
+            } catch (IllegalArgumentException _) {
+                return false;
+            }
+        }
+
+        return defaultPasswordEncoder.matches(rawPassword, extracted);
     }
 
     private String verifyPrefixAndExtractPassword(String encodedPassword) {
@@ -43,5 +59,9 @@ public class BackwardsCompatibleDelegatingPasswordEncoder implements PasswordEnc
             throw new IllegalArgumentException("Password encoding {%s} is not supported".formatted(prefix));
         }
         return encodedPassword.substring(endIndex + 1);
+    }
+
+    private boolean isBcryptHash(String value) {
+        return BCRYPT_HASH_PREFIXES.stream().anyMatch(value::startsWith);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoderTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/beans/BackwardsCompatibleDelegatingPasswordEncoderTest.java
@@ -81,4 +81,34 @@ class BackwardsCompatibleDelegatingPasswordEncoderTest {
             verify(mockPasswordEncoder).matches("password", "encodedPassword");
         }
     }
+
+    @Nested
+    class WithEmptyPassword {
+        // Spring Security 7's BCryptPasswordEncoder extends AbstractValidatingPasswordEncoder
+        // which short-circuits matches() and returns false for empty rawPassword.
+        // UAA legitimately stores BCrypt hashes of empty strings (clients with no secret,
+        // e.g. the CF CLI client). Verify that this class handles empty rawPassword correctly
+        // so ClientAdminBootstrap.updatePasswordsIfChanged() does not re-encode on every startup.
+        private final BCryptPasswordEncoder realEncoder = new BCryptPasswordEncoder();
+        private final PasswordEncoder realBackwardsEncoder =
+                new BackwardsCompatibleDelegatingPasswordEncoder(realEncoder);
+
+        @Test
+        void emptyPasswordMatchesItsOwnHash() {
+            String hash = realEncoder.encode("");
+            assertThat(realBackwardsEncoder.matches("", hash)).isTrue();
+        }
+
+        @Test
+        void emptyPasswordDoesNotMatchDifferentHash() {
+            String hash = realEncoder.encode("notempty");
+            assertThat(realBackwardsEncoder.matches("", hash)).isFalse();
+        }
+
+        @Test
+        void emptyPasswordMatchesBcryptPrefixedHash() {
+            String hash = "{bcrypt}" + realEncoder.encode("");
+            assertThat(realBackwardsEncoder.matches("", hash)).isTrue();
+        }
+    }
 }


### PR DESCRIPTION
Spring Security 7's BCryptPasswordEncoder now extends AbstractValidatingPasswordEncoder, which returns false from matches() when rawPassword is empty. ClientAdminBootstrap calls nonCachingPasswordEncoder.matches("", storedHash) to check whether a client's secret has changed; for clients with an empty secret (e.g. the CF CLI `cf` client) this now always returns false, causing a new BCrypt hash to be written to the DB on every UAA startup.

**Note:** This PR has been AI-generated. It resolves the issue we currently have with the BOSH disaster-recovery-acceptance-tests ("failed to verify token with uaa"):
https://concourse.wg-ard.ci.cloudfoundry.org/teams/main/pipelines/cf-deployment/jobs/bbr-run-drats/builds/2453

I cannot judge however if the fix is conceptually correct. Please review carefully.