### PR TITLE
Fix expiring code redemption

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
@@ -143,8 +143,11 @@ public class JdbcExpiringCodeStore implements ExpiringCodeStore {
             ExpiringCode expiringCode = jdbcTemplate.queryForObject(selectAllFields, rowMapper, code, zoneId);
             if (expiringCode != null) {
                 int deleted = jdbcTemplate.update(delete, code, zoneId);
+                if (deleted == 0) {
+                    return null;
+                }
                 if (deleted != 1) {
-                    logger.warn("Expected to delete 1 expiring code row for code={}, zoneId={} but deleted {}", code, zoneId, deleted);
+                    logger.warn("Expected to delete 1 expiring code row for zoneId={} but deleted {}", zoneId, deleted);
                     return null;
                 }
             }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
@@ -142,7 +142,10 @@ public class JdbcExpiringCodeStore implements ExpiringCodeStore {
         try {
             ExpiringCode expiringCode = jdbcTemplate.queryForObject(selectAllFields, rowMapper, code, zoneId);
             if (expiringCode != null) {
-                jdbcTemplate.update(delete, code, zoneId);
+                int deleted = jdbcTemplate.update(delete, code, zoneId);
+                if (deleted == 0) {
+                    return null;
+                }
             }
             if (expiringCode != null && expiringCode.getExpiresAt().getTime() < timeService.getCurrentTimeMillis()) {
                 expiringCode = null;

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStore.java
@@ -143,7 +143,8 @@ public class JdbcExpiringCodeStore implements ExpiringCodeStore {
             ExpiringCode expiringCode = jdbcTemplate.queryForObject(selectAllFields, rowMapper, code, zoneId);
             if (expiringCode != null) {
                 int deleted = jdbcTemplate.update(delete, code, zoneId);
-                if (deleted == 0) {
+                if (deleted != 1) {
+                    logger.warn("Expected to delete 1 expiring code row for code={}, zoneId={} but deleted {}", code, zoneId, deleted);
                     return null;
                 }
             }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStoreTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/codestore/JdbcExpiringCodeStoreTest.java
@@ -14,6 +14,13 @@ import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -59,6 +66,45 @@ class JdbcExpiringCodeStoreTest extends ExpiringCodeStoreTests {
     @Override
     int countCodes() {
         return jdbcTemplate.queryForObject("select count(*) from expiring_code_store", Integer.class);
+    }
+
+    @Test
+    void retrieveCodeConcurrently() throws Exception {
+        String data = "{}";
+        Timestamp expiresAt = new Timestamp(System.currentTimeMillis() + 60000);
+        ExpiringCode generatedCode = expiringCodeStore.generateCode(data, expiresAt, null, IdentityZone.getUaaZoneId());
+
+        int threadCount = 5;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger nullCount = new AtomicInteger(0);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    latch.await();
+                    ExpiringCode retrievedCode = expiringCodeStore.retrieveCode(generatedCode.getCode(), IdentityZone.getUaaZoneId());
+                    if (retrievedCode != null) {
+                        successCount.incrementAndGet();
+                    } else {
+                        nullCount.incrementAndGet();
+                    }
+                } catch (Exception e) {
+                    e.printStackTrace();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        latch.countDown();
+        doneLatch.await(10, TimeUnit.SECONDS);
+
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(nullCount.get()).isEqualTo(threadCount - 1);
     }
 
 }


### PR DESCRIPTION
Fix: Addressed a Time-of-Check to Time-of-Use (TOCTOU) race condition in JdbcExpiringCodeStore that could allow multiple concurrent requests to consume the same expiring code.

Details: Modified the retrieveCode method to verify the result of the DELETE SQL statement. It now ensures that exactly one row is deleted (jdbcTemplate.update(delete, ...) == 1). If the delete operation affects 0 rows, it safely returns null, preventing race conditions.