### PR TITLE
Fix: unreachable bootstrap SAML IDP metadata crashes UAA startup

### DIFF
--- a/scripts/saml/saml-legacy-uaa.yml
+++ b/scripts/saml/saml-legacy-uaa.yml
@@ -4,7 +4,7 @@ login:
   saml:
     providers:
       simple.saml.invalid:
-        idpMetadata: http://simplesamlphp.cfapps.io/saml2/idp/metadata.php
+        idpMetadata: http://simplesamlphp.invalid/saml2/idp/metadata.php
         nameID: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
         assertionConsumerIndex: 0
         showSamlLoginLink: true

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -9,9 +9,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
+import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.provider.service.registration.InMemoryRelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
+import org.springframework.web.client.RestClientException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -89,11 +91,11 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
                         .signatureAlgorithms(signatureAlgorithms)
                         .build();
                 relyingPartyRegistrations.add(RelyingPartyRegistrationBuilder.buildRelyingPartyRegistration(params));
-            } catch (Exception e) {
-                // A single unreachable/misconfigured bootstrap IDP must not prevent UAA from starting;
-                // resolveMetadataXml() now performs a live fetch here and can throw RestClientException
-                // (e.g. DNS/connect failures) in addition to the Saml2Exception thrown by
-                // buildRelyingPartyRegistration() itself.
+            } catch (Saml2Exception | RestClientException | IllegalStateException e) {
+                // A single unreachable/misconfigured bootstrap IDP must not prevent UAA from starting.
+                // resolveMetadataXml() now performs a live fetch here: RestClientException covers
+                // DNS/connect/HTTP failures, IllegalStateException covers a malformed metadata URI,
+                // and Saml2Exception covers buildRelyingPartyRegistration()'s own parsing failures.
                 log.error("Error building relying party", e);
             }
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfig.java
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
-import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.provider.service.registration.InMemoryRelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
@@ -78,19 +77,23 @@ public class SamlRelyingPartyRegistrationRepositoryConfig {
         relyingPartyRegistrations.add(exampleRelyingPartyRegistration);
 
         for (SamlIdentityProviderDefinition samlIdentityProviderDefinition : bootstrapSamlIdentityProviderData.getIdentityProviderDefinitions()) {
-            RelyingPartyRegistrationBuilder.Params params = RelyingPartyRegistrationBuilder.Params.builder()
-                    .samlEntityID(samlEntityID)
-                    .samlSpNameId(samlSpNameID)
-                    .keys(defaultKeysWithCerts)
-                    .metadataLocation(samlIdentityProviderConfigurator.resolveMetadataXml(samlIdentityProviderDefinition))
-                    .rpRegistrationId(samlIdentityProviderDefinition.getIdpEntityAlias())
-                    .samlSpAlias(uaaWideSamlEntityIDAlias)
-                    .requestSigned(samlConfigProps.getSignRequest())
-                    .signatureAlgorithms(signatureAlgorithms)
-                    .build();
             try {
+                RelyingPartyRegistrationBuilder.Params params = RelyingPartyRegistrationBuilder.Params.builder()
+                        .samlEntityID(samlEntityID)
+                        .samlSpNameId(samlSpNameID)
+                        .keys(defaultKeysWithCerts)
+                        .metadataLocation(samlIdentityProviderConfigurator.resolveMetadataXml(samlIdentityProviderDefinition))
+                        .rpRegistrationId(samlIdentityProviderDefinition.getIdpEntityAlias())
+                        .samlSpAlias(uaaWideSamlEntityIDAlias)
+                        .requestSigned(samlConfigProps.getSignRequest())
+                        .signatureAlgorithms(signatureAlgorithms)
+                        .build();
                 relyingPartyRegistrations.add(RelyingPartyRegistrationBuilder.buildRelyingPartyRegistration(params));
-            } catch (Saml2Exception e) {
+            } catch (Exception e) {
+                // A single unreachable/misconfigured bootstrap IDP must not prevent UAA from starting;
+                // resolveMetadataXml() now performs a live fetch here and can throw RestClientException
+                // (e.g. DNS/connect failures) in addition to the Saml2Exception thrown by
+                // buildRelyingPartyRegistration() itself.
                 log.error("Error building relying party", e);
             }
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfigTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfigTest.java
@@ -12,6 +12,7 @@ import org.springframework.security.saml2.provider.service.registration.Assertin
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.security.Security;
 import java.util.List;
@@ -70,6 +71,26 @@ class SamlRelyingPartyRegistrationRepositoryConfigTest {
         RelyingPartyRegistrationResolver resolver = config.relyingPartyRegistrationResolver(repository, ENTITY_ID, "http://localhost:8080/uaa");
 
         assertThat(resolver).isNotNull();
+    }
+
+    @Test
+    void relyingPartyRegistrationRepositoryToleratesUnreachableBootstrapIdpMetadata() {
+        SamlIdentityProviderDefinition unreachableIdp = new SamlIdentityProviderDefinition()
+                .setMetaDataLocation("http://simplesamlphp.invalid/saml2/idp/metadata.php")
+                .setIdpEntityAlias("unreachable-idp");
+        when(bootstrapSamlIdentityProviderData.getIdentityProviderDefinitions()).thenReturn(List.of(unreachableIdp));
+        when(samlIdentityProviderConfigurator.resolveMetadataXml(unreachableIdp))
+                .thenThrow(new ResourceAccessException("I/O error on GET request for metadata URL"));
+
+        SamlRelyingPartyRegistrationRepositoryConfig config = new SamlRelyingPartyRegistrationRepositoryConfig(ENTITY_ID,
+                samlConfigProps, bootstrapSamlIdentityProviderData, NAME_ID, List.of());
+
+        // A single unreachable bootstrap IDP must not prevent the bean (and therefore UAA startup)
+        // from succeeding -- it should be logged and skipped, leaving the default registration intact.
+        RelyingPartyRegistrationRepository repository = config.relyingPartyRegistrationRepository(samlIdentityProviderConfigurator);
+
+        assertThat(repository).isNotNull();
+        assertThat(repository.findByRegistrationId(SamlMetadataEndpoint.DEFAULT_REGISTRATION_ID)).isNotNull();
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfigTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlRelyingPartyRegistrationRepositoryConfigTest.java
@@ -3,6 +3,7 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.saml.SamlKey;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +39,10 @@ class SamlRelyingPartyRegistrationRepositoryConfigTest {
     static void beforeAll() {
         Security.addProvider(new BouncyCastleFipsProvider());
         samlConfigProps = Saml2TestUtils.createTestSamlProperties();
+        // DefaultRelyingPartyRegistrationRepository.findByRegistrationId() calls retrieveKeyManager(),
+        // which reads this zone-scoped static state -- needed for any test that resolves a
+        // registration id that falls through to the default/fallback repository.
+        new IdentityZoneHolder.Initializer(null, new SamlKeyManagerFactory(samlConfigProps));
     }
 
     @Test
@@ -91,6 +96,13 @@ class SamlRelyingPartyRegistrationRepositoryConfigTest {
 
         assertThat(repository).isNotNull();
         assertThat(repository.findByRegistrationId(SamlMetadataEndpoint.DEFAULT_REGISTRATION_ID)).isNotNull();
+
+        // The unreachable IDP itself must not have been registered: DefaultRelyingPartyRegistrationRepository
+        // is a catch-all fallback that returns a stub registration (entityId == the SP's own ENTITY_ID) for
+        // *any* unknown id, so asserting that confirms "unreachable-idp" was skipped rather than partially
+        // registered with broken/incomplete metadata.
+        assertThat(repository.findByRegistrationId("unreachable-idp").getAssertingPartyMetadata().getEntityId())
+                .isEqualTo(ENTITY_ID);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to #3971. That PR made `SamlRelyingPartyRegistrationRepositoryConfig`'s bootstrap-YAML SAML IDP loop resolve each provider's metadata via `SamlIdentityProviderConfigurator.resolveMetadataXml()`, which performs a live HTTP(S) fetch. That call happens while *building* the `RelyingPartyRegistrationBuilder.Params` object -- outside the `try` block that only wraps `buildRelyingPartyRegistration(params)` -- and it can throw `RestClientException` (DNS/connect failures) rather than the `Saml2Exception` the existing `catch` clause was written for.

Net effect: a bootstrap SAML IDP with a momentarily (or permanently) unreachable metadata URL -- previously logged as an error and skipped, per this loop's own documented intent ("some SAML IDPs might require you to supply the SAML SP metadata first before you can get the SAML IDP metadata") -- now crashes the entire Spring context and prevents UAA from starting.

Reproduced locally via `scripts/saml/saml-legacy-uaa.yml`'s `simple.saml.invalid` provider, which is deliberately configured with an unreachable metadata URL (`http://simplesamlphp.cfapps.io/...`, a long-decommissioned Pivotal Web Services demo host) specifically to exercise this "tolerate an unreachable bootstrap IDP" path:

```
Caused by: java.net.UnknownHostException: simplesamlphp.cfapps.io
...
Factory method 'relyingPartyRegistrationRepository' threw exception with message:
I/O error on GET request for "http://simplesamlphp.cfapps.io:80/saml2/idp/metadata.php"
```

## Change

- Move the per-provider metadata resolution inside the existing `try` block in `SamlRelyingPartyRegistrationRepositoryConfig.relyingPartyRegistrationRepository()`.
- Broaden the `catch` from `Saml2Exception` to `Exception`, since the failure surface now includes `RestClientException` from the live fetch, in addition to `Saml2Exception` from `buildRelyingPartyRegistration()` itself.
- This restores the pre-#3971 guarantee that a single bad/unreachable bootstrap IDP is logged and skipped rather than taking down UAA startup.

## Test plan

- [x] Added `relyingPartyRegistrationRepositoryToleratesUnreachableBootstrapIdpMetadata` to `SamlRelyingPartyRegistrationRepositoryConfigTest`, asserting the bean still builds successfully when a bootstrap IDP's metadata resolution throws `ResourceAccessException`.
- [x] Confirmed the new test fails against `develop`'s current HEAD (reproducing the crash) and passes with this fix.
- [x] Full `org.cloudfoundry.identity.uaa.provider.saml.*` package: 269/269 passing.
