### PR TITLE
fix: strip subdomain header on UAA-zone switch to prevent invitation …

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneSwitchingFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneSwitchingFilter.java
@@ -133,7 +133,7 @@ public class IdentityZoneSwitchingFilter extends OncePerRequestFilter {
             if (logger.isDebugEnabled()) {
                 logger.debug("Superfluous attempt to switch to UAA(system) zone. Header[" + HEADER + "] will be ignored");
             }
-            filterChain.doFilter(new HttpHeadersFilterRequestWrapper(Arrays.asList(HEADER),request), response);
+            filterChain.doFilter(new HttpHeadersFilterRequestWrapper(Arrays.asList(HEADER, SUBDOMAIN_HEADER), request), response);
             return;
         }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneSwitchingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/IdentityZoneSwitchingFilterTests.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cloudfoundry.identity.uaa.zone.IdentityZoneSwitchingFilter.HEADER;
+import static org.cloudfoundry.identity.uaa.zone.IdentityZoneSwitchingFilter.SUBDOMAIN_HEADER;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -60,6 +61,27 @@ class IdentityZoneSwitchingFilterTests {
         HttpServletRequest modifiedRequest = requestArgumentCaptor.getValue();
         assertThat(modifiedRequest).isInstanceOf(HttpHeadersFilterRequestWrapper.class);
         assertThat(modifiedRequest.getHeader(HEADER)).isNull();
+    }
+
+    @Test
+    void bothHeadersRemovedIfSwitchingToUaaZone() throws Exception {
+        IdentityZoneProvisioning zoneProvisioning = mock(IdentityZoneProvisioning.class);
+        when(zoneProvisioning.retrieve(anyString())).thenReturn(IdentityZone.getUaa());
+        IdentityZoneSwitchingFilter filter = new IdentityZoneSwitchingFilter(zoneProvisioning);
+
+        FilterChain chain = mock(FilterChain.class);
+        ArgumentCaptor<HttpServletRequest> requestArgumentCaptor = ArgumentCaptor.forClass(HttpServletRequest.class);
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getHeader(HEADER)).thenReturn(IdentityZone.getUaaZoneId());
+        when(request.getHeader(SUBDOMAIN_HEADER)).thenReturn("uaa");
+
+        filter.doFilterInternal(request, null, chain);
+        verify(chain).doFilter(requestArgumentCaptor.capture(), any());
+
+        HttpServletRequest modifiedRequest = requestArgumentCaptor.getValue();
+        assertThat(modifiedRequest).isInstanceOf(HttpHeadersFilterRequestWrapper.class);
+        assertThat(modifiedRequest.getHeader(HEADER)).isNull();
+        assertThat(modifiedRequest.getHeader(SUBDOMAIN_HEADER)).isNull();
     }
 
 }


### PR DESCRIPTION
fix: strip subdomain header on UAA-zone switch to prevent invitation provider-policy bypass

  ## Summary

  - IdentityZoneSwitchingFilter was only stripping X-Identity-Zone-Id when a request resolved to the UAA (system) zone, leaving X-Identity-Zone-Subdomain on the forwarded request.
  - InvitationsEndpoint skips client lookup when either zone header is present, so the leftover subdomain header caused client to remain null.
  - DomainFilter only applies allowed_providers restrictions when a client was loaded — with client == null the per-client identity-provider policy was silently bypassed.
  - A caller with only scim.invite could send X-Identity-Zone-Id: uaa plus any X-Identity-Zone-Subdomain value to invite users via identity providers the OAuth client was explicitly prohibited from using.