### PR TITLE
Fix: SAML login fails for inline metadata containing a UTF-8 BOM (#3994)

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/provider/SamlIdentityProviderDefinition.java
@@ -91,7 +91,15 @@ public class SamlIdentityProviderDefinition extends ExternalIdentityProviderDefi
     }
 
     public static MetadataLocation getType(String urlOrXmlData) {
+        // Strip a leading UTF-8 BOM (U+FEFF) before classifying. String.trim() only removes
+        // characters <= U+0020, so a BOM survives and would cause the startsWith("<?xml") /
+        // startsWith("<EntityDescriptor") checks below to fail, misclassifying inline XML as
+        // UNKNOWN. Microsoft Entra/ADFS federationmetadata.xml is served UTF-8-with-BOM and is
+        // frequently pasted verbatim into idpMetadata. See cloudfoundry/uaa#3994.
         String trimmedValue = urlOrXmlData.trim();
+        if (!trimmedValue.isEmpty() && trimmedValue.charAt(0) == '\uFEFF') {
+            trimmedValue = trimmedValue.substring(1).trim();
+        }
 
         if (trimmedValue.startsWith("<?xml") ||
                 trimmedValue.startsWith("<md:EntityDescriptor") ||

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderDefinitionTests.java
@@ -141,6 +141,22 @@ public class SamlIdentityProviderDefinitionTests {
         assertThat(definition.getType()).isEqualTo(DATA);
     }
 
+    @Test
+    void get_data_type_when_valid_with_leading_utf8_bom() {
+        // Microsoft Entra/ADFS federationmetadata.xml is served UTF-8-with-BOM and the BOM
+        // (U+FEFF) is frequently pasted verbatim into idpMetadata. String.trim() does not strip
+        // it, so getType() must handle it explicitly, otherwise the metadata is misclassified as
+        // UNKNOWN and login fails. See cloudfoundry/uaa#3994.
+        definition.setMetaDataLocation('\uFEFF' + IDP_METADATA);
+        assertThat(definition.getType()).isEqualTo(DATA);
+    }
+
+    @Test
+    void get_url_type_with_leading_utf8_bom() {
+        definition.setMetaDataLocation('\uFEFF' + "http://uaa.com/saml/metadata");
+        assertThat(definition.getType()).isEqualTo(URL);
+    }
+
     public static final String ALIAS = "alias";
     public static final String IDP_METADATA = "<?xml version=\"1.0\"?>\n" +
             "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\" entityID=\"http://" + ALIAS + ".cfapps.io/saml2/idp/metadata.php\" ID=\"pfx06ad4153-c17c-d286-194c-dec30bb92796\"><ds:Signature>\n" +

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfigurator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/saml/SamlIdentityProviderConfigurator.java
@@ -166,7 +166,14 @@ public class SamlIdentityProviderConfigurator {
         try {
             String adjustedMetadataURIForPort = adjustURIForPort(metadataLocation);
             byte[] metadata = fixedHttpMetaDataProvider.fetchMetadata(adjustedMetadataURIForPort, def.isSkipSslValidation());
-            return new String(metadata, StandardCharsets.UTF_8);
+            String xml = new String(metadata, StandardCharsets.UTF_8);
+            // Strip a leading UTF-8 BOM (U+FEFF) that some IDP metadata endpoints (notably
+            // Microsoft Entra/ADFS) prepend, so downstream classification/parsing treats the
+            // response as inline XML rather than an opaque resource location. See cloudfoundry/uaa#3994.
+            if (!xml.isEmpty() && xml.charAt(0) == '\uFEFF') {
+                xml = xml.substring(1);
+            }
+            return xml;
         } catch (URISyntaxException e) {
             throw new IllegalStateException("Invalid socket factory(invalid URI):" + metadataLocation, e);
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepositoryTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/saml/ConfiguratorRelyingPartyRegistrationRepositoryTest.java
@@ -190,6 +190,31 @@ class ConfiguratorRelyingPartyRegistrationRepositoryTest {
     }
 
     @Test
+    void buildsCorrectRegistrationWhenMetadataXmlHasLeadingUtf8Bom() {
+        // Regression for cloudfoundry/uaa#3994: inline SAML metadata beginning with a UTF-8 BOM
+        // (U+FEFF) -- as served by Microsoft Entra/ADFS federationmetadata.xml -- was
+        // misclassified as a metadata *location* (not DATA) and handed to
+        // RelyingPartyRegistrations.fromMetadataLocation(), throwing FileNotFoundException and a
+        // Saml2Exception during login. It must instead be parsed as inline XML.
+        String metadata = '\uFEFF' + loadResouceAsString("saml-sample-metadata.xml");
+        when(repository.retrieveZone()).thenReturn(identityZone);
+        when(identityZone.isUaa()).thenReturn(true);
+        when(identityZone.getConfig()).thenReturn(identityZoneConfiguration);
+        when(identityZoneConfiguration.getSamlConfig()).thenReturn(samlConfig);
+        when(definition.getIdpEntityAlias()).thenReturn(REGISTRATION_ID);
+        when(definition.getNameID()).thenReturn(NAME_ID);
+        when(definition.getMetaDataLocation()).thenReturn(metadata);
+        when(configurator.getIdentityProviderDefinitionsForZone(identityZone)).thenReturn(List.of(definition));
+
+        RelyingPartyRegistration registration = repository.findByRegistrationId(REGISTRATION_ID);
+        assertThat(registration)
+                .returns(REGISTRATION_ID, RelyingPartyRegistration::getRegistrationId)
+                .returns(ENTITY_ID, RelyingPartyRegistration::getEntityId)
+                .extracting(RelyingPartyRegistration::getAssertingPartyMetadata)
+                .returns("https://idp-saml.ua3.int/simplesaml/saml2/idp/metadata.php", AssertingPartyMetadata::getEntityId);
+    }
+
+    @Test
     void zoneWithCredentialsUsesCorrectValues() {
         samlConfigProps.setKeys(Map.of(keyName1(), samlKey1(), keyName2(), samlKey2()));
         samlConfigProps.setActiveKeyId(keyName1());


### PR DESCRIPTION
## Problem

After `79.3.0` → `79.4.0`, SAML login fails for IdPs whose **inline** metadata (`idpMetadata: <EntityDescriptor…>`) begins with a UTF-8 BOM (`U+FEFF`). This is common for Microsoft Entra / Azure AD / ADFS `federationmetadata.xml`, which is served UTF-8-with-BOM and pasted verbatim into config. `GET /saml2/authenticate/{origin}` returns HTTP 500:

```
Cannot retrieve SAML trusted party for registrationId: {origin}
org.springframework.security.saml2.Saml2Exception: java.io.FileNotFoundException:
  class path resource [<BOM><?xml ...<EntityDescriptor ...>] cannot be opened because it does not exist
    at RelyingPartyRegistrations.fromMetadataLocation(...)
    at RelyingPartyRegistrationBuilder.buildRelyingPartyRegistration(...)
    at ConfiguratorRelyingPartyRegistrationRepository.createRelyingPartyRegistration(...)
```

Fixes #3994.

## Root cause

`SamlIdentityProviderDefinition.getType(String)` classifies metadata as inline XML (`DATA`) vs `URL` by prefix-matching after `String.trim()`. `String.trim()` only removes characters `<= U+0020`, so a leading BOM survives and the `startsWith("<?xml")` / `startsWith("<EntityDescriptor")` checks fail → the value is classified `UNKNOWN`. `RelyingPartyRegistrationBuilder` then sends anything not `DATA` to `RelyingPartyRegistrations.fromMetadataLocation(...)`, which treats the XML blob as a resource location and throws `FileNotFoundException`.

This was a latent gap in `getType()`; it surfaced on the login path when #3971 routed live login through `SamlIdentityProviderConfigurator.resolveMetadataXml()` → `getType()`. (Distinct from the other #3971 follow-up, #3974.)

## Fix

- Strip a leading `U+FEFF` in `SamlIdentityProviderDefinition.getType()` before classification — minimal change, fixes all call sites (login, admin/validate, metadata delegate).
- Defense-in-depth: also strip a leading BOM from the bytes returned by `SamlIdentityProviderConfigurator.resolveMetadataXml()` (covers URL endpoints that serve BOM-prefixed metadata).

## Tests

- `SamlIdentityProviderDefinitionTests`: `getType()` classifies BOM-prefixed inline XML as `DATA` and BOM-prefixed URL as `URL`.
- `ConfiguratorRelyingPartyRegistrationRepositoryTest`: BOM-prefixed inline metadata resolves to a valid `RelyingPartyRegistration`.

## Verification

```
./gradlew :cloudfoundry-identity-model:test \
  --tests "org.cloudfoundry.identity.uaa.provider.saml.SamlIdentityProviderDefinitionTests"
# BUILD SUCCESSFUL — 18 tests passed

./gradlew :cloudfoundry-identity-server:test \
  --tests "org.cloudfoundry.identity.uaa.provider.saml.ConfiguratorRelyingPartyRegistrationRepositoryTest"
# BUILD SUCCESSFUL — 15 tests passed
```

## Rollback

Revert this commit; no schema, config, or API changes.

## Security impact

Affects SAML IdP metadata parsing/classification only. No change to signature validation, trust, or authorization; BOM stripping is limited to a single leading `U+FEFF` before XML parsing (which OpenSAML already tolerates).