### PR TITLE
Implement SAML SLO signature validation

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
@@ -35,8 +35,10 @@ public class SamlLogoutRequestValidator implements Saml2LogoutRequestValidator {
         if (parameters != null
                 && parameters.getLogoutRequest().getBinding() == Saml2MessageBinding.REDIRECT
                 && parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
+            boolean hasSignature = parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIGNATURE) != null;
+            String description = hasSignature ? "Missing signature algorithm" : "Missing signature";
             return Saml2LogoutValidatorResult.withErrors(new Saml2Error(
-                    Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature")).build();
+                    Saml2ErrorCodes.INVALID_SIGNATURE, description)).build();
         }
 
         return delegate.validate(parameters);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidator.java
@@ -35,25 +35,10 @@ public class SamlLogoutRequestValidator implements Saml2LogoutRequestValidator {
         if (parameters != null
                 && parameters.getLogoutRequest().getBinding() == Saml2MessageBinding.REDIRECT
                 && parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIG_ALG) == null) {
-            // Signature present without SigAlg is malformed — reject rather than bypass.
-            if (parameters.getLogoutRequest().getParameters().get(Saml2ParameterNames.SIGNATURE) != null) {
-                return Saml2LogoutValidatorResult.withErrors(new Saml2Error(
-                        Saml2ErrorCodes.INVALID_SIGNATURE, "Signature present without SigAlg")).build();
-            }
-            return SamlUnsignedMessageValidator.validateLogoutRequest(
-                    parameters.getLogoutRequest().getSamlRequest(),
-                    parameters.getLogoutRequest().getBinding(),
-                    parameters.getRelyingPartyRegistration());
+            return Saml2LogoutValidatorResult.withErrors(new Saml2Error(
+                    Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature")).build();
         }
 
-        Saml2LogoutValidatorResult result = delegate.validate(parameters);
-        if (!result.hasErrors()) {
-            return result;
-        }
-
-        Collection<Saml2Error> errors = result.getErrors().stream()
-                .filter(error -> !error.getDescription().contains("signature"))
-                .toList();
-        return Saml2LogoutValidatorResult.withErrors().errors(c -> c.addAll(errors)).build();
+        return delegate.validate(parameters);
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
@@ -62,13 +62,6 @@ class SamlLogoutRequestValidatorTest {
         }
 
         @Test
-        void validateRemovesMissingSignatureError() {
-            Saml2Error signatureError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Missing signature for object");
-            when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(signatureError).build());
-            assertThat(validator.validate(parameters).hasErrors()).isFalse();
-        }
-
-        @Test
         void validateDifferentErrorIsPassedThru() {
             Saml2Error otherError = new Saml2Error(Saml2ErrorCodes.INVALID_SIGNATURE, "Failed to match issuer to configured issuer");
             when(delegate.validate(any())).thenReturn(Saml2LogoutValidatorResult.withErrors(otherError).build());
@@ -77,34 +70,16 @@ class SamlLogoutRequestValidatorTest {
     }
 
     @Test
-    void unsignedRedirectRequestBypassesDelegateAndValidatesIssuerAndDestination() {
-        String destination = "http://sp.example.com/saml/SingleLogout";
-        String issuer = "http://idp.example.com";
-        String xml = """
-                <samlp:LogoutRequest
-                    xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
-                    xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
-                    Destination="%s">
-                  <saml:Issuer>%s</saml:Issuer>
-                  <saml:NameID>user@example.com</saml:NameID>
-                </samlp:LogoutRequest>
-                """.formatted(destination, issuer);
-
+    void unsignedRedirectRequestIsRejected() {
         when(logoutRequest.getBinding()).thenReturn(Saml2MessageBinding.REDIRECT);
         when(logoutRequest.getParameters()).thenReturn(Collections.emptyMap()); // no SigAlg
-        when(logoutRequest.getSamlRequest()).thenReturn(Saml2Utils.samlEncode(Saml2Utils.samlDeflate(xml)));
-
-        AssertingPartyMetadata party = mock(AssertingPartyMetadata.class);
-        when(party.getEntityId()).thenReturn(issuer);
-        RelyingPartyRegistration reg = mock(RelyingPartyRegistration.class);
-        when(reg.getAssertingPartyMetadata()).thenReturn(party);
-        when(reg.getSingleLogoutServiceLocation()).thenReturn(destination);
-        when(parameters.getRelyingPartyRegistration()).thenReturn(reg);
 
         Saml2LogoutValidatorResult result = validator.validate(parameters);
-
-        assertThat(result.hasErrors()).isFalse();
         verify(delegate, never()).validate(any());
+
+        assertThat(result.hasErrors()).isTrue();
+        assertThat(result.getErrors()).hasSize(1);
+        assertThat(result.getErrors().iterator().next().getDescription()).isEqualTo("Missing signature");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/authentication/SamlLogoutRequestValidatorTest.java
@@ -78,8 +78,12 @@ class SamlLogoutRequestValidatorTest {
         verify(delegate, never()).validate(any());
 
         assertThat(result.hasErrors()).isTrue();
-        assertThat(result.getErrors()).hasSize(1);
-        assertThat(result.getErrors().iterator().next().getDescription()).isEqualTo("Missing signature");
+        assertThat(result.getErrors())
+                .singleElement()
+                .satisfies(e -> {
+                    assertThat(e.getErrorCode()).isEqualTo(Saml2ErrorCodes.INVALID_SIGNATURE);
+                    assertThat(e.getDescription()).isEqualTo("Missing signature");
+                });
     }
 
     @Test
@@ -97,9 +101,14 @@ class SamlLogoutRequestValidatorTest {
         when(logoutRequest.getParameters()).thenReturn(Map.of(Saml2ParameterNames.SIGNATURE, "somesig")); // Signature but no SigAlg
 
         Saml2LogoutValidatorResult result = validator.validate(parameters);
+        verify(delegate, never()).validate(any());
 
         assertThat(result.hasErrors()).isTrue();
-        assertThat(result.getErrors()).anyMatch(e -> e.getErrorCode().equals(Saml2ErrorCodes.INVALID_SIGNATURE));
-        verify(delegate, never()).validate(any());
+        assertThat(result.getErrors())
+                .singleElement()
+                .satisfies(e -> {
+                    assertThat(e.getErrorCode()).isEqualTo(Saml2ErrorCodes.INVALID_SIGNATURE);
+                    assertThat(e.getDescription()).isEqualTo("Missing signature algorithm");
+                });
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/SamlLoginIT.java
@@ -517,8 +517,9 @@ public class SamlLoginIT {
         // UAA should redirect to the welcome page
         new SamlWelcomePage(webDriver, samlServerConfig);
 
-        // UAA Should no longer be logged in
-        HomePage.assertThatGoHome_redirectsToLoginPage(webDriver, baseUrl);
+        // Unsigned SLO request from simpleSAMLphp should be rejected, leaving user logged in
+        webDriver.get(baseUrl + "/home");
+        new HomePage(webDriver, baseUrl);
     }
 
     @Test


### PR DESCRIPTION
Fix: Re-enabled strict signature verification for SAML Single Logout (SLO) requests by removing overly permissive error filtering.

Details: In SamlLogoutRequestValidator, previously an issue filtered out any SAML validation errors containing the word "signature". We removed this bypass so that if an unsigned SAML LogoutRequest arrives via the REDIRECT binding without a SigAlg parameter, it now accurately rejects the request with an INVALID_SIGNATURE error.