### PR TITLE
build(deps): bump brace-expansion from 5.0.7 to 5.0.8 in /uaa

### DIFF
--- a/uaa/package-lock.json
+++ b/uaa/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "server",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
@@ -28,15 +29,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob": {


### PR DESCRIPTION
## Summary
- Bumps `brace-expansion` from 5.0.7 to 5.0.8 in `/uaa` to fix [CVE-2026-14257](https://github.com/advisories/GHSA-mh99-v99m-4gvg)
- The vulnerability is a DoS: chaining many `{}` brace groups keeps the result count under the existing `max` guard while each result string grows, allowing memory exhaustion and an uncatchable OOM crash. 5.0.8 adds a `maxLength` character budget to bound total output size.
- `brace-expansion` is a transitive dependency (via `minimatch`), so only `package-lock.json` changes; `package.json` is unaffected.
- Manual bump since Dependabot had not yet opened a PR for this advisory (published 2026-07-24).

## Test plan
- [x] CI passes