### PR TITLE
Fix SAML RelayState allowlist validation

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandler.java
@@ -46,13 +46,13 @@ public class UaaSavedRequestAwareAuthenticationSuccessHandler extends SavedReque
         if (savedRequest == null) {
             String relayState = UaaStringUtils.getCleanedUserControlString(request.getParameter(Saml2ParameterNames.RELAY_STATE), UaaStringUtils.EMPTY_STRING);
             if (UaaStringUtils.hasText(relayState) && UaaUrlUtils.isUrl(relayState)) {
-                log.debug("Redirecting to relayState URI: {}", relayState);
                 java.util.List<String> samlRelayStateWhitelist = java.util.Optional.ofNullable(
                         org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get().getConfig().getLinks().getLogout().getWhitelist()
                 ).orElse(java.util.Collections.emptyList());
                 String fallbackUrl = this.getDefaultTargetUrl();
-                String matchingRedirectUri = UaaUrlUtils.findMatchingRedirectUri(samlRelayStateWhitelist, relayState, fallbackUrl);
-                this.getRedirectStrategy().sendRedirect(request, response, matchingRedirectUri);
+                String redirectUri = UaaUrlUtils.findMatchingRedirectUri(samlRelayStateWhitelist, relayState, fallbackUrl);
+                log.debug("Redirecting after SAML login. requestedRelayState='{}' redirectUri='{}'", relayState, redirectUri);
+                this.getRedirectStrategy().sendRedirect(request, response, redirectUri);
             } else {
                 super.onAuthenticationSuccess(request, response, authentication);
             }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandler.java
@@ -47,7 +47,12 @@ public class UaaSavedRequestAwareAuthenticationSuccessHandler extends SavedReque
             String relayState = UaaStringUtils.getCleanedUserControlString(request.getParameter(Saml2ParameterNames.RELAY_STATE), UaaStringUtils.EMPTY_STRING);
             if (UaaStringUtils.hasText(relayState) && UaaUrlUtils.isUrl(relayState)) {
                 log.debug("Redirecting to relayState URI: {}", relayState);
-                this.getRedirectStrategy().sendRedirect(request, response, relayState);
+                java.util.List<String> samlRelayStateWhitelist = java.util.Optional.ofNullable(
+                        org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get().getConfig().getLinks().getLogout().getWhitelist()
+                ).orElse(java.util.Collections.emptyList());
+                String fallbackUrl = this.getDefaultTargetUrl();
+                String matchingRedirectUri = UaaUrlUtils.findMatchingRedirectUri(samlRelayStateWhitelist, relayState, fallbackUrl);
+                this.getRedirectStrategy().sendRedirect(request, response, matchingRedirectUri);
             } else {
                 super.onAuthenticationSuccess(request, response, authentication);
             }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandler.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandler.java
@@ -26,8 +26,12 @@ import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
 import org.springframework.security.web.savedrequest.SavedRequest;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 public class UaaSavedRequestAwareAuthenticationSuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
@@ -46,9 +50,9 @@ public class UaaSavedRequestAwareAuthenticationSuccessHandler extends SavedReque
         if (savedRequest == null) {
             String relayState = UaaStringUtils.getCleanedUserControlString(request.getParameter(Saml2ParameterNames.RELAY_STATE), UaaStringUtils.EMPTY_STRING);
             if (UaaStringUtils.hasText(relayState) && UaaUrlUtils.isUrl(relayState)) {
-                java.util.List<String> samlRelayStateWhitelist = java.util.Optional.ofNullable(
-                        org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get().getConfig().getLinks().getLogout().getWhitelist()
-                ).orElse(java.util.Collections.emptyList());
+                List<String> samlRelayStateWhitelist = Optional.ofNullable(
+                        IdentityZoneHolder.get().getConfig().getLinks().getLogout().getWhitelist()
+                ).orElse(Collections.emptyList());
                 String fallbackUrl = this.getDefaultTargetUrl();
                 String redirectUri = UaaUrlUtils.findMatchingRedirectUri(samlRelayStateWhitelist, relayState, fallbackUrl);
                 log.debug("Redirecting after SAML login. requestedRelayState='{}' redirectUri='{}'", relayState, redirectUri);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerTests.java
@@ -93,18 +93,20 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerTests {
         request.setParameter(Saml2ParameterNames.RELAY_STATE, redirectUri);
 
         org.cloudfoundry.identity.uaa.zone.IdentityZone zone = org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get();
-        zone.getConfig().getLinks().getLogout().setWhitelist(java.util.List.of("https://test.com/test2"));
+        java.util.List<String> originalWhitelist = zone.getConfig().getLinks().getLogout().getWhitelist();
+        zone.getConfig().getLinks().getLogout().setWhitelist(java.util.List.of(redirectUri));
         org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.set(zone);
 
-        var response = new MockHttpServletResponse();
-        var authentication = mock(Authentication.class);
-        handler.onAuthenticationSuccess(request, response, authentication);
+        try {
+            var response = new MockHttpServletResponse();
+            var authentication = mock(Authentication.class);
+            handler.onAuthenticationSuccess(request, response, authentication);
 
-        assertThat(response.getRedirectedUrl()).isEqualTo(redirectUri);
-        
-        // clean up
-        zone.getConfig().getLinks().getLogout().setWhitelist(null);
-        org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.clear();
+            assertThat(response.getRedirectedUrl()).isEqualTo(redirectUri);
+        } finally {
+            zone.getConfig().getLinks().getLogout().setWhitelist(originalWhitelist);
+            org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.set(zone);
+        }
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerTests.java
@@ -22,8 +22,12 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.saml2.core.Saml2ParameterNames;
 import org.springframework.security.web.savedrequest.SavedRequest;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
 
 import jakarta.servlet.http.HttpSession;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.cloudfoundry.identity.uaa.web.UaaSavedRequestAwareAuthenticationSuccessHandler.FORM_REDIRECT_PARAMETER;
@@ -92,10 +96,10 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerTests {
         String redirectUri = "https://test.com/test2";
         request.setParameter(Saml2ParameterNames.RELAY_STATE, redirectUri);
 
-        org.cloudfoundry.identity.uaa.zone.IdentityZone zone = org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get();
-        java.util.List<String> originalWhitelist = zone.getConfig().getLinks().getLogout().getWhitelist();
-        zone.getConfig().getLinks().getLogout().setWhitelist(java.util.List.of(redirectUri));
-        org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.set(zone);
+        IdentityZone zone = IdentityZoneHolder.get();
+        List<String> originalWhitelist = zone.getConfig().getLinks().getLogout().getWhitelist();
+        zone.getConfig().getLinks().getLogout().setWhitelist(List.of(redirectUri));
+        IdentityZoneHolder.set(zone);
 
         try {
             var response = new MockHttpServletResponse();
@@ -105,7 +109,7 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerTests {
             assertThat(response.getRedirectedUrl()).isEqualTo(redirectUri);
         } finally {
             zone.getConfig().getLinks().getLogout().setWhitelist(originalWhitelist);
-            org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.set(zone);
+            IdentityZoneHolder.set(zone);
         }
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerTests.java
@@ -76,7 +76,7 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerTests {
     }
 
     @Test
-    void onAuthenticationSuccess_noSavedRequest_hasRelayStateUrl() throws Exception {
+    void onAuthenticationSuccess_noSavedRequest_hasRelayStateUrl_notWhitelisted() throws Exception {
         String redirectUri = "https://test.com/test2";
         request.setParameter(Saml2ParameterNames.RELAY_STATE, redirectUri);
 
@@ -84,7 +84,27 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerTests {
         var authentication = mock(Authentication.class);
         handler.onAuthenticationSuccess(request, response, authentication);
 
+        assertThat(response.getRedirectedUrl()).isEqualTo("/");
+    }
+
+    @Test
+    void onAuthenticationSuccess_noSavedRequest_hasRelayStateUrl_whitelisted() throws Exception {
+        String redirectUri = "https://test.com/test2";
+        request.setParameter(Saml2ParameterNames.RELAY_STATE, redirectUri);
+
+        org.cloudfoundry.identity.uaa.zone.IdentityZone zone = org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get();
+        zone.getConfig().getLinks().getLogout().setWhitelist(java.util.List.of("https://test.com/test2"));
+        org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.set(zone);
+
+        var response = new MockHttpServletResponse();
+        var authentication = mock(Authentication.class);
+        handler.onAuthenticationSuccess(request, response, authentication);
+
         assertThat(response.getRedirectedUrl()).isEqualTo(redirectUri);
+        
+        // clean up
+        zone.getConfig().getLinks().getLogout().setWhitelist(null);
+        org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.clear();
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests.java
@@ -24,7 +24,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.saml2.core.Saml2ParameterNames;
+import org.springframework.security.web.savedrequest.SavedRequest;
 import org.cloudfoundry.identity.uaa.extensions.EnabledIfZonePathsEnabled;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -113,8 +118,7 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests {
         String savedRedirectUrl = mode.redirectPrefix().isEmpty()
                 ? "http://localhost/oauth/authorize?client_id=admin"
                 : "http://localhost" + mode.redirectPrefix() + "/oauth/authorize?client_id=admin";
-        org.springframework.security.web.savedrequest.SavedRequest savedRequest =
-                mock(org.springframework.security.web.savedrequest.SavedRequest.class);
+        SavedRequest savedRequest = mock(SavedRequest.class);
         when(savedRequest.getRedirectUrl()).thenReturn(savedRedirectUrl);
         request.getSession(true).setAttribute(SPRING_SECURITY_SAVED_REQUEST, savedRequest);
 
@@ -132,7 +136,7 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests {
         mode.setZone();
         mode.applyRequestPath(request, "/login.do");
         String redirectUri = "https://test.com/test2";
-        request.setParameter(org.springframework.security.saml2.core.Saml2ParameterNames.RELAY_STATE, redirectUri);
+        request.setParameter(Saml2ParameterNames.RELAY_STATE, redirectUri);
         
         MockHttpServletResponse response = new MockHttpServletResponse();
         Authentication authentication = mock(Authentication.class);
@@ -149,11 +153,11 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests {
         mode.setZone();
         mode.applyRequestPath(request, "/login.do");
         String redirectUri = "https://test.com/test2";
-        request.setParameter(org.springframework.security.saml2.core.Saml2ParameterNames.RELAY_STATE, redirectUri);
+        request.setParameter(Saml2ParameterNames.RELAY_STATE, redirectUri);
         
-        org.cloudfoundry.identity.uaa.zone.IdentityZone zone = org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get();
-        java.util.List<String> originalWhitelist = zone.getConfig().getLinks().getLogout().getWhitelist();
-        zone.getConfig().getLinks().getLogout().setWhitelist(java.util.List.of(redirectUri));
+        IdentityZone zone = IdentityZoneHolder.get();
+        List<String> originalWhitelist = zone.getConfig().getLinks().getLogout().getWhitelist();
+        zone.getConfig().getLinks().getLogout().setWhitelist(List.of(redirectUri));
         
         try {
             MockHttpServletResponse response = new MockHttpServletResponse();

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/web/UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests.java
@@ -125,4 +125,45 @@ class UaaSavedRequestAwareAuthenticationSuccessHandlerZonePathTests {
 
         assertThat(response.getRedirectedUrl()).isEqualTo(savedRedirectUrl);
     }
+
+    @ParameterizedTest
+    @EnumSource(ZoneRequestPathMode.class)
+    void onAuthenticationSuccess_noSavedRequest_hasRelayStateUrl_notWhitelisted(ZoneRequestPathMode mode) throws Exception {
+        mode.setZone();
+        mode.applyRequestPath(request, "/login.do");
+        String redirectUri = "https://test.com/test2";
+        request.setParameter(org.springframework.security.saml2.core.Saml2ParameterNames.RELAY_STATE, redirectUri);
+        
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        Authentication authentication = mock(Authentication.class);
+        
+        handler.onAuthenticationSuccess(request, response, authentication);
+        
+        String expected = mode.redirectPrefix().isEmpty() ? "/" : mode.redirectPrefix() + "/";
+        assertThat(response.getRedirectedUrl()).isEqualTo(expected);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ZoneRequestPathMode.class)
+    void onAuthenticationSuccess_noSavedRequest_hasRelayStateUrl_whitelisted(ZoneRequestPathMode mode) throws Exception {
+        mode.setZone();
+        mode.applyRequestPath(request, "/login.do");
+        String redirectUri = "https://test.com/test2";
+        request.setParameter(org.springframework.security.saml2.core.Saml2ParameterNames.RELAY_STATE, redirectUri);
+        
+        org.cloudfoundry.identity.uaa.zone.IdentityZone zone = org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder.get();
+        java.util.List<String> originalWhitelist = zone.getConfig().getLinks().getLogout().getWhitelist();
+        zone.getConfig().getLinks().getLogout().setWhitelist(java.util.List.of(redirectUri));
+        
+        try {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            Authentication authentication = mock(Authentication.class);
+            
+            handler.onAuthenticationSuccess(request, response, authentication);
+            
+            assertThat(response.getRedirectedUrl()).isEqualTo(redirectUri);
+        } finally {
+            zone.getConfig().getLinks().getLogout().setWhitelist(originalWhitelist);
+        }
+    }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -779,7 +779,7 @@ public class SamlLoginIT {
         webDriver.findElement(By.xpath(samlServerConfig.getLoginPromptXpathExpr()));
         sendCredentials(testAccounts.getUserName(), testAccounts.getPassword());
         Page.assertThatUrlEventuallySatisfies(webDriver,
-                assertUrl -> assertUrl.startsWith("https://www.google.com"));
+                assertUrl -> assertUrl.startsWith(baseUrl));
 
         webDriver.get("%s/logout.do".formatted(baseUrl));
     }
@@ -1228,7 +1228,7 @@ public class SamlLoginIT {
         sendCredentials(testAccounts.getUserName(), "koala");
 
         Page.assertThatUrlEventuallySatisfies(webDriver,
-                assertUrl -> assertUrl.startsWith("https://www.google.com"));
+                assertUrl -> assertUrl.startsWith(zoneUrl));
         webDriver.get(baseUrl + "/logout.do");
         webDriver.get(zoneUrl + "/logout.do");
     }


### PR DESCRIPTION
Fix: Prevented open redirect vulnerabilities by securely validating the RelayState parameter during SAML authentication.

Details: Updated UaaSavedRequestAwareAuthenticationSuccessHandler to validate the RelayState URL against the links.logout.whitelist configured in the identity zone (using UaaUrlUtils.findMatchingRedirectUri). If the target is not in the allowlist, the application safely falls back to redirecting to the context path root (/).