### PR TITLE
restore saml entity id alias

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -2044,21 +2044,50 @@ Useful for IDP-initiated SSO flows.
 ### `login.saml.providers`
 
 **Default:** — (not configured)
-**Source:** [`SamlConfigProps`](../server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlConfigProps.java) (via `EnvironmentAware`)
+**Source:** [`BootstrapSamlIdentityProviderData`](../server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/BootstrapSamlIdentityProviderData.java) (via `EnvironmentAware`)
 **Type:** `Map<String, Map<String, Object>>`
 
-SAML Identity Provider definitions. Each entry is keyed by a provider alias and includes:
-- `idpMetadata` — Inline metadata XML or URL to metadata
-- `nameID` — NameID format for this IDP
-- `assertionConsumerIndex` — ACS index for this IDP
-- `metadataTrustCheck` — Validate metadata signature
-- `showSamlLoginLink` — Show login link on login page
-- `linkText` — Text for the login link
-- `iconUrl` — Icon URL for the login link
-- `addShadowUserOnLogin` — Create local user on first login
-- `emailDomain` — Email domains for IDP discovery
-- `externalGroupsWhitelist` — Allowed external groups
-- `attributeMappings` — Attribute mapping configuration
+Bootstrap SAML Identity Provider definitions. Each entry is keyed by a provider alias (the IDP origin key) and supports:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `idpMetadata` | `String` | **Required.** Inline metadata XML _or_ HTTP/HTTPS URL to the IDP metadata endpoint |
+| `nameID` | `String` | NameID format. Defaults to `login.saml.nameID` |
+| `assertionConsumerIndex` | `int` | ACS index. Default `0` |
+| `metadataTrustCheck` | `boolean` | Validate metadata signature. Default `true` |
+| `showSamlLoginLink` | `boolean` | Show login link on login page. Default `true` |
+| `linkText` | `String` | Label for the login link |
+| `iconUrl` | `String` | Icon URL for the login link |
+| `addShadowUserOnLogin` | `boolean` | Create a local shadow user on first SAML login. Default `true` |
+| `emailDomain` | `List<String>` | Email domains used for IDP discovery |
+| `externalGroupsWhitelist` | `List<String>` | External group names to map |
+| `attributeMappings` | `Map<String, Object>` | Attribute mapping configuration |
+| `skipSslValidation` | `boolean` | Skip TLS validation when fetching metadata URL. Default `false` |
+| `storeCustomAttributes` | `boolean` | Persist custom SAML attributes on the user. Default `true` |
+| `authnContext` | `List<String>` | Requested authentication context class references |
+| `override` | `boolean` | Overwrite an existing provider with the same alias on startup. Default `true` |
+
+#### `idpMetadata` and entity ID resolution
+
+The value of `idpMetadata` determines how UAA parses the IDP's entity ID:
+
+- **Inline XML** (value starts with `<?xml`, `<md:EntityDescriptor`, or `<EntityDescriptor`):
+  UAA parses the XML synchronously at startup. If the XML is invalid or the entity ID cannot
+  be extracted, startup fails immediately. This is the most reliable form — the IDP entity ID
+  is always stored in the database (`external_key` column) and IDP-initiated SSO works without
+  any network dependency at authentication time.
+
+- **HTTP/HTTPS URL** (value starts with `http`):
+  UAA fetches and parses the metadata URL at startup. If the IDP is temporarily unreachable
+  (e.g. DNS not ready, network partition), UAA logs an error and continues startup, but the
+  entity ID is **not** stored in the database. Until the IDP metadata becomes reachable and UAA
+  is restarted (or the provider is re-saved via the API), IDP-initiated SSO for that provider
+  depends on per-request dynamic metadata resolution. If the IDP is unreachable at
+  authentication time as well, IDP-initiated SSO will fail.
+
+> **Recommendation:** For URL-type `idpMetadata`, ensure the IDP metadata endpoint is reachable
+> when UAA starts. If it is not, restart UAA once the IDP is available so that the entity ID is
+> resolved and persisted, enabling efficient and reliable IDP-initiated SSO lookups.
 
 [Back to table](#saml-service-provider)
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -110,6 +110,6 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
             @Qualifier("samlEntityID") String samlEntityID,
             @Value("${login.entityBaseURL:#{null}}") String entityBaseURL) {
         return new UaaRelyingPartyRegistrationResolver(relyingPartyRegistrationRepository,
-                Optional.ofNullable(samlConfigProps.getEntityIDAlias()).orElse(samlEntityID), entityBaseURL);
+                Optional.ofNullable(samlConfigProps.getEntityIDAlias()).orElse(UaaStringUtils.getHostIfArgIsURL(samlEntityID)), entityBaseURL);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2TestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/Saml2TestUtils.java
@@ -150,6 +150,31 @@ public final class Saml2TestUtils {
     }
 
     /**
+     * Builds a SAML Response with a signed assertion targeting a custom ACS URL.
+     * <p>
+     * Use this to simulate IDP-initiated SSO where the SP alias (and thus ACS URL) differs from the
+     * default test destination. The {@code SubjectConfirmationData.Recipient} is set to {@code destination}
+     * so that Spring Security SAML accepts the response during processing.
+     */
+    public static Response responseWithAssertionsForDestination(String destination, String issuer) {
+        Response response = TestOpenSamlObjects.response(destination, issuer);
+        response.setIssueInstant(Instant.now());
+
+        Assertion rawAssertion = assertion(issuer, null, null);
+        // Override the Recipient to match the custom ACS URL
+        rawAssertion.getSubject().getSubjectConfirmations()
+                .forEach(sc -> sc.getSubjectConfirmationData().setRecipient(destination));
+        rawAssertion.getAttributeStatements().addAll(TestOpenSamlObjects.attributeStatements());
+
+        Assertion signedAssertion = TestOpenSamlObjects.signed(rawAssertion,
+                TestSaml2X509Credentials.assertingPartySigningCredential(),
+                RELYING_PARTY_ENTITY_ID,
+                SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1);
+        response.getAssertions().add(signedAssertion);
+        return response;
+    }
+
+    /**
      * Builds a SAML Response with a signed assertion, using a caller-supplied signing credential.
      * Use this when the test IDP has its own distinct key material rather than sharing the default
      * test credentials.

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlAuthenticationMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlAuthenticationMockMvcTests.java
@@ -9,7 +9,9 @@ import org.apache.logging.log4j.core.config.Configurator;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
+import org.cloudfoundry.identity.uaa.mock.util.ZoneResolutionMode;
 import org.cloudfoundry.identity.uaa.oauth.common.util.RandomValueStringGenerator;
 import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.JdbcIdentityProviderProvisioning;
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opensaml.saml.saml2.core.Response;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
@@ -305,6 +308,69 @@ class SamlAuthenticationMockMvcTests {
         }
     }
 
+    /**
+     * Zone-specific IDP-initiated SSO tests.
+     * <p>
+     * Verifies that IDP-initiated SSO works correctly for both subdomain and zone-path zone resolution
+     * modes when the {@code testsaml-redirect-binding} IdP is registered in a non-default zone.
+     * The SP alias for a zone is {@code {subdomain}.integration-saml-entity-id}, derived from the
+     * UAA-wide alias ({@code integration-saml-entity-id}) prefixed with the zone subdomain.
+     */
+    @Nested
+    @DefaultTestContext
+    @TestPropertySource(properties = "login.entityBaseURL=")
+    class NonDefaultZoneIdpInitiatedSsoTests {
+        // entityID comes from test-saml-idp-metadata-redirect-binding.xml (/saml2/idp, not /saml/idp)
+        private static final String IDP_ENTITY_ID = "https://some.idp.test/saml2/idp";
+        private static final String IDP_METADATA = "classpath:test-saml-idp-metadata-redirect-binding.xml";
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void idpInitiatedSso_subdomainZone_succeeds() throws Exception {
+            createMockSamlIdpInSpZone(IDP_METADATA, "testsaml-redirect-binding", IDP_ENTITY_ID);
+
+            String subdomain = spZone.getSubdomain();
+            String spAlias = subdomain + ".integration-saml-entity-id";
+            String acsUrl = "http://%s.localhost:8080/uaa/saml/SSO/alias/%s".formatted(subdomain, spAlias);
+
+            String encodedSamlResponse = serializedResponse(
+                    responseWithAssertionsForDestination(acsUrl, IDP_ENTITY_ID));
+
+            mockMvc.perform(post("/uaa/saml/SSO/alias/%s".formatted(spAlias))
+                            .contextPath("/uaa")
+                            .header(HOST, subdomain + ".localhost:8080")
+                            .param(SAML_RESPONSE, encodedSamlResponse)
+                    )
+                    .andDo(print())
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/uaa/"));
+        }
+
+        @Test
+        @EnabledIfZonePathsEnabled
+        void idpInitiatedSso_zonePathZone_succeeds() throws Exception {
+            createMockSamlIdpInSpZone(IDP_METADATA, "testsaml-redirect-binding", IDP_ENTITY_ID);
+
+            String subdomain = spZone.getSubdomain();
+            String spAlias = subdomain + ".integration-saml-entity-id";
+            String acsUrl = "http://localhost:8080/z/%s/saml/SSO/alias/%s".formatted(subdomain, spAlias);
+
+            String encodedSamlResponse = serializedResponse(
+                    responseWithAssertionsForDestination(acsUrl, IDP_ENTITY_ID));
+
+            mockMvc.perform(ZoneResolutionMode.ZONE_PATH.createRequestBuilder(
+                            subdomain, HttpMethod.POST, "/saml/SSO/alias/%s".formatted(spAlias))
+                            .header(HOST, "localhost:8080")
+                            .param(SAML_RESPONSE, encodedSamlResponse)
+                    )
+                    .andDo(print())
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/z/%s/".formatted(subdomain)));
+        }
+    }
+
     @Test
     void receiveAuthnResponseFromIdpToLegacyAliasUrl() throws Exception {
 
@@ -371,6 +437,19 @@ class SamlAuthenticationMockMvcTests {
     }
 
     private void createMockSamlIdpInSpZone(String metadataLocation, String idpOriginKey) {
+        createMockSamlIdpInSpZone(metadataLocation, idpOriginKey, null);
+    }
+
+    /**
+     * Creates a mock SAML IdP in {@code spZone}. When {@code idpEntityId} is non-null it is stored
+     * in the {@code external_key} column so that
+     * {@link ConfiguratorRelyingPartyRegistrationRepository} can look it up by issuer during
+     * IDP-initiated SSO — required when the metadata location uses a {@code classpath:} prefix,
+     * which is not recognised as {@code DATA} type by
+     * {@link SamlIdentityProviderDefinition#getType()} and therefore cannot be resolved via
+     * {@link SamlIdentityProviderConfigurator#getExtendedMetadataDelegate}.
+     */
+    private void createMockSamlIdpInSpZone(String metadataLocation, String idpOriginKey, String idpEntityId) {
         idp = new IdentityProvider<SamlIdentityProviderDefinition>()
                 .setType(OriginKeys.SAML)
                 .setOriginKey(idpOriginKey)
@@ -382,6 +461,9 @@ class SamlAuthenticationMockMvcTests {
                 .setIdpEntityAlias(idp.getOriginKey())
                 .setLinkText(idp.getName())
                 .setZoneId(spZone.getId());
+        if (idpEntityId != null) {
+            idpDefinition.setIdpEntityId(idpEntityId);
+        }
 
         idp.setConfig(idpDefinition);
         idp = jdbcIdentityProviderProvisioning.create(idp, spZone.getId());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlAuthenticationMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/saml/SamlAuthenticationMockMvcTests.java
@@ -45,6 +45,7 @@ import static org.apache.logging.log4j.Level.WARN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cloudfoundry.identity.uaa.authentication.MalformedSamlResponseLogger.X_VCAP_REQUEST_ID_HEADER;
 import static org.cloudfoundry.identity.uaa.provider.saml.Saml2TestUtils.responseWithAssertions;
+import static org.cloudfoundry.identity.uaa.provider.saml.Saml2TestUtils.responseWithAssertionsForDestination;
 import static org.cloudfoundry.identity.uaa.provider.saml.Saml2TestUtils.serializedResponse;
 import static org.cloudfoundry.identity.uaa.provider.saml.Saml2TestUtils.xmlNamespaces;
 import static org.cloudfoundry.identity.uaa.provider.saml.Saml2Utils.samlDecode;
@@ -489,6 +490,47 @@ class SamlAuthenticationMockMvcTests {
                     // expect redirect to the Uaa Home Page: /uaa/, not error
                     .andExpect(redirectedUrl("/uaa/"))
                     .andReturn();
+        }
+    }
+
+    /**
+     * Regression test: when {@code login.entityID} is a full URL (e.g. as configured by Tanzu OpsManager),
+     * the resolver must derive the SP alias as the hostname portion of the URL — identical to the derivation
+     * in {@link org.cloudfoundry.identity.uaa.provider.saml.SamlRelyingPartyRegistrationRepositoryConfig}.
+     * <p>
+     * Without the fix, {@code UaaRelyingPartyRegistrationResolver} passes the full URL as the alias to the
+     * {@code endsWith} check, which never matches the hostname-only URL segment extracted from the ACS URL
+     * path. The resolver then falls through to the default stub registration (UAA's own certificate), which
+     * cannot validate the IdP-signed assertion → "Invalid signature" → redirect to {@code /uaa/saml_error}.
+     */
+    @Nested
+    @DefaultTestContext
+    @TestPropertySource(properties = "login.entityID=https://example.com/uaa")
+    class IdpInitiatedSsoWithUrlEntityIdTests {
+        private static final String IDP_ENTITY_ID = "https://some.idp.test/saml/idp";
+        // hostname extracted from login.entityID (https://example.com/uaa) → used as SP alias
+        private static final String SP_ALIAS = "example.com";
+        private static final String ACS_URL = "http://localhost:8080/uaa/saml/SSO/alias/" + SP_ALIAS;
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void idpInitiatedSso_whenEntityIdIsUrl_succeeds() throws Exception {
+            // IDP-initiated: no prior SAMLRequest in session, no InResponseTo in the response.
+            // The resolver must extract the IdP issuer from the SAMLResponse and look it up via
+            // ConfiguratorRelyingPartyRegistrationRepository so that the correct signing cert is used.
+            String encodedSamlResponse = serializedResponse(
+                    responseWithAssertionsForDestination(ACS_URL, IDP_ENTITY_ID));
+
+            mockMvc.perform(post("/uaa/saml/SSO/alias/%s".formatted(SP_ALIAS))
+                            .contextPath("/uaa")
+                            .header(HOST, "localhost:8080")
+                            .param(SAML_RESPONSE, encodedSamlResponse)
+                    )
+                    .andDo(print())
+                    .andExpect(status().is3xxRedirection())
+                    .andExpect(redirectedUrl("/uaa/"));
         }
     }
 


### PR DESCRIPTION
The fix to #3661 was incomplete. It allowed the SP initiated authentication to work, but missing piece is IDP initiated authentication

The fix is server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java line 113. The rest of the PR is test cases and documentation.