### PR TITLE
Use constant-time comparison for HMAC signature verification

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/UaaMacSigner.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwt/UaaMacSigner.java
@@ -18,6 +18,7 @@ import org.cloudfoundry.identity.uaa.oauth.InvalidSignatureException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.text.ParseException;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -84,8 +85,10 @@ public class UaaMacSigner implements JWSSigner {
             String kid = header.getKeyID();
             JWK jwKey = jwkSet.getKeys().stream().filter(e -> kid.equals(e.getKeyID())).findFirst().orElseThrow();
             UaaMacSigner internal = new UaaMacSigner((String) jwKey.toJSONObject().get(JWKParameterNames.OCT_KEY_VALUE));
-            // symmetric signature check: create internal signature and compare if matches the signature from token
-            if (token.getSignature().equals(internal.sign(header, token.getSigningInput())) && SUPPORTED_ALGORITHMS.contains(header.getAlgorithm())) {
+            // symmetric signature check: create internal signature and compare if matches the signature from token,
+            // using a constant-time comparison to avoid leaking timing information about the expected HMAC
+            Base64URL expectedSignature = internal.sign(header, token.getSigningInput());
+            if (MessageDigest.isEqual(token.getSignature().decode(), expectedSignature.decode()) && SUPPORTED_ALGORITHMS.contains(header.getAlgorithm())) {
                 return token.getJWTClaimsSet();
             }
             throw new InvalidSignatureException("HMAC not mached");


### PR DESCRIPTION
## Summary
- `UaaMacSigner.verify` compared the recomputed HMAC signature to the token's signature via `Base64URL.equals` (backed by `String.equals`), which short-circuits on the first differing byte and can leak timing information useful for forging a valid HMAC.
- Switched to `MessageDigest.isEqual` on the decoded signature bytes, matching the constant-time comparison pattern already used elsewhere in the codebase (e.g. `PasswordComparisonAuthenticator`).

## Test plan
- [x] `./gradlew :cloudfoundry-identity-server:compileJava`
- [x] `./gradlew :cloudfoundry-identity-server:test --tests JwtHelperTest --tests CommonSignerTest --tests JwtTokenSignedByThisUAATest`