### PR TITLE
Fix additionalConfiguration not mapped during YAML IdP bootstrap

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
@@ -148,6 +148,7 @@ public class OauthIDPWrapperFactoryBean {
         idpDefinition.setTokenKey((String) idpDefinitionMap.get("tokenKey"));
         idpDefinition.setIssuer((String) idpDefinitionMap.get("issuer"));
         idpDefinition.setAttributeMappings((Map<String, Object>) idpDefinitionMap.get(ATTRIBUTE_MAPPINGS));
+        idpDefinition.setAdditionalConfiguration((Map<String, Object>) idpDefinitionMap.get("additionalConfiguration"));
         idpDefinition.setScopes((List<String>) idpDefinitionMap.get("scopes"));
         idpDefinition.setUserPropagationParameter((String) idpDefinitionMap.get("userPropagationParameter"));
         idpDefinition.setGroupMappingMode(parseExternalGroupMappingMode(idpDefinitionMap.get("groupMappingMode")));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
@@ -120,6 +120,22 @@ class OauthIdentityProviderDefinitionFactoryBeanTest {
     }
 
     @Test
+    void additionalConfigurationIsMapped() {
+        Map<String, Object> additionalConfiguration = map(
+                entry("origin_override", map(entry("uaa", "uaa")))
+        );
+        idpDefinitionMap.put("additionalConfiguration", additionalConfiguration);
+        factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
+        assertThat(providerDefinition.getAdditionalConfiguration()).containsExactlyInAnyOrderEntriesOf(additionalConfiguration);
+    }
+
+    @Test
+    void additionalConfigurationIsNullWhenNotProvided() {
+        factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
+        assertThat(providerDefinition.getAdditionalConfiguration()).isNull();
+    }
+
+    @Test
     void jwtClientAuthenticationTrue() {
         Map<String, Map> definitions = new HashMap<>();
         idpDefinitionMap.put("jwtclientAuthentication", Boolean.TRUE);


### PR DESCRIPTION
## Summary
- `OauthIDPWrapperFactoryBean#setCommonProperties()` maps nearly every field from a YAML-defined OAuth/OIDC identity provider onto the provider definition object (`attributeMappings`, `scopes`, `issuer`, etc.), but silently skipped `additionalConfiguration`.
- Any OAuth/OIDC identity provider bootstrapped from YAML therefore always ends up with `additionalConfiguration == null`, regardless of what the manifest sets. Providers created/updated via the REST API are unaffected, since Jackson deserializes the field correctly there.
- Added the missing one-line mapping, following the exact pattern used for the other fields in this method.

## Test plan
- [x] Added `additionalConfigurationIsMapped` — verifies a YAML map containing `additionalConfiguration` is reflected on the definition object after `setCommonProperties`.
- [x] Added `additionalConfigurationIsNullWhenNotProvided` — verifies null passthrough when the key is absent.
- [x] Ran `OauthIdentityProviderDefinitionFactoryBeanTest` locally — all 26 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)