### PR TITLE
Fix cors allowed origin pattern matching

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -2264,6 +2264,9 @@ Regex patterns for URIs that allow CORS requests (non-XHR). Default permits all.
 
 Regex patterns for allowed CORS origins (non-XHR).
 
+**Note:** Origin patterns are evaluated as full-string matches (they are implicitly anchored with `^` and `$`). If you previously relied on substring matching, you must update your patterns.
+For example, to safely match a domain with any subdomain and an optional port, use a pattern like: `^https?://([a-zA-Z0-9-]+\.)*example\.com(:[0-9]+)?$`
+
 [Back to table](#cors)
 
 ---
@@ -2335,6 +2338,9 @@ Regex patterns for URIs that allow XHR CORS requests.
 **Type:** `List<String>`
 
 Regex patterns for allowed XHR CORS origins.
+
+**Note:** Origin patterns are evaluated as full-string matches (they are implicitly anchored with `^` and `$`). If you previously relied on substring matching, you must update your patterns.
+For example, to safely match a domain with any subdomain and an optional port, use a pattern like: `^https?://([a-zA-Z0-9-]+\.)*example\.com(:[0-9]+)?$`
 
 [Back to table](#cors)
 

--- a/model/src/main/java/org/cloudfoundry/identity/uaa/zone/CorsConfiguration.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/zone/CorsConfiguration.java
@@ -34,14 +34,14 @@ public class CorsConfiguration {
      * requests.
      */
     private List<String> allowedOrigins = Collections.singletonList(".*");
-    private final List<Pattern> allowedOriginPatterns = new ArrayList<>();
+    private List<Pattern> allowedOriginPatterns = new ArrayList<>();
 
     /**
      * A comma delimited list of regular expression patterns that defines which
      * UAA URIs allow the "X-Requested-With" header in CORS requests.
      */
     private List<String> allowedUris = Collections.singletonList(".*");
-    private final List<Pattern> allowedUriPatterns = new ArrayList<>();
+    private List<Pattern> allowedUriPatterns = new ArrayList<>();
 
     /**
      * A comma delimited list of regular expression patterns that define which
@@ -58,6 +58,17 @@ public class CorsConfiguration {
 
     public boolean isAllowedCredentials() {
         return allowedCredentials;
+    }
+
+    @com.fasterxml.jackson.annotation.JsonIgnore
+    private volatile boolean patternsCompiled = false;
+
+    public boolean isPatternsCompiled() {
+        return patternsCompiled;
+    }
+
+    public void setPatternsCompiled(boolean patternsCompiled) {
+        this.patternsCompiled = patternsCompiled;
     }
 
     public void setAllowedCredentials(boolean allowedCredentials) {
@@ -84,16 +95,25 @@ public class CorsConfiguration {
         return allowedOriginPatterns;
     }
 
+    public void setAllowedOriginPatterns(List<Pattern> allowedOriginPatterns) {
+        this.allowedOriginPatterns = allowedOriginPatterns;
+    }
+
     public List<String> getAllowedOrigins() {
         return allowedOrigins;
     }
 
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
+        this.patternsCompiled = false;
     }
 
     public List<Pattern> getAllowedUriPatterns() {
         return allowedUriPatterns;
+    }
+
+    public void setAllowedUriPatterns(List<Pattern> allowedUriPatterns) {
+        this.allowedUriPatterns = allowedUriPatterns;
     }
 
     public List<String> getAllowedUris() {
@@ -102,6 +122,7 @@ public class CorsConfiguration {
 
     public void setAllowedUris(List<String> allowedUris) {
         this.allowedUris = allowedUris;
+        this.patternsCompiled = false;
     }
 
     public int getMaxAge() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
@@ -29,6 +29,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -112,8 +113,7 @@ public class CorsFilter extends OncePerRequestFilter {
     public void initialize() {
         // initialize the configs for default zone
         for (CorsConfiguration configuration : Arrays.asList(xhrConfiguration, defaultConfiguration)) {
-            configuration.getAllowedUriPatterns().clear();
-            configuration.getAllowedOriginPatterns().clear();
+            configuration.setPatternsCompiled(false);
             compileAllowedOriginsAndUris(configuration,
                     configuration == xhrConfiguration ? "xhr" : "default");
         }
@@ -377,27 +377,42 @@ public class CorsFilter extends OncePerRequestFilter {
     }
 
     private void compileAllowedOriginsAndUris(CorsConfiguration configuration, String type) {
-        configuration.getAllowedUriPatterns().clear();
-        if (configuration.getAllowedUris() != null) {
-            for (String allowedUri : configuration.getAllowedUris()) {
-                try {
-                    configuration.getAllowedUriPatterns().add(Pattern.compile(allowedUri));
-                    log.debug("URI '%s' is allowed for a %s CORS requests.".formatted(allowedUri, type));
-                } catch (PatternSyntaxException patternSyntaxException) {
-                    log.error("Invalid regular expression pattern in cors.{}.allowed.uris: {}", type, allowedUri, patternSyntaxException);
-                }
-            }
+        if (configuration.isPatternsCompiled()) {
+            return;
         }
-        configuration.getAllowedOriginPatterns().clear();
-        if (configuration.getAllowedOrigins() != null) {
-            for (String allowedOrigin : configuration.getAllowedOrigins()) {
-                try {
-                    configuration.getAllowedOriginPatterns().add(Pattern.compile(anchorPattern(allowedOrigin)));
-                    log.debug("Origin '%s' is allowed for a %s CORS requests.".formatted(allowedOrigin, type));
-                } catch (PatternSyntaxException patternSyntaxException) {
-                    log.error("Invalid regular expression pattern in cors.{}.allowed.origins: {}", type, allowedOrigin, patternSyntaxException);
+
+        synchronized (configuration) {
+            if (configuration.isPatternsCompiled()) {
+                return;
+            }
+
+            List<Pattern> uriPatterns = new ArrayList<>();
+            if (configuration.getAllowedUris() != null) {
+                for (String allowedUri : configuration.getAllowedUris()) {
+                    try {
+                        uriPatterns.add(Pattern.compile(allowedUri));
+                        log.debug("URI '%s' is allowed for a %s CORS requests.".formatted(allowedUri, type));
+                    } catch (PatternSyntaxException patternSyntaxException) {
+                        log.error("Invalid regular expression pattern in cors.{}.allowed.uris: {}", type, allowedUri, patternSyntaxException);
+                    }
                 }
             }
+            configuration.setAllowedUriPatterns(uriPatterns);
+
+            List<Pattern> originPatterns = new ArrayList<>();
+            if (configuration.getAllowedOrigins() != null) {
+                for (String allowedOrigin : configuration.getAllowedOrigins()) {
+                    try {
+                        originPatterns.add(Pattern.compile(anchorPattern(allowedOrigin)));
+                        log.debug("Origin '%s' is allowed for a %s CORS requests.".formatted(allowedOrigin, type));
+                    } catch (PatternSyntaxException patternSyntaxException) {
+                        log.error("Invalid regular expression pattern in cors.{}.allowed.origins: {}", type, allowedOrigin, patternSyntaxException);
+                    }
+                }
+            }
+            configuration.setAllowedOriginPatterns(originPatterns);
+
+            configuration.setPatternsCompiled(true);
         }
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
@@ -324,7 +324,7 @@ public class CorsFilter extends OncePerRequestFilter {
     protected boolean isAllowedOrigin(final String origin, CorsConfiguration configuration) {
         for (Pattern pattern : configuration.getAllowedOriginPatterns()) {
             // Making sure that the pattern matches
-            if (pattern.matcher(origin).find()) {
+            if (pattern.matcher(origin).matches()) {
                 return true;
             }
         }
@@ -366,6 +366,16 @@ public class CorsFilter extends OncePerRequestFilter {
         return getDefaultConfiguration();
     }
 
+    private String anchorPattern(String pattern) {
+        if (!pattern.startsWith("^")) {
+            pattern = "^" + pattern;
+        }
+        if (!pattern.endsWith("$")) {
+            pattern = pattern + "$";
+        }
+        return pattern;
+    }
+
     private void compileAllowedOriginsAndUris(CorsConfiguration configuration, String type) {
         if (configuration.getAllowedUris() != null) {
             for (String allowedUri : configuration.getAllowedUris()) {
@@ -380,7 +390,7 @@ public class CorsFilter extends OncePerRequestFilter {
         if (configuration.getAllowedOrigins() != null) {
             for (String allowedOrigin : configuration.getAllowedOrigins()) {
                 try {
-                    configuration.getAllowedOriginPatterns().add(Pattern.compile(allowedOrigin));
+                    configuration.getAllowedOriginPatterns().add(Pattern.compile(anchorPattern(allowedOrigin)));
                     log.debug("Origin '%s' is allowed for a %s CORS requests.".formatted(allowedOrigin, type));
                 } catch (PatternSyntaxException patternSyntaxException) {
                     log.error("Invalid regular expression pattern in cors.{}.allowed.origins: {}", type, allowedOrigin, patternSyntaxException);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
@@ -377,6 +377,7 @@ public class CorsFilter extends OncePerRequestFilter {
     }
 
     private void compileAllowedOriginsAndUris(CorsConfiguration configuration, String type) {
+        configuration.getAllowedUriPatterns().clear();
         if (configuration.getAllowedUris() != null) {
             for (String allowedUri : configuration.getAllowedUris()) {
                 try {
@@ -387,6 +388,7 @@ public class CorsFilter extends OncePerRequestFilter {
                 }
             }
         }
+        configuration.getAllowedOriginPatterns().clear();
         if (configuration.getAllowedOrigins() != null) {
             for (String allowedOrigin : configuration.getAllowedOrigins()) {
                 try {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/CorsFilterNonDefaultZoneTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/CorsFilterNonDefaultZoneTests.java
@@ -92,8 +92,8 @@ class CorsFilterNonDefaultZoneTests {
 
     @Test
     void requestWithAllowedOriginPatterns() throws Exception {
-        identityZone.getConfig().getCorsPolicy().getXhrConfiguration().getAllowedOriginPatterns()
-                .add(Pattern.compile("bunnyoutlet-shop.com$"));
+        identityZone.getConfig().getCorsPolicy().getXhrConfiguration().getAllowedOrigins()
+                .add("^.*bunnyoutlet-shop\\.com$");
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uaa/userinfo");
         request.addHeader("Origin", "bunnyoutlet-shop.com");
@@ -105,8 +105,8 @@ class CorsFilterNonDefaultZoneTests {
 
     @Test
     void requestWithAllowedUriPatterns() throws Exception {
-        identityZone.getConfig().getCorsPolicy().getXhrConfiguration().getAllowedUriPatterns()
-                .add(Pattern.compile("/uaa/*"));
+        identityZone.getConfig().getCorsPolicy().getXhrConfiguration().getAllowedUris()
+                .add("^/uaa/.*$");
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uaa/login");
         request.addHeader("Origin", "example.com");
@@ -258,8 +258,8 @@ class CorsFilterNonDefaultZoneTests {
 
     @Test
     void defaultCorsWithAllowedOriginPatterns() throws Exception {
-        identityZone.getConfig().getCorsPolicy().getDefaultConfiguration().getAllowedOriginPatterns()
-                .add(Pattern.compile("bunnyoutlet.com$"));
+        identityZone.getConfig().getCorsPolicy().getDefaultConfiguration().getAllowedOrigins()
+                .add("^.*bunnyoutlet\\.com$");
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uaa/userinfo");
         request.addHeader("Origin", "bunnyoutlet.com");
@@ -270,8 +270,8 @@ class CorsFilterNonDefaultZoneTests {
 
     @Test
     void defaultCorsWithAllowedUriPatterns() throws Exception {
-        identityZone.getConfig().getCorsPolicy().getDefaultConfiguration().getAllowedUriPatterns()
-                .add(Pattern.compile("/uaa/*"));
+        identityZone.getConfig().getCorsPolicy().getDefaultConfiguration().getAllowedUris()
+                .add("^/uaa/.*$");
 
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uaa/login");
         request.addHeader("Origin", "example.com");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -2172,7 +2172,7 @@ public class LoginMockMvcTests {
      */
     @Test
     void logOutCorsPreflightForIdentityZone() throws Exception {
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout.do$"));
         corsFilter.getFilter().initialize();
 
@@ -2266,7 +2266,7 @@ public class LoginMockMvcTests {
     @Test
     void xhrCorsPreflightForNonDefaultZoneWhenZoneSpecificCorsPolicyIsNull() throws Exception {
         // setting the default zone CORS policy
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout.do$"));
         corsFilter.getFilter().initialize();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -2173,7 +2173,7 @@ public class LoginMockMvcTests {
     @Test
     void logOutCorsPreflightForIdentityZone() throws Exception {
         corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
-        corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout.do$"));
+        corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout\\.do$"));
         corsFilter.getFilter().initialize();
 
         HttpHeaders httpHeaders = new HttpHeaders();
@@ -2267,7 +2267,7 @@ public class LoginMockMvcTests {
     void xhrCorsPreflightForNonDefaultZoneWhenZoneSpecificCorsPolicyIsNull() throws Exception {
         // setting the default zone CORS policy
         corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
-        corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout.do$"));
+        corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout\\.do$"));
         corsFilter.getFilter().initialize();
 
         // set the non default zone CORS Xhr policy to null

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
@@ -2623,7 +2623,7 @@ public class LoginMockMvcZonePathTests {
         String subdomain = "testzone1";
         IdentityZone zone = MockMvcUtils.createOtherIdentityZone(subdomain, mockMvc, webApplicationContext, false, IdentityZoneHolder.getCurrentZoneId());
         corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
-        List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH ? asList("^/logout.do$", "^/z/[^/]+/logout.do$") : singletonList("^/logout.do$");
+        List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH ? asList("^/logout\\.do$", "^/z/[^/]+/logout\\.do$") : singletonList("^/logout\\.do$");
         corsFilter.getFilter().setCorsXhrAllowedUris(allowedUris);
         corsFilter.getFilter().initialize();
 
@@ -2737,8 +2737,8 @@ public class LoginMockMvcZonePathTests {
         corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         // For ZONE_PATH mode, the request path is /z/{subdomain}/logout.do, so we need to allow that pattern
         List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH
-                ? asList("^/logout.do$", "^/z/[^/]+/logout.do$")
-                : singletonList("^/logout.do$");
+                ? asList("^/logout\\.do$", "^/z/[^/]+/logout\\.do$")
+                : singletonList("^/logout\\.do$");
         corsFilter.getFilter().setCorsXhrAllowedUris(allowedUris);
         corsFilter.getFilter().initialize();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
@@ -2622,7 +2622,7 @@ public class LoginMockMvcZonePathTests {
     void logOutCorsPreflightForIdentityZone(ZoneResolutionMode mode) throws Exception {
         String subdomain = "testzone1";
         IdentityZone zone = MockMvcUtils.createOtherIdentityZone(subdomain, mockMvc, webApplicationContext, false, IdentityZoneHolder.getCurrentZoneId());
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH ? asList("^/logout.do$", "^/z/[^/]+/logout.do$") : singletonList("^/logout.do$");
         corsFilter.getFilter().setCorsXhrAllowedUris(allowedUris);
         corsFilter.getFilter().initialize();
@@ -2734,7 +2734,7 @@ public class LoginMockMvcZonePathTests {
     @EnumSource(ZoneResolutionMode.class)
     void xhrCorsPreflightForNonDefaultZoneWhenZoneSpecificCorsPolicyIsNull(ZoneResolutionMode mode) throws Exception {
         // setting the default zone CORS policy
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         // For ZONE_PATH mode, the request path is /z/{subdomain}/logout.do, so we need to allow that pattern
         List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH
                 ? asList("^/logout.do$", "^/z/[^/]+/logout.do$")


### PR DESCRIPTION
Ticket: cors-allowed-origin-patterns-matched-with-find-instead-of-matches

Fix: Updated the CorsFilter to anchor (^...$) operator-supplied origin patterns during compilation and transitioned from .find() to .matches() for CORS Origin evaluations, ensuring unanchored spoofed domains are rejected while retaining intended .find() URI substring behavior.