### PR TITLE
Fix double submit csrf cookie

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CookieBasedCsrfTokenRepository.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CookieBasedCsrfTokenRepository.java
@@ -113,10 +113,18 @@ public class CookieBasedCsrfTokenRepository implements CsrfTokenRepository {
             token = generateToken(request);
             expire = true;
         }
-        Cookie csrfCookie = new Cookie(token.getParameterName(), token.getToken());
+        
+        boolean isSecure = secure || "https".equals(request.getScheme());
+        String cookieName = isSecure ? "__Host-" + token.getParameterName() : token.getParameterName();
+
+        Cookie csrfCookie = new Cookie(cookieName, token.getToken());
         csrfCookie.setHttpOnly(true);
-        csrfCookie.setSecure(secure || "https".equals(request.getScheme()));
-        csrfCookie.setPath(ofNullable(request.getContextPath()).orElse("") + "/");
+        csrfCookie.setSecure(isSecure);
+        if (cookieName.startsWith("__Host-")) {
+            csrfCookie.setPath("/");
+        } else {
+            csrfCookie.setPath(ofNullable(request.getContextPath()).orElse("") + "/");
+        }
         if (expire) {
             csrfCookie.setMaxAge(0);
         } else {
@@ -133,8 +141,10 @@ public class CookieBasedCsrfTokenRepository implements CsrfTokenRepository {
         if (requiresCsrfProtection) {
             Cookie[] cookies = request.getCookies();
             if (cookies != null) {
-                for (Cookie cookie : request.getCookies()) {
-                    if (getParameterName().equals(cookie.getName())) {
+                boolean isSecure = secure || "https".equals(request.getScheme());
+                String expectedCookieName = isSecure ? "__Host-" + getParameterName() : getParameterName();
+                for (Cookie cookie : cookies) {
+                    if (expectedCookieName.equals(cookie.getName())) {
                         return new DefaultCsrfToken(getHeaderName(), getParameterName(), cookie.getValue());
                     }
                 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CookieBasedCsrfTokenRepository.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CookieBasedCsrfTokenRepository.java
@@ -115,7 +115,8 @@ public class CookieBasedCsrfTokenRepository implements CsrfTokenRepository {
         }
         
         boolean isSecure = secure || "https".equals(request.getScheme());
-        String cookieName = isSecure ? "__Host-" + token.getParameterName() : token.getParameterName();
+        String baseName = token.getParameterName().startsWith("__Host-") ? token.getParameterName().substring("__Host-".length()) : token.getParameterName();
+        String cookieName = isSecure ? "__Host-" + baseName : baseName;
 
         Cookie csrfCookie = new Cookie(cookieName, token.getToken());
         csrfCookie.setHttpOnly(true);
@@ -142,7 +143,8 @@ public class CookieBasedCsrfTokenRepository implements CsrfTokenRepository {
             Cookie[] cookies = request.getCookies();
             if (cookies != null) {
                 boolean isSecure = secure || "https".equals(request.getScheme());
-                String expectedCookieName = isSecure ? "__Host-" + getParameterName() : getParameterName();
+                String baseName = getParameterName().startsWith("__Host-") ? getParameterName().substring("__Host-".length()) : getParameterName();
+                String expectedCookieName = isSecure ? "__Host-" + baseName : baseName;
                 for (Cookie cookie : cookies) {
                     if (expectedCookieName.equals(cookie.getName())) {
                         return new DefaultCsrfToken(getHeaderName(), getParameterName(), cookie.getValue());

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/CookieBasedCsrfTokenRepositoryTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/CookieBasedCsrfTokenRepositoryTests.java
@@ -166,6 +166,17 @@ class CookieBasedCsrfTokenRepositoryTests {
     }
 
     private Cookie saveTokenAndReturnCookie(boolean isSecure, String protocol) {
-        return saveTokenAndReturnResponse(isSecure, protocol).getCookie("X-Uaa-Csrf");
+        MockHttpServletResponse response = saveTokenAndReturnResponse(isSecure, protocol);
+        boolean expectSecure = isSecure || "https".equals(protocol);
+        String expectedCookieName = expectSecure ? "__Host-X-Uaa-Csrf" : "X-Uaa-Csrf";
+        
+        String setCookie = response.getHeader("Set-Cookie");
+        if (setCookie != null && setCookie.contains(expectedCookieName + "=")) {
+            Cookie cookie = new Cookie(expectedCookieName, "");
+            cookie.setSecure(setCookie.contains("Secure"));
+            cookie.setHttpOnly(setCookie.contains("HttpOnly"));
+            return cookie;
+        }
+        return response.getCookie(expectedCookieName);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/CookieBasedCsrfTokenRepositoryTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/CookieBasedCsrfTokenRepositoryTests.java
@@ -171,12 +171,16 @@ class CookieBasedCsrfTokenRepositoryTests {
         String expectedCookieName = expectSecure ? "__Host-X-Uaa-Csrf" : "X-Uaa-Csrf";
         
         String setCookie = response.getHeader("Set-Cookie");
-        if (setCookie != null && setCookie.contains(expectedCookieName + "=")) {
-            Cookie cookie = new Cookie(expectedCookieName, "");
-            cookie.setSecure(setCookie.contains("Secure"));
-            cookie.setHttpOnly(setCookie.contains("HttpOnly"));
-            return cookie;
+        if (setCookie == null || !setCookie.contains(expectedCookieName + "=")) {
+            throw new IllegalStateException("Expected Set-Cookie header for " + expectedCookieName + " but was: " + setCookie);
         }
-        return response.getCookie(expectedCookieName);
+
+        int valueStart = setCookie.indexOf(expectedCookieName + "=") + (expectedCookieName + "=").length();
+        int valueEnd = setCookie.indexOf(';', valueStart);
+        String value = valueEnd >= 0 ? setCookie.substring(valueStart, valueEnd) : setCookie.substring(valueStart);
+        Cookie cookie = new Cookie(expectedCookieName, value);
+        cookie.setSecure(setCookie.contains("Secure"));
+        cookie.setHttpOnly(setCookie.contains("HttpOnly"));
+        return cookie;
     }
 }


### PR DESCRIPTION
Ticket: double-submit-csrf-cookie-without-host-prefix-samesite-none-session

Fix: Adjusted CookieBasedCsrfTokenRepository to inject the __Host- prefix on the cookie name, strict / path, and Secure attribute dynamically whenever the connection is secure.