### PR TITLE
Support ne and not SCIM filter operators

### DIFF
--- a/docs/UAA-APIs.rst
+++ b/docs/UAA-APIs.rst
@@ -78,6 +78,7 @@ Filtering supports
 Attribute operators
 
 * eq - equalsIgnoreCase
+* ne - not equal - in SQL becomes ``<>``
 * co - contains - in SQL becomes 'like %value%', case insensitive
 * sw - starts with - in SQL becomes 'like value%', case insensitive
 * pr - present - in SQL becomes 'IS NOT NULL'
@@ -90,6 +91,7 @@ Logical operators
 
 * and - logical and
 * or - logical or
+* not - logical negation of a grouped expression, e.g. ``not (username eq "joe")``
 
 Grouping operators
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverter.java
@@ -212,6 +212,9 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
         for (Filter subfilter : ofNullable(filter.getCombinedFilters()).orElse(emptyList())) {
             validateFilterAttributes(subfilter, invalidAttribues, validAttributeNames, depth + 1);
         }
+        if (filter.getInvertedFilter() != null) {
+            validateFilterAttributes(filter.getInvertedFilter(), invalidAttribues, validAttributeNames, depth + 1);
+        }
     }
 
     private void extractValues(Filter filter, MultiValueMap<String, Object> values) throws ScimException {
@@ -230,11 +233,15 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
                 break;
             case OR:
                 throw new BadRequestException("[or] operator is not supported.");
+            case NOT:
+                throw new BadRequestException("[not] operator is not supported.");
             case EQUAL:
                 Object value = getStringOrDate(filter.getComparisonValue().asString());
                 String key = filter.getAttributePath().toString();
                 values.add(key, value);
                 break;
+            case NOT_EQUAL:
+                throw new BadRequestException("[ne] operator is not supported.");
             case CONTAINS:
                 throw new BadRequestException("[co] operator is not supported.");
             case STARTS_WITH:
@@ -276,7 +283,9 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
         return switch (filter.getFilterType()) {
             case AND -> buildCombiningClause(filter, " AND ", values, mapper, paramPrefix, depth);
             case OR -> buildCombiningClause(filter, " OR ", values, mapper, paramPrefix, depth);
+            case NOT -> "NOT (" + whereClauseFromFilter(filter.getInvertedFilter(), values, mapper, paramPrefix, depth + 1) + ")";
             case EQUAL -> comparisonClause(filter, "=", values, "", "", paramPrefix);
+            case NOT_EQUAL -> comparisonClause(filter, "<>", values, "", "", paramPrefix);
             case CONTAINS -> comparisonClause(filter, "LIKE", values, "%", "%", paramPrefix);
             case STARTS_WITH -> comparisonClause(filter, "LIKE", values, "", "%", paramPrefix);
             case PRESENT -> getAttributeName(filter, mapper) + " IS NOT NULL";
@@ -298,7 +307,7 @@ public class SimpleSearchQueryConverter implements SearchQueryConverter {
         String paramName = ":" + pName;
         ValueNode compValue = filter.getComparisonValue();
         if (compValue == null || compValue.isNull()) {
-            return getAttributeName(filter, mapper) + " IS NULL";
+            return getAttributeName(filter, mapper) + ("<>".equals(comparator) ? " IS NOT NULL" : " IS NULL");
         } else if (compValue.isString()) {
             Object value = getStringOrDate(compValue.asString());
             if (value instanceof String) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpoints.java
@@ -184,7 +184,9 @@ public class UserIdConversionEndpoints implements InitializingBean {
                 }
             case PRESENT, STARTS_WITH, CONTAINS:
                 throw new ScimException("Wildcards are not allowed in filter.", HttpStatus.BAD_REQUEST);
-            case GREATER_THAN, GREATER_OR_EQUAL, LESS_THAN, LESS_OR_EQUAL:
+            case GREATER_THAN, GREATER_OR_EQUAL, LESS_THAN, LESS_OR_EQUAL, NOT_EQUAL, NOT:
+                // "ne" and "not" would match a broad, low-selectivity set of resources (e.g. "everyone but X"),
+                // which defeats this endpoint's intent of requiring a precise id/userName identity match.
                 throw new ScimException("Invalid operator.", HttpStatus.BAD_REQUEST);
             default:
                 throw new ScimException("Unsupported filter type.", HttpStatus.BAD_REQUEST);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/resources/jdbc/SimpleSearchQueryConverterTests.java
@@ -85,13 +85,22 @@ class SimpleSearchQueryConverterTests {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"co", "sw", "ge", "gt", "lt", "le"})
+    @ValueSource(strings = {"co", "sw", "ge", "gt", "lt", "le", "ne"})
     void invalidOperator(final String operator) {
         String query = "origin eq \"origin-value\" and externalGroup " + operator + " \"group-value\"";
         List<String> validAttributes = Arrays.asList("origin", "externalGroup".toLowerCase());
         assertThatThrownBy(() -> converter.getFilterValues(query, validAttributes))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("[" + operator + "] operator is not supported.");
+    }
+
+    @Test
+    void invalidConditionalNot() {
+        String query = "origin eq \"origin-value\" and not (externalGroup eq \"group-value\")";
+        List<String> validAttributes = Arrays.asList("origin", "externalGroup".toLowerCase());
+        assertThatThrownBy(() -> converter.getFilterValues(query, validAttributes))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("[not] operator is not supported.");
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/UserIdConversionEndpointsTests.java
@@ -167,7 +167,9 @@ class UserIdConversionEndpointsTests {
     @ValueSource(strings = {
             "id gt \"foo\"",
             "id le \"foo\"",
-            "id lt \"foo\""
+            "id lt \"foo\"",
+            "id ne \"foo\"",
+            "not (id eq \"foo\")"
     })
     void badFilterUnsupportedOperator(final String filter) {
         assertThatThrownBy(() -> endpoints.findUsers(filter, "ascending", 0, 100, false)).isInstanceOf(ScimException.class).hasMessage("Invalid operator.");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/scim/jdbc/ScimSearchQueryConverterTests.java
@@ -56,6 +56,9 @@ class ScimSearchQueryConverterTests {
         validate(filterProcessor.convert("active eq true", null, false, zoneId), "active = :__value_0", null, 1, Boolean.class);
         validate(filterProcessor.convert("Version eq 1000000.45", null, false, zoneId), "Version = :__value_0", null, 1, Double.class);
         validate(filterProcessor.convert("meta.VerSion eq 1000000", null, false, zoneId), "VerSion = :__value_0", null, 1, Double.class);
+        validate(filterProcessor.convert("username ne \"joe\"", null, false, zoneId), "LOWER(username) <> LOWER(:__value_0)", null, 1);
+        validate(filterProcessor.convert("not (username eq \"joe\")", null, false, zoneId), "NOT (LOWER(username) = LOWER(:__value_0))", null, 1);
+        validate(filterProcessor.convert("username eq \"joe\" and not (active eq true)", null, false, zoneId), "(LOWER(username) = LOWER(:__value_0) AND NOT (active = :__value_1))", null, 2);
     }
 
     @Test
@@ -83,6 +86,8 @@ class ScimSearchQueryConverterTests {
         validate(filterProcessor.convert("active eq true", null, false, zoneId), "active = :__value_0", null, 1, Boolean.class);
         validate(filterProcessor.convert("Version eq 1000000.45", null, false, zoneId), "Version = :__value_0", null, 1, Double.class);
         validate(filterProcessor.convert("meta.VerSion eq 1000000", null, false, zoneId), "VerSion = :__value_0", null, 1, Double.class);
+        validate(filterProcessor.convert("username ne \"joe\"", null, false, zoneId), "username <> :__value_0", null, 1);
+        validate(filterProcessor.convert("not (username eq \"joe\")", null, false, zoneId), "NOT (username = :__value_0)", null, 1);
     }
 
     @Test


### PR DESCRIPTION
The scim2-sdk-common parser already understood ne/not, but SimpleSearchQueryConverter had no switch cases for them and fell through to a generic error. Add ne (-> <>) and not (-> NOT (...)) to the SQL WHERE-clause builder used by /Users and /Groups search, including a fix for null-comparison and for attribute/depth validation skipping over not(...) subclauses.

The equality-only extraction path used by the deprecated /Groups/External filter param, and the identity-match check in /ids/Users, now explicitly reject ne/not with clear messages rather than a generic "unsupported" error, since silently allowing them there would either misinterpret negation as equality or defeat the endpoint's precise-match/anti-enumeration intent.