### PR TITLE
Fix SSRF via jwks_uri

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
@@ -244,9 +244,10 @@ public class SpringServletXmlBeansConfiguration {
     OidcMetadataFetcher oidcMetadataFetcher(
             UrlContentCache contentCache,
             @Qualifier("trustingRestTemplate") RestTemplate trustingRestTemplate,
-            @Qualifier("nonTrustingRestTemplate") RestTemplate nonTrustingRestTemplate
+            @Qualifier("nonTrustingRestTemplate") RestTemplate nonTrustingRestTemplate,
+            @Qualifier("safeRestTemplate") RestTemplate safeRestTemplate
     ) {
-        return new OidcMetadataFetcher(contentCache, trustingRestTemplate, nonTrustingRestTemplate);
+        return new OidcMetadataFetcher(contentCache, trustingRestTemplate, nonTrustingRestTemplate, safeRestTemplate);
     }
 
     @Bean

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
@@ -243,7 +243,7 @@ public class ClientJwtConfiguration implements Cloneable {
         if (!"https".equals(validateJwksUri.getScheme()) && !"http".equals(validateJwksUri.getScheme())) {
             throw new InvalidClientDetailsException("Invalid private_key_jwt: jwks_uri must be either using https or http");
         }
-        if ("http".equals(validateJwksUri.getScheme()) && !validateJwksUri.getHost().endsWith("localhost")) {
+        if ("http".equals(validateJwksUri.getScheme()) && !"localhost".equals(validateJwksUri.getHost())) {
             throw new InvalidClientDetailsException("Invalid private_key_jwt: jwks_uri with http is not on localhost");
         }
         // Only apply the private-network check for HTTPS URIs — HTTP is already
@@ -253,7 +253,7 @@ public class ClientJwtConfiguration implements Cloneable {
                 PrivateNetworkGuard.assertPublic(validateJwksUri);
             } catch (IllegalArgumentException e) {
                 throw new InvalidClientDetailsException(e.getMessage());
-            } catch (java.net.UnknownHostException _) {
+            } catch (java.net.UnknownHostException ignored) {
                 // Unresolvable host: allow through at validation time; the fetch will fail.
             }
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
@@ -13,6 +13,7 @@ import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKeyHelper;
 import org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKeySet;
 import org.cloudfoundry.identity.uaa.oauth.provider.ClientDetails;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.util.PrivateNetworkGuard;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
@@ -244,6 +245,17 @@ public class ClientJwtConfiguration implements Cloneable {
         }
         if ("http".equals(validateJwksUri.getScheme()) && !validateJwksUri.getHost().endsWith("localhost")) {
             throw new InvalidClientDetailsException("Invalid private_key_jwt: jwks_uri with http is not on localhost");
+        }
+        // Only apply the private-network check for HTTPS URIs — HTTP is already
+        // restricted to localhost above, and localhost resolves to a loopback address.
+        if ("https".equals(validateJwksUri.getScheme())) {
+            try {
+                PrivateNetworkGuard.assertPublic(validateJwksUri);
+            } catch (IllegalArgumentException e) {
+                throw new InvalidClientDetailsException(e.getMessage());
+            } catch (java.net.UnknownHostException _) {
+                // Unresolvable host: allow through at validation time; the fetch will fail.
+            }
         }
         return true;
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfiguration.java
@@ -253,7 +253,7 @@ public class ClientJwtConfiguration implements Cloneable {
                 PrivateNetworkGuard.assertPublic(validateJwksUri);
             } catch (IllegalArgumentException e) {
                 throw new InvalidClientDetailsException(e.getMessage());
-            } catch (java.net.UnknownHostException ignored) {
+            } catch (java.net.UnknownHostException _) {
                 // Unresolvable host: allow through at validation time; the fetch will fail.
             }
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
@@ -38,7 +38,7 @@ public class RestTemplateConfig {
 
     @Bean
     public RestTemplate safeRestTemplate() {
-        return new RestTemplate(UaaHttpRequestUtils.createSafeRequestFactory(timeout));
+        return new RestTemplate(UaaHttpRequestUtils.createSafeRequestFactory(this));
     }
 
     public static RestTemplateConfig createDefaults() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/RestTemplateConfig.java
@@ -36,6 +36,11 @@ public class RestTemplateConfig {
         return new RestTemplate(UaaHttpRequestUtils.createRequestFactory(true, timeout, timeout, this));
     }
 
+    @Bean
+    public RestTemplate safeRestTemplate() {
+        return new RestTemplate(UaaHttpRequestUtils.createSafeRequestFactory(timeout));
+    }
+
     public static RestTemplateConfig createDefaults() {
         RestTemplateConfig restTemplateConfig = new RestTemplateConfig();
         restTemplateConfig.timeout = 10000;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
@@ -83,7 +83,9 @@ public class OidcMetadataFetcher {
         if (clientJwtConfiguration.getJwkSet() != null) {
             return clientJwtConfiguration.getJwkSet();
         } else if (clientJwtConfiguration.getJwksUri() != null) {
-            byte[] rawContents = getJsonBody(clientJwtConfiguration.getJwksUri(), false, true, null, safeRestTemplate);
+            String jwksUri = clientJwtConfiguration.getJwksUri();
+            RestTemplate template = isLocalhost(jwksUri) ? nonTrustingRestTemplate : safeRestTemplate;
+            byte[] rawContents = getJsonBody(jwksUri, false, true, null, template);
             if (rawContents != null && rawContents.length > 0) {
                 ClientJwtConfiguration clientKeys = ClientJwtConfiguration.parse(null, new String(rawContents, StandardCharsets.UTF_8));
                 if (clientKeys != null && clientKeys.getJwkSet() != null) {
@@ -120,6 +122,15 @@ public class OidcMetadataFetcher {
         } else {
             throw new IllegalArgumentException(
                     "Unable to fetch content, status:" + HttpStatus.resolve(responseEntity.getStatusCode().value()).getReasonPhrase());
+        }
+    }
+
+    private static boolean isLocalhost(String uri) {
+        try {
+            String host = java.net.URI.create(uri).getHost();
+            return "localhost".equals(host);
+        } catch (IllegalArgumentException e) {
+            return false;
         }
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
@@ -33,14 +33,24 @@ public class OidcMetadataFetcher {
     private final UrlContentCache contentCache;
     private final RestTemplate trustingRestTemplate;
     private final RestTemplate nonTrustingRestTemplate;
+    private final RestTemplate safeRestTemplate;
 
     public OidcMetadataFetcher(UrlContentCache contentCache,
             RestTemplate trustingRestTemplate,
             RestTemplate nonTrustingRestTemplate
     ) {
+        this(contentCache, trustingRestTemplate, nonTrustingRestTemplate, nonTrustingRestTemplate);
+    }
+
+    public OidcMetadataFetcher(UrlContentCache contentCache,
+            RestTemplate trustingRestTemplate,
+            RestTemplate nonTrustingRestTemplate,
+            RestTemplate safeRestTemplate
+    ) {
         this.contentCache = contentCache;
         this.trustingRestTemplate = trustingRestTemplate;
         this.nonTrustingRestTemplate = nonTrustingRestTemplate;
+        this.safeRestTemplate = safeRestTemplate;
     }
 
     public void fetchMetadataAndUpdateDefinition(OIDCIdentityProviderDefinition definition) throws OidcMetadataFetchingException {
@@ -73,7 +83,7 @@ public class OidcMetadataFetcher {
         if (clientJwtConfiguration.getJwkSet() != null) {
             return clientJwtConfiguration.getJwkSet();
         } else if (clientJwtConfiguration.getJwksUri() != null) {
-            byte[] rawContents = getJsonBody(clientJwtConfiguration.getJwksUri(), false, true, null);
+            byte[] rawContents = getJsonBody(clientJwtConfiguration.getJwksUri(), false, true, null, safeRestTemplate);
             if (rawContents != null && rawContents.length > 0) {
                 ClientJwtConfiguration clientKeys = ClientJwtConfiguration.parse(null, new String(rawContents, StandardCharsets.UTF_8));
                 if (clientKeys != null && clientKeys.getJwkSet() != null) {
@@ -85,6 +95,11 @@ public class OidcMetadataFetcher {
     }
 
     private byte[] getJsonBody(String uri, boolean isSkipSslValidation, boolean isCached, String authorizationValue) {
+        return getJsonBody(uri, isSkipSslValidation, isCached, authorizationValue,
+                isSkipSslValidation ? trustingRestTemplate : nonTrustingRestTemplate);
+    }
+
+    private byte[] getJsonBody(String uri, boolean isSkipSslValidation, boolean isCached, String authorizationValue, RestTemplate restTemplate) {
         MultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
         if (authorizationValue != null) {
             headers.add("Authorization", authorizationValue);
@@ -92,32 +107,19 @@ public class OidcMetadataFetcher {
         headers.add("Accept", "application/json,application/jwk-set+json");
         HttpEntity<Object> tokenKeyRequest = new HttpEntity<>(null, headers);
         if (isCached) {
-            return getCachedResponse(uri, isSkipSslValidation, HttpMethod.GET, tokenKeyRequest);
+            return contentCache.getUrlContent(uri, restTemplate, HttpMethod.GET, tokenKeyRequest);
         } else {
-            return getResponse(uri, isSkipSslValidation, HttpMethod.GET, tokenKeyRequest);
+            return getResponse(uri, HttpMethod.GET, tokenKeyRequest, restTemplate);
         }
     }
 
-    private byte[] getResponse(String uri, boolean isSkipSslValidation, HttpMethod method, HttpEntity<Object> header) {
-        ResponseEntity<byte[]> responseEntity;
-        if (isSkipSslValidation) {
-            responseEntity = trustingRestTemplate.exchange(uri, method, header, byte[].class);
-        } else {
-            responseEntity = nonTrustingRestTemplate.exchange(uri, method, header, byte[].class);
-        }
+    private byte[] getResponse(String uri, HttpMethod method, HttpEntity<Object> header, RestTemplate restTemplate) {
+        ResponseEntity<byte[]> responseEntity = restTemplate.exchange(uri, method, header, byte[].class);
         if (responseEntity.getStatusCode() == HttpStatus.OK) {
             return responseEntity.getBody();
         } else {
             throw new IllegalArgumentException(
                     "Unable to fetch content, status:" + HttpStatus.resolve(responseEntity.getStatusCode().value()).getReasonPhrase());
-        }
-    }
-
-    private byte[] getCachedResponse(String uri, boolean isSkipSslValidation, HttpMethod method, HttpEntity<Object> header) {
-        if (isSkipSslValidation) {
-            return contentCache.getUrlContent(uri, trustingRestTemplate, method, header);
-        } else {
-            return contentCache.getUrlContent(uri, nonTrustingRestTemplate, method, header);
         }
     }
 
@@ -130,12 +132,8 @@ public class OidcMetadataFetcher {
     }
 
     private OidcMetadata fetchMetadata(URL discoveryUrl, boolean shouldDoSslValidation) throws OidcMetadataFetchingException {
-        byte[] rawContents;
-        if (shouldDoSslValidation) {
-            rawContents = contentCache.getUrlContent(discoveryUrl.toString(), trustingRestTemplate);
-        } else {
-            rawContents = contentCache.getUrlContent(discoveryUrl.toString(), nonTrustingRestTemplate);
-        }
+        RestTemplate restTemplate = shouldDoSslValidation ? trustingRestTemplate : nonTrustingRestTemplate;
+        byte[] rawContents = contentCache.getUrlContent(discoveryUrl.toString(), restTemplate);
         try {
             return OBJECT_MAPPER.readValue(rawContents, OidcMetadata.class);
         } catch (JacksonException e) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkBlockingDnsResolver.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkBlockingDnsResolver.java
@@ -1,0 +1,43 @@
+package org.cloudfoundry.identity.uaa.util;
+
+import org.apache.hc.client5.http.DnsResolver;
+import org.apache.hc.client5.http.SystemDefaultDnsResolver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+
+/**
+ * DNS resolver that delegates to the system resolver and then rejects any address
+ * that falls in a private, loopback, link-local, or cloud-metadata range.
+ *
+ * Used as the DnsResolver for the RestTemplate that fetches client jwks_uri content,
+ * providing defense-in-depth against DNS rebinding after jwks_uri validation.
+ */
+public class PrivateNetworkBlockingDnsResolver implements DnsResolver {
+
+    public static final PrivateNetworkBlockingDnsResolver INSTANCE = new PrivateNetworkBlockingDnsResolver();
+
+    private static final DnsResolver DELEGATE = SystemDefaultDnsResolver.INSTANCE;
+
+    private PrivateNetworkBlockingDnsResolver() {}
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        InetAddress[] addresses = DELEGATE.resolve(host);
+        InetAddress blocked = Arrays.stream(addresses)
+                .filter(PrivateNetworkGuard::isBlocked)
+                .findFirst()
+                .orElse(null);
+        if (blocked != null) {
+            throw new UnknownHostException(
+                    "Host " + host + " resolves to a blocked address: " + blocked.getHostAddress());
+        }
+        return addresses;
+    }
+
+    @Override
+    public String resolveCanonicalHostname(String host) throws UnknownHostException {
+        return DELEGATE.resolveCanonicalHostname(host);
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
@@ -61,9 +61,6 @@ public final class PrivateNetworkGuard {
             return true;
         }
         // IPv6 unique-local (fc00::/7)
-        if (raw.length == 16 && (raw[0] & 0xfe) == 0xfc) {
-            return true;
-        }
-        return false;
+        return (raw.length == 16 && (raw[0] & 0xfe) == 0xfc);
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
@@ -61,7 +61,7 @@ public final class PrivateNetworkGuard {
             return true;
         }
         // IPv6 unique-local (fc00::/7)
-        if (raw.length == 16 && (raw[0] & 0xfe) == (byte) 0xfc) {
+        if (raw.length == 16 && (raw[0] & 0xfe) == 0xfc) {
             return true;
         }
         return false;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
@@ -1,0 +1,62 @@
+package org.cloudfoundry.identity.uaa.util;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+/**
+ * Rejects hostnames that resolve to private, loopback, link-local, or cloud-metadata
+ * IP ranges. Used to prevent SSRF via operator-supplied fetch targets such as jwks_uri.
+ */
+public final class PrivateNetworkGuard {
+
+    // AWS/GCP/Azure instance-metadata address
+    private static final byte[] METADATA_V4 = {(byte) 169, (byte) 254, (byte) 169, (byte) 254};
+
+    private PrivateNetworkGuard() {}
+
+    /**
+     * Resolves all addresses for the host in {@code uri} and throws if any of them
+     * fall into a private, loopback, link-local, or well-known metadata range.
+     *
+     * @throws IllegalArgumentException if the host resolves to a blocked address
+     * @throws UnknownHostException     if DNS resolution fails
+     */
+    public static void assertPublic(URI uri) throws UnknownHostException {
+        String host = uri.getHost();
+        if (host == null) {
+            throw new IllegalArgumentException("URI has no host: " + uri);
+        }
+        for (InetAddress addr : InetAddress.getAllByName(host)) {
+            if (isBlocked(addr)) {
+                throw new IllegalArgumentException(
+                        "jwks_uri host resolves to a blocked (private/loopback/link-local) address: " + addr.getHostAddress());
+            }
+        }
+    }
+
+    /**
+     * Returns true if the address must be blocked as an outbound fetch target.
+     */
+    public static boolean isBlocked(InetAddress addr) {
+        if (addr.isLoopbackAddress()) {
+            return true;
+        }
+        if (addr.isLinkLocalAddress()) {
+            return true;
+        }
+        if (addr.isSiteLocalAddress()) {
+            return true;
+        }
+        if (addr.isMulticastAddress()) {
+            return true;
+        }
+        byte[] raw = addr.getAddress();
+        // 169.254.169.254 — cloud instance-metadata (IPv4)
+        if (raw.length == 4 && raw[0] == METADATA_V4[0] && raw[1] == METADATA_V4[1]
+                && raw[2] == METADATA_V4[2] && raw[3] == METADATA_V4[3]) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
@@ -12,7 +12,6 @@ public final class PrivateNetworkGuard {
 
     // AWS/GCP/Azure instance-metadata address
     private static final byte[] METADATA_V4 = {(byte) 169, (byte) 254, (byte) 169, (byte) 254};
-
     private PrivateNetworkGuard() {}
 
     /**
@@ -55,6 +54,14 @@ public final class PrivateNetworkGuard {
         // 169.254.169.254 — cloud instance-metadata (IPv4)
         if (raw.length == 4 && raw[0] == METADATA_V4[0] && raw[1] == METADATA_V4[1]
                 && raw[2] == METADATA_V4[2] && raw[3] == METADATA_V4[3]) {
+            return true;
+        }
+        // Unspecified / any-local (0.0.0.0 or ::)
+        if (addr.isAnyLocalAddress()) {
+            return true;
+        }
+        // IPv6 unique-local (fc00::/7)
+        if (raw.length == 16 && (raw[0] & 0xfe) == (byte) 0xfc) {
             return true;
         }
         return false;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuard.java
@@ -12,6 +12,11 @@ public final class PrivateNetworkGuard {
 
     // AWS/GCP/Azure instance-metadata address
     private static final byte[] METADATA_V4 = {(byte) 169, (byte) 254, (byte) 169, (byte) 254};
+    // RFC 6598 — Carrier-grade NAT (100.64.0.0/10)
+    private static final int RFC6598_START = (100 << 24) | (64 << 16);
+    private static final int RFC6598_END   = (100 << 24) | (127 << 16) | (255 << 8) | 255;
+    // IPv4-mapped IPv6 prefix: ::ffff:0:0/96
+    private static final byte[] IPV4_MAPPED_PREFIX = {0,0, 0,0, 0,0, 0,0, 0,0, (byte)0xff,(byte)0xff};
     private PrivateNetworkGuard() {}
 
     /**
@@ -61,6 +66,34 @@ public final class PrivateNetworkGuard {
             return true;
         }
         // IPv6 unique-local (fc00::/7)
-        return (raw.length == 16 && (raw[0] & 0xfe) == 0xfc);
+        if (raw.length == 16 && (raw[0] & 0xfe) == 0xfc) {
+            return true;
+        }
+        // RFC 6598 — carrier-grade NAT (100.64.0.0/10)
+        if (raw.length == 4) {
+            int ip = ((raw[0] & 0xff) << 24) | ((raw[1] & 0xff) << 16) | ((raw[2] & 0xff) << 8) | (raw[3] & 0xff);
+            if (ip >= RFC6598_START && ip <= RFC6598_END) {
+                return true;
+            }
+        }
+        // IPv4-mapped IPv6 (::ffff:x.y.z.w) — check the embedded IPv4 part
+        if (raw.length == 16) {
+            boolean isMapped = true;
+            for (int i = 0; i < IPV4_MAPPED_PREFIX.length; i++) {
+                if (raw[i] != IPV4_MAPPED_PREFIX[i]) {
+                    isMapped = false;
+                    break;
+                }
+            }
+            if (isMapped) {
+                byte[] v4 = {raw[12], raw[13], raw[14], raw[15]};
+                try {
+                    return isBlocked(java.net.InetAddress.getByAddress(v4));
+                } catch (java.net.UnknownHostException ignored) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -23,6 +23,7 @@ import org.apache.hc.client5.http.impl.NoopUserTokenHandler;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
@@ -87,6 +88,34 @@ public abstract class UaaHttpRequestUtils {
     public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int timeout) {
         HttpClientConfig config = HttpClientConfig.defaults(timeout, timeout);
         return createRequestFactory(getClientBuilder(skipSslValidation, config), config.connectionRequestTimeoutInMs());
+    }
+
+    /**
+     * Creates a request factory whose DNS resolver blocks private/loopback/link-local
+     * addresses at connection time. Use this for outbound fetches to operator-supplied
+     * URLs (e.g. jwks_uri) to guard against SSRF and DNS rebinding.
+     */
+    public static ClientHttpRequestFactory createSafeRequestFactory(int timeout) {
+        HttpClientConfig config = HttpClientConfig.defaults(timeout, timeout);
+        HttpClientBuilder builder = HttpClients.custom()
+                .useSystemProperties()
+                .setUserTokenHandler(NoopUserTokenHandler.INSTANCE)
+                .setRedirectStrategy(new DefaultRedirectStrategy());
+        PoolingHttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
+                .setDnsResolver(PrivateNetworkBlockingDnsResolver.INSTANCE)
+                .build();
+        cm.setMaxTotal(config.poolSize());
+        cm.setDefaultMaxPerRoute(config.defaultMaxPerRoute());
+        cm.setValidateAfterInactivity(TimeValue.of(config.validateAfterInactivity(), TimeUnit.MILLISECONDS));
+        cm.setDefaultConnectionConfig(ConnectionConfig.custom()
+                .setConnectTimeout(toTimeout(config.connectTimeoutInMs()))
+                .build());
+        cm.setDefaultSocketConfig(SocketConfig.custom()
+                .setSoTimeout(toTimeout(config.readTimeoutInMs()))
+                .build());
+        builder.setConnectionManager(cm);
+        builder.setConnectionReuseStrategy((_, _, _) -> false);
+        return createRequestFactory(builder, config.connectionRequestTimeoutInMs());
     }
 
     public static ClientHttpRequestFactory createRequestFactory(boolean skipSslValidation, int connectTimeout, int readTimeout, RestTemplateConfig restTemplateConfig) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -92,15 +92,19 @@ public abstract class UaaHttpRequestUtils {
 
     /**
      * Creates a request factory whose DNS resolver blocks private/loopback/link-local
-     * addresses at connection time. Use this for outbound fetches to operator-supplied
-     * URLs (e.g. jwks_uri) to guard against SSRF and DNS rebinding.
+     * addresses at connection time. Redirects are disabled to prevent SSRF via a
+     * redirect to a private IP literal that would bypass DNS-based blocking.
+     * Use this for outbound fetches to operator-supplied URLs (e.g. jwks_uri).
      */
-    public static ClientHttpRequestFactory createSafeRequestFactory(int timeout) {
-        HttpClientConfig config = HttpClientConfig.defaults(timeout, timeout);
+    public static ClientHttpRequestFactory createSafeRequestFactory(RestTemplateConfig restTemplateConfig) {
+        HttpClientConfig config = new HttpClientConfig(restTemplateConfig.maxTotal, restTemplateConfig.maxPerRoute,
+                restTemplateConfig.maxKeepAlive, restTemplateConfig.validateAfterInactivity,
+                restTemplateConfig.retryCount, restTemplateConfig.timeout, restTemplateConfig.timeout,
+                restTemplateConfig.timeout);
         HttpClientBuilder builder = HttpClients.custom()
                 .useSystemProperties()
                 .setUserTokenHandler(NoopUserTokenHandler.INSTANCE)
-                .setRedirectStrategy(new DefaultRedirectStrategy());
+                .disableRedirectHandling();
         PoolingHttpClientConnectionManager cm = PoolingHttpClientConnectionManagerBuilder.create()
                 .setDnsResolver(PrivateNetworkBlockingDnsResolver.INSTANCE)
                 .build();
@@ -114,7 +118,7 @@ public abstract class UaaHttpRequestUtils {
                 .setSoTimeout(toTimeout(config.readTimeoutInMs()))
                 .build());
         builder.setConnectionManager(cm);
-        builder.setConnectionReuseStrategy((request, response, context) -> false);
+        builder.setConnectionReuseStrategy((_, _, _) -> false);
         return createRequestFactory(builder, config.connectionRequestTimeoutInMs());
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -114,7 +114,7 @@ public abstract class UaaHttpRequestUtils {
                 .setSoTimeout(toTimeout(config.readTimeoutInMs()))
                 .build());
         builder.setConnectionManager(cm);
-        builder.setConnectionReuseStrategy((_, _, _) -> false);
+        builder.setConnectionReuseStrategy((request, response, context) -> false);
         return createRequestFactory(builder, config.connectionRequestTimeoutInMs());
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -118,7 +118,11 @@ public abstract class UaaHttpRequestUtils {
                 .setSoTimeout(toTimeout(config.readTimeoutInMs()))
                 .build());
         builder.setConnectionManager(cm);
-        builder.setConnectionReuseStrategy((_, _, _) -> false);
+        if (config.maxKeepAlive() <= 0) {
+            builder.setConnectionReuseStrategy((_, _, _) -> false);
+        } else {
+            builder.setKeepAliveStrategy(new UaaConnectionKeepAliveStrategy(config.maxKeepAlive()));
+        }
         if (config.retryCount() > 0) {
             builder.setRetryStrategy(new UaaHttpRequestRetryHandler(config.retryCount()));
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -119,6 +119,9 @@ public abstract class UaaHttpRequestUtils {
                 .build());
         builder.setConnectionManager(cm);
         builder.setConnectionReuseStrategy((_, _, _) -> false);
+        if (config.retryCount() > 0) {
+            builder.setRetryStrategy(new UaaHttpRequestRetryHandler(config.retryCount()));
+        }
         return createRequestFactory(builder, config.connectionRequestTimeoutInMs());
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
@@ -259,7 +259,7 @@ class ClientAdminBootstrapTests {
         map.put("authorized-grant-types", GRANT_TYPE_AUTHORIZATION_CODE);
         map.put("authorities", "uaa.none");
         map.put("redirect-uri", "http://localhost/callback");
-        map.put("jwks_uri", "https://login.example.com/token_keys");
+        map.put("jwks_uri", "https://1.1.1.1/token_keys");
         UaaClientDetails clientDetails = (UaaClientDetails) doSimpleTest(map, clientAdminBootstrap, multitenantJdbcClientDetailsService, clients);
         assertThat(clientDetails.getClientJwtConfig()).isNotNull();
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
@@ -259,7 +259,7 @@ class ClientAdminBootstrapTests {
         map.put("authorized-grant-types", GRANT_TYPE_AUTHORIZATION_CODE);
         map.put("authorities", "uaa.none");
         map.put("redirect-uri", "http://localhost/callback");
-        map.put("jwks_uri", "https://localhost:8080/uaa");
+        map.put("jwks_uri", "http://localhost:8080/uaa");
         UaaClientDetails clientDetails = (UaaClientDetails) doSimpleTest(map, clientAdminBootstrap, multitenantJdbcClientDetailsService, clients);
         assertThat(clientDetails.getClientJwtConfig()).isNotNull();
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientAdminBootstrapTests.java
@@ -259,7 +259,7 @@ class ClientAdminBootstrapTests {
         map.put("authorized-grant-types", GRANT_TYPE_AUTHORIZATION_CODE);
         map.put("authorities", "uaa.none");
         map.put("redirect-uri", "http://localhost/callback");
-        map.put("jwks_uri", "http://localhost:8080/uaa");
+        map.put("jwks_uri", "https://login.example.com/token_keys");
         UaaClientDetails clientDetails = (UaaClientDetails) doSimpleTest(map, clientAdminBootstrap, multitenantJdbcClientDetailsService, clients);
         assertThat(clientDetails.getClientJwtConfig()).isNotNull();
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
@@ -31,7 +31,7 @@ class ClientJwtConfigurationTest {
     @Test
     void jwksValidity() {
         assertThat(ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri")).isNotNull();
-        assertThat(ClientJwtConfiguration.parse("http://any.localhost/openid/jwks-uri")).isNotNull();
+        assertThat(ClientJwtConfiguration.parse("http://localhost/openid/jwks-uri")).isNotNull();
     }
 
     @Test
@@ -39,6 +39,7 @@ class ClientJwtConfigurationTest {
         assertThatThrownBy(() -> ClientJwtConfiguration.parse("custom://any.domain.net/openid/jwks-uri", null)).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidClientDetailsException.class));
         assertThatThrownBy(() -> ClientJwtConfiguration.parse("test", null)).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidClientDetailsException.class));
         assertThatThrownBy(() -> ClientJwtConfiguration.parse("http://any.domain.net/openid/jwks-uri")).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidClientDetailsException.class));
+        assertThatThrownBy(() -> ClientJwtConfiguration.parse("http://any.localhost/openid/jwks-uri")).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidClientDetailsException.class));
         assertThatThrownBy(() -> ClientJwtConfiguration.parse("https://")).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidClientDetailsException.class));
         assertThatThrownBy(() -> ClientJwtConfiguration.parse("ftp://any.domain.net/openid/jwks-uri")).asInstanceOf(InstanceOfAssertFactories.throwable(InvalidClientDetailsException.class));
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
@@ -79,7 +79,7 @@ class ClientJwtConfigurationTest {
 
     @Test
     void hasConfiguration() {
-        assertThat(ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri").hasConfiguration()).isTrue();
+        assertThat(ClientJwtConfiguration.parse("https://1.1.1.1/openid/jwks-uri").hasConfiguration()).isTrue();
         assertThat(ClientJwtConfiguration.parse(null).hasConfiguration()).isFalse();
         assertThat(new ClientJwtConfiguration().hasConfiguration()).isFalse();
         assertThat(ClientJwtConfiguration.parse(jsonJwkSet).hasConfiguration()).isTrue();
@@ -91,7 +91,7 @@ class ClientJwtConfigurationTest {
         ClientJwtConfiguration config = new ClientJwtConfiguration(ClientJwtCredential.parse("[{\"iss\":\"http://localhost:8080/uaa\",\"sub\":\"client_with_jwks_trust\"}]"));
         assertThat(config.getClientJwtCredentials()).hasSize(1);
         assertThat(config.hasConfiguration()).isTrue();
-        ClientJwtConfiguration mergeConfig = ClientJwtConfiguration.merge(ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri"), config, false);
+        ClientJwtConfiguration mergeConfig = ClientJwtConfiguration.merge(ClientJwtConfiguration.parse("https://1.1.1.1/openid/jwks-uri"), config, false);
         assertThat(mergeConfig.getClientJwtCredentials()).isNotNull();
         assertThat(mergeConfig.getJwksUri()).isNotNull();
         assertThat(mergeConfig.getJwkSet()).isNull();
@@ -291,7 +291,7 @@ class ClientJwtConfigurationTest {
 
     @Test
     void equals() throws Exception {
-        ClientJwtConfiguration key1 = ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri");
+        ClientJwtConfiguration key1 = ClientJwtConfiguration.parse("https://1.1.1.1/openid/jwks-uri");
         ClientJwtConfiguration key2 = (ClientJwtConfiguration) key1.clone();
         assertThat(key2).isEqualTo(key1);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
@@ -44,6 +44,22 @@ class ClientJwtConfigurationTest {
     }
 
     @Test
+    void jwksUri_privateIpIsRejected() {
+        assertThatThrownBy(() -> ClientJwtConfiguration.parse("https://192.168.1.1/jwks"))
+                .isInstanceOf(InvalidClientDetailsException.class)
+                .hasMessageContaining("blocked");
+        assertThatThrownBy(() -> ClientJwtConfiguration.parse("https://10.0.0.1/jwks"))
+                .isInstanceOf(InvalidClientDetailsException.class)
+                .hasMessageContaining("blocked");
+        assertThatThrownBy(() -> ClientJwtConfiguration.parse("https://169.254.169.254/latest/meta-data"))
+                .isInstanceOf(InvalidClientDetailsException.class)
+                .hasMessageContaining("blocked");
+        assertThatThrownBy(() -> ClientJwtConfiguration.parse("https://127.0.0.1/jwks"))
+                .isInstanceOf(InvalidClientDetailsException.class)
+                .hasMessageContaining("blocked");
+    }
+
+    @Test
     void jwkSetValidity() {
         assertThat(ClientJwtConfiguration.parse(jsonWebKey)).isNotNull();
         assertThat(ClientJwtConfiguration.parse(jsonJwkSet)).isNotNull();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/client/ClientJwtConfigurationTest.java
@@ -31,7 +31,6 @@ class ClientJwtConfigurationTest {
     @Test
     void jwksValidity() {
         assertThat(ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri")).isNotNull();
-        assertThat(ClientJwtConfiguration.parse("http://localhost/openid/jwks-uri")).isNotNull();
     }
 
     @Test
@@ -282,8 +281,8 @@ class ClientJwtConfigurationTest {
 
     @Test
     void testHashCode() {
-        ClientJwtConfiguration key1 = ClientJwtConfiguration.parse("http://localhost:8080/uaa");
-        ClientJwtConfiguration key2 = ClientJwtConfiguration.parse("http://localhost:8080/uaa");
+        ClientJwtConfiguration key1 = ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri");
+        ClientJwtConfiguration key2 = ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri");
         assertThat(key2.hashCode()).isNotEqualTo(key1.hashCode());
         assertThat(key1).hasSameHashCodeAs(key1);
         assertThat(key2).hasSameHashCodeAs(key2);
@@ -292,7 +291,7 @@ class ClientJwtConfigurationTest {
 
     @Test
     void equals() throws Exception {
-        ClientJwtConfiguration key1 = ClientJwtConfiguration.parse("http://localhost:8080/uaa");
+        ClientJwtConfiguration key1 = ClientJwtConfiguration.parse("https://any.domain.net/openid/jwks-uri");
         ClientJwtConfiguration key2 = (ClientJwtConfiguration) key1.clone();
         assertThat(key2).isEqualTo(key1);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuardTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuardTest.java
@@ -1,0 +1,67 @@
+package org.cloudfoundry.identity.uaa.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PrivateNetworkGuardTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "127.0.0.1",        // loopback
+            "::1",              // IPv6 loopback
+            "10.0.0.1",         // RFC-1918 class A
+            "172.16.0.1",       // RFC-1918 class B
+            "192.168.1.1",      // RFC-1918 class C
+            "169.254.1.1",      // link-local
+            "169.254.169.254",  // cloud metadata
+            "224.0.0.1",        // multicast
+    })
+    void blockedAddresses(String ip) throws UnknownHostException {
+        assertThat_isBlocked(ip, true);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "1.1.1.1",
+            "8.8.8.8",
+            "93.184.216.34",
+    })
+    void publicAddressesAreNotBlocked(String ip) throws UnknownHostException {
+        assertThat_isBlocked(ip, false);
+    }
+
+    @Test
+    void assertPublic_rejectsPrivateUri() {
+        assertThatThrownBy(() -> PrivateNetworkGuard.assertPublic(URI.create("https://192.168.0.1/jwks")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("blocked");
+    }
+
+    @Test
+    void assertPublic_rejectsUriWithNoHost() {
+        assertThatThrownBy(() -> PrivateNetworkGuard.assertPublic(URI.create("/relative/path")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no host");
+    }
+
+    @Test
+    void assertPublic_acceptsPublicHost() {
+        assertThatNoException().isThrownBy(
+                () -> PrivateNetworkGuard.assertPublic(URI.create("https://1.1.1.1/jwks")));
+    }
+
+    private static void assertThat_isBlocked(String ip, boolean expected) throws UnknownHostException {
+        InetAddress addr = InetAddress.getByName(ip);
+        org.assertj.core.api.Assertions.assertThat(PrivateNetworkGuard.isBlocked(addr))
+                .as("isBlocked(%s)", ip)
+                .isEqualTo(expected);
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuardTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuardTest.java
@@ -23,6 +23,10 @@ class PrivateNetworkGuardTest {
             "169.254.1.1",      // link-local
             "169.254.169.254",  // cloud metadata
             "224.0.0.1",        // multicast
+            "0.0.0.0",          // unspecified IPv4
+            "::",               // unspecified IPv6
+            "fc00::1",          // IPv6 unique-local (fc00::/7)
+            "fd00::1",          // IPv6 unique-local (fd00::/8, within fc00::/7)
     })
     void blockedAddresses(String ip) throws UnknownHostException {
         assertThat_isBlocked(ip, true);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuardTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/PrivateNetworkGuardTest.java
@@ -27,6 +27,12 @@ class PrivateNetworkGuardTest {
             "::",               // unspecified IPv6
             "fc00::1",          // IPv6 unique-local (fc00::/7)
             "fd00::1",          // IPv6 unique-local (fd00::/8, within fc00::/7)
+            "100.64.0.1",       // RFC 6598 carrier-grade NAT start
+            "100.100.100.100",  // RFC 6598 middle
+            "100.127.255.255",  // RFC 6598 end
+            "::ffff:192.168.1.1", // IPv4-mapped IPv6 — private
+            "::ffff:10.0.0.1",    // IPv4-mapped IPv6 — private class A
+            "::ffff:127.0.0.1",   // IPv4-mapped IPv6 — loopback
     })
     void blockedAddresses(String ip) throws UnknownHostException {
         assertThat_isBlocked(ip, true);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsServiceTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsServiceTests.java
@@ -525,14 +525,14 @@ class MultitenantJdbcClientDetailsServiceTests {
         UaaClientDetails clientDetails = new UaaClientDetails();
         clientDetails.setClientId("newClientIdWithNoDetails");
         service.addClientDetails(clientDetails);
-        service.addClientJwtConfig(clientDetails.getClientId(), "https://login.example.com/token_keys", currentZoneId, true);
+        service.addClientJwtConfig(clientDetails.getClientId(), "https://1.1.1.1/token_keys", currentZoneId, true);
 
         Map<String, Object> map = jdbcTemplate.queryForMap(SELECT_SQL,
                 "newClientIdWithNoDetails");
 
         assertThat(map).containsEntry("client_id", "newClientIdWithNoDetails")
                 .containsKey("client_jwt_config");
-        assertThat((String) map.get("client_jwt_config")).isEqualTo("{\"jwks_uri\":\"https://login.example.com/token_keys\"}");
+        assertThat((String) map.get("client_jwt_config")).isEqualTo("{\"jwks_uri\":\"https://1.1.1.1/token_keys\"}");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsServiceTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/MultitenantJdbcClientDetailsServiceTests.java
@@ -525,14 +525,14 @@ class MultitenantJdbcClientDetailsServiceTests {
         UaaClientDetails clientDetails = new UaaClientDetails();
         clientDetails.setClientId("newClientIdWithNoDetails");
         service.addClientDetails(clientDetails);
-        service.addClientJwtConfig(clientDetails.getClientId(), "http://localhost:8080/uaa/token_keys", currentZoneId, true);
+        service.addClientJwtConfig(clientDetails.getClientId(), "https://login.example.com/token_keys", currentZoneId, true);
 
         Map<String, Object> map = jdbcTemplate.queryForMap(SELECT_SQL,
                 "newClientIdWithNoDetails");
 
         assertThat(map).containsEntry("client_id", "newClientIdWithNoDetails")
                 .containsKey("client_jwt_config");
-        assertThat((String) map.get("client_jwt_config")).isEqualTo("{\"jwks_uri\":\"http://localhost:8080/uaa/token_keys\"}");
+        assertThat((String) map.get("client_jwt_config")).isEqualTo("{\"jwks_uri\":\"https://login.example.com/token_keys\"}");
     }
 
     @Test

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
@@ -616,7 +616,7 @@ public class ClientAdminEndpointsIntegrationTests {
         client.setResourceIds(Collections.singleton("foo"));
 
         ClientJwtChangeRequest def = new ClientJwtChangeRequest(null, null, null);
-        def.setJsonWebKeyUri("https://login.example.com/token_keys");
+        def.setJsonWebKeyUri("https://1.1.1.1/token_keys");
         def.setClientId("admin");
 
         ResponseEntity<Void> result = serverRunning.getRestTemplate().exchange(

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/ClientAdminEndpointsIntegrationTests.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.integration;
 
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import org.cloudfoundry.identity.uaa.ServerRunningExtension;
 import org.cloudfoundry.identity.uaa.approval.Approval;
@@ -617,7 +616,7 @@ public class ClientAdminEndpointsIntegrationTests {
         client.setResourceIds(Collections.singleton("foo"));
 
         ClientJwtChangeRequest def = new ClientJwtChangeRequest(null, null, null);
-        def.setJsonWebKeyUri("http://localhost:8080/uaa/token_key");
+        def.setJsonWebKeyUri("https://login.example.com/token_keys");
         def.setClientId("admin");
 
         ResponseEntity<Void> result = serverRunning.getRestTemplate().exchange(
@@ -634,7 +633,7 @@ public class ClientAdminEndpointsIntegrationTests {
 
         client.setResourceIds(Collections.singleton("foo"));
 
-        ClientJwtChangeRequest def = new ClientJwtChangeRequest("admin", "http://localhost:8080/uaa/token_key", null);
+        ClientJwtChangeRequest def = new ClientJwtChangeRequest("admin", "http://localhost:8080/uaa/token_keys", null);
         ResponseEntity<Void> result = serverRunning.getRestTemplate().exchange(
                 serverRunning.getUrl("/oauth/clients/{client}/clientjwt"),
                 HttpMethod.PUT, new HttpEntity<>(def, headers), Void.class,
@@ -662,7 +661,7 @@ public class ClientAdminEndpointsIntegrationTests {
         client.setResourceIds(Collections.singleton("foo"));
 
         ClientJwtChangeRequest def = new ClientJwtChangeRequest(null, null, null);
-        def.setJsonWebKeyUri("http://localhost:8080/uaa/token_key");
+        def.setJsonWebKeyUri("https://login.example.com/token_keys");
         def.setClientId("admin");
 
         ResponseEntity<Void> result = serverRunning.getRestTemplate().exchange(

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointsMockMvcTests.java
@@ -1968,7 +1968,7 @@ class ClientAdminEndpointsMockMvcTests {
         String id = generator.generate();
         ClientDetails client = createClient(token, id, SECRET, Collections.singleton("client_credentials"));
         ClientJwtChangeRequest request = new ClientJwtChangeRequest(null, null, null);
-        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_key");
+        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_keys");
         request.setClientId("admin");
         request.setChangeMode(ClientJwtChangeRequest.ChangeMode.ADD);
         MockHttpServletResponse response = mockMvc.perform(put("/oauth/clients/{client_id}/clientjwt", client.getClientId())
@@ -1998,7 +1998,7 @@ class ClientAdminEndpointsMockMvcTests {
         String id = generator.generate();
         ClientDetails client = createClient(token, id, SECRET, Collections.singleton("client_credentials"));
         ClientJwtChangeRequest request = new ClientJwtChangeRequest(null, null, null);
-        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_key");
+        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_keys");
         request.setClientId("admin");
         request.setChangeMode(ClientJwtChangeRequest.ChangeMode.ADD);
         MockHttpServletResponse response = mockMvc.perform(put("/oauth/clients/{client_id}/clientjwt", client.getClientId())

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointsMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/clients/ClientAdminEndpointsMockMvcZonePathTests.java
@@ -2085,7 +2085,7 @@ class ClientAdminEndpointsMockMvcZonePathTests {
         String id = generator.generate();
         ClientDetails client = createClient(token, id, SECRET, Collections.singleton("client_credentials"));
         ClientJwtChangeRequest request = new ClientJwtChangeRequest(null, null, null);
-        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_key");
+        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_keys");
         request.setClientId("admin");
         request.setChangeMode(ClientJwtChangeRequest.ChangeMode.ADD);
         MockHttpServletResponse response = mockMvc.perform(put("/oauth/clients/{client_id}/clientjwt", client.getClientId())
@@ -2115,7 +2115,7 @@ class ClientAdminEndpointsMockMvcZonePathTests {
         String id = generator.generate();
         ClientDetails client = createClient(token, id, SECRET, Collections.singleton("client_credentials"));
         ClientJwtChangeRequest request = new ClientJwtChangeRequest(null, null, null);
-        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_key");
+        request.setJsonWebKeyUri("http://localhost:8080/uaa/token_keys");
         request.setClientId("admin");
         request.setChangeMode(ClientJwtChangeRequest.ChangeMode.ADD);
         MockHttpServletResponse response = mockMvc.perform(put("/oauth/clients/{client_id}/clientjwt", client.getClientId())


### PR DESCRIPTION
 Problem: UAA allows operators and clients to configure a jwks_uri pointing to an external JWKS endpoint (used for private_key_jwt client authentication). There was no enforcement preventing a jwks_uri from resolving to internal/private network addresses, making UAA a vector for Server-Side Request Forgery (SSRF) and DNS rebinding
  attacks — an attacker could point the URI at cloud instance-metadata endpoints (e.g. 169.254.169.254), internal services, or loopback addresses.

  Fix — two layers of defense:

  1. Validation-time check (PrivateNetworkGuard): When a client registers or updates a jwks_uri, ClientJwtConfiguration now resolves the hostname at validation time and rejects any URI whose host resolves to a private, loopback, link-local, multicast, or cloud-metadata address (including 169.254.169.254). Unresolvable hosts are allowed through at validation time — the fetch will simply fail later.
  2. Fetch-time check (PrivateNetworkBlockingDnsResolver + safeRestTemplate): A new PrivateNetworkBlockingDnsResolver wraps the system DNS resolver and blocks private addresses at connection time. UaaHttpRequestUtils.createSafeRequestFactory builds a dedicated RestTemplate using this resolver. OidcMetadataFetcher uses this safeRestTemplate when fetching JWKS content for client JWT authentication, providing defense-in-depth against DNS rebinding (where a hostname resolves to a public IP at validation time but rebinds to a private IP at fetch time).