### PR TITLE
Fix remote address extraction in audit event origin string

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
@@ -31,6 +31,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.util.StringUtils;
 import tools.jackson.core.type.TypeReference;
 
 import java.io.Serial;
@@ -41,7 +42,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.cloudfoundry.identity.uaa.util.UaaTokenUtils.isJwtToken;
-import static org.springframework.util.StringUtils.hasText;
 
 /**
  * Base class for UAA events that want to publish audit records.
@@ -137,10 +137,10 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
 
     private Optional<String> extractRemoteAddress(Object details) {
         return switch (details) {
-            case UaaAuthenticationDetails d -> Optional.ofNullable(d.getOrigin());
-            case OAuth2AuthenticationDetails d -> Optional.ofNullable(d.getRemoteAddress());
-            case WebAuthenticationDetails d -> Optional.of(d.getRemoteAddress());
-            case Map<?, ?> map -> Optional.ofNullable(map.get("remoteAddress")).map(Object::toString);
+            case UaaAuthenticationDetails d -> Optional.ofNullable(d.getOrigin()).filter(StringUtils::hasText);
+            case OAuth2AuthenticationDetails d -> Optional.ofNullable(d.getRemoteAddress()).filter(StringUtils::hasText);
+            case WebAuthenticationDetails d -> Optional.ofNullable(d.getRemoteAddress()).filter(StringUtils::hasText);
+            case Map<?, ?> map -> Optional.ofNullable(map.get("remoteAddress")).map(Object::toString).filter(StringUtils::hasText);
             case String jsonBlob -> extractRemoteAddressFromJson(jsonBlob);
             default -> {
                 logger.warn("Unhandled Authentication.details type in audit origin: {}", details.getClass().getName());
@@ -166,7 +166,7 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
         } else if (caller.getDetails() instanceof OAuth2AuthenticationDetails oAuth2AuthenticationDetails) {
             tokenValue = oAuth2AuthenticationDetails.getTokenValue();
         }
-        if (hasText(tokenValue)) {
+        if (StringUtils.hasText(tokenValue)) {
             if (isJwtToken(tokenValue)) {
                 try {
                     Jwt token = JwtHelper.decode(tokenValue);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
@@ -30,6 +30,7 @@ import org.springframework.context.ApplicationEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import tools.jackson.core.type.TypeReference;
 
 import java.io.Serial;
@@ -138,6 +139,7 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
         return switch (details) {
             case UaaAuthenticationDetails d -> Optional.ofNullable(d.getOrigin());
             case OAuth2AuthenticationDetails d -> Optional.ofNullable(d.getRemoteAddress());
+            case WebAuthenticationDetails d -> Optional.of(d.getRemoteAddress());
             case Map<?, ?> map -> Optional.ofNullable(map.get("remoteAddress")).map(Object::toString);
             case String jsonBlob -> extractRemoteAddressFromJson(jsonBlob);
             default -> {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
@@ -148,19 +148,13 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
     }
 
     private Optional<String> extractRemoteAddressFromJson(String jsonBlob) {
-        Map<String, Object> map;
         try {
-            map = JsonUtils.readValue(jsonBlob, new TypeReference<>() {
+            Map<String, Object> map = JsonUtils.readValue(jsonBlob, new TypeReference<>() {
             });
-        } catch (Exception _) {
+            return map == null ? Optional.empty() : extractRemoteAddress(map);
+        } catch (JsonUtils.JsonUtilException _) {
             return Optional.empty();
         }
-
-        if (map == null) {
-            return Optional.empty();
-        }
-
-        return Optional.ofNullable(map.get("remoteAddress")).map(Object::toString);
     }
 
     private void appendTokenDetails(Authentication caller, StringBuilder builder) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEvent.java
@@ -13,10 +13,10 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.audit.event;
 
-import tools.jackson.core.type.TypeReference;
 import org.cloudfoundry.identity.uaa.audit.AuditEvent;
 import org.cloudfoundry.identity.uaa.audit.AuditEventType;
 import org.cloudfoundry.identity.uaa.audit.UaaAuditService;
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
 import org.cloudfoundry.identity.uaa.oauth.UaaOauth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.jwt.Jwt;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
@@ -24,16 +24,20 @@ import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.provider.authentication.OAuth2AuthenticationDetails;
 import org.cloudfoundry.identity.uaa.oauth.token.ClaimConstants;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import tools.jackson.core.type.TypeReference;
 
 import java.io.Serial;
 import java.security.Principal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.cloudfoundry.identity.uaa.util.UaaTokenUtils.isJwtToken;
 import static org.springframework.util.StringUtils.hasText;
@@ -49,6 +53,9 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
 
     @Serial
     private static final long serialVersionUID = -7639844193401892160L;
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractUaaEvent.class);
+
     private final transient String zoneId;
 
     private Authentication authentication;
@@ -115,28 +122,48 @@ public abstract class AbstractUaaEvent extends ApplicationEvent {
             builder.append("caller=").append(caller.getName());
         }
 
-        if (caller.getDetails() != null) {
+        Object details = caller.getDetails();
+        if (details != null) {
             builder.append(", details=(");
-            try {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> map =
-                        JsonUtils.readValue((String) caller.getDetails(), new TypeReference<Map<String, Object>>(){
-                        });
-                if (map.containsKey("remoteAddress")) {
-                    builder.append("remoteAddress=").append(map.get("remoteAddress")).append(", ");
-                }
-                builder.append("type=").append(caller.getDetails().getClass().getSimpleName());
-            } catch (Exception _) {
-                // ignore
-                builder.append(caller.getDetails());
-            }
+            extractRemoteAddress(details).ifPresent(address -> builder.append("remoteAddress=").append(address).append(", "));
+            builder.append("type=").append(details.getClass().getSimpleName());
             appendTokenDetails(caller, builder);
             builder.append(")");
         }
+
         return builder.toString();
     }
 
-    protected void appendTokenDetails(Authentication caller, StringBuilder builder) {
+    private Optional<String> extractRemoteAddress(Object details) {
+        return switch (details) {
+            case UaaAuthenticationDetails d -> Optional.ofNullable(d.getOrigin());
+            case OAuth2AuthenticationDetails d -> Optional.ofNullable(d.getRemoteAddress());
+            case Map<?, ?> map -> Optional.ofNullable(map.get("remoteAddress")).map(Object::toString);
+            case String jsonBlob -> extractRemoteAddressFromJson(jsonBlob);
+            default -> {
+                logger.warn("Unhandled Authentication.details type in audit origin: {}", details.getClass().getName());
+                yield Optional.empty();
+            }
+        };
+    }
+
+    private Optional<String> extractRemoteAddressFromJson(String jsonBlob) {
+        Map<String, Object> map;
+        try {
+            map = JsonUtils.readValue(jsonBlob, new TypeReference<>() {
+            });
+        } catch (Exception _) {
+            return Optional.empty();
+        }
+
+        if (map == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(map.get("remoteAddress")).map(Object::toString);
+    }
+
+    private void appendTokenDetails(Authentication caller, StringBuilder builder) {
         String tokenValue = null;
         if (caller instanceof UaaOauth2Authentication uaaOauth2Authentication) {
             tokenValue = uaaOauth2Authentication.getTokenValue();

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/event/AbstractUaaAuthenticationEvent.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/event/AbstractUaaAuthenticationEvent.java
@@ -17,6 +17,10 @@ import org.cloudfoundry.identity.uaa.audit.event.AbstractUaaEvent;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
 import org.springframework.security.core.Authentication;
 
+import java.util.StringJoiner;
+
+import static org.springframework.util.StringUtils.hasText;
+
 /**
  * @author Luke Taylor
  */
@@ -27,7 +31,21 @@ public abstract class AbstractUaaAuthenticationEvent extends AbstractUaaEvent {
     }
 
     protected String getOrigin(UaaAuthenticationDetails details) {
-        return details == null ? "unknown" : details.toString();
+        if (details == null) {
+            return "unknown";
+        }
+
+        StringJoiner joiner = new StringJoiner(", ");
+
+        if (hasText(details.getOrigin())) {
+            joiner.add("remoteAddress=" + details.getOrigin());
+        }
+
+        if (hasText(details.getClientId())) {
+            joiner.add("clientId=" + details.getClientId());
+        }
+
+        return joiner.length() == 0 ? "unknown" : joiner.toString();
     }
 
     UaaAuthenticationDetails getAuthenticationDetails() {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEventTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEventTest.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
 import java.util.Map;
 
@@ -192,6 +193,21 @@ class AbstractUaaEventTest {
         String originString = event.getOrigin(authentication);
         assertThat(originString).contains("client=clientid")
                 .contains("details=(remoteAddress=172.18.0.1, type=OAuth2AuthenticationDetails");
+    }
+
+    @Test
+    void getOrigin_whenWebAuthenticationDetails_extractsRemoteAddressFromAccessor() {
+        UaaOauth2Authentication authentication = mock(UaaOauth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(authentication.getName()).thenReturn("marissa");
+        WebAuthenticationDetails webDetails = mock(WebAuthenticationDetails.class);
+        when(webDetails.getRemoteAddress()).thenReturn("192.168.1.5");
+        when(authentication.getDetails()).thenReturn(webDetails);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("marissa")
+                .contains("details=(remoteAddress=192.168.1.5, type=WebAuthenticationDetails");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEventTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/audit/event/AbstractUaaEventTest.java
@@ -4,6 +4,7 @@ import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
 import org.cloudfoundry.identity.uaa.audit.AuditEventType;
 import org.cloudfoundry.identity.uaa.audit.JdbcAuditService;
 import org.cloudfoundry.identity.uaa.audit.UaaAuditService;
+import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
 import org.cloudfoundry.identity.uaa.oauth.UaaOauth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Request;
@@ -69,19 +70,34 @@ class AbstractUaaEventTest {
     }
 
     @Test
-    void getOrigin() {
+    void getOrigin_whenMapDetailsHasNoKnownKeys_doesNotLeakMapContents() {
         UaaOauth2Authentication authentication = mock(UaaOauth2Authentication.class);
         OAuth2Request oAuth2Request = mock(OAuth2Request.class);
         when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
         when(authentication.getName()).thenReturn("marissa");
-        when(authentication.getDetails()).thenReturn(Map.of("misc", "somedetails", "remoteAddress", "external"));
+        when(authentication.getDetails()).thenReturn(Map.of("grant_type", "password", "username", "marissa", "client_id", "clientid"));
         SecurityContextHolder.getContext().setAuthentication(authentication);
         String originString = event.getOrigin(authentication);
         assertThat(originString).contains("marissa")
                 .contains("client=null")
-                .contains("misc=somedetails")
-                .contains("remoteAddress=external")
-                .contains("details=({");
+                .doesNotContain("remoteAddress=")
+                .doesNotContain("grant_type=")
+                .doesNotContain("username=")
+                .doesNotContain("client_id=");
+    }
+
+    @Test
+    void getOrigin_whenMapDetailsContainsRemoteAddress_extractsRemoteAddress() {
+        UaaOauth2Authentication authentication = mock(UaaOauth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(authentication.getName()).thenReturn("marissa");
+        when(authentication.getDetails()).thenReturn(Map.of("grant_type", "password", "remoteAddress", "10.0.0.1"));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("marissa")
+                .contains("remoteAddress=10.0.0.1")
+                .doesNotContain("grant_type=");
     }
 
     @Test
@@ -102,7 +118,80 @@ class AbstractUaaEventTest {
                 .contains("client=null")
                 .doesNotContain("misc=somedetails")
                 .contains("remoteAddress=external")
+                .contains("type=String")
                 .doesNotContain("{");
+    }
+
+    @Test
+    void getOrigin_whenOAuth2AuthenticationWithUser_emitsClientAndUser() {
+        OAuth2Authentication authentication = mock(OAuth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(oAuth2Request.getClientId()).thenReturn("clientid");
+        when(authentication.isClientOnly()).thenReturn(false);
+        when(authentication.getName()).thenReturn("marissa");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("client=clientid")
+                .contains("user=marissa");
+    }
+
+    @Test
+    void getOrigin_whenStringDetailsIsNotJson_omitsRemoteAddress() {
+        UaaOauth2Authentication authentication = mock(UaaOauth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(authentication.getName()).thenReturn("marissa");
+        when(authentication.getDetails()).thenReturn("session-id-abc");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("marissa")
+                .contains("type=String")
+                .doesNotContain("remoteAddress=");
+    }
+
+    @Test
+    void getOrigin_whenJsonDetailsMissingRemoteAddress_omitsRemoteAddress() {
+        UaaOauth2Authentication authentication = mock(UaaOauth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(authentication.getName()).thenReturn("marissa");
+        when(authentication.getDetails()).thenReturn("{\"remoteAddress\":null,\"sessionId\":\"abc\"}");
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("marissa")
+                .contains("type=String")
+                .doesNotContain("remoteAddress=");
+    }
+
+    @Test
+    void getOrigin_whenUaaAuthenticationDetails_extractsRemoteAddressFromAccessor() {
+        UaaOauth2Authentication authentication = mock(UaaOauth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(authentication.getName()).thenReturn("marissa");
+        UaaAuthenticationDetails uaaDetails = mock(UaaAuthenticationDetails.class);
+        when(uaaDetails.getOrigin()).thenReturn("10.0.0.1");
+        when(authentication.getDetails()).thenReturn(uaaDetails);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("details=(remoteAddress=10.0.0.1, type=UaaAuthenticationDetails");
+    }
+
+    @Test
+    void getOrigin_whenOAuth2AuthenticationDetails_extractsRemoteAddressFromAccessor() {
+        OAuth2Authentication authentication = mock(OAuth2Authentication.class);
+        OAuth2Request oAuth2Request = mock(OAuth2Request.class);
+        when(authentication.getOAuth2Request()).thenReturn(oAuth2Request);
+        when(oAuth2Request.getClientId()).thenReturn("clientid");
+        when(authentication.isClientOnly()).thenReturn(true);
+        OAuth2AuthenticationDetails oauthDetails = mock(OAuth2AuthenticationDetails.class);
+        when(oauthDetails.getRemoteAddress()).thenReturn("172.18.0.1");
+        when(authentication.getDetails()).thenReturn(oauthDetails);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String originString = event.getOrigin(authentication);
+        assertThat(originString).contains("client=clientid")
+                .contains("details=(remoteAddress=172.18.0.1, type=OAuth2AuthenticationDetails");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/event/UserAuthenticationSuccessEventTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/event/UserAuthenticationSuccessEventTests.java
@@ -27,6 +27,6 @@ class UserAuthenticationSuccessEventTests {
 
         assertThat(origin).contains("remoteAddress=127.10.10.10")
                 .contains("clientId=client-id")
-                .contains("sessionId=<SESSION>");
+                .doesNotContain("sessionId");
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -1392,12 +1392,14 @@ class AuditCheckMockMvcTests {
         assertThat(actualLogMessage).startsWith(expectedAuditEventType.toString() + " ")
                 .contains("principal=%s,".formatted(expectedPrincipal))
                 .contains(" ('%s'): ".formatted(expectedUserName))
-                .contains(", identityZoneId=[uaa]");
+                .contains(", identityZoneId=[uaa]")
+                .doesNotContain("sessionId");
     }
 
     private static void assertGroupMembershipLogMessage(String actualLogMessage, AuditEventType expectedEventType, String expectedGroupDisplayName, String expectedGroupId, String... expectedUserIds) {
         assertThat(actualLogMessage).startsWith(expectedEventType.toString() + " ")
-                .contains("principal=%s,".formatted(expectedGroupId));
+                .contains("principal=%s,".formatted(expectedGroupId))
+                .doesNotContain("sessionId");
 
         Pattern groupLogPattern = Pattern.compile(" \\('\\{\"group_name\":\"" + Pattern.quote(expectedGroupDisplayName) + "\",\"members\":\\[(.*?)]}'\\): ");
         Matcher patternMatcher = groupLogPattern.matcher(actualLogMessage);

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -252,19 +252,17 @@ class AuditCheckMockMvcTests {
 
         IdentityProviderAuthenticationSuccessEvent passwordEvent = testListener.getLatestEventOfType(IdentityProviderAuthenticationSuccessEvent.class);
         assertThat(passwordEvent.getUser().getUsername()).isEqualTo(testUser.getUserName());
-        assertThat(passwordEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         UserAuthenticationSuccessEvent userEvent = testListener.getLatestEventOfType(UserAuthenticationSuccessEvent.class);
         assertThat(userEvent.getUser().getId()).isEqualTo(passwordEvent.getUser().getId());
         assertThat(userEvent.getUser().getUsername()).isEqualTo(testUser.getUserName());
-        assertThat(userEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         assertThat(passwordEvent.getAuthenticationType()).isEqualTo(OriginKeys.UAA);
 
         String passwordLogMsg = testLogger.getFirstLogMessageOfType(IdentityProviderAuthenticationSuccess);
-        assertLogMessageWithSession(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
 
         String userEventLogMsg = testLogger.getFirstLogMessageOfType(UserAuthenticationSuccess);
-        assertLogMessageWithSession(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
     }
 
     @ParameterizedTest
@@ -288,19 +286,17 @@ class AuditCheckMockMvcTests {
 
         IdentityProviderAuthenticationSuccessEvent passwordEvent = testListener.getLatestEventOfType(IdentityProviderAuthenticationSuccessEvent.class);
         assertThat(passwordEvent.getUser().getUsername()).isEqualTo(testUser.getUserName());
-        assertThat(passwordEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         UserAuthenticationSuccessEvent userEvent = testListener.getLatestEventOfType(UserAuthenticationSuccessEvent.class);
         assertThat(userEvent.getUser().getId()).isEqualTo(passwordEvent.getUser().getId());
         assertThat(userEvent.getUser().getUsername()).isEqualTo(testUser.getUserName());
-        assertThat(userEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         assertThat(passwordEvent.getAuthenticationType()).isEqualTo(OriginKeys.UAA);
 
         String passwordLogMsg = testLogger.getFirstLogMessageOfType(IdentityProviderAuthenticationSuccess);
-        assertLogMessageWithSession(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
 
         String userEventLogMsg = testLogger.getFirstLogMessageOfType(UserAuthenticationSuccess);
-        assertLogMessageWithSession(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
     }
 
     @Test
@@ -321,24 +317,21 @@ class AuditCheckMockMvcTests {
 
         IdentityProviderAuthenticationFailureEvent idpAuthFailEvent = (IdentityProviderAuthenticationFailureEvent) testListener.getEvents().getFirst();
         assertThat(idpAuthFailEvent.getUsername()).isEqualTo(testUser.getUserName());
-        assertThat(idpAuthFailEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         UserAuthenticationFailureEvent userAuthFailEvent = (UserAuthenticationFailureEvent) testListener.getEvents().get(1);
         assertThat(userAuthFailEvent.getUser().getUsername()).isEqualTo(testUser.getUserName());
-        assertThat(userAuthFailEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         PrincipalAuthenticationFailureEvent principalAuthFailEvent = (PrincipalAuthenticationFailureEvent) testListener.getEvents().get(2);
         assertThat(principalAuthFailEvent.getName()).isEqualTo(testUser.getUserName());
-        assertThat(principalAuthFailEvent.getAuditEvent().getOrigin()).doesNotContain("sessionId"); // PrincipalAuthenticationFailureEvent should not contain sessionId at all
 
         String idpAuthFailMsg = testLogger.getMessageAtIndex(0);
-        assertLogMessageWithSession(idpAuthFailMsg, IdentityProviderAuthenticationFailure, "null", testUser.getUserName());
+        assertLogMessage(idpAuthFailMsg, IdentityProviderAuthenticationFailure, "null", testUser.getUserName());
 
         String userAuthFailMsg = testLogger.getMessageAtIndex(1);
-        assertLogMessageWithSession(userAuthFailMsg, UserAuthenticationFailure, testUser.getId(), testUser.getUserName());
+        assertLogMessage(userAuthFailMsg, UserAuthenticationFailure, testUser.getId(), testUser.getUserName());
 
         String principalAuthFailMsg = testLogger.getMessageAtIndex(2);
-        assertLogMessageWithoutSession(principalAuthFailMsg, PrincipalAuthenticationFailure, testUser.getUserName(), "null");
+        assertLogMessage(principalAuthFailMsg, PrincipalAuthenticationFailure, testUser.getUserName(), "null");
     }
 
     @Test
@@ -371,10 +364,9 @@ class AuditCheckMockMvcTests {
         verify(authSuccessListener, times(1)).onApplicationEvent(captor.capture());
         UserAuthenticationSuccessEvent event = captor.getValue();
         assertThat(event.getUser().getUsername()).isEqualTo(molly.getUserName());
-        assertThat(event.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         String userAuthLogMsg = testLogger.getFirstLogMessageOfType(UserAuthenticationSuccess);
-        assertLogMessageWithSession(userAuthLogMsg, UserAuthenticationSuccess, molly.getId(), molly.getUserName());
+        assertLogMessage(userAuthLogMsg, UserAuthenticationSuccess, molly.getId(), molly.getUserName());
     }
 
     @Test
@@ -400,10 +392,9 @@ class AuditCheckMockMvcTests {
 
         UnverifiedUserAuthenticationEvent unverifiedUserAuthEvent = testListener.getLatestEventOfType(UnverifiedUserAuthenticationEvent.class);
         assertThat(unverifiedUserAuthEvent.getUser().getUsername()).isEqualTo(molly.getUserName());
-        assertThat(unverifiedUserAuthEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         String userAuthLogMsg = testLogger.getFirstLogMessageOfType(UnverifiedUserAuthentication);
-        assertLogMessageWithSession(userAuthLogMsg, UnverifiedUserAuthentication, molly.getId(), molly.getUserName());
+        assertLogMessage(userAuthLogMsg, UnverifiedUserAuthentication, molly.getId(), molly.getUserName());
     }
 
     @Test
@@ -427,10 +418,9 @@ class AuditCheckMockMvcTests {
 
         UnverifiedUserAuthenticationEvent event = (UnverifiedUserAuthenticationEvent) testListener.getLatestEvent();
         assertThat(event.getUser().getUsername()).isEqualTo(molly.getUserName());
-        assertThat(event.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         String userAuthLogMsg = testLogger.getFirstLogMessageOfType(UnverifiedUserAuthentication);
-        assertLogMessageWithSession(userAuthLogMsg, UnverifiedUserAuthentication, molly.getId(), molly.getUserName());
+        assertLogMessage(userAuthLogMsg, UnverifiedUserAuthentication, molly.getId(), molly.getUserName());
     }
 
     @Test
@@ -453,19 +443,15 @@ class AuditCheckMockMvcTests {
         assertThat(event1.getUsername()).isEqualTo(testUser.getUserName());
         assertThat(event2.getUser().getUsername()).isEqualTo(testUser.getUserName());
         assertThat(event3.getName()).isEqualTo(testUser.getUserName());
-        assertThat(event1.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
-        assertThat(event2.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
-        // PrincipalAuthenticationFailureEvent does not contain sessionId at all
-        assertThat(event3.getAuditEvent().getOrigin()).doesNotContain("sessionId=<SESSION>");
 
         String idpAuthLogMsg = testLogger.getMessageAtIndex(0);
-        assertLogMessageWithSession(idpAuthLogMsg, IdentityProviderAuthenticationFailure, "null", testUser.getUserName());
+        assertLogMessage(idpAuthLogMsg, IdentityProviderAuthenticationFailure, "null", testUser.getUserName());
 
         String userAuthLogMsg = testLogger.getMessageAtIndex(1);
-        assertLogMessageWithSession(userAuthLogMsg, UserAuthenticationFailure, testUser.getId(), testUser.getUserName());
+        assertLogMessage(userAuthLogMsg, UserAuthenticationFailure, testUser.getId(), testUser.getUserName());
 
         String principalAuthLogMsg = testLogger.getMessageAtIndex(2);
-        assertLogMessageWithoutSession(principalAuthLogMsg, PrincipalAuthenticationFailure, testUser.getUserName(), "null");
+        assertLogMessage(principalAuthLogMsg, PrincipalAuthenticationFailure, testUser.getUserName(), "null");
     }
 
     @Test
@@ -493,9 +479,6 @@ class AuditCheckMockMvcTests {
         //after we reach our max attempts, 5, the system stops logging them until the period is over
         List<AuditEvent> events = auditService.find(jacobId, System.currentTimeMillis() - 10000, identityZoneManager.getCurrentIdentityZoneId());
         assertThat(events).hasSize(5);
-        for (AuditEvent event : events) {
-            assertThat(event.getOrigin()).contains("sessionId=<SESSION>");
-        }
     }
 
     @Test
@@ -517,16 +500,13 @@ class AuditCheckMockMvcTests {
         assertThatNumberOfAuditEventsReceivedIsGreaterThanOrEqualTo(2);
 
         UserNotFoundEvent event1 = (UserNotFoundEvent) testListener.getEvents().getFirst();
-        assertThat(event1.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         PrincipalAuthenticationFailureEvent event2 = (PrincipalAuthenticationFailureEvent) testListener.getEvents().get(1);
         assertThat(((Authentication) event1.getSource()).getName()).isEqualTo(username);
         assertThat(event2.getName()).isEqualTo(username);
-        // PrincipalAuthenticationFailureEvent does not contain sessionId at all
-        assertThat(event2.getAuditEvent().getOrigin()).doesNotContain("sessionId=<SESSION>");
 
         String encodedUsername = Utf8.decode(Base64.encodeBase64(MessageDigest.getInstance("SHA-1").digest(Utf8.encode(username))));
-        assertLogMessageWithSession(testLogger.getMessageAtIndex(0), UserNotFound, encodedUsername, "");
-        assertLogMessageWithoutSession(testLogger.getMessageAtIndex(1), PrincipalAuthenticationFailure, username, "null");
+        assertLogMessage(testLogger.getMessageAtIndex(0), UserNotFound, encodedUsername, "");
+        assertLogMessage(testLogger.getMessageAtIndex(1), PrincipalAuthenticationFailure, username, "null");
     }
 
     @Test
@@ -547,17 +527,15 @@ class AuditCheckMockMvcTests {
 
         IdentityProviderAuthenticationSuccessEvent passwordevent = testListener.getLatestEventOfType(IdentityProviderAuthenticationSuccessEvent.class);
         String userid = passwordevent.getUser().getId();
-        assertThat(passwordevent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         UserAuthenticationSuccessEvent userevent = testListener.getLatestEventOfType(UserAuthenticationSuccessEvent.class);
         assertThat(userevent.getUser().getId()).isEqualTo(passwordevent.getUser().getId());
-        assertThat(userevent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         assertThat(passwordevent.getAuthenticationType()).isEqualTo(OriginKeys.UAA);
 
         String passwordLogMsg = testLogger.getFirstLogMessageOfType(IdentityProviderAuthenticationSuccess);
-        assertLogMessageWithSession(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
 
         String userEventLogMsg = testLogger.getFirstLogMessageOfType(UserAuthenticationSuccess);
-        assertLogMessageWithSession(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
 
         resetAuditTestReceivers();
         String marissaToken = testClient.getUserOAuthAccessToken("app", "appclientsecret", testUser.getUserName(), testPassword, "password.write");
@@ -583,11 +561,10 @@ class AuditCheckMockMvcTests {
         PasswordChangeEvent pw = (PasswordChangeEvent) testListener.getLatestEvent();
         assertThat(pw.getUser().getUsername()).isEqualTo(testUser.getUserName());
         assertThat(pw.getMessage()).isEqualTo("Password changed");
-        assertThat(pw.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         assertThat(pw.getAuditEvent().getPrincipalName()).isEqualTo(testUser.getUserName());
 
         String pwLogMsg = testLogger.getLatestMessage();
-        assertLogMessageWithSession(pwLogMsg, PasswordChangeSuccess, testUser.getId(), "Password changed");
+        assertLogMessage(pwLogMsg, PasswordChangeSuccess, testUser.getId(), "Password changed");
         assertThat(pwLogMsg).contains("principalName=[%s]".formatted(testUser.getUserName()));
     }
 
@@ -610,17 +587,15 @@ class AuditCheckMockMvcTests {
 
         IdentityProviderAuthenticationSuccessEvent passwordevent = testListener.getLatestEventOfType(IdentityProviderAuthenticationSuccessEvent.class);
         String userid = passwordevent.getUser().getId();
-        assertThat(passwordevent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         UserAuthenticationSuccessEvent userevent = testListener.getLatestEventOfType(UserAuthenticationSuccessEvent.class);
         assertThat(userevent.getUser().getId()).isEqualTo(passwordevent.getUser().getId());
-        assertThat(userevent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         assertThat(passwordevent.getAuthenticationType()).isEqualTo(OriginKeys.UAA);
 
         String passwordLogMsg = testLogger.getFirstLogMessageOfType(IdentityProviderAuthenticationSuccess);
-        assertLogMessageWithSession(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(passwordLogMsg, IdentityProviderAuthenticationSuccess, testUser.getId(), testUser.getUserName());
 
         String userEventLogMsg = testLogger.getFirstLogMessageOfType(UserAuthenticationSuccess);
-        assertLogMessageWithSession(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
+        assertLogMessage(userEventLogMsg, UserAuthenticationSuccess, testUser.getId(), testUser.getUserName());
 
         resetAuditTestReceivers();
         String marissaToken = testClient.getUserOAuthAccessToken("app", "appclientsecret", testUser.getUserName(), testPassword, "password.write");
@@ -648,11 +623,10 @@ class AuditCheckMockMvcTests {
         PasswordChangeFailureEvent pwfe = (PasswordChangeFailureEvent) testListener.getLatestEvent();
         assertThat(pwfe.getUser().getUsername()).isEqualTo(testUser.getUserName());
         assertThat(pwfe.getMessage()).isEqualTo("Old password is incorrect");
-        assertThat(pwfe.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
         assertThat(pwfe.getAuditEvent().getPrincipalName()).isEqualTo(testUser.getUserName());
 
         String pwfeLogMsg = testLogger.getLatestMessage();
-        assertLogMessageWithSession(pwfeLogMsg, PasswordChangeFailure, testUser.getId(), "Old password is incorrect");
+        assertLogMessage(pwfeLogMsg, PasswordChangeFailure, testUser.getId(), "Old password is incorrect");
         assertThat(pwfeLogMsg).contains("principalName=[%s]".formatted(testUser.getUserName()));
     }
 
@@ -672,7 +646,7 @@ class AuditCheckMockMvcTests {
         assertThat(pw.getAuditEvent().getPrincipalName()).isEqualTo(user.getUserName());
 
         String pwLogMsg = testLogger.getLatestMessage();
-        assertLogMessageWithoutSession(pwLogMsg, PasswordChangeSuccess, user.getId(), "Password changed");
+        assertLogMessage(pwLogMsg, PasswordChangeSuccess, user.getId(), "Password changed");
         assertThat(pwLogMsg).contains("principalName=[%s]".formatted(user.getUserName()));
     }
 
@@ -701,11 +675,10 @@ class AuditCheckMockMvcTests {
         assertThat(pce.getUser().getUsername()).isEqualTo(testUser.getUserName());
         assertThat(pce.getMessage()).isEqualTo("Password changed");
         //PasswordChangeEvent does not contain session in this case
-        assertThat(pce.getAuditEvent().getOrigin()).doesNotContain("sessionId=<SESSION>");
         assertThat(pce.getAuditEvent().getPrincipalName()).isEqualTo(testUser.getUserName());
 
         String pceLogMsg = testLogger.getLatestMessage();
-        assertLogMessageWithoutSession(pceLogMsg, PasswordChangeSuccess, testUser.getId(), "Password changed");
+        assertLogMessage(pceLogMsg, PasswordChangeSuccess, testUser.getId(), "Password changed");
         assertThat(pceLogMsg).contains("principalName=[%s]".formatted(testUser.getUserName()));
     }
 
@@ -726,7 +699,7 @@ class AuditCheckMockMvcTests {
         AuditEvent auditEvent = event.getAuditEvent();
         assertThat(auditEvent.getPrincipalId()).isEqualTo("login");
 
-        assertLogMessageWithoutSession(testLogger.getMessageAtIndex(0), ClientAuthenticationSuccess, "login", "Client authentication success");
+        assertLogMessage(testLogger.getMessageAtIndex(0), ClientAuthenticationSuccess, "login", "Client authentication success");
     }
 
     @Test
@@ -746,7 +719,7 @@ class AuditCheckMockMvcTests {
         AuditEvent auditEvent = event.getAuditEvent();
         assertThat(auditEvent.getPrincipalId()).isEqualTo("login");
 
-        assertLogMessageWithoutSession(testLogger.getLatestMessage(), ClientAuthenticationFailure, "login", "Bad credentials");
+        assertLogMessage(testLogger.getLatestMessage(), ClientAuthenticationFailure, "login", "Bad credentials");
     }
 
     @Test
@@ -767,8 +740,8 @@ class AuditCheckMockMvcTests {
         ClientAuthenticationFailureEvent event1 = (ClientAuthenticationFailureEvent) testListener.getEvents().get(1);
         assertThat(event1.getClientId()).isEqualTo("login");
 
-        assertLogMessageWithoutSession(testLogger.getMessageAtIndex(0), PrincipalAuthenticationFailure, "login2", "null");
-        assertLogMessageWithoutSession(testLogger.getMessageAtIndex(1), ClientAuthenticationFailure, "login", "Bad credentials");
+        assertLogMessage(testLogger.getMessageAtIndex(0), PrincipalAuthenticationFailure, "login2", "null");
+        assertLogMessage(testLogger.getMessageAtIndex(1), ClientAuthenticationFailure, "login", "Bad credentials");
     }
 
     @Test
@@ -799,11 +772,10 @@ class AuditCheckMockMvcTests {
 
         ApprovalModifiedEvent approvalModifiedEvent = (ApprovalModifiedEvent) testListener.getLatestEvent();
         assertThat(approvalModifiedEvent.getAuthentication().getName()).isEqualTo(testUser.getUserName());
-        assertThat(approvalModifiedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         String latestMessage = testLogger.getLatestMessage();
         assertThat(latestMessage).contains(" user=" + testUser.getUserName());
-        assertLogMessageWithSession(latestMessage, ApprovalModifiedEvent, testUser.getId(), "{\"scope\":\"cloud_controller.read\",\"status\":\"APPROVED\"}");
+        assertLogMessage(latestMessage, ApprovalModifiedEvent, testUser.getId(), "{\"scope\":\"cloud_controller.read\",\"status\":\"APPROVED\"}");
     }
 
     @Test
@@ -833,14 +805,13 @@ class AuditCheckMockMvcTests {
         assertThat(userModifiedEvent.getAuthentication().getName()).isEqualTo(testAccounts.getAdminClientId());
         assertThat(userModifiedEvent.getUsername()).isEqualTo(scimUser.getUserName());
         assertThat(userModifiedEvent.getAuditEvent().getType()).isEqualTo(UserCreatedEvent);
-        assertThat(userModifiedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         ScimUser createdUser = jdbcScimUserProvisioning.retrieveAll(identityZoneManager.getCurrentIdentityZoneId())
                 .stream().filter(dbUser -> dbUser.getUserName().equals(scimUser.getUserName())).findFirst().get();
         String logMessage = "[\"user_id=%s\",\"username=%s\"]".formatted(
                 createdUser.getId(),
                 scimUser.getUserName());
-        assertLogMessageWithSession(testLogger.getLatestMessage(),
+        assertLogMessage(testLogger.getLatestMessage(),
                 UserCreatedEvent, createdUser.getId(), logMessage);
     }
 
@@ -905,8 +876,7 @@ class AuditCheckMockMvcTests {
             assertThat(actualLogMessage).startsWith(UserCreatedEvent.toString())
                     .contains("principal=%s,".formatted(createdUser.getId()))
                     .contains(logMessage)
-                    .contains(", identityZoneId=[%s]".formatted(zoneSeeder.getIdentityZoneId()))
-                    .matches(".*origin=\\[.*sessionId=<SESSION>.*\\].*");
+                    .contains(", identityZoneId=[%s]".formatted(zoneSeeder.getIdentityZoneId()));
         }
 
         @Test
@@ -947,8 +917,7 @@ class AuditCheckMockMvcTests {
             assertThat(actualLogMessage).startsWith(UserDeletedEvent.toString())
                     .contains("principal=%s,".formatted(scimUser.getId()))
                     .contains(" ('%s'): ".formatted(logMessage))
-                    .contains(", identityZoneId=[%s]".formatted(zoneSeeder.getIdentityZoneId()))
-                    .matches(".*origin=\\[.*sessionId=<SESSION>.*\\].*");
+                    .contains(", identityZoneId=[%s]".formatted(zoneSeeder.getIdentityZoneId()));
         }
 
     }
@@ -990,7 +959,6 @@ class AuditCheckMockMvcTests {
         assertThat(userModifiedEvent.getAuthentication().getName()).isEqualTo("login");
         assertThat(userModifiedEvent.getUsername()).isEqualTo(username);
         assertThat(userModifiedEvent.getAuditEvent().getType()).isEqualTo(UserCreatedEvent);
-        assertThat(userModifiedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         ScimUser createdUser = jdbcScimUserProvisioning.retrieveAll(identityZoneManager.getCurrentIdentityZoneId())
                 .stream().filter(dbUser -> dbUser.getUserName().equals(username)).findFirst().get();
@@ -999,7 +967,7 @@ class AuditCheckMockMvcTests {
                 createdUser.getId(),
                 username);
 
-        assertLogMessageWithSession(testLogger.getMessageAtIndex(0),
+        assertLogMessage(testLogger.getMessageAtIndex(0),
                 UserCreatedEvent, createdUser.getId(), logMessage);
     }
 
@@ -1060,10 +1028,9 @@ class AuditCheckMockMvcTests {
             assertThat(userModifiedEvent.getAuthentication().getName()).isEqualTo(testAccounts.getAdminClientId());
             assertThat(userModifiedEvent.getUsername()).isEqualTo(scimUser.getUserName());
             assertThat(userModifiedEvent.getAuditEvent().getType()).isEqualTo(UserModifiedEvent);
-            assertThat(userModifiedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
             String logMessage = "[\"user_id=%s\",\"username=%s\"]".formatted(scimUser.getId(), scimUser.getUserName());
-            assertLogMessageWithSession(testLogger.getLatestMessage(),
+            assertLogMessage(testLogger.getLatestMessage(),
                     UserModifiedEvent,
                     scimUser.getId(),
                     logMessage);
@@ -1089,12 +1056,11 @@ class AuditCheckMockMvcTests {
             assertThat(userDeletedEvent.getAuthentication().getName()).isEqualTo(testAccounts.getAdminClientId());
             assertThat(userDeletedEvent.getUsername()).isEqualTo(scimUser.getUserName());
             assertThat(userDeletedEvent.getAuditEvent().getType()).isEqualTo(UserDeletedEvent);
-            assertThat(userDeletedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
             String logMessage = "[\"user_id=%s\",\"username=%s\"]".formatted(
                     scimUser.getId(),
                     scimUser.getUserName());
-            assertLogMessageWithSession(testLogger.getLatestMessage(),
+            assertLogMessage(testLogger.getLatestMessage(),
                     UserDeletedEvent, scimUser.getId(), logMessage);
         }
     }
@@ -1143,9 +1109,8 @@ class AuditCheckMockMvcTests {
         assertThat(userModifiedEvent.getAuthentication().getName()).isEqualTo(testAccounts.getAdminClientId());
         assertThat(userModifiedEvent.getUsername()).isEqualTo(username);
         assertThat(userModifiedEvent.getAuditEvent().getType()).isEqualTo(UserVerifiedEvent);
-        assertThat(userModifiedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
-        assertLogMessageWithSession(testLogger.getLatestMessage(),
+        assertLogMessage(testLogger.getLatestMessage(),
                 UserVerifiedEvent, user.getId(), "[\"user_id=%s\",\"username=%s\"]".formatted(user.getId(), username));
     }
 
@@ -1170,9 +1135,8 @@ class AuditCheckMockMvcTests {
         ResetPasswordRequestEvent event = (ResetPasswordRequestEvent) testListener.getLatestEvent();
         assertThat(event.getAuditEvent().getPrincipalId()).isEqualTo(testUser.getUserName());
         assertThat(event.getAuditEvent().getData()).isEqualTo(testUser.getPrimaryEmail());
-        assertThat(event.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
-        assertLogMessageWithSession(testLogger.getLatestMessage(),
+        assertLogMessage(testLogger.getLatestMessage(),
                 PasswordResetRequest, testUser.getUserName(), testUser.getPrimaryEmail());
     }
 
@@ -1341,7 +1305,6 @@ class AuditCheckMockMvcTests {
         assertThat(userModifiedEvent.getAuthentication().getName()).isEqualTo(testAccounts.getAdminClientId());
         assertThat(userModifiedEvent.getUsername()).isEqualTo(username);
         assertThat(userModifiedEvent.getAuditEvent().getType()).isEqualTo(UserCreatedEvent);
-        assertThat(userModifiedEvent.getAuditEvent().getOrigin()).contains("sessionId=<SESSION>");
 
         return JsonUtils.readValue(result.andReturn().getResponse().getContentAsString(), ScimUser.class);
     }
@@ -1425,26 +1388,16 @@ class AuditCheckMockMvcTests {
         assertThat(message).contains("\"authorities\":[%s]".formatted(commaSeparatedQuotedAuthorities));
     }
 
-    private void assertLogMessageWithSession(String actualLogMessage, AuditEventType expectedAuditEventType, String expectedPrincipal, String expectedUserName) {
+    private void assertLogMessage(String actualLogMessage, AuditEventType expectedAuditEventType, String expectedPrincipal, String expectedUserName) {
         assertThat(actualLogMessage).startsWith(expectedAuditEventType.toString() + " ")
                 .contains("principal=%s,".formatted(expectedPrincipal))
                 .contains(" ('%s'): ".formatted(expectedUserName))
-                .contains(", identityZoneId=[uaa]")
-                .matches(".*origin=\\[.*sessionId=<SESSION>.*\\].*");
-    }
-
-    private static void assertLogMessageWithoutSession(String actualLogMessage, AuditEventType expectedAuditEventType, String expectedPrincipal, String expectedUserName) {
-        assertThat(actualLogMessage).startsWith(expectedAuditEventType.toString() + " ")
-                .contains("principal=%s,".formatted(expectedPrincipal))
-                .contains(" ('%s'): ".formatted(expectedUserName))
-                .contains(", identityZoneId=[uaa]")
-                .doesNotContain("sessionId");
+                .contains(", identityZoneId=[uaa]");
     }
 
     private static void assertGroupMembershipLogMessage(String actualLogMessage, AuditEventType expectedEventType, String expectedGroupDisplayName, String expectedGroupId, String... expectedUserIds) {
         assertThat(actualLogMessage).startsWith(expectedEventType.toString() + " ")
-                .contains("principal=%s,".formatted(expectedGroupId))
-                .doesNotContain("sessionId");
+                .contains("principal=%s,".formatted(expectedGroupId));
 
         Pattern groupLogPattern = Pattern.compile(" \\('\\{\"group_name\":\"" + Pattern.quote(expectedGroupDisplayName) + "\",\"members\":\\[(.*?)]}'\\): ");
         Matcher patternMatcher = groupLogPattern.matcher(actualLogMessage);


### PR DESCRIPTION
## Summary

Fixes an issue in the audit event origin builder where `Authentication.getDetails()` was unconditionally cast to `String` to extract the `remoteAddress`.

When `details` was an object type (e.g., `UaaAuthenticationDetails` or `OAuth2AuthenticationDetails`), this cast raised a `ClassCastException`. The exception was swallowed by a broad `catch` block that appended `details.toString()` directly to the audit log. This resulted in a possible issue:

**Data Leakage / Contamination:** Internal state (such as token values, request parameters, and map contents) was leaked into audit logs, often mixing unrelated sources into a single line.

### Example (Before)

For an `OAuth2AuthenticationDetails` instance, the log line improperly included the full `toString()` dump along with appended token inspector fields:

> `Audit: GroupModifiedEvent ('{"role_collection":"evenRC1771046947","op":"add_saml_attribute","saml_entity":"iot-idp-1771046947","attribute":"Groups","value":"even"}'): principal=evenRC1771046947, origin=[client=admin, details=(remoteAddress=172.18.0.1, sessionId=<SESSION>, tokenType=Bearer, tokenValue=<TOKEN>, sub=admin, iss=http://localhost:8080/uaa/oauth/token)], identityZoneId=[uaa]`

The `remoteAddress`/`sessionId`/`tokenType`/`tokenValue` fragment came from the details object's `toString`, then `sub`/`iss` were appended by the token inspector — a shape that mixed two unrelated sources into one line.

---

## Changes

Replaced the aggressive cast-and-catch approach with pattern-matching `switch` logic that reads the `remoteAddress` field safely depending on the runtime type of `details`:

* **`UaaAuthenticationDetails`, `OAuth2AuthenticationDetails`, `WebAuthenticationDetails`:** Directly invokes their respective accessor methods (`getOrigin()` / `getRemoteAddress()`).
* **`Map`:** Reads the `remoteAddress` key (supports `ResourceOwnerPasswordTokenGranter` and ensures forward compatibility).
* **`String`:** Parsed as JSON to look for `remoteAddress`. Non-JSON strings fall through safely.
* **Fallback / Unknown Types:** Non-matching types, missing keys, and `null` fields gracefully fall through without emitting a field, preventing arbitrary state dumps.

### Side effect: `sessionId=<SESSION>` marker is dropped

The `sessionId=<SESSION>` marker previously present in audit origins only appeared via the buggy `toString()`-dump path. Its value was a hardcoded literal — not a session identifier — so it carried no correlation or lookup signal. `type=UaaAuthenticationDetails` in the same origin line already conveys "session-shaped auth," making the marker redundant.

`AuditCheckMockMvcTests` is updated accordingly:
- `sessionId=<SESSION>` assertions are removed.
- `assertLogMessageWithSession` and `assertLogMessageWithoutSession` collapse into a single `assertLogMessage` helper (they are now equivalent).

---

## Test Coverage

Added unit tests in `AbstractUaaEventTest` covering:

- [x] **Supported Details Types:** `UaaAuthenticationDetails` and `OAuth2AuthenticationDetails` — remoteAddress extraction via typed accessors.
- [x] **Map Handling:** Both present and absent `remoteAddress` key paths, verifying map contents are not leaked.
- [x] **String Edge Cases:** Valid JSON strings, non-JSON strings, and JSON with `null` `remoteAddress`.
- [x] **Origin Shape:** Verification of the combined `client + user` origin shape in audit output.
