### PR TITLE
Remove unused and redundant dependency declarations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,6 @@ jacocoAgent = { module = "org.jacoco:org.jacoco.agent", version.ref = "jacocoAge
 jakartaValidationApi = { module = "jakarta.validation:jakarta.validation-api" }
 
 # JSON Processing
-jsonAssert = { module = "org.skyscreamer:jsonassert" }
 jsonPath = { module = "com.jayway.jsonpath:json-path" }
 jsonPathAssert = { module = "com.jayway.jsonpath:json-path-assert" }
 orgJson = { module = "org.json:json", version.ref = "orgJson" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,7 +107,6 @@ jakartaValidationApi = { module = "jakarta.validation:jakarta.validation-api" }
 
 # JSON Processing
 jsonPath = { module = "com.jayway.jsonpath:json-path" }
-jsonPathAssert = { module = "com.jayway.jsonpath:json-path-assert" }
 orgJson = { module = "org.json:json", version.ref = "orgJson" }
 
 # JUnit 5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,10 +67,6 @@ bouncyCastlePkixFips = { module = "org.bouncycastle:bcpkix-fips", version.ref = 
 bouncyCastleTlsFips = { module = "org.bouncycastle:bctls-fips", version.ref = "bouncyCastleTls" }
 bouncyCastleUtilFips = { module = "org.bouncycastle:bcutil-fips", version.ref = "bouncyCastleUtil" }
 
-# ByteBuddy
-bytebuddy = { module = "net.bytebuddy:byte-buddy" }
-bytebuddyagent = { module = "net.bytebuddy:byte-buddy-agent" }
-
 # Eclipse JGit
 eclipseJgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "eclipseJgit" }
 

--- a/metrics-data/build.gradle.kts
+++ b/metrics-data/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
     testImplementation(libs.junit5JupiterApi)
     testImplementation(libs.junit5JupiterParams)
     testImplementation(libs.junit5JupiterEngine)
-    testImplementation(libs.unboundIdLdapSdk)
 
     testRuntimeOnly(libs.jacocoAgent)
     testRuntimeOnly(libs.junit5PlatformLauncher)

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -37,8 +37,6 @@ dependencies {
     testRuntimeOnly(libs.jacocoAgent)
     testRuntimeOnly(libs.junit5PlatformLauncher)
 
-    testImplementation(libs.jsonAssert)
-    
     compileOnly(libs.lombok)
     annotationProcessor(libs.lombok)
 }

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
 
     implementation(libs.springWeb)
     implementation(libs.springWebMvc)
-    implementation(libs.springSecurityConfig)
+    implementation(libs.springSecurityCore)
 
     implementation(libs.nimbusJwt)
 

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     testImplementation(libs.junit5JupiterApi)
     testImplementation(libs.junit5JupiterParams)
     testImplementation(libs.junit5JupiterEngine)
-    testImplementation(libs.unboundIdLdapSdk)
     testRuntimeOnly(libs.jacocoAgent)
     testRuntimeOnly(libs.junit5PlatformLauncher)
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     implementation(libs.log4jCore)
 
     implementation(libs.nimbusJwt)
-    implementation(libs.orgJson)
 
     implementation(libs.apacheHttpClient)
     implementation(libs.commonsIo)
@@ -99,6 +98,7 @@ dependencies {
     testImplementation(libs.junit5JupiterEngine)
     testImplementation(libs.springTest)
     testImplementation(libs.mockitoJunit5)
+    testImplementation(libs.orgJson)
 
     testImplementation(libs.postgresql)
     testImplementation(libs.mariaJdbcDriver)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -109,7 +109,6 @@ dependencies {
     testImplementation(libs.tomcatElApi)
     testImplementation(libs.tomcatJasperEl)
 
-    testImplementation(libs.jsonPathAssert)
     testImplementation(libs.xmlUnit)
     testImplementation(libs.awaitility)
 

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -99,8 +99,6 @@ dependencies {
     testImplementation(libs.junit5JupiterEngine)
     testImplementation(libs.unboundIdLdapSdk)
     testImplementation(libs.springTest)
-    testImplementation(libs.bytebuddy)
-    testImplementation(libs.bytebuddyagent)
     testImplementation(libs.mockitoJunit5)
 
     testImplementation(libs.postgresql)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -97,7 +97,6 @@ dependencies {
     testImplementation(libs.junit5JupiterApi)
     testImplementation(libs.junit5JupiterParams)
     testImplementation(libs.junit5JupiterEngine)
-    testImplementation(libs.unboundIdLdapSdk)
     testImplementation(libs.springTest)
     testImplementation(libs.mockitoJunit5)
 

--- a/statsd-lib/build.gradle.kts
+++ b/statsd-lib/build.gradle.kts
@@ -26,8 +26,6 @@ dependencies {
     testImplementation(libs.junit5JupiterEngine)
     testImplementation(libs.unboundIdLdapSdk)
     testImplementation(libs.mockitoJunit5)
-    testImplementation(libs.bytebuddy)
-    testImplementation(libs.bytebuddyagent)
 
     testRuntimeOnly(libs.jacocoAgent)
     testRuntimeOnly(libs.junit5PlatformLauncher)

--- a/statsd-lib/build.gradle.kts
+++ b/statsd-lib/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     testImplementation(libs.junit5JupiterApi)
     testImplementation(libs.junit5JupiterParams)
     testImplementation(libs.junit5JupiterEngine)
-    testImplementation(libs.unboundIdLdapSdk)
     testImplementation(libs.mockitoJunit5)
 
     testRuntimeOnly(libs.jacocoAgent)

--- a/statsd/build.gradle.kts
+++ b/statsd/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     testImplementation(libs.junit5JupiterApi)
     testImplementation(libs.junit5JupiterParams)
     testImplementation(libs.junit5JupiterEngine)
-    testImplementation(libs.unboundIdLdapSdk)
     testRuntimeOnly(libs.jacocoAgent)
     testRuntimeOnly(libs.junit5PlatformLauncher)
 

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -109,7 +109,6 @@ dependencies {
     testImplementation(libs.springBootStarterMail)
     testImplementation(libs.passay)
     testImplementation(libs.mockitoJunit5)
-    testImplementation(libs.tomcatJdbc)
     testImplementation(libs.springRestdocs)
     testImplementation(libs.greenmail)
     testImplementation(libs.commonsIo)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -94,6 +94,9 @@ dependencies {
     testImplementation(libs.unboundIdLdapSdk)
     testImplementation(project(":cloudfoundry-identity-model"))
     testImplementation(project(":cloudfoundry-identity-metrics-data"))
+    testImplementation(libs.apacheLdapApi) {
+        exclude(module = "slf4j-api")
+    }
     testImplementation(libs.flywayCore)
     testImplementation(libs.hibernateValidator)
     testImplementation(libs.selenium)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -103,7 +103,6 @@ dependencies {
     testImplementation(libs.seleniumRemoteDriver)
     testImplementation(libs.seleniumHttp)
     testImplementation(libs.orgJson)
-    testImplementation(libs.jsonAssert)
     testImplementation(libs.jsonPathAssert)
     testImplementation(libs.scim2SdkCommon)
     testImplementation(libs.springBootStarterLog4j2)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -113,8 +113,6 @@ dependencies {
     testImplementation(libs.springBootStarterMail)
     testImplementation(libs.passay)
     testImplementation(libs.mockitoJunit5)
-    testImplementation(libs.bytebuddy)
-    testImplementation(libs.bytebuddyagent)
     testImplementation(libs.tomcatJdbc)
     testImplementation(libs.springRestdocs)
     testImplementation(libs.greenmail)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -53,22 +53,9 @@ dependencies {
     }
     implementation(project(":cloudfoundry-identity-statsd-lib"))
     implementation(project(":cloudfoundry-identity-model"))
-    implementation(libs.springSecurityConfig)
     implementation(libs.springSecurityWeb)
     implementation(libs.springBootStarter)
     implementation(libs.springBootStarterWeb)
-    implementation(libs.thymeLeaf) {
-        exclude(module = "ognl")
-    }
-    implementation(libs.thymeleafSpring) {
-        exclude(module = "ognl")
-    }
-    implementation(libs.thymeleafDialect) {
-        exclude(module = "ognl")
-    }
-    implementation(libs.thymeleafExtrasSpringSecurity) {
-        exclude(module = "ognl")
-    }
     implementation(libs.braveInstrumentation)
     implementation(libs.braveContextSlf4j)
 
@@ -107,6 +94,7 @@ dependencies {
     testImplementation(libs.springContextSupport)
     testImplementation(libs.springSessionJdbc)
     testImplementation(libs.springTest)
+    testImplementation(libs.springSecurityConfig)
     testImplementation(libs.springSecurityLdap)
     testImplementation(libs.springSecurityTest)
     testImplementation(libs.springBootStarterMail)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -103,7 +103,6 @@ dependencies {
     testImplementation(libs.seleniumRemoteDriver)
     testImplementation(libs.seleniumHttp)
     testImplementation(libs.orgJson)
-    testImplementation(libs.scim2SdkCommon)
     testImplementation(libs.springBootStarterLog4j2)
     testImplementation(libs.springContextSupport)
     testImplementation(libs.springSessionJdbc)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -103,7 +103,6 @@ dependencies {
     testImplementation(libs.seleniumRemoteDriver)
     testImplementation(libs.seleniumHttp)
     testImplementation(libs.orgJson)
-    testImplementation(libs.jsonPathAssert)
     testImplementation(libs.scim2SdkCommon)
     testImplementation(libs.springBootStarterLog4j2)
     testImplementation(libs.springContextSupport)

--- a/uaa/build.gradle.kts
+++ b/uaa/build.gradle.kts
@@ -94,9 +94,6 @@ dependencies {
     testImplementation(libs.unboundIdLdapSdk)
     testImplementation(project(":cloudfoundry-identity-model"))
     testImplementation(project(":cloudfoundry-identity-metrics-data"))
-    testImplementation(libs.apacheLdapApi) {
-        exclude(module = "slf4j-api")
-    }
     testImplementation(libs.flywayCore)
     testImplementation(libs.hibernateValidator)
     testImplementation(libs.selenium)


### PR DESCRIPTION
## Summary

Dependency audit follow-up: removes declarations with zero direct usage and corrects mis-scoped ones. Every commit was individually gated on module unit tests against a recorded baseline; `server:integrationTest` green; `uaa:integrationTest` failures were proven pre-existing on clean develop (JDK 26 environment, not these changes).

- Remove `org.skyscreamer:jsonassert` (model, uaa tests + catalog) — zero imports, and the root build globally excludes it, so it never reached a classpath
- Remove `com.jayway.jsonpath:json-path-assert` (server, uaa tests + catalog) — zero imports; MockMvc's `jsonPath()` uses spring-test + json-path
- Remove explicit `byte-buddy`/`byte-buddy-agent` (server, uaa, statsd-lib tests + catalog) — Mockito provides both transitively at the Spring Boot BOM version
- Remove `unboundid-ldapsdk` from metrics-data, model, server, statsd, statsd-lib — its only user is uaa's `InMemoryLdapServer`; kept there
- Remove `scim2-sdk-common` and `tomcat-jdbc` from uaa tests — zero uaa imports; both arrive transitively via the server project
- model: declare `spring-security-core` instead of `spring-security-config` — model never imports `security.config`; core (still containing `security.access` in Spring Security 7.1) is what it compiles against
- uaa: remove 4 redundant Thymeleaf declarations; demote `spring-security-config` to `testImplementation` (only test code imports it; runtime gets it via server). bootWar verified to still bundle all five jars
- server: demote `org.json` to `testImplementation` — production imports are gone; the json jar no longer ships in the WAR

Note: an attempted removal of `api-ldap-model` from uaa tests is reverted in-branch — three test files use `commons-collections4.HashedMap`, which only reaches the classpath through it. Migrating them to `java.util.HashMap` would unlock that removal.

## Test plan
- [x] `server:integrationTest` green
- [x] `uaa:integrationTest`: 7 failures identical on unmodified develop (ByteBuddy/xmlunit vs JDK 26 Unsafe lockdown) — environmental
- [x] bootWar inspected: thymeleaf + spring-security-config jars still present (transitive), org.json jar gone
