### PR TITLE
Persist SAML entityID for the default identity zone during bootstrap

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/SpringServletXmlBeansConfiguration.java
@@ -397,7 +397,8 @@ public class SpringServletXmlBeansConfiguration {
             @Qualifier("links") HashMap<String, Object> links,
             @Qualifier("prompts") List<Prompt> prompts,
             @Qualifier("defaultUserConfig") UserConfig defaultUserConfig,
-            @Value("${issuer.uri}") String issuerUri
+            @Value("${issuer.uri}") String issuerUri,
+            @Value("${login.entityID:}") String samlEntityID
     ) {
         IdentityZoneConfigurationBootstrap bean = new IdentityZoneConfigurationBootstrap(provisioning);
         bean.setValidator(identityZoneValidator);
@@ -426,6 +427,7 @@ public class SpringServletXmlBeansConfiguration {
         bean.setDisableSamlInResponseToCheck(loginProps.saml().disableInResponseToCheck());
         bean.setSamlWantAssertionSigned(loginProps.saml().wantAssertionSigned());
         bean.setSamlRequestSigned(loginProps.saml().signRequest());
+        bean.setSamlEntityID(samlEntityID);
         bean.setDefaultUserConfig(defaultUserConfig);
         bean.setDefaultIdentityProvider(loginProps.defaultIdentityProvider());
         bean.setIssuer(issuerUri);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityZoneConfigurationBootstrap.java
@@ -57,6 +57,7 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
     private String samlSpPrivateKey;
     private String samlSpPrivateKeyPassphrase;
     private String samlSpCertificate;
+    private String samlEntityID;
     private boolean disableSamlInResponseToCheck;
 
     /**
@@ -96,6 +97,9 @@ public class IdentityZoneConfigurationBootstrap implements InitializingBean {
         definition.getSamlConfig().setDisableInResponseToCheck(disableSamlInResponseToCheck);
         definition.getSamlConfig().setWantAssertionSigned(samlWantAssertionSigned);
         definition.getSamlConfig().setRequestSigned(samlRequestSigned);
+        if (hasText(samlEntityID)) {
+            definition.getSamlConfig().setEntityID(samlEntityID);
+        }
         definition.setIdpDiscoveryEnabled(idpDiscoveryEnabled);
         definition.setAccountChooserEnabled(accountChooserEnabled);
         definition.setDefaultIdentityProvider(defaultIdentityProvider);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityZoneConfigurationBootstrapTests.java
@@ -356,4 +356,28 @@ public class IdentityZoneConfigurationBootstrapTests {
         assertThat(defaultZone.getConfig().getIssuer()).isEqualTo(testIssuer);
         assertThat(defaultZone.getConfig().getTokenPolicy().getActiveKeyId()).isEqualTo("defaultkey");
     }
+
+    @Test
+    void samlEntityIdConfiguration() throws Exception {
+        bootstrap.setSamlEntityID("test-entity-id");
+        bootstrap.afterPropertiesSet();
+        IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
+        assertThat(config.getSamlConfig().getEntityID()).isEqualTo("test-entity-id");
+    }
+
+    @Test
+    void samlEntityIdConfiguration_nullValue() throws Exception {
+        bootstrap.setSamlEntityID(null);
+        bootstrap.afterPropertiesSet();
+        IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
+        assertThat(config.getSamlConfig().getEntityID()).isNull();
+    }
+
+    @Test
+    void samlEntityIdConfiguration_emptyValue() throws Exception {
+        bootstrap.setSamlEntityID("");
+        bootstrap.afterPropertiesSet();
+        IdentityZoneConfiguration config = provisioning.retrieve(IdentityZone.getUaaZoneId()).getConfig();
+        assertThat(config.getSamlConfig().getEntityID()).isNull();
+    }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/zones/IdentityZoneEndpointsMockMvcTests.java
@@ -2146,6 +2146,41 @@ class IdentityZoneEndpointsMockMvcTests {
     }
 
     @Test
+    void createZoneWithSamlConfig_entityIdAndSigningFlagsArePersisted() throws Exception {
+        String id = generator.generate().toLowerCase();
+        String entityId = "test-entity-id-" + id;
+
+        IdentityZoneConfiguration zoneConfiguration = new IdentityZoneConfiguration();
+        SamlConfig samlConfig = new SamlConfig();
+        samlConfig.setEntityID(entityId);
+        samlConfig.setRequestSigned(false);
+        samlConfig.setWantAssertionSigned(false);
+        zoneConfiguration.setSamlConfig(samlConfig);
+
+        IdentityZone created = createZone(id, HttpStatus.CREATED, identityClientToken, zoneConfiguration);
+        assertThat(created.getConfig().getSamlConfig())
+                .returns(entityId, SamlConfig::getEntityID)
+                .returns(false, SamlConfig::isRequestSigned)
+                .returns(false, SamlConfig::isWantAssertionSigned);
+
+        IdentityZone fetched = getIdentityZone(id, HttpStatus.OK, identityClientToken);
+        assertThat(fetched.getConfig().getSamlConfig())
+                .returns(entityId, SamlConfig::getEntityID)
+                .returns(false, SamlConfig::isRequestSigned)
+                .returns(false, SamlConfig::isWantAssertionSigned);
+    }
+
+    @Test
+    void defaultZoneSamlConfig_isPopulatedFromBootstrapYaml() throws Exception {
+        // mockmvc_unittest_properties.yml sets login.entityID, login.saml.signRequest, login.saml.wantAssertionSigned
+        IdentityZone uaaZone = getIdentityZone(IdentityZone.getUaaZoneId(), HttpStatus.OK, identityClientToken);
+        assertThat(uaaZone.getConfig().getSamlConfig())
+                .returns("integration-saml-entity-id", SamlConfig::getEntityID)
+                .returns(true, SamlConfig::isRequestSigned)
+                .returns(true, SamlConfig::isWantAssertionSigned);
+    }
+
+    @Test
     void updateZoneWithDifferentIdInBodyAndPath_fails() throws Exception {
         IdentityZone identityZone = createZone(new AlphanumericRandomValueStringGenerator(5).generate(), HttpStatus.CREATED, adminToken, new IdentityZoneConfiguration());
         String id = identityZone.getId();


### PR DESCRIPTION
## Summary
- `GET /identity-zones/uaa` omits the SAML `entityID` because the bootstrap flow for the default zone never persists `login.entityID` into `SamlConfig`, even though a separate runtime bean reads it for SAML metadata generation.
- Binds `login.entityID` into `IdentityZoneConfigurationBootstrap` (mirroring how `issuer` is already handled) and persists it on the zone's `SamlConfig` when present.
- First commit adds a regression test demonstrating the gap (verified it fails in isolation before the fix); second commit is the fix plus supporting unit tests.

## Test plan
- [x] `IdentityZoneConfigurationBootstrapTests` (new `samlEntityIdConfiguration*` tests + full suite) pass
- [x] `IdentityZoneEndpointsMockMvcTests` full suite passes, including the new `defaultZoneSamlConfig_isPopulatedFromBootstrapYaml` and `createZoneWithSamlConfig_entityIdAndSigningFlagsArePersisted`
- [x] `provider.saml.*` server tests pass (confirms no change to actual SAML runtime behavior, since the two runtime consumers of `SamlConfig.getEntityID()` already bypass the default zone)
- [x] `IdentityZoneEndpointDocs` REST-docs tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)