### PR TITLE
Fix deprecated Gradle Kotlin DSL delegate providers (Gradle 9.6)

### DIFF
--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -39,9 +39,9 @@ dependencies {
     annotationProcessor(libs.lombok)
 }
 
-val testArtifacts by configurations.creating
+configurations.create("testArtifacts")
 
-val testJar by tasks.registering(Jar::class) {
+val testJar = tasks.register<Jar>("testJar") {
     dependsOn(tasks.testClasses)
     archiveClassifier.set("tests")
     from(sourceSets.test.get().output)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -168,7 +168,7 @@ tasks.named("check") {
     dependsOn("integrationTest")
 }
 
-val tomcatListenerJar by tasks.registering(Jar::class) {
+val tomcatListenerJar = tasks.register<Jar>("tomcatListenerJar") {
     archiveBaseName.set("tomcat-listener")
     from(sourceSets.main.get().output)
     include("org/cloudfoundry/identity/uaa/web/tomcat/UaaStartupFailureListener.*")


### PR DESCRIPTION
## Summary
- Gradle 9.6 flags `by configurations.creating` / `by tasks.registering` as deprecated (see the Gradle 9.6 upgrading guide).
- Replaces these in `model/build.gradle.kts` and `server/build.gradle.kts` with the recommended `configurations.create()` / `tasks.register<Type>(name) { }` API, removing the associated configure-time warnings.
