### PR TITLE
Fix authorization code consumption

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -144,7 +144,7 @@ public class UaaTokenStore implements AuthorizationCodeServices {
             TokenCode tokenCode = (TokenCode) template.queryForObject(SQL_SELECT_STATEMENT, rowMapper, code);
             if (tokenCode != null) {
                 int deletedRows = template.update(SQL_DELETE_STATEMENT, code);
-                if (deletedRows == 0) {
+                if (deletedRows != 1) {
                     throw new InvalidGrantException("Invalid authorization code: " + code);
                 }
                 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStore.java
@@ -143,15 +143,16 @@ public class UaaTokenStore implements AuthorizationCodeServices {
         try {
             TokenCode tokenCode = (TokenCode) template.queryForObject(SQL_SELECT_STATEMENT, rowMapper, code);
             if (tokenCode != null) {
-                try {
-                    if (tokenCode.isExpired()) {
-                        logger.debug("[oauth_code] Found code, but it expired:{}", tokenCode);
-                        throw new InvalidGrantException("Authorization code expired: " + code);
-                    } else {
-                        return tokenCode.deserialize();
-                    }
-                } finally {
-                    template.update(SQL_DELETE_STATEMENT, code);
+                int deletedRows = template.update(SQL_DELETE_STATEMENT, code);
+                if (deletedRows == 0) {
+                    throw new InvalidGrantException("Invalid authorization code: " + code);
+                }
+                
+                if (tokenCode.isExpired()) {
+                    logger.debug("[oauth_code] Found code, but it expired:{}", tokenCode);
+                    throw new InvalidGrantException("Authorization code expired: " + code);
+                } else {
+                    return tokenCode.deserialize();
                 }
             }
         } catch (EmptyResultDataAccessException _) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStoreTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenStoreTests.java
@@ -191,6 +191,42 @@ class UaaTokenStoreTests {
     }
 
     @Test
+    void consumeAuthorizationCodeConcurrently() throws Exception {
+        String code = store.createAuthorizationCode(clientAuthentication);
+        assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM oauth_code WHERE code = ?", Integer.class, new Object[]{code})).isOne();
+
+        int numThreads = 5;
+        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(numThreads);
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+        java.util.concurrent.atomic.AtomicInteger successCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        java.util.concurrent.atomic.AtomicInteger exceptionCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        java.util.List<java.util.concurrent.Future<Void>> futures = new java.util.ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            futures.add(executor.submit(() -> {
+                latch.await();
+                try {
+                    store.consumeAuthorizationCode(code);
+                    successCount.incrementAndGet();
+                } catch (InvalidGrantException e) {
+                    exceptionCount.incrementAndGet();
+                }
+                return null;
+            }));
+        }
+
+        latch.countDown();
+        for (java.util.concurrent.Future<Void> future : futures) {
+            future.get();
+        }
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(exceptionCount.get()).isEqualTo(numThreads - 1);
+        assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM oauth_code WHERE code = ?", Integer.class, new Object[]{code})).isZero();
+    }
+
+    @Test
     void retrieveExpiredToken() {
         String code = store.createAuthorizationCode(clientAuthentication);
         assertThat(jdbcTemplate.queryForObject("SELECT count(*) FROM oauth_code WHERE code = ?", Integer.class, new Object[]{code})).isOne();


### PR DESCRIPTION
Ticket: authorization-code-consumption-ignores-delete-rowcount-toctou

Fix: Validated that JdbcTemplate.update deletes exactly 1 row when consuming an authorization code, preventing TOCTOU races resulting in multiple access tokens per single code.