### PR TITLE
id token enhancer

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -1127,7 +1127,8 @@ the `authorities` claim: `exclude: [authorities]`.
 ### `jwt.token.idToken.enhancer.allowClaimModification`
 
 **Default:** `false`
-**Source:** `@Value("${jwt.token.idToken.enhancer.allowClaimModification:false}")` in [`OauthEndpointBeanConfiguration`](../server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java)
+**Source:** `@Value("${jwt.token.idToken.enhancer.allowClaimModification:false}")` in
+[`OauthEndpointBeanConfiguration`][oauth-endpoint-bean-config]
 **Type:** `boolean`
 
 Controls whether registered `IdTokenEnhancer` beans may overwrite claims that already
@@ -1135,6 +1136,8 @@ exist on the `id_token`. When `false` (the default), enhancers may only add new 
 any attempt to change a claim already set by `IdTokenCreator` or by another enhancer is
 ignored and the original value is preserved. Set to `true` to let enhancers replace the
 value of existing claims. Adding brand-new claims never requires this flag.
+
+[oauth-endpoint-bean-config]: ../server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
 
 Enhancer implementations register as `IdTokenEnhancer` beans and read the
 `OAuth2Authentication`, the access-token claims, and the refresh-token claims through the

--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -115,6 +115,7 @@ or `$CLOUDFOUNDRY_CONFIG_PATH/uaa.yml`.
 | <a href="#jwttokenrefreshrotate"><img src="images/click-me.png" width="14" height="14"/></a> `jwt.token.refresh.rotate` | `false`| Rotate refresh tokens|
 | <a href="#jwttokenrefreshrestrict_grant"><img src="images/click-me.png" width="14" height="14"/></a> `jwt.token.refresh.restrict_grant` | —| Restrict refresh token grant|
 | <a href="#jwttokenclaimsexclude"><img src="images/click-me.png" width="14" height="14"/></a> `jwt.token.claims.exclude` | `[]`| Claims excluded from tokens|
+| <a href="#jwttokenidtokenenhancerallowclaimmodification"><img src="images/click-me.png" width="14" height="14"/></a> `jwt.token.idToken.enhancer.allowClaimModification` | `false`| Allow id_token enhancers to modify existing claims|
 
 ### OAuth Clients & Users
 
@@ -1118,6 +1119,27 @@ in their scopes for offline access.
 
 A list of claim names to exclude from issued JWT tokens. For example, to omit
 the `authorities` claim: `exclude: [authorities]`.
+
+[Back to table](#jwt-token-policy)
+
+---
+
+### `jwt.token.idToken.enhancer.allowClaimModification`
+
+**Default:** `false`
+**Source:** `@Value("${jwt.token.idToken.enhancer.allowClaimModification:false}")` in [`OauthEndpointBeanConfiguration`](../server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java)
+**Type:** `boolean`
+
+Controls whether registered `IdTokenEnhancer` beans may overwrite claims that already
+exist on the `id_token`. When `false` (the default), enhancers may only add new claims;
+any attempt to change a claim already set by `IdTokenCreator` or by another enhancer is
+ignored and the original value is preserved. Set to `true` to let enhancers replace the
+value of existing claims. Adding brand-new claims never requires this flag.
+
+Enhancer implementations register as `IdTokenEnhancer` beans and read the
+`OAuth2Authentication`, the access-token claims, the refresh-token root claims, and any
+values under `jwt.token.idToken.enhancer.properties` through the supplied
+`IdTokenEnhancementContext`.
 
 [Back to table](#jwt-token-policy)
 

--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -1137,9 +1137,8 @@ ignored and the original value is preserved. Set to `true` to let enhancers repl
 value of existing claims. Adding brand-new claims never requires this flag.
 
 Enhancer implementations register as `IdTokenEnhancer` beans and read the
-`OAuth2Authentication`, the access-token claims, the refresh-token root claims, and any
-values under `jwt.token.idToken.enhancer.properties` through the supplied
-`IdTokenEnhancementContext`.
+`OAuth2Authentication`, the access-token claims, and the refresh-token claims through the
+supplied `IdTokenEnhancementContext`.
 
 [Back to table](#jwt-token-policy)
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -507,7 +507,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 throw new IllegalStateException("Cannot convert id token to JSON");
             }
             Map<String, Object> idTokenClaims = idTokenClaimEnhancer.enhance(
-                    idTokenContent.getClaimMap(), authentication, jwtAccessToken, additionalRootClaims);
+                    idTokenContent.getClaimMap(), authentication, jwtAccessToken,
+                    decodeRefreshTokenClaims(refreshToken, additionalRootClaims));
             String encodedIdTokenContent = JwtHelper.encode(idTokenClaims, keyInfoService.getActiveKey()).getEncoded();
             compositeToken.setIdTokenValue(encodedIdTokenContent);
         }
@@ -515,6 +516,27 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
         publish(new TokenIssuedEvent(compositeToken, SecurityContextHolder.getContext().getAuthentication(), IdentityZoneHolder.getCurrentZoneId()));
 
         return compositeToken;
+    }
+
+    /**
+     * Resolve the claims of the refresh token issued in the same response, for use as the
+     * {@code refreshTokenClaims} argument to {@link IdTokenClaimEnhancer#enhance}.
+     *
+     * <p>The refresh token value handed to {@link #createCompositeToken} is always the
+     * internally-issued JWT (opaque refresh tokens are only substituted in the response
+     * returned to the caller), so this decodes it directly. Falls back to
+     * {@code additionalRootClaims} when no refresh token was issued or it cannot be decoded
+     * as a JWT.</p>
+     */
+    private static Map<String, Object> decodeRefreshTokenClaims(String refreshToken, Map<String, Object> additionalRootClaims) {
+        if (refreshToken != null) {
+            try {
+                return JsonUtils.readValueAsMap(JwtHelper.decode(refreshToken).getClaims());
+            } catch (RuntimeException e) {
+                // not a JWT (e.g. an opaque refresh token); fall through to the default below
+            }
+        }
+        return additionalRootClaims == null ? Collections.emptyMap() : additionalRootClaims;
     }
 
     private static Map<String, Object> addRootClaimEntry(Map<String, Object> additionalRootClaims, String entry, String value) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -32,6 +32,7 @@ import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenExcepti
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
 import org.cloudfoundry.identity.uaa.oauth.openid.IdToken;
 import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenCreationException;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenClaimEnhancer;
 import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenCreator;
 import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenGranter;
 import org.cloudfoundry.identity.uaa.oauth.openid.UserAuthenticationData;
@@ -150,6 +151,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     private final RevocableTokenProvisioning tokenProvisioning;
     private Set<String> excludedClaims;
     private List<UaaTokenEnhancer> uaaTokenEnhancers = new ArrayList<>();
+    private IdTokenClaimEnhancer idTokenClaimEnhancer = IdTokenClaimEnhancer.noOp();
     private final IdTokenCreator idTokenCreator;
     private final RefreshTokenCreator refreshTokenCreator;
     private TokenEndpointBuilder tokenEndpointBuilder;
@@ -211,6 +213,10 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
     @Deprecated
     public void setUaaTokenEnhancer(UaaTokenEnhancer uaaTokenEnhancer) {
         this.setUaaTokenEnhancers(uaaTokenEnhancer == null ? emptyList() : singletonList(uaaTokenEnhancer));
+    }
+
+    public void setIdTokenClaimEnhancer(IdTokenClaimEnhancer idTokenClaimEnhancer) {
+        this.idTokenClaimEnhancer = idTokenClaimEnhancer == null ? IdTokenClaimEnhancer.noOp() : idTokenClaimEnhancer;
     }
 
     @Override
@@ -306,7 +312,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                         additionalRootClaims,
                         claims.getRevSig(),
                         isRevocable,
-                        authenticationData
+                        authenticationData,
+                        null
                 );
 
         CompositeExpiringOAuth2RefreshToken expiringRefreshToken = new CompositeExpiringOAuth2RefreshToken(
@@ -439,7 +446,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             Map<String, Object> additionalRootClaims,
             String revocableHashSignature,
             boolean isRevocable,
-            UserAuthenticationData userAuthenticationData) throws AuthenticationException {
+            UserAuthenticationData userAuthenticationData,
+            OAuth2Authentication authentication) throws AuthenticationException {
         CompositeToken compositeToken = new CompositeToken(tokenId);
         compositeToken.setExpiration(accessTokenValidityResolver.resolve(clientId));
         compositeToken.setRefreshToken(refreshToken == null ? null : new DefaultOAuth2RefreshToken(refreshToken));
@@ -498,7 +506,9 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
             } catch (RuntimeException | IdTokenCreationException _) {
                 throw new IllegalStateException("Cannot convert id token to JSON");
             }
-            String encodedIdTokenContent = JwtHelper.encode(idTokenContent.getClaimMap(), keyInfoService.getActiveKey()).getEncoded();
+            Map<String, Object> idTokenClaims = idTokenClaimEnhancer.enhance(
+                    idTokenContent.getClaimMap(), authentication, jwtAccessToken, additionalRootClaims);
+            String encodedIdTokenContent = JwtHelper.encode(idTokenClaims, keyInfoService.getActiveKey()).getEncoded();
             compositeToken.setIdTokenValue(encodedIdTokenContent);
         }
 
@@ -722,7 +732,8 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                         additionalRootClaims,
                         revocableHashSignature,
                         isAccessTokenRevocable,
-                        authenticationData);
+                        authenticationData,
+                        authentication);
 
         return persistRevocableToken(tokenId, accessToken, refreshToken, client, clientId, userId, isOpaque, isAccessTokenRevocable, null);
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -536,7 +536,7 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 // not a JWT (e.g. an opaque refresh token); fall through to the default below
             }
         }
-        return additionalRootClaims == null ? Collections.emptyMap() : additionalRootClaims;
+        return Collections.emptyMap();
     }
 
     private static Map<String, Object> addRootClaimEntry(Map<String, Object> additionalRootClaims, String entry, String value) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
@@ -793,8 +793,7 @@ public class OauthEndpointBeanConfiguration {
     ) {
         return new IdTokenClaimEnhancer(
                 idTokenEnhancers.orderedStream().toList(),
-                allowClaimModification,
-                Map.of());
+                allowClaimModification);
     }
 
     @Bean("refreshTokenCreator")

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
@@ -45,7 +45,9 @@ import org.cloudfoundry.identity.uaa.oauth.UaaOauth2RequestValidator;
 import org.cloudfoundry.identity.uaa.oauth.UaaTokenServices;
 import org.cloudfoundry.identity.uaa.oauth.UaaTokenStore;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtClientAuthentication;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenClaimEnhancer;
 import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenCreator;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenEnhancer;
 import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenGranter;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2RequestFactory;
 import org.cloudfoundry.identity.uaa.oauth.provider.authentication.OAuth2AuthenticationManager;
@@ -784,6 +786,30 @@ public class OauthEndpointBeanConfiguration {
         );
     }
 
+    @Bean("idTokenEnhancerProperties")
+    Map<String, Object> idTokenEnhancerProperties(
+            @Value("#{@config['jwt']==null ? T(java.util.Collections).EMPTY_MAP : " +
+                    "@config['jwt.token']==null ? T(java.util.Collections).EMPTY_MAP :" +
+                    "@config['jwt.token.idToken']==null ? T(java.util.Collections).EMPTY_MAP :" +
+                    "@config['jwt.token.idToken.enhancer']==null ? T(java.util.Collections).EMPTY_MAP :" +
+                    "@config['jwt.token.idToken.enhancer.properties']==null ? T(java.util.Collections).EMPTY_MAP : @config['jwt.token.idToken.enhancer.properties']}")
+            Map<String, Object> properties
+    ) {
+        return properties;
+    }
+
+    @Bean("idTokenClaimEnhancer")
+    IdTokenClaimEnhancer idTokenClaimEnhancer(
+            org.springframework.beans.factory.ObjectProvider<IdTokenEnhancer> idTokenEnhancers,
+            @Qualifier("idTokenEnhancerProperties") Map<String, Object> idTokenEnhancerProperties,
+            @Value("${jwt.token.idToken.enhancer.allowClaimModification:false}") boolean allowClaimModification
+    ) {
+        return new IdTokenClaimEnhancer(
+                idTokenEnhancers.orderedStream().toList(),
+                allowClaimModification,
+                idTokenEnhancerProperties);
+    }
+
     @Bean("refreshTokenCreator")
     RefreshTokenCreator refreshTokenCreator(
             @Value("${jwt.token.refresh.restrict_grant:false}") boolean isRestrictRefreshGrant,
@@ -844,9 +870,10 @@ public class OauthEndpointBeanConfiguration {
             @Qualifier("excludedClaims") LinkedHashSet<String> excludedClaims,
             @Qualifier("globalTokenPolicy") TokenPolicy globalTokenPolicy,
             @Qualifier("keyInfoService") KeyInfoService keyInfoService,
-            @Qualifier("idTokenGranter") IdTokenGranter idTokenGranter
+            @Qualifier("idTokenGranter") IdTokenGranter idTokenGranter,
+            @Qualifier("idTokenClaimEnhancer") IdTokenClaimEnhancer idTokenClaimEnhancer
     ) {
-        return new UaaTokenServices(
+        UaaTokenServices tokenServices = new UaaTokenServices(
                 idTokenCreator,
                 tokenEndpointBuilder,
                 jdbcClientDetailsService,
@@ -862,6 +889,8 @@ public class OauthEndpointBeanConfiguration {
                 idTokenGranter,
                 approvalService
         );
+        tokenServices.setIdTokenClaimEnhancer(idTokenClaimEnhancer);
+        return tokenServices;
     }
 
     @Bean("uaaAuthenticationMgr")

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
@@ -786,28 +786,15 @@ public class OauthEndpointBeanConfiguration {
         );
     }
 
-    @Bean("idTokenEnhancerProperties")
-    Map<String, Object> idTokenEnhancerProperties(
-            @Value("#{@config['jwt']==null ? T(java.util.Collections).EMPTY_MAP : " +
-                    "@config['jwt.token']==null ? T(java.util.Collections).EMPTY_MAP :" +
-                    "@config['jwt.token.idToken']==null ? T(java.util.Collections).EMPTY_MAP :" +
-                    "@config['jwt.token.idToken.enhancer']==null ? T(java.util.Collections).EMPTY_MAP :" +
-                    "@config['jwt.token.idToken.enhancer.properties']==null ? T(java.util.Collections).EMPTY_MAP : @config['jwt.token.idToken.enhancer.properties']}")
-            Map<String, Object> properties
-    ) {
-        return properties;
-    }
-
     @Bean("idTokenClaimEnhancer")
     IdTokenClaimEnhancer idTokenClaimEnhancer(
             org.springframework.beans.factory.ObjectProvider<IdTokenEnhancer> idTokenEnhancers,
-            @Qualifier("idTokenEnhancerProperties") Map<String, Object> idTokenEnhancerProperties,
             @Value("${jwt.token.idToken.enhancer.allowClaimModification:false}") boolean allowClaimModification
     ) {
         return new IdTokenClaimEnhancer(
                 idTokenEnhancers.orderedStream().toList(),
                 allowClaimModification,
-                idTokenEnhancerProperties);
+                Map.of());
     }
 
     @Bean("refreshTokenCreator")

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancer.java
@@ -2,36 +2,79 @@ package org.cloudfoundry.identity.uaa.oauth.openid;
 
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Applies the configured {@link IdTokenEnhancer}s to an id_token's claims.
  *
- * <p>Skeleton implementation: every method throws until the behaviour is implemented.</p>
+ * <p>Holds the ordered list of enhancers, the operator-controlled
+ * {@code allowClaimModification} switch (default {@code false}), and the configuration
+ * properties exposed to enhancers. A single instance is shared across all token requests;
+ * a fresh {@link IdTokenEnhancementContext} is created per {@link #enhance} call.</p>
  */
 public class IdTokenClaimEnhancer {
+
+    private final List<IdTokenEnhancer> enhancers;
+    private final boolean allowClaimModification;
+    private final Map<String, Object> properties;
 
     public IdTokenClaimEnhancer(
             List<IdTokenEnhancer> enhancers,
             boolean allowClaimModification,
             Map<String, Object> properties) {
-        throw new UnsupportedOperationException("IdTokenClaimEnhancer is not implemented yet");
+        this.enhancers = enhancers == null ? Collections.emptyList() : List.copyOf(enhancers);
+        this.allowClaimModification = allowClaimModification;
+        this.properties = properties == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(properties));
     }
 
+    /**
+     * @return an enhancer that makes no changes and imposes no per-request cost
+     */
     public static IdTokenClaimEnhancer noOp() {
-        throw new UnsupportedOperationException("not implemented");
+        return new IdTokenClaimEnhancer(Collections.emptyList(), false, Collections.emptyMap());
     }
 
     public boolean isClaimModificationAllowed() {
-        throw new UnsupportedOperationException("not implemented");
+        return allowClaimModification;
     }
 
+    /**
+     * Run every configured enhancer against the given id_token claims.
+     *
+     * <p>When no enhancers are configured the supplied map is returned unchanged and
+     * un-copied, so the default issuance path is unaffected. Otherwise the enhancers
+     * operate on a private copy and the resulting claim map is returned; the
+     * {@code idTokenClaims} argument is never mutated.</p>
+     *
+     * @param idTokenClaims      the standard claims assembled by {@link IdTokenCreator}
+     * @param authentication     the current authentication, or {@code null} (e.g. refresh flow)
+     * @param accessTokenClaims  claims of the access token issued in the same response
+     * @param refreshTokenClaims additional root claims associated with the refresh token
+     * @return the (possibly enhanced) id_token claims to be signed
+     */
     public Map<String, Object> enhance(
             Map<String, Object> idTokenClaims,
             OAuth2Authentication authentication,
             Map<String, Object> accessTokenClaims,
             Map<String, Object> refreshTokenClaims) {
-        throw new UnsupportedOperationException("not implemented");
+        if (enhancers.isEmpty()) {
+            return idTokenClaims;
+        }
+        IdTokenEnhancementContext context = new IdTokenEnhancementContext(
+                idTokenClaims,
+                authentication,
+                accessTokenClaims,
+                refreshTokenClaims,
+                properties,
+                allowClaimModification);
+        for (IdTokenEnhancer enhancer : enhancers) {
+            enhancer.enhance(context);
+        }
+        return context.getClaims();
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancer.java
@@ -3,40 +3,34 @@ package org.cloudfoundry.identity.uaa.oauth.openid;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
  * Applies the configured {@link IdTokenEnhancer}s to an id_token's claims.
  *
- * <p>Holds the ordered list of enhancers, the operator-controlled
- * {@code allowClaimModification} switch (default {@code false}), and the configuration
- * properties exposed to enhancers. A single instance is shared across all token requests;
- * a fresh {@link IdTokenEnhancementContext} is created per {@link #enhance} call.</p>
+ * <p>Holds the ordered list of enhancers and the operator-controlled
+ * {@code allowClaimModification} switch (default {@code false}). A single instance is
+ * shared across all token requests; a fresh {@link IdTokenEnhancementContext} is created
+ * per {@link #enhance} call.</p>
  */
 public class IdTokenClaimEnhancer {
 
     private final List<IdTokenEnhancer> enhancers;
     private final boolean allowClaimModification;
-    private final Map<String, Object> properties;
 
     public IdTokenClaimEnhancer(
             List<IdTokenEnhancer> enhancers,
-            boolean allowClaimModification,
-            Map<String, Object> properties) {
+            boolean allowClaimModification) {
         this.enhancers = enhancers == null ? Collections.emptyList() : List.copyOf(enhancers);
         this.allowClaimModification = allowClaimModification;
-        this.properties = properties == null
-                ? Collections.emptyMap()
-                : Collections.unmodifiableMap(new LinkedHashMap<>(properties));
     }
 
     /**
      * @return an enhancer that makes no changes and imposes no per-request cost
      */
     public static IdTokenClaimEnhancer noOp() {
-        return new IdTokenClaimEnhancer(Collections.emptyList(), false, Collections.emptyMap());
+        return new IdTokenClaimEnhancer(Collections.emptyList(), false);
     }
 
     public boolean isClaimModificationAllowed() {
@@ -54,7 +48,8 @@ public class IdTokenClaimEnhancer {
      * @param idTokenClaims      the standard claims assembled by {@link IdTokenCreator}
      * @param authentication     the current authentication, or {@code null} (e.g. refresh flow)
      * @param accessTokenClaims  claims of the access token issued in the same response
-     * @param refreshTokenClaims additional root claims associated with the refresh token
+     * @param refreshTokenClaims claims of the refresh token issued in the same response, or
+     *                           empty when no refresh token was issued
      * @return the (possibly enhanced) id_token claims to be signed
      */
     public Map<String, Object> enhance(
@@ -70,7 +65,6 @@ public class IdTokenClaimEnhancer {
                 authentication,
                 accessTokenClaims,
                 refreshTokenClaims,
-                properties,
                 allowClaimModification);
         for (IdTokenEnhancer enhancer : enhancers) {
             enhancer.enhance(context);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancer.java
@@ -1,0 +1,37 @@
+package org.cloudfoundry.identity.uaa.oauth.openid;
+
+import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Applies the configured {@link IdTokenEnhancer}s to an id_token's claims.
+ *
+ * <p>Skeleton implementation: every method throws until the behaviour is implemented.</p>
+ */
+public class IdTokenClaimEnhancer {
+
+    public IdTokenClaimEnhancer(
+            List<IdTokenEnhancer> enhancers,
+            boolean allowClaimModification,
+            Map<String, Object> properties) {
+        throw new UnsupportedOperationException("IdTokenClaimEnhancer is not implemented yet");
+    }
+
+    public static IdTokenClaimEnhancer noOp() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public boolean isClaimModificationAllowed() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Map<String, Object> enhance(
+            Map<String, Object> idTokenClaims,
+            OAuth2Authentication authentication,
+            Map<String, Object> accessTokenClaims,
+            Map<String, Object> refreshTokenClaims) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
@@ -1,0 +1,82 @@
+package org.cloudfoundry.identity.uaa.oauth.openid;
+
+import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Mutable, per-request context handed to each {@link IdTokenEnhancer}.
+ *
+ * <p>Skeleton implementation: every method throws until the behaviour is implemented.
+ * The accompanying tests therefore fail on this commit and pass once the implementation
+ * commit lands.</p>
+ */
+public class IdTokenEnhancementContext {
+
+    public IdTokenEnhancementContext(
+            Map<String, Object> idTokenClaims,
+            OAuth2Authentication authentication,
+            Map<String, Object> accessTokenClaims,
+            Map<String, Object> refreshTokenClaims,
+            Map<String, Object> properties,
+            boolean allowClaimModification) {
+        throw new UnsupportedOperationException("IdTokenEnhancementContext is not implemented yet");
+    }
+
+    public boolean setClaim(String name, Object value) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Object getClaim(String name) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public boolean hasClaim(String name) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public OAuth2Authentication getAuthentication() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Map<String, Object> getAccessTokenClaims() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Object getAccessTokenClaim(String name) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Map<String, Object> getRefreshTokenClaims() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Object getRefreshTokenClaim(String name) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Map<String, Object> getProperties() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Object getProperty(String name) {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public boolean isClaimModificationAllowed() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Map<String, Object> getClaims() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Set<String> getModifiedClaims() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+
+    public Set<String> getRejectedClaimModifications() {
+        throw new UnsupportedOperationException("not implemented");
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
@@ -1,6 +1,7 @@
 package org.cloudfoundry.identity.uaa.oauth.openid;
 
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -75,7 +76,15 @@ public class IdTokenEnhancementContext {
     }
 
     public Object getClaim(String name) {
-        return claims.get(name);
+        Object value = claims.get(name);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return JsonUtils.readValue(JsonUtils.writeValueAsString(value), Object.class);
+        } catch (Exception e) {
+            return value;
+        }
     }
 
     public boolean hasClaim(String name) {
@@ -110,7 +119,11 @@ public class IdTokenEnhancementContext {
      * @return a snapshot copy of the id_token claims accumulated so far; safe to hand out
      */
     public Map<String, Object> getClaims() {
-        return new LinkedHashMap<>(claims);
+        try {
+            return JsonUtils.readValueAsMap(JsonUtils.writeValueAsString(claims));
+        } catch (Exception e) {
+            return new LinkedHashMap<>(claims);
+        }
     }
 
     public Set<String> getModifiedClaims() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
@@ -15,8 +15,7 @@ import java.util.Set;
  * <p>Carries the id_token claims assembled so far together with read-only access to the
  * inputs an enhancer may reason about: the {@link OAuth2Authentication} (possibly
  * {@code null} on the refresh flow), the claims of the access token issued in the same
- * response, the additional root claims associated with the refresh token, and the
- * configuration properties exposed to enhancers.</p>
+ * response, and the claims of the refresh token issued in the same response.</p>
  *
  * <p>Not thread-safe; a new instance is created for every token request.</p>
  */
@@ -26,7 +25,6 @@ public class IdTokenEnhancementContext {
     private final OAuth2Authentication authentication;
     private final Map<String, Object> accessTokenClaims;
     private final Map<String, Object> refreshTokenClaims;
-    private final Map<String, Object> properties;
     private final boolean allowClaimModification;
     private final Set<String> modifiedClaims = new LinkedHashSet<>();
     private final Set<String> rejectedClaimModifications = new LinkedHashSet<>();
@@ -36,13 +34,11 @@ public class IdTokenEnhancementContext {
             OAuth2Authentication authentication,
             Map<String, Object> accessTokenClaims,
             Map<String, Object> refreshTokenClaims,
-            Map<String, Object> properties,
             boolean allowClaimModification) {
         this.claims = new LinkedHashMap<>(idTokenClaims == null ? Collections.emptyMap() : idTokenClaims);
         this.authentication = authentication;
         this.accessTokenClaims = unmodifiableCopy(accessTokenClaims);
         this.refreshTokenClaims = unmodifiableCopy(refreshTokenClaims);
-        this.properties = unmodifiableCopy(properties);
         this.allowClaimModification = allowClaimModification;
     }
 
@@ -104,14 +100,6 @@ public class IdTokenEnhancementContext {
 
     public Object getRefreshTokenClaim(String name) {
         return refreshTokenClaims.get(name);
-    }
-
-    public Map<String, Object> getProperties() {
-        return properties;
-    }
-
-    public Object getProperty(String name) {
-        return properties.get(name);
     }
 
     public boolean isClaimModificationAllowed() {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContext.java
@@ -2,17 +2,34 @@ package org.cloudfoundry.identity.uaa.oauth.openid;
 
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
  * Mutable, per-request context handed to each {@link IdTokenEnhancer}.
  *
- * <p>Skeleton implementation: every method throws until the behaviour is implemented.
- * The accompanying tests therefore fail on this commit and pass once the implementation
- * commit lands.</p>
+ * <p>Carries the id_token claims assembled so far together with read-only access to the
+ * inputs an enhancer may reason about: the {@link OAuth2Authentication} (possibly
+ * {@code null} on the refresh flow), the claims of the access token issued in the same
+ * response, the additional root claims associated with the refresh token, and the
+ * configuration properties exposed to enhancers.</p>
+ *
+ * <p>Not thread-safe; a new instance is created for every token request.</p>
  */
 public class IdTokenEnhancementContext {
+
+    private final Map<String, Object> claims;
+    private final OAuth2Authentication authentication;
+    private final Map<String, Object> accessTokenClaims;
+    private final Map<String, Object> refreshTokenClaims;
+    private final Map<String, Object> properties;
+    private final boolean allowClaimModification;
+    private final Set<String> modifiedClaims = new LinkedHashSet<>();
+    private final Set<String> rejectedClaimModifications = new LinkedHashSet<>();
 
     public IdTokenEnhancementContext(
             Map<String, Object> idTokenClaims,
@@ -21,62 +38,98 @@ public class IdTokenEnhancementContext {
             Map<String, Object> refreshTokenClaims,
             Map<String, Object> properties,
             boolean allowClaimModification) {
-        throw new UnsupportedOperationException("IdTokenEnhancementContext is not implemented yet");
+        this.claims = new LinkedHashMap<>(idTokenClaims == null ? Collections.emptyMap() : idTokenClaims);
+        this.authentication = authentication;
+        this.accessTokenClaims = unmodifiableCopy(accessTokenClaims);
+        this.refreshTokenClaims = unmodifiableCopy(refreshTokenClaims);
+        this.properties = unmodifiableCopy(properties);
+        this.allowClaimModification = allowClaimModification;
     }
 
+    private static Map<String, Object> unmodifiableCopy(Map<String, Object> source) {
+        return source == null
+                ? Collections.emptyMap()
+                : Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+
+    /**
+     * Add or, when permitted, modify an id_token claim.
+     *
+     * <p>Adding a claim that is not yet present always succeeds. Replacing the value of a
+     * claim that already exists (whether set by {@link IdTokenCreator} or by an earlier
+     * enhancer) is only applied when claim modification has been explicitly enabled;
+     * otherwise the original value is preserved and the attempt is recorded in
+     * {@link #getRejectedClaimModifications()}.</p>
+     *
+     * @return {@code true} when the value was applied, {@code false} when it was refused
+     */
     public boolean setClaim(String name, Object value) {
-        throw new UnsupportedOperationException("not implemented");
+        Objects.requireNonNull(name, "claim name must not be null");
+        if (!claims.containsKey(name)) {
+            claims.put(name, value);
+            return true;
+        }
+        if (allowClaimModification) {
+            claims.put(name, value);
+            modifiedClaims.add(name);
+            return true;
+        }
+        rejectedClaimModifications.add(name);
+        return false;
     }
 
     public Object getClaim(String name) {
-        throw new UnsupportedOperationException("not implemented");
+        return claims.get(name);
     }
 
     public boolean hasClaim(String name) {
-        throw new UnsupportedOperationException("not implemented");
+        return claims.containsKey(name);
     }
 
     public OAuth2Authentication getAuthentication() {
-        throw new UnsupportedOperationException("not implemented");
+        return authentication;
     }
 
     public Map<String, Object> getAccessTokenClaims() {
-        throw new UnsupportedOperationException("not implemented");
+        return accessTokenClaims;
     }
 
     public Object getAccessTokenClaim(String name) {
-        throw new UnsupportedOperationException("not implemented");
+        return accessTokenClaims.get(name);
     }
 
     public Map<String, Object> getRefreshTokenClaims() {
-        throw new UnsupportedOperationException("not implemented");
+        return refreshTokenClaims;
     }
 
     public Object getRefreshTokenClaim(String name) {
-        throw new UnsupportedOperationException("not implemented");
+        return refreshTokenClaims.get(name);
     }
 
     public Map<String, Object> getProperties() {
-        throw new UnsupportedOperationException("not implemented");
+        return properties;
     }
 
     public Object getProperty(String name) {
-        throw new UnsupportedOperationException("not implemented");
+        return properties.get(name);
     }
 
     public boolean isClaimModificationAllowed() {
-        throw new UnsupportedOperationException("not implemented");
+        return allowClaimModification;
     }
 
+    /**
+     * @return a snapshot copy of the id_token claims accumulated so far; safe to hand out
+     */
     public Map<String, Object> getClaims() {
-        throw new UnsupportedOperationException("not implemented");
+        return new LinkedHashMap<>(claims);
     }
 
     public Set<String> getModifiedClaims() {
-        throw new UnsupportedOperationException("not implemented");
+        return Collections.unmodifiableSet(new LinkedHashSet<>(modifiedClaims));
     }
 
     public Set<String> getRejectedClaimModifications() {
-        throw new UnsupportedOperationException("not implemented");
+        return Collections.unmodifiableSet(new LinkedHashSet<>(rejectedClaimModifications));
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancer.java
@@ -12,10 +12,9 @@ package org.cloudfoundry.identity.uaa.oauth.openid;
  *
  * <p>Through the supplied {@link IdTokenEnhancementContext} an implementation may:</p>
  * <ul>
- *   <li>read UAA configuration properties exposed to enhancers,</li>
  *   <li>read the current {@link org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication},</li>
  *   <li>read the claims of the access token issued in the same response,</li>
- *   <li>read the additional root claims associated with the refresh token, and</li>
+ *   <li>read the claims of the refresh token issued in the same response, and</li>
  *   <li>add new claims to the id_token.</li>
  * </ul>
  *

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancer.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancer.java
@@ -1,0 +1,40 @@
+package org.cloudfoundry.identity.uaa.oauth.openid;
+
+/**
+ * Extension point for contributing or adjusting claims on the OpenID Connect
+ * {@code id_token} that UAA issues.
+ *
+ * <p>This is the id_token counterpart to
+ * {@link org.cloudfoundry.identity.uaa.oauth.UaaTokenEnhancer}, which only affects the
+ * access and refresh tokens. Implementations are invoked once per id_token, after
+ * {@link IdTokenCreator} has assembled the standard claim set and immediately before the
+ * token is signed.</p>
+ *
+ * <p>Through the supplied {@link IdTokenEnhancementContext} an implementation may:</p>
+ * <ul>
+ *   <li>read UAA configuration properties exposed to enhancers,</li>
+ *   <li>read the current {@link org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication},</li>
+ *   <li>read the claims of the access token issued in the same response,</li>
+ *   <li>read the additional root claims associated with the refresh token, and</li>
+ *   <li>add new claims to the id_token.</li>
+ * </ul>
+ *
+ * <p>Adding a claim that is not already present always succeeds. Overwriting a claim that
+ * {@link IdTokenCreator} (or an earlier enhancer) already set is refused unless the operator
+ * has explicitly opted in via {@code jwt.token.idToken.enhancer.allowClaimModification}
+ * (default {@code false}); see {@link IdTokenEnhancementContext#setClaim(String, Object)}.</p>
+ *
+ * <p>Implementations must be thread-safe: a single instance is shared across all token
+ * requests. They must also tolerate a {@code null} authentication, which occurs on the
+ * refresh-token flow where no live authentication object exists.</p>
+ */
+@FunctionalInterface
+public interface IdTokenEnhancer {
+
+    /**
+     * Contribute to or adjust the id_token claims held by the given context.
+     *
+     * @param context mutable per-request enhancement context; never {@code null}
+     */
+    void enhance(IdTokenEnhancementContext context);
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancerTest.java
@@ -1,0 +1,117 @@
+package org.cloudfoundry.identity.uaa.oauth.openid;
+
+import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IdTokenClaimEnhancerTest {
+
+    private static Map<String, Object> mapOf(Object... kv) {
+        Map<String, Object> map = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            map.put((String) kv[i], kv[i + 1]);
+        }
+        return map;
+    }
+
+    private final OAuth2Authentication authentication = mock(OAuth2Authentication.class);
+    private final Map<String, Object> accessTokenClaims =
+            mapOf("scope", List.of("openid", "roles"), "client_id", "login");
+    private final Map<String, Object> refreshTokenClaims = mapOf("jti", "refresh-jti");
+
+    private Map<String, Object> enhance(IdTokenClaimEnhancer enhancer, Map<String, Object> idTokenClaims) {
+        return enhancer.enhance(idTokenClaims, authentication, accessTokenClaims, refreshTokenClaims);
+    }
+
+    @Test
+    void enhance_withNoEnhancers_returnsClaimsUnchanged() {
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(emptyList(), false, emptyMap());
+        Map<String, Object> base = mapOf("sub", "marissa");
+
+        assertThat(enhance(enhancer, base)).isSameAs(base);
+    }
+
+    @Test
+    void noOp_returnsClaimsUnchanged() {
+        Map<String, Object> base = mapOf("sub", "marissa");
+
+        assertThat(enhance(IdTokenClaimEnhancer.noOp(), base)).isSameAs(base);
+        assertThat(IdTokenClaimEnhancer.noOp().isClaimModificationAllowed()).isFalse();
+    }
+
+    @Test
+    void enhance_addsNewRootClaim() {
+        IdTokenEnhancer adder = context -> context.setClaim("tenant", "blue");
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(adder), false, emptyMap());
+
+        assertThat(enhance(enhancer, mapOf("sub", "marissa")))
+                .containsEntry("sub", "marissa")
+                .containsEntry("tenant", "blue");
+    }
+
+    @Test
+    void enhance_runsEnhancersInRegistrationOrder() {
+        IdTokenEnhancer first = context -> context.setClaim("chain", "a");
+        IdTokenEnhancer second =
+                context -> context.setClaim("chain", String.valueOf(context.getClaim("chain")) + "b");
+        // 'second' modifies a claim that 'first' added, which requires modification to be enabled
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(first, second), true, emptyMap());
+
+        assertThat(enhance(enhancer, mapOf("sub", "marissa"))).containsEntry("chain", "ab");
+    }
+
+    @Test
+    void enhance_enhancerReadsAccessRefreshPropertyAndAuthentication() {
+        when(authentication.getName()).thenReturn("marissa");
+        IdTokenEnhancer reader = context -> {
+            context.setClaim("copied_client", context.getAccessTokenClaim("client_id"));
+            context.setClaim("refresh_jti", context.getRefreshTokenClaim("jti"));
+            context.setClaim("tenant", context.getProperty("acme.tenant"));
+            context.setClaim("who", context.getAuthentication().getName());
+        };
+        IdTokenClaimEnhancer enhancer =
+                new IdTokenClaimEnhancer(List.of(reader), false, mapOf("acme.tenant", "blue"));
+
+        assertThat(enhance(enhancer, mapOf("sub", "marissa")))
+                .containsEntry("copied_client", "login")
+                .containsEntry("refresh_jti", "refresh-jti")
+                .containsEntry("tenant", "blue")
+                .containsEntry("who", "marissa");
+    }
+
+    @Test
+    void enhance_existingClaimNotModifiedByDefault() {
+        IdTokenEnhancer overwriter = context -> context.setClaim("sub", "somebody-else");
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(overwriter), false, emptyMap());
+
+        assertThat(enhance(enhancer, mapOf("sub", "marissa"))).containsEntry("sub", "marissa");
+    }
+
+    @Test
+    void enhance_existingClaimModifiedWhenAllowed() {
+        IdTokenEnhancer overwriter = context -> context.setClaim("sub", "somebody-else");
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(overwriter), true, emptyMap());
+
+        assertThat(enhance(enhancer, mapOf("sub", "marissa"))).containsEntry("sub", "somebody-else");
+    }
+
+    @Test
+    void enhance_doesNotMutateTheProvidedBaseMap() {
+        IdTokenEnhancer adder = context -> context.setClaim("tenant", "blue");
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(adder), false, emptyMap());
+        Map<String, Object> base = mapOf("sub", "marissa");
+
+        enhance(enhancer, base);
+
+        assertThat(base).doesNotContainKey("tenant");
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancerTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenClaimEnhancerTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -34,7 +33,7 @@ class IdTokenClaimEnhancerTest {
 
     @Test
     void enhance_withNoEnhancers_returnsClaimsUnchanged() {
-        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(emptyList(), false, emptyMap());
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(emptyList(), false);
         Map<String, Object> base = mapOf("sub", "marissa");
 
         assertThat(enhance(enhancer, base)).isSameAs(base);
@@ -51,7 +50,7 @@ class IdTokenClaimEnhancerTest {
     @Test
     void enhance_addsNewRootClaim() {
         IdTokenEnhancer adder = context -> context.setClaim("tenant", "blue");
-        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(adder), false, emptyMap());
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(adder), false);
 
         assertThat(enhance(enhancer, mapOf("sub", "marissa")))
                 .containsEntry("sub", "marissa")
@@ -64,34 +63,31 @@ class IdTokenClaimEnhancerTest {
         IdTokenEnhancer second =
                 context -> context.setClaim("chain", String.valueOf(context.getClaim("chain")) + "b");
         // 'second' modifies a claim that 'first' added, which requires modification to be enabled
-        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(first, second), true, emptyMap());
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(first, second), true);
 
         assertThat(enhance(enhancer, mapOf("sub", "marissa"))).containsEntry("chain", "ab");
     }
 
     @Test
-    void enhance_enhancerReadsAccessRefreshPropertyAndAuthentication() {
+    void enhance_enhancerReadsAccessRefreshClaimsAndAuthentication() {
         when(authentication.getName()).thenReturn("marissa");
         IdTokenEnhancer reader = context -> {
             context.setClaim("copied_client", context.getAccessTokenClaim("client_id"));
             context.setClaim("refresh_jti", context.getRefreshTokenClaim("jti"));
-            context.setClaim("tenant", context.getProperty("acme.tenant"));
             context.setClaim("who", context.getAuthentication().getName());
         };
-        IdTokenClaimEnhancer enhancer =
-                new IdTokenClaimEnhancer(List.of(reader), false, mapOf("acme.tenant", "blue"));
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(reader), false);
 
         assertThat(enhance(enhancer, mapOf("sub", "marissa")))
                 .containsEntry("copied_client", "login")
                 .containsEntry("refresh_jti", "refresh-jti")
-                .containsEntry("tenant", "blue")
                 .containsEntry("who", "marissa");
     }
 
     @Test
     void enhance_existingClaimNotModifiedByDefault() {
         IdTokenEnhancer overwriter = context -> context.setClaim("sub", "somebody-else");
-        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(overwriter), false, emptyMap());
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(overwriter), false);
 
         assertThat(enhance(enhancer, mapOf("sub", "marissa"))).containsEntry("sub", "marissa");
     }
@@ -99,7 +95,7 @@ class IdTokenClaimEnhancerTest {
     @Test
     void enhance_existingClaimModifiedWhenAllowed() {
         IdTokenEnhancer overwriter = context -> context.setClaim("sub", "somebody-else");
-        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(overwriter), true, emptyMap());
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(overwriter), true);
 
         assertThat(enhance(enhancer, mapOf("sub", "marissa"))).containsEntry("sub", "somebody-else");
     }
@@ -107,7 +103,7 @@ class IdTokenClaimEnhancerTest {
     @Test
     void enhance_doesNotMutateTheProvidedBaseMap() {
         IdTokenEnhancer adder = context -> context.setClaim("tenant", "blue");
-        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(adder), false, emptyMap());
+        IdTokenClaimEnhancer enhancer = new IdTokenClaimEnhancer(List.of(adder), false);
         Map<String, Object> base = mapOf("sub", "marissa");
 
         enhance(enhancer, base);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContextTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContextTest.java
@@ -100,6 +100,34 @@ class IdTokenEnhancementContextTest {
             assertThat(context.setClaim("tenant", "blue")).isTrue();
             assertThat(context.getClaim("tenant")).isEqualTo("blue");
         }
+
+        @Test
+        void getClaim_returnsDeepCopyToPreventInPlaceMutation() {
+            IdTokenEnhancementContext context =
+                    context(mapOf("aud", new java.util.ArrayList<>(java.util.List.of("client1"))), false);
+
+            @SuppressWarnings("unchecked")
+            java.util.List<String> aud = (java.util.List<String>) context.getClaim("aud");
+            aud.add("attacker_client");
+
+            @SuppressWarnings("unchecked")
+            java.util.List<String> safeAud = (java.util.List<String>) context.getClaim("aud");
+            assertThat(safeAud).containsExactly("client1");
+        }
+
+        @Test
+        void getClaims_returnsDeepCopyToPreventInPlaceMutation() {
+            IdTokenEnhancementContext context =
+                    context(mapOf("aud", new java.util.ArrayList<>(java.util.List.of("client1"))), false);
+
+            @SuppressWarnings("unchecked")
+            java.util.List<String> aud = (java.util.List<String>) context.getClaims().get("aud");
+            aud.add("attacker_client");
+
+            @SuppressWarnings("unchecked")
+            java.util.List<String> safeAud = (java.util.List<String>) context.getClaim("aud");
+            assertThat(safeAud).containsExactly("client1");
+        }
     }
 
     @Nested

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContextTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContextTest.java
@@ -26,7 +26,6 @@ class IdTokenEnhancementContextTest {
                 mock(OAuth2Authentication.class),
                 mapOf("scope", "openid"),
                 mapOf("jti", "refresh-jti"),
-                mapOf("acme.tenant", "blue"),
                 allowModification);
     }
 
@@ -53,20 +52,18 @@ class IdTokenEnhancementContextTest {
     }
 
     @Test
-    void exposesAuthenticationAccessRefreshAndProperties() {
+    void exposesAuthenticationAccessAndRefreshClaims() {
         OAuth2Authentication authentication = mock(OAuth2Authentication.class);
         IdTokenEnhancementContext context = new IdTokenEnhancementContext(
                 mapOf("sub", "marissa"),
                 authentication,
                 mapOf("scope", "openid", "client_id", "login"),
                 mapOf("jti", "refresh-jti"),
-                mapOf("acme.tenant", "blue"),
                 false);
 
         assertThat(context.getAuthentication()).isSameAs(authentication);
         assertThat(context.getAccessTokenClaim("scope")).isEqualTo("openid");
         assertThat(context.getRefreshTokenClaim("jti")).isEqualTo("refresh-jti");
-        assertThat(context.getProperty("acme.tenant")).isEqualTo("blue");
         assertThat(context.isClaimModificationAllowed()).isFalse();
     }
 

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContextTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/openid/IdTokenEnhancementContextTest.java
@@ -1,0 +1,124 @@
+package org.cloudfoundry.identity.uaa.oauth.openid;
+
+import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class IdTokenEnhancementContextTest {
+
+    private static Map<String, Object> mapOf(Object... kv) {
+        Map<String, Object> map = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            map.put((String) kv[i], kv[i + 1]);
+        }
+        return map;
+    }
+
+    private IdTokenEnhancementContext context(Map<String, Object> baseClaims, boolean allowModification) {
+        return new IdTokenEnhancementContext(
+                baseClaims,
+                mock(OAuth2Authentication.class),
+                mapOf("scope", "openid"),
+                mapOf("jti", "refresh-jti"),
+                mapOf("acme.tenant", "blue"),
+                allowModification);
+    }
+
+    @Test
+    void setClaim_addsNewClaim() {
+        IdTokenEnhancementContext context = context(mapOf("sub", "marissa"), false);
+
+        boolean applied = context.setClaim("tenant", "blue");
+
+        assertThat(applied).isTrue();
+        assertThat(context.getClaims())
+                .containsEntry("tenant", "blue")
+                .containsEntry("sub", "marissa");
+        assertThat(context.getRejectedClaimModifications()).isEmpty();
+    }
+
+    @Test
+    void getClaims_returnsSnapshotThatDoesNotLeakInternalState() {
+        IdTokenEnhancementContext context = context(mapOf("sub", "marissa"), false);
+
+        context.getClaims().put("injected", "nope");
+
+        assertThat(context.getClaims()).doesNotContainKey("injected");
+    }
+
+    @Test
+    void exposesAuthenticationAccessRefreshAndProperties() {
+        OAuth2Authentication authentication = mock(OAuth2Authentication.class);
+        IdTokenEnhancementContext context = new IdTokenEnhancementContext(
+                mapOf("sub", "marissa"),
+                authentication,
+                mapOf("scope", "openid", "client_id", "login"),
+                mapOf("jti", "refresh-jti"),
+                mapOf("acme.tenant", "blue"),
+                false);
+
+        assertThat(context.getAuthentication()).isSameAs(authentication);
+        assertThat(context.getAccessTokenClaim("scope")).isEqualTo("openid");
+        assertThat(context.getRefreshTokenClaim("jti")).isEqualTo("refresh-jti");
+        assertThat(context.getProperty("acme.tenant")).isEqualTo("blue");
+        assertThat(context.isClaimModificationAllowed()).isFalse();
+    }
+
+    @Test
+    void hasClaim_reflectsBaseAndAddedClaims() {
+        IdTokenEnhancementContext context = context(mapOf("sub", "marissa"), false);
+
+        assertThat(context.hasClaim("sub")).isTrue();
+        assertThat(context.hasClaim("tenant")).isFalse();
+        context.setClaim("tenant", "blue");
+        assertThat(context.hasClaim("tenant")).isTrue();
+    }
+
+    @Nested
+    class WhenClaimModificationDisallowed {
+
+        @Test
+        void setClaim_existingClaim_isRejectedAndOriginalPreserved() {
+            IdTokenEnhancementContext context =
+                    context(mapOf("sub", "marissa", "email", "marissa@test.org"), false);
+
+            boolean applied = context.setClaim("email", "attacker@evil.example");
+
+            assertThat(applied).isFalse();
+            assertThat(context.getClaim("email")).isEqualTo("marissa@test.org");
+            assertThat(context.getRejectedClaimModifications()).containsExactly("email");
+            assertThat(context.getModifiedClaims()).isEmpty();
+        }
+
+        @Test
+        void setClaim_newClaimIsStillAllowed() {
+            IdTokenEnhancementContext context = context(mapOf("sub", "marissa"), false);
+
+            assertThat(context.setClaim("tenant", "blue")).isTrue();
+            assertThat(context.getClaim("tenant")).isEqualTo("blue");
+        }
+    }
+
+    @Nested
+    class WhenClaimModificationAllowed {
+
+        @Test
+        void setClaim_existingClaim_isOverwrittenAndRecorded() {
+            IdTokenEnhancementContext context =
+                    context(mapOf("sub", "marissa", "email", "marissa@test.org"), true);
+
+            boolean applied = context.setClaim("email", "marissa@corp.example");
+
+            assertThat(applied).isTrue();
+            assertThat(context.getClaim("email")).isEqualTo("marissa@corp.example");
+            assertThat(context.getModifiedClaims()).containsExactly("email");
+            assertThat(context.getRejectedClaimModifications()).isEmpty();
+        }
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/IdTokenEnhancerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/IdTokenEnhancerMockMvcTests.java
@@ -1,0 +1,106 @@
+package org.cloudfoundry.identity.uaa.mock.token;
+
+import tools.jackson.core.type.TypeReference;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenClaimEnhancer;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenEnhancer;
+import org.cloudfoundry.identity.uaa.scim.ScimUser;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZoneHolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.cloudfoundry.identity.uaa.mock.util.JwtTokenUtils.getClaimsForToken;
+import static org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken.ACCESS_TOKEN;
+import static org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken.REFRESH_TOKEN;
+import static org.cloudfoundry.identity.uaa.oauth.common.util.OAuth2Utils.CLIENT_ID;
+import static org.cloudfoundry.identity.uaa.oauth.common.util.OAuth2Utils.GRANT_TYPE;
+import static org.cloudfoundry.identity.uaa.oauth.common.util.OAuth2Utils.SCOPE;
+import static org.springframework.http.HttpHeaders.ACCEPT;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * End-to-end coverage for the {@link IdTokenEnhancer} SPI through a real {@code /oauth/token}
+ * MockMvc request, closing the gap between the unit-level coverage in
+ * {@code IdTokenClaimEnhancerTest}/{@code IdTokenEnhancementContextTest} and the direct-service-call
+ * coverage in {@code UaaTokenServicesTests}.
+ */
+@DisplayName("IdTokenEnhancer SPI, exercised through a real /oauth/token request")
+@TestPropertySource(properties = "jwt.token.refresh.format=jwt")
+class IdTokenEnhancerMockMvcTests extends AbstractTokenMockMvcTests {
+
+    @AfterEach
+    void restoreDefaultEnhancer() {
+        tokenServices.setIdTokenClaimEnhancer(IdTokenClaimEnhancer.noOp());
+    }
+
+    @Test
+    @DisplayName("an enhancer's nested claim on the id_token is derived from the real access- and refresh-token claims")
+    void enhancerAddsNestedClaimDerivedFromRealAccessAndRefreshTokenClaims() throws Exception {
+        String clientId = "id-token-enhancer-client" + generator.generate();
+        setUpClients(clientId, "", "openid", "password,refresh_token", true);
+        ScimUser developer = setUpUser(
+                jdbcScimUserProvisioning,
+                jdbcScimGroupMembershipManager,
+                jdbcScimGroupProvisioning,
+                "testuser" + generator.generate(),
+                "openid",
+                OriginKeys.UAA,
+                IdentityZoneHolder.get().getId());
+
+        IdTokenEnhancer authInfoEnhancer = enhancementContext -> {
+            Map<String, Object> authInfo = new HashMap<>();
+            authInfo.put("access_token_id", enhancementContext.getAccessTokenClaim("jti"));
+            authInfo.put("refresh_token_id", enhancementContext.getRefreshTokenClaim("jti"));
+            authInfo.put("refresh_token_expiration", enhancementContext.getRefreshTokenClaim("exp"));
+            enhancementContext.setClaim("auth_info", authInfo);
+        };
+        tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(authInfoEnhancer), false));
+
+        MvcResult result = mockMvc.perform(post("/oauth/token")
+                        .header(CONTENT_TYPE, APPLICATION_FORM_URLENCODED)
+                        .header(ACCEPT, "application/json")
+                        .param(GRANT_TYPE, "password")
+                        .param(CLIENT_ID, clientId)
+                        .param("client_secret", SECRET)
+                        .param("username", developer.getUserName())
+                        .param("password", SECRET)
+                        .param(SCOPE, "openid"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> tokenResponse = JsonUtils.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<Map<String, Object>>() {
+                });
+        assertThat(tokenResponse).containsKey(ACCESS_TOKEN).containsKey(REFRESH_TOKEN);
+
+        Map<String, Object> idTokenClaims = getClaimsForToken((String) tokenResponse.get("id_token"));
+        assertThat(idTokenClaims).containsKey("auth_info");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> authInfo = (Map<String, Object>) idTokenClaims.get("auth_info");
+
+        Map<String, Object> accessTokenClaims = decodeClaims((String) tokenResponse.get(ACCESS_TOKEN));
+        assertThat(authInfo.get("access_token_id")).isEqualTo(accessTokenClaims.get("jti"));
+
+        Map<String, Object> refreshTokenClaims = decodeClaims((String) tokenResponse.get(REFRESH_TOKEN));
+        assertThat(authInfo.get("refresh_token_id")).isEqualTo(refreshTokenClaims.get("jti"));
+        assertThat(authInfo.get("refresh_token_expiration")).isEqualTo(refreshTokenClaims.get("exp"));
+    }
+
+    private static Map<String, Object> decodeClaims(String jwt) {
+        return JsonUtils.readValue(JwtHelper.decode(jwt).getClaims(), new TypeReference<Map<String, Object>>() {
+        });
+    }
+}

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/IdTokenEnhancerMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/IdTokenEnhancerMockMvcTests.java
@@ -49,16 +49,7 @@ class IdTokenEnhancerMockMvcTests extends AbstractTokenMockMvcTests {
     @Test
     @DisplayName("an enhancer's nested claim on the id_token is derived from the real access- and refresh-token claims")
     void enhancerAddsNestedClaimDerivedFromRealAccessAndRefreshTokenClaims() throws Exception {
-        String clientId = "id-token-enhancer-client" + generator.generate();
-        setUpClients(clientId, "", "openid", "password,refresh_token", true);
-        ScimUser developer = setUpUser(
-                jdbcScimUserProvisioning,
-                jdbcScimGroupMembershipManager,
-                jdbcScimGroupProvisioning,
-                "testuser" + generator.generate(),
-                "openid",
-                OriginKeys.UAA,
-                IdentityZoneHolder.get().getId());
+        ClientAndUser clientAndUser = setUpClientAndUser();
 
         IdTokenEnhancer authInfoEnhancer = enhancementContext -> {
             Map<String, Object> authInfo = new HashMap<>();
@@ -69,21 +60,7 @@ class IdTokenEnhancerMockMvcTests extends AbstractTokenMockMvcTests {
         };
         tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(authInfoEnhancer), false));
 
-        MvcResult result = mockMvc.perform(post("/oauth/token")
-                        .header(CONTENT_TYPE, APPLICATION_FORM_URLENCODED)
-                        .header(ACCEPT, "application/json")
-                        .param(GRANT_TYPE, "password")
-                        .param(CLIENT_ID, clientId)
-                        .param("client_secret", SECRET)
-                        .param("username", developer.getUserName())
-                        .param("password", SECRET)
-                        .param(SCOPE, "openid"))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        Map<String, Object> tokenResponse = JsonUtils.readValue(
-                result.getResponse().getContentAsString(), new TypeReference<Map<String, Object>>() {
-                });
+        Map<String, Object> tokenResponse = requestToken(clientAndUser);
         assertThat(tokenResponse).containsKey(ACCESS_TOKEN).containsKey(REFRESH_TOKEN);
 
         Map<String, Object> idTokenClaims = getClaimsForToken((String) tokenResponse.get("id_token"));
@@ -99,8 +76,71 @@ class IdTokenEnhancerMockMvcTests extends AbstractTokenMockMvcTests {
         assertThat(authInfo.get("refresh_token_expiration")).isEqualTo(refreshTokenClaims.get("exp"));
     }
 
+    @Test
+    @DisplayName("an enhancer cannot overwrite a core id_token claim when claim modification is not allowed")
+    void enhancerCannotOverwriteCoreClaimWithoutPermission() throws Exception {
+        ClientAndUser clientAndUser = setUpClientAndUser();
+
+        IdTokenEnhancer subOverwriter = enhancementContext -> enhancementContext.setClaim("sub", "attacker-controlled-subject");
+        tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(subOverwriter), false));
+
+        Map<String, Object> tokenResponse = requestToken(clientAndUser);
+
+        Map<String, Object> idTokenClaims = getClaimsForToken((String) tokenResponse.get("id_token"));
+        assertThat(idTokenClaims.get("sub")).isEqualTo(clientAndUser.user().getId());
+    }
+
+    @Test
+    @DisplayName("an enhancer can overwrite a core id_token claim once claim modification is allowed")
+    void enhancerOverwritesCoreClaimWhenPermissionIsConfigured() throws Exception {
+        ClientAndUser clientAndUser = setUpClientAndUser();
+
+        IdTokenEnhancer subOverwriter = enhancementContext -> enhancementContext.setClaim("sub", "attacker-controlled-subject");
+        tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(subOverwriter), true));
+
+        Map<String, Object> tokenResponse = requestToken(clientAndUser);
+
+        Map<String, Object> idTokenClaims = getClaimsForToken((String) tokenResponse.get("id_token"));
+        assertThat(idTokenClaims.get("sub")).isEqualTo("attacker-controlled-subject");
+    }
+
+    private ClientAndUser setUpClientAndUser() {
+        String clientId = "id-token-enhancer-client" + generator.generate();
+        setUpClients(clientId, "", "openid", "password,refresh_token", true);
+        ScimUser developer = setUpUser(
+                jdbcScimUserProvisioning,
+                jdbcScimGroupMembershipManager,
+                jdbcScimGroupProvisioning,
+                "testuser" + generator.generate(),
+                "openid",
+                OriginKeys.UAA,
+                IdentityZoneHolder.get().getId());
+        return new ClientAndUser(clientId, developer);
+    }
+
+    private Map<String, Object> requestToken(ClientAndUser clientAndUser) throws Exception {
+        MvcResult result = mockMvc.perform(post("/oauth/token")
+                        .header(CONTENT_TYPE, APPLICATION_FORM_URLENCODED)
+                        .header(ACCEPT, "application/json")
+                        .param(GRANT_TYPE, "password")
+                        .param(CLIENT_ID, clientAndUser.clientId())
+                        .param("client_secret", SECRET)
+                        .param("username", clientAndUser.user().getUserName())
+                        .param("password", SECRET)
+                        .param(SCOPE, "openid"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        return JsonUtils.readValue(
+                result.getResponse().getContentAsString(), new TypeReference<Map<String, Object>>() {
+                });
+    }
+
     private static Map<String, Object> decodeClaims(String jwt) {
         return JsonUtils.readValue(JwtHelper.decode(jwt).getClaims(), new TypeReference<Map<String, Object>>() {
         });
+    }
+
+    private record ClientAndUser(String clientId, ScimUser user) {
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -850,7 +850,7 @@ class UaaTokenServicesTests {
                 authInfo.put("refresh_token_expiration", enhancementContext.getRefreshTokenClaim("exp"));
                 enhancementContext.setClaim("auth_info", authInfo);
             };
-            tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(authInfoEnhancer), false, Map.of()));
+            tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(authInfoEnhancer), false));
 
             try {
                 AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, grantType, "openid");

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -885,6 +885,27 @@ class UaaTokenServicesTests {
             }
         }
 
+        @DisplayName("the enhancer receives empty refresh token claims when no refresh token is issued")
+        @Test
+        void enhancerReceivesEmptyRefreshTokenClaimsWhenNoneIssued() {
+            IdTokenEnhancer authInfoEnhancer = enhancementContext -> {
+                enhancementContext.setClaim("refresh_token_claims_size", enhancementContext.getRefreshTokenClaims().size());
+            };
+            tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(authInfoEnhancer), false));
+
+            try {
+                AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, GRANT_TYPE_IMPLICIT, "openid");
+                OAuth2Authentication authentication = constructUserAuthenticationFromAuthzRequest(authorizationRequest, "admin", "uaa");
+
+                CompositeToken token = (CompositeToken) tokenServices.createAccessToken(authentication);
+
+                Map<String, Object> idClaims = decodeClaims(token.getIdTokenValue());
+                assertThat(idClaims.get("refresh_token_claims_size")).isEqualTo(0);
+            } finally {
+                tokenServices.setIdTokenClaimEnhancer(IdTokenClaimEnhancer.noOp());
+            }
+        }
+
         private Map<String, Object> decodeClaims(String jwt) {
             return JsonUtils.readValue(JwtHelper.decode(jwt).getClaims(), new TypeReference<Map<String, Object>>() {});
         }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServicesTests.java
@@ -19,6 +19,8 @@ import org.cloudfoundry.identity.uaa.authentication.UaaPrincipal;
 import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.jwt.Jwt;
 import org.cloudfoundry.identity.uaa.oauth.jwt.JwtHelper;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenClaimEnhancer;
+import org.cloudfoundry.identity.uaa.oauth.openid.IdTokenEnhancer;
 import org.cloudfoundry.identity.uaa.oauth.provider.AuthorizationRequest;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Authentication;
 import org.cloudfoundry.identity.uaa.oauth.provider.OAuth2Request;
@@ -822,6 +824,85 @@ class UaaTokenServicesTests {
                             }, 2592000, timeService);
             return new RefreshTokenCreator(false, tokenValidityResolver,
                     tokenEndpointBuilder, timeService, keyInfoService);
+        }
+    }
+
+    @Nested
+    @DisplayName("when an id_token enhancer is provided")
+    @DefaultTestContext
+    @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa", "jwt.token.refresh.format=jwt"})
+    class WhenAnIdTokenEnhancerIsProvided {
+
+        @BeforeEach
+        void ensureClientIsUp() {
+            assumeTrue(waitForClient(clientId, 3), "Test client jku_test not up yet");
+        }
+
+        @DisplayName("the enhancer adds a complex auth_info claim to the id_token")
+        @ParameterizedTest
+        @ValueSource(strings = {GRANT_TYPE_PASSWORD, GRANT_TYPE_AUTHORIZATION_CODE})
+        void enhancerAddsAuthInfoClaim(String grantType) {
+            IdTokenEnhancer authInfoEnhancer = enhancementContext -> {
+                Map<String, Object> authInfo = new HashMap<>();
+                authInfo.put("access_token_id", enhancementContext.getAccessTokenClaim("jti"));
+                authInfo.put("access_token_expiration", enhancementContext.getAccessTokenClaim("exp"));
+                authInfo.put("refresh_token_id", enhancementContext.getRefreshTokenClaim("jti"));
+                authInfo.put("refresh_token_expiration", enhancementContext.getRefreshTokenClaim("exp"));
+                enhancementContext.setClaim("auth_info", authInfo);
+            };
+            tokenServices.setIdTokenClaimEnhancer(new IdTokenClaimEnhancer(List.of(authInfoEnhancer), false, Map.of()));
+
+            try {
+                AuthorizationRequest authorizationRequest = constructAuthorizationRequest(clientId, grantType, "openid");
+                OAuth2Authentication authentication = constructUserAuthenticationFromAuthzRequest(authorizationRequest, "admin", "uaa");
+
+                CompositeToken token = (CompositeToken) tokenServices.createAccessToken(authentication);
+
+                Map<String, Object> idClaims = decodeClaims(token.getIdTokenValue());
+                assertThat(idClaims).containsKey("auth_info");
+
+                @SuppressWarnings("unchecked")
+                Map<String, Object> authInfo = (Map<String, Object>) idClaims.get("auth_info");
+                assertThat(authInfo).containsKeys(
+                        "access_token_id", "access_token_expiration", "refresh_token_id", "refresh_token_expiration");
+
+                // access-token linkage is real: the claim equals the issued access token's jti
+                Map<String, Object> accessClaims = decodeClaims(token.getValue());
+                assertThat(authInfo.get("access_token_id")).isEqualTo(accessClaims.get("jti"));
+                assertThat(authInfo.get("access_token_expiration")).isNotNull();
+
+                // refresh-token linkage: the claim equals the issued refresh token's jti.
+                // NOTE: this drives the remaining wiring change -- createCompositeToken currently passes
+                // additionalRootClaims as the refresh-token claims, which does NOT contain the refresh
+                // token's own jti/exp. Feed the issued refresh token's real claims to the context to
+                // make these two assertions pass.
+                assertThat(token.getRefreshToken()).isNotNull();
+                Map<String, Object> refreshClaims = decodeClaims(token.getRefreshToken().getValue());
+                assertThat(authInfo.get("refresh_token_id")).isEqualTo(refreshClaims.get("jti"));
+                assertThat(authInfo.get("refresh_token_expiration")).isNotNull();
+            } finally {
+                tokenServices.setIdTokenClaimEnhancer(IdTokenClaimEnhancer.noOp());
+            }
+        }
+
+        private Map<String, Object> decodeClaims(String jwt) {
+            return JsonUtils.readValue(JwtHelper.decode(jwt).getClaims(), new TypeReference<Map<String, Object>>() {});
+        }
+    }
+
+    @Nested
+    @DisplayName("when jwt.token.idToken.enhancer.allowClaimModification is configured")
+    @DefaultTestContext
+    @TestPropertySource(properties = {"uaa.url=https://uaa.some.test.domain.com:555/uaa", "jwt.token.idToken.enhancer.allowClaimModification=true"})
+    class WhenAllowClaimModificationIsConfigured {
+
+        @Autowired
+        private IdTokenClaimEnhancer idTokenClaimEnhancer;
+
+        @DisplayName("the wired enhancer bean reads the boolean from configuration")
+        @Test
+        void beanReadsTheConfiguredFlag() {
+            assertThat(idTokenClaimEnhancer.isClaimModificationAllowed()).isTrue();
         }
     }
 


### PR DESCRIPTION
we have a need for an id token enhancer.

I made the IdTokenEnhancementContext intentionally wide, to allow downstream implementations to widest leverage.

I introduced a new flag, that determines if the existing claims (the default claims we have today in an id_token) can be modified or not.