### PR TITLE
Move test LDAP config out of production uaa.yml defaults

### DIFF
--- a/scripts/boot/uaa.yml
+++ b/scripts/boot/uaa.yml
@@ -14,6 +14,30 @@ issuer:
 #The secret that an external login server will use to authenticate to the uaa using the id `login`
 LOGIN_SECRET: loginsecret
 
+# Points at the local OpenLDAP test server started by scripts/lib_ldap_helper.sh /
+# scripts/ldap/ldap-start-and-populate.sh (see scripts/docker-compose.yml). Only takes
+# effect when the `ldap` Spring profile is active, which is how LdapIntegrationTests
+# and LdapLoginIT run this dev/integration-test server.
+ldap:
+  profile:
+    file: ldap/ldap-search-and-bind.xml
+  base:
+    url: 'ldap://localhost:389/'
+    userDn: 'cn=admin,dc=test,dc=com'
+    password: 'password'
+    searchBase: 'dc=test,dc=com'
+    searchFilter: 'cn={0}'
+  groups:
+    file: ldap/ldap-groups-as-scopes.xml
+    searchBase: 'dc=test,dc=com'
+    groupRoleAttribute: 'cn'
+    groupSearchFilter: 'member={0}'
+    searchSubtree: true
+    maxSearchDepth: 10
+    autoAdd: true
+  externalGroupsWhitelist:
+    - '*'
+
 jwt:
   token:
     policy:

--- a/uaa/src/main/resources/uaa.yml
+++ b/uaa/src/main/resources/uaa.yml
@@ -594,25 +594,29 @@ uaa:
 #    maxPerRoute: 2
 #    maxKeepAlive: 0
 
-ldap:
-  profile:
-    file: ldap/ldap-search-and-bind.xml
-  base:
-    url: 'ldap://localhost:389/'
-    userDn: 'cn=admin,dc=test,dc=com'
-    password: 'password'
-    searchBase: 'dc=test,dc=com'
-    searchFilter: 'cn={0}'
-  groups:
-    file: ldap/ldap-groups-as-scopes.xml
-    searchBase: 'dc=test,dc=com'
-    groupRoleAttribute: 'cn'
-    groupSearchFilter: 'member={0}'
-    searchSubtree: true
-    maxSearchDepth: 10
-    autoAdd: true
-  externalGroupsWhitelist:
-    - '*'
+# LDAP is not configured by default. Uncomment and adjust the block below (or provide
+# the equivalent `ldap.*` properties via your own config) together with the `ldap`
+# profile to enable LDAP authentication. The values below are only an example; do not
+# use them in production, they describe a local test LDAP server.
+#ldap:
+#  profile:
+#    file: ldap/ldap-search-and-bind.xml
+#  base:
+#    url: 'ldap://localhost:389/'
+#    userDn: 'cn=admin,dc=test,dc=com'
+#    password: 'password'
+#    searchBase: 'dc=test,dc=com'
+#    searchFilter: 'cn={0}'
+#  groups:
+#    file: ldap/ldap-groups-as-scopes.xml
+#    searchBase: 'dc=test,dc=com'
+#    groupRoleAttribute: 'cn'
+#    groupSearchFilter: 'member={0}'
+#    searchSubtree: true
+#    maxSearchDepth: 10
+#    autoAdd: true
+#  externalGroupsWhitelist:
+#    - '*'
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## Problem

`uaa/src/main/resources/uaa.yml` shipped a live `ldap:` block (`ldap://localhost:389/`, `cn=admin,dc=test,dc=com` / `password`, `dc=test,dc=com`) in the production default config. As noted in #4025, these are not sensible defaults — they are strictly test configuration.

The block only takes effect when the `ldap` Spring profile is active, but the file's own documented example (`#spring_profiles: ldap`) means anyone enabling that profile without overriding these values silently ends up with a misconfigured LDAP provider pointed at a nonexistent local server, instead of a clear "not configured" state.

## Fix

- Commented out the `ldap:` block in `uaa/src/main/resources/uaa.yml`, matching the style of the other documented LDAP examples already in that file.
- Moved the live values to `scripts/boot/uaa.yml`, the dev/integration-test bootstrap config already used for this purpose (e.g. `zones.paths.enabled`), which is loaded via `CLOUDFOUNDRY_CONFIG_PATH` when the real UAA server is booted for integration tests. This keeps `LdapIntegrationTests` and `LdapLoginIT` working against the docker-compose OpenLDAP test server started by `scripts/lib_ldap_helper.sh`.

## Testing

- `YamlProcessorTest`, `YamlConfigurationValidationTests` — pass (both yml files still parse)
- `IdentityProviderBootstrapTest` (23 tests) — pass
- `org.cloudfoundry.identity.uaa.mock.ldap.*` — 91 passed / 23 pre-existing skips, 0 failed

Fixes #4025

🤖 Generated with [Claude Code](https://claude.com/claude-code)
