### PR TITLE
Fix: tolerate a leading byte order marker in SAML IdP metadata

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.cloudfoundry.identity.uaa.util.ObjectUtils;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.springframework.util.StringUtils;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -91,7 +92,7 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
     }
 
     public static MetadataLocation getType(String urlOrXmlData) {
-        String trimmedValue = urlOrXmlData.trim();
+        String trimmedValue = stripLeadingCharacters(urlOrXmlData);
 
         if (trimmedValue.startsWith("<?xml") ||
                 trimmedValue.startsWith("<md:EntityDescriptor") ||
@@ -109,6 +110,20 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
             }
         }
         return MetadataLocation.UNKNOWN;
+    }
+
+    /**
+     * Trims whitespace and, if present, a leading byte order marker character. Some IdPs (e.g.
+     * Microsoft Entra ID's federation metadata endpoint) prepend a byte order marker to their
+     * XML response; whether it was originally a UTF-8, UTF-16LE, or UTF-16BE BOM, correctly
+     * decoded bytes leave this same character (U+FEFF) at the start of the resulting String,
+     * which would otherwise defeat the {@code startsWith} sniffing in {@link #getType(String)}.
+     */
+    private static String stripLeadingCharacters(String value) {
+        String trimmedValue = value.trim();
+        return trimmedValue.startsWith(UaaStringUtils.BYTE_ORDER_MARKER)
+                ? trimmedValue.substring(UaaStringUtils.BYTE_ORDER_MARKER.length()).trim()
+                : trimmedValue;
     }
 
     @JsonIgnore

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/util/UaaStringUtils.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/util/UaaStringUtils.java
@@ -51,6 +51,14 @@ public final class UaaStringUtils {
 
     public static final String EMPTY_STRING = "";
 
+    /**
+     * The Unicode byte order marker (codepoint U+FEFF), as decoded into a Java String. This is
+     * the same character regardless of which encoding's BOM bytes produced it (UTF-8's EF BB BF,
+     * UTF-16LE's FF FE, UTF-16BE's FE FF, ...) once decoded with the correct charset for that
+     * encoding, or when a UTF-8 BOM survives an incorrect {@code new String(bytes, UTF_8)} decode.
+     */
+    public static final String BYTE_ORDER_MARKER = String.valueOf((char) 0xFEFF);
+
     public static final String DEFAULT_UAA_URL = "http://localhost:8080/uaa";
 
     private UaaStringUtils() {

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
@@ -2,6 +2,7 @@ package org.cloudfoundry.identity.uaa.provider.saml;
 
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.ReflectionUtils;
@@ -138,6 +139,18 @@ public class SamlIdentityProviderDefinitionTests {
     @Test
     void get_data_type_when_valid() {
         definition.setMetaDataLocation(IDP_METADATA);
+        assertThat(definition.getType()).isEqualTo(DATA);
+    }
+
+    @Test
+    void get_data_type_when_valid_with_leading_byte_order_marker() {
+        // Microsoft Entra ID's federation metadata endpoint prepends a byte order marker to its
+        // XML response. Whether the original bytes were a UTF-8, UTF-16LE, or UTF-16BE BOM,
+        // correctly decoded text has this same character (U+FEFF) leading it; String.trim() does
+        // not strip it, so metadata that is otherwise identical to get_data_type_when_valid()
+        // must still classify as DATA, not UNKNOWN.
+        String byteOrderMarkerPrefixedMetadata = UaaStringUtils.BYTE_ORDER_MARKER + IDP_METADATA;
+        definition.setMetaDataLocation(byteOrderMarkerPrefixedMetadata);
         assertThat(definition.getType()).isEqualTo(DATA);
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfigurator.java
@@ -1,5 +1,6 @@
 package org.cloudfoundry.identity.uaa.provider.saml;
 
+import org.apache.commons.io.ByteOrderMark;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.core5.net.URIBuilder;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -17,7 +18,9 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.springframework.util.StringUtils.hasText;
@@ -166,9 +169,31 @@ public class SamlIdentityProviderConfigurator {
         try {
             String adjustedMetadataURIForPort = adjustURIForPort(metadataLocation);
             byte[] metadata = fixedHttpMetaDataProvider.fetchMetadata(adjustedMetadataURIForPort, def.isSkipSslValidation());
-            return new String(metadata, StandardCharsets.UTF_8);
+            return new String(metadata, detectCharset(metadata));
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Invalid socket factory(invalid URI):" + metadataLocation, e);
         }
+    }
+
+    /**
+     * Detects the charset of fetched metadata bytes from a leading byte order marker. Only
+     * UTF-16 needs to be sniffed explicitly here: a UTF-8 byte order marker, if present, already
+     * decodes correctly under the UTF-8 default and is stripped later by
+     * {@link SamlIdentityProviderDefinition#getType(String)}, since it decodes to the same
+     * character (U+FEFF) as a correctly-decoded UTF-16 BOM.
+     */
+    static Charset detectCharset(byte[] metadata) {
+        if (hasLeadingByteOrderMark(metadata, ByteOrderMark.UTF_16LE)) {
+            return StandardCharsets.UTF_16LE;
+        }
+        if (hasLeadingByteOrderMark(metadata, ByteOrderMark.UTF_16BE)) {
+            return StandardCharsets.UTF_16BE;
+        }
+        return StandardCharsets.UTF_8;
+    }
+
+    private static boolean hasLeadingByteOrderMark(byte[] data, ByteOrderMark byteOrderMark) {
+        byte[] bom = byteOrderMark.getBytes();
+        return data.length >= bom.length && Arrays.equals(data, 0, bom.length, bom, 0, bom.length);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepositoryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepositoryTest.java
@@ -6,6 +6,7 @@ import org.cloudfoundry.identity.uaa.provider.IdentityProvider;
 import org.cloudfoundry.identity.uaa.provider.IdentityProviderProvisioning;
 import org.cloudfoundry.identity.uaa.provider.SamlIdentityProviderDefinition;
 import org.cloudfoundry.identity.uaa.test.network.NetworkTestUtils;
+import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneConfiguration;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
@@ -185,6 +186,38 @@ class ConfiguratorRelyingPartyRegistrationRepositoryTest {
                 .returns("{baseUrl}/saml/SSO/alias/entityIdAlias", RelyingPartyRegistration::getAssertionConsumerServiceLocation)
                 .returns("{baseUrl}/saml/SingleLogout/alias/entityIdAlias", RelyingPartyRegistration::getSingleLogoutServiceResponseLocation)
                 // from xml
+                .extracting(RelyingPartyRegistration::getAssertingPartyMetadata)
+                .returns("https://idp-saml.ua3.int/simplesaml/saml2/idp/metadata.php", AssertingPartyMetadata::getEntityId);
+    }
+
+    @Test
+    void buildsCorrectRegistrationWhenFetchedUrlMetadataHasLeadingByteOrderMarker() {
+        // Some IdPs prepend a UTF-8 byte order marker to their federation metadata response.
+        // SamlIdentityProviderConfigurator.resolveMetadataXml() fetches and decodes that response
+        // *before* handing it to RelyingPartyRegistrationBuilder.buildRelyingPartyRegistration(),
+        // so this simulates exactly what that decode produces for a URL-type IDP, one call
+        // further down the real login path than a plain getType() unit test reaches. Without the
+        // fix, the BOM defeats the DATA/URL sniffing in buildRelyingPartyRegistration() and the
+        // fetched XML is mistaken for a classpath resource location (Saml2Exception wrapping a
+        // FileNotFoundException).
+        String metadata = loadResouceAsString("saml-sample-metadata.xml");
+        when(repository.retrieveZone()).thenReturn(identityZone);
+        when(identityZone.isUaa()).thenReturn(true);
+        when(identityZone.getConfig()).thenReturn(identityZoneConfiguration);
+        when(identityZoneConfiguration.getSamlConfig()).thenReturn(samlConfig);
+        when(definition.getIdpEntityAlias()).thenReturn(REGISTRATION_ID);
+        when(definition.getNameID()).thenReturn(NAME_ID);
+        when(definition.getMetaDataLocation())
+                .thenReturn("https://login.microsoftonline.com/tenant-id/federationmetadata/2007-06/federationmetadata.xml");
+        when(configurator.resolveMetadataXml(definition))
+                .thenReturn(UaaStringUtils.BYTE_ORDER_MARKER + metadata);
+        when(configurator.getIdentityProviderDefinitionsForZone(identityZone)).thenReturn(List.of(definition));
+
+        RelyingPartyRegistration registration = repository.findByRegistrationId(REGISTRATION_ID);
+        assertThat(registration)
+                .returns(REGISTRATION_ID, RelyingPartyRegistration::getRegistrationId)
+                .returns(ENTITY_ID, RelyingPartyRegistration::getEntityId)
+                .returns(NAME_ID, RelyingPartyRegistration::getNameIdFormat)
                 .extracting(RelyingPartyRegistration::getAssertingPartyMetadata)
                 .returns("https://idp-saml.ua3.int/simplesaml/saml2/idp/metadata.php", AssertingPartyMetadata::getEntityId);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfiguratorTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfiguratorTests.java
@@ -15,6 +15,7 @@
 
 package org.cloudfoundry.identity.uaa.provider.saml;
 
+import org.apache.commons.io.ByteOrderMark;
 import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.cloudfoundry.identity.uaa.cache.UrlContentCache;
@@ -37,6 +38,7 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.web.client.ResourceAccessException;
 
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -154,6 +156,92 @@ public class SamlIdentityProviderConfiguratorTests {
                     fail("Unknown provider %s".formatted(def.getIdpEntityAlias()));
             }
         }
+    }
+
+    @Test
+    void resolvesUrlMetadataWithLeadingUtf8ByteOrderMark() {
+        // Some IdPs (e.g. Microsoft Entra ID's federation metadata endpoint) prepend a UTF-8
+        // byte order marker (EF BB BF) to their XML response.
+        byte[] utf8Bom = ByteOrderMark.UTF_8.getBytes();
+        byte[] metadataBytes = concat(utf8Bom, getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_8));
+        when(fixedHttpMetaDataProvider.fetchMetadata(any(), anyBoolean())).thenReturn(metadataBytes);
+
+        SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition()
+                .setMetaDataLocation("http://simplesamlphp.somewhere.com/metadata")
+                .setIdpEntityAlias("simplesamlphp-utf8-bom")
+                .setZoneId("uaa");
+
+        RelyingPartyRegistration extendedMetadataDelegate = configurator.getExtendedMetadataDelegate(def);
+        assertThat(extendedMetadataDelegate.getAssertingPartyMetadata().getEntityId())
+                .isEqualTo("http://simplesamlphp.somewhere.com/saml2/idp/metadata.php");
+    }
+
+    @Test
+    void resolvesUrlMetadataWithLeadingUtf16LittleEndianByteOrderMark() {
+        byte[] utf16LeBom = ByteOrderMark.UTF_16LE.getBytes();
+        byte[] metadataBytes = concat(utf16LeBom, getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_16LE));
+        when(fixedHttpMetaDataProvider.fetchMetadata(any(), anyBoolean())).thenReturn(metadataBytes);
+
+        SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition()
+                .setMetaDataLocation("http://simplesamlphp.somewhere.com/metadata")
+                .setIdpEntityAlias("simplesamlphp-utf16-le-bom")
+                .setZoneId("uaa");
+
+        RelyingPartyRegistration extendedMetadataDelegate = configurator.getExtendedMetadataDelegate(def);
+        assertThat(extendedMetadataDelegate.getAssertingPartyMetadata().getEntityId())
+                .isEqualTo("http://simplesamlphp.somewhere.com/saml2/idp/metadata.php");
+    }
+
+    @Test
+    void resolvesUrlMetadataWithLeadingUtf16BigEndianByteOrderMark() {
+        byte[] utf16BeBom = ByteOrderMark.UTF_16BE.getBytes();
+        byte[] metadataBytes = concat(utf16BeBom, getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_16BE));
+        when(fixedHttpMetaDataProvider.fetchMetadata(any(), anyBoolean())).thenReturn(metadataBytes);
+
+        SamlIdentityProviderDefinition def = new SamlIdentityProviderDefinition()
+                .setMetaDataLocation("http://simplesamlphp.somewhere.com/metadata")
+                .setIdpEntityAlias("simplesamlphp-utf16-be-bom")
+                .setZoneId("uaa");
+
+        RelyingPartyRegistration extendedMetadataDelegate = configurator.getExtendedMetadataDelegate(def);
+        assertThat(extendedMetadataDelegate.getAssertingPartyMetadata().getEntityId())
+                .isEqualTo("http://simplesamlphp.somewhere.com/saml2/idp/metadata.php");
+    }
+
+    @Test
+    void detectCharsetReturnsUtf8WhenNoByteOrderMarkIsPresent() {
+        byte[] metadataBytes = getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_8);
+        assertThat(SamlIdentityProviderConfigurator.detectCharset(metadataBytes)).isEqualTo(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void detectCharsetReturnsUtf8WhenUtf8ByteOrderMarkIsPresent() {
+        byte[] metadataBytes = concat(ByteOrderMark.UTF_8.getBytes(), getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_8));
+        assertThat(SamlIdentityProviderConfigurator.detectCharset(metadataBytes)).isEqualTo(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void detectCharsetReturnsUtf16LittleEndianWhenThatByteOrderMarkIsPresent() {
+        byte[] metadataBytes = concat(ByteOrderMark.UTF_16LE.getBytes(), getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_16LE));
+        assertThat(SamlIdentityProviderConfigurator.detectCharset(metadataBytes)).isEqualTo(StandardCharsets.UTF_16LE);
+    }
+
+    @Test
+    void detectCharsetReturnsUtf16BigEndianWhenThatByteOrderMarkIsPresent() {
+        byte[] metadataBytes = concat(ByteOrderMark.UTF_16BE.getBytes(), getSimpleSamlPhpMetadata("http://simplesamlphp.somewhere.com").getBytes(StandardCharsets.UTF_16BE));
+        assertThat(SamlIdentityProviderConfigurator.detectCharset(metadataBytes)).isEqualTo(StandardCharsets.UTF_16BE);
+    }
+
+    @Test
+    void detectCharsetReturnsUtf8ForByteArrayShorterThanAnyByteOrderMark() {
+        assertThat(SamlIdentityProviderConfigurator.detectCharset(new byte[]{(byte) 0xFF})).isEqualTo(StandardCharsets.UTF_8);
+    }
+
+    private static byte[] concat(byte[] first, byte[] second) {
+        byte[] result = new byte[first.length + second.length];
+        System.arraycopy(first, 0, result, 0, first.length);
+        System.arraycopy(second, 0, result, first.length, second.length);
+        return result;
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Some SAML IdPs prepend a byte order marker (BOM) to their federation metadata XML response. When metadata is fetched from a URL, the leading BOM character survived decoding and defeated the DATA/URL sniffing in `SamlIdentityProviderDefinition.getType()`, causing the fetched XML to be mistaken for a classpath resource location and the relying party registration build to fail.
- `getType()` now strips a leading BOM character before sniffing, regardless of which encoding originally produced it.
- `SamlIdentityProviderConfigurator.resolveMetadataXml()` now detects a UTF-16LE/BE BOM on fetched bytes and decodes with the matching charset, instead of always assuming UTF-8.

## Test plan
- [x] `SamlIdentityProviderDefinitionTests` — `getType()` classifies BOM-prefixed metadata as `DATA`
- [x] `SamlIdentityProviderConfiguratorTests` — `detectCharset()` unit tests (no BOM, UTF-8, UTF-16LE, UTF-16BE, short-array edge case) and end-to-end `resolveMetadataXml()`/`getExtendedMetadataDelegate()` tests for all three BOM encodings
- [x] `ConfiguratorRelyingPartyRegistrationRepositoryTest` — regression test at the real login-flow level with a BOM-prefixed fetched metadata response
- [x] Full `org.cloudfoundry.identity.uaa.provider.saml.*` suite passes in both `model` and `server` modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)