### PR TITLE
Propagate externalGroupsWhitelist for bootstrapped OAuth/OIDC identity providers

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIDPWrapperFactoryBean.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OAUTH20;
 import static org.cloudfoundry.identity.uaa.constants.OriginKeys.OIDC10;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.ATTRIBUTE_MAPPINGS;
+import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EXTERNAL_GROUPS_WHITELIST;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.STORE_CUSTOM_ATTRIBUTES_NAME;
 import static org.springframework.util.StringUtils.hasText;
 
@@ -148,6 +149,7 @@ public class OauthIDPWrapperFactoryBean {
         idpDefinition.setTokenKey((String) idpDefinitionMap.get("tokenKey"));
         idpDefinition.setIssuer((String) idpDefinitionMap.get("issuer"));
         idpDefinition.setAttributeMappings((Map<String, Object>) idpDefinitionMap.get(ATTRIBUTE_MAPPINGS));
+        idpDefinition.setExternalGroupsWhitelist((List<String>) idpDefinitionMap.get(EXTERNAL_GROUPS_WHITELIST));
         idpDefinition.setAdditionalConfiguration((Map<String, Object>) idpDefinitionMap.get("additionalConfiguration"));
         idpDefinition.setScopes((List<String>) idpDefinitionMap.get("scopes"));
         idpDefinition.setUserPropagationParameter((String) idpDefinitionMap.get("userPropagationParameter"));

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/OauthIdentityProviderDefinitionFactoryBeanTest.java
@@ -25,11 +25,13 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.EXTERNAL_GROUPS_WHITELIST;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.GROUP_ATTRIBUTE_NAME;
 import static org.cloudfoundry.identity.uaa.provider.ExternalIdentityProviderDefinition.STORE_CUSTOM_ATTRIBUTES_NAME;
 import static org.cloudfoundry.identity.uaa.util.UaaMapUtils.entry;
@@ -117,6 +119,19 @@ class OauthIdentityProviderDefinitionFactoryBeanTest {
         factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
         assertThat(providerDefinition.getAttributeMappings()).containsExactlyInAnyOrderEntriesOf(externalGroupMapping);
         assertThat(providerDefinition.getGroupMappingMode()).isNull();
+    }
+
+    @Test
+    void external_groups_whitelist_default_is_empty() {
+        factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
+        assertThat(providerDefinition.getExternalGroupsWhitelist()).isEmpty();
+    }
+
+    @Test
+    void external_groups_whitelist_in_body() {
+        idpDefinitionMap.put(EXTERNAL_GROUPS_WHITELIST, List.of("*"));
+        factoryBean.setCommonProperties(idpDefinitionMap, providerDefinition);
+        assertThat(providerDefinition.getExternalGroupsWhitelist()).containsExactly("*");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `OauthIDPWrapperFactoryBean` bootstraps OAuth/OIDC identity providers from YAML config, but never read `externalGroupsWhitelist` from that config map — every bootstrapped OAuth/OIDC IdP silently got an empty whitelist regardless of what was configured, so external group claims were never included in the resulting token.
- LDAP (`LdapUtils`) and SAML (`BootstrapSamlIdentityProviderData`) bootstrap paths already wire this property through from their respective config maps; only the OAuth/OIDC path was missing it.
- Fix: read `externalGroupsWhitelist` from the IdP definition map in `setCommonProperties` and apply it via `setExternalGroupsWhitelist`, matching the existing LDAP/SAML behavior.

## Test plan
- [x] Added `external_groups_whitelist_default_is_empty` — confirms unset config still defaults to an empty whitelist.
- [x] Added `external_groups_whitelist_in_body` — confirms a configured whitelist (e.g. `["*"]`) now flows through to the provider definition.
- [x] Ran `OauthIdentityProviderDefinitionFactoryBeanTest` locally — all 28 tests pass.