### PR TITLE
refactor: replace direct commons-codec usages with JDK equivalents

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwk/JsonWebKey.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/jwk/JsonWebKey.java
@@ -22,7 +22,6 @@ import com.nimbusds.jose.jwk.JWKParameterNames;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 
 import java.math.BigInteger;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -38,7 +37,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.commons.codec.binary.BaseNCodec.PEM_CHUNK_SIZE;
 import static org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey.KeyType.MAC;
 import static org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey.KeyType.RSA;
 import static org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey.KeyType.oct;
@@ -51,7 +49,8 @@ import static org.cloudfoundry.identity.uaa.oauth.jwk.JsonWebKey.KeyType.oct;
 @JsonSerialize(using = JsonWebKeySerializer.class)
 public class JsonWebKey {
 
-    private static final Base64.Encoder base64encoder = Base64.getMimeEncoder(PEM_CHUNK_SIZE, "\n".getBytes(Charset.defaultCharset()));
+    private static final int PEM_LINE_LENGTH = 64;
+    private static final Base64.Encoder base64encoder = Base64.getMimeEncoder(PEM_LINE_LENGTH, "\n".getBytes(StandardCharsets.US_ASCII));
     private static final Base64.Decoder base64decoder = Base64.getUrlDecoder();
 
     // value is not defined in RFC 7517

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/client/JdbcClientMetadataProvisioning.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/client/JdbcClientMetadataProvisioning.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.client;
 
 import tools.jackson.core.type.TypeReference;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.cloudfoundry.identity.uaa.zone.MultitenantClientServices;
@@ -77,7 +77,7 @@ public class JdbcClientMetadataProvisioning implements ClientMetadataProvisionin
             ps.setString(pos++, appLaunchUrl == null ? null : appLaunchUrl.toString());
             String appIcon = resource.getAppIcon();
             if (appIcon != null) {
-                byte[] decodedAppIcon = Base64.decodeBase64(appIcon.getBytes());
+                byte[] decodedAppIcon = Base64.getMimeDecoder().decode(appIcon.getBytes());
                 ps.setBinaryStream(pos++, new ByteArrayInputStream(decodedAppIcon), decodedAppIcon.length);
             } else {
                 ps.setBinaryStream(pos++, new ByteArrayInputStream(new byte[]{}), 0);
@@ -119,7 +119,7 @@ public class JdbcClientMetadataProvisioning implements ClientMetadataProvisionin
             }
             byte[] iconBytes = rs.getBytes("app_icon");
             if (iconBytes != null) {
-                clientMetadata.setAppIcon(Base64.encodeBase64String(iconBytes));
+                clientMetadata.setAppIcon(Base64.getEncoder().encodeToString(iconBytes));
             }
             clientMetadata.setCreatedBy(rs.getString("created_by"));
             String json = rs.getString("additional_information");

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/OpenIdSessionStateCalculator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/OpenIdSessionStateCalculator.java
@@ -1,16 +1,17 @@
 package org.cloudfoundry.identity.uaa.oauth;
 
-
-import org.apache.commons.codec.binary.Hex;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.cloudfoundry.identity.uaa.util.UaaStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.HexFormat;
 
 public class OpenIdSessionStateCalculator {
+    private static final HexFormat HEX_FORMAT = HexFormat.of();
     private final Logger logger = LoggerFactory.getLogger(OpenIdSessionStateCalculator.class);
     private SecureRandom secureRandom;
 
@@ -21,15 +22,19 @@ public class OpenIdSessionStateCalculator {
     public String calculate(String currentUserId, String clientId, String origin) {
         byte[] array = new byte[32];
         secureRandom.nextBytes(array);
-        String salt = Hex.encodeHexString(array).toLowerCase();
+        String salt = HEX_FORMAT.formatHex(array);
 
         String text = "%s %s %s %s".formatted(clientId, origin, currentUserId, salt);
-        byte[] hash = DigestUtils.sha256(text.getBytes(StandardCharsets.UTF_8));
-        logger.debug("Calculated OIDC session state for clientId={}, origin={}, sessionId=REDACTED, salt={}",
-                UaaStringUtils.getCleanedUserControlString(clientId),
-                UaaStringUtils.getCleanedUserControlString(origin),
-                UaaStringUtils.getCleanedUserControlString(salt));
-        return "%s.%s".formatted(Hex.encodeHexString(hash).toLowerCase(), salt);
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(text.getBytes(StandardCharsets.UTF_8));
+            logger.debug("Calculated OIDC session state for clientId={}, origin={}, sessionId=REDACTED, salt={}",
+                    UaaStringUtils.getCleanedUserControlString(clientId),
+                    UaaStringUtils.getCleanedUserControlString(origin),
+                    UaaStringUtils.getCleanedUserControlString(salt));
+            return "%s.%s".formatted(HEX_FORMAT.formatHex(hash), salt);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     public void setSecureRandom(SecureRandom secureRandom) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/RemoteTokenServices.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.oauth;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenException;
@@ -220,7 +220,7 @@ public class RemoteTokenServices implements ResourceServerTokenServices {
 
     private String getAuthorizationHeader(String clientId, String clientSecret) {
         String creds = "%s:%s".formatted(clientId, clientSecret);
-        return "Basic " + Base64.encodeBase64String((creds.getBytes(StandardCharsets.UTF_8)));
+        return "Basic " + Base64.getEncoder().encodeToString(creds.getBytes(StandardCharsets.UTF_8));
     }
 
     private Map<String, Object> postForMap(String path, MultiValueMap<String, String> formData, HttpHeaders headers) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/pkce/verifiers/S256PkceVerifier.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/pkce/verifiers/S256PkceVerifier.java
@@ -1,13 +1,11 @@
 package org.cloudfoundry.identity.uaa.oauth.pkce.verifiers;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.oauth.pkce.PkceVerifier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * SHA-256 code challenge method implementation.
@@ -17,7 +15,6 @@ import org.slf4j.LoggerFactory;
  */
 public class S256PkceVerifier implements PkceVerifier {
 
-    private static final Logger logger = LoggerFactory.getLogger(S256PkceVerifier.class);
     private final String codeChallengeMethod = "S256";
 
     public S256PkceVerifier() {
@@ -33,17 +30,15 @@ public class S256PkceVerifier implements PkceVerifier {
 
     public String compute(String codeVerifier) {
         try {
-            byte[] bytes = codeVerifier.getBytes("US-ASCII");
+            byte[] bytes = codeVerifier.getBytes(StandardCharsets.US_ASCII);
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             md.update(bytes, 0, bytes.length);
             byte[] digest = md.digest();
-            return Base64.encodeBase64URLSafeString(digest);
-        } catch (UnsupportedEncodingException e) {
-            logger.debug(e.getMessage(), e);
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
         } catch (NoSuchAlgorithmException e) {
-            logger.debug(e.getMessage(), e);
+            // SHA-256 is guaranteed by the JCA spec; unreachable in practice.
+            throw new IllegalStateException(e);
         }
-        return null;
     }
 
     @Override

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/token/DefaultTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/provider/token/DefaultTokenServices.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.oauth.provider.token;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.oauth.common.DefaultExpiringOAuth2RefreshToken;
 import org.cloudfoundry.identity.uaa.oauth.common.DefaultOAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.common.DefaultOAuth2RefreshToken;
@@ -261,7 +261,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
             return null;
         }
         int validitySeconds = getRefreshTokenValiditySeconds(authentication.getOAuth2Request());
-        String tokenValue = new String(Base64.encodeBase64URLSafe(DEFAULT_TOKEN_GENERATOR.generateKey()), US_ASCII);
+        String tokenValue = new String(Base64.getUrlEncoder().withoutPadding().encode(DEFAULT_TOKEN_GENERATOR.generateKey()), US_ASCII);
         if (validitySeconds > 0) {
             return new DefaultExpiringOAuth2RefreshToken(tokenValue, new Date(System.currentTimeMillis()
                     + (validitySeconds * 1000L)));
@@ -270,7 +270,7 @@ public class DefaultTokenServices implements AuthorizationServerTokenServices, R
     }
 
     private OAuth2AccessToken createAccessToken(OAuth2Authentication authentication, OAuth2RefreshToken refreshToken) {
-        String tokenValue = new String(Base64.encodeBase64URLSafe(DEFAULT_TOKEN_GENERATOR.generateKey()), US_ASCII);
+        String tokenValue = new String(Base64.getUrlEncoder().withoutPadding().encode(DEFAULT_TOKEN_GENERATOR.generateKey()), US_ASCII);
         DefaultOAuth2AccessToken token = new DefaultOAuth2AccessToken(tokenValue);
         int validitySeconds = getAccessTokenValiditySeconds(authentication.getOAuth2Request());
         if (validitySeconds > 0) {

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -23,7 +23,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.apache.commons.lang3.ObjectUtils;
 import org.cloudfoundry.identity.uaa.authentication.AbstractClientParametersAuthenticationFilter;
 import org.cloudfoundry.identity.uaa.authentication.ProviderConfigurationException;
@@ -675,7 +675,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             String data = signedRequests[1];
             Map<String, Object> jsonData;
             try {
-                jsonData = JsonUtils.readValue(new String(Base64.decodeBase64(data), StandardCharsets.UTF_8), new TypeReference<>() {
+                jsonData = JsonUtils.readValue(new String(decodeBase64Lenient(data), StandardCharsets.UTF_8), new TypeReference<>() {
                 });
                 //check signature algorithm
                 final var algorithm = Optional.ofNullable(jsonData)
@@ -687,8 +687,8 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                 }
                 // check if data is signed correctly using constant-time comparison
                 try {
-                    byte[] expectedMac = Base64.decodeBase64(hmacSignAndEncode(signedRequests[1], secret));
-                    byte[] suppliedMac = Base64.decodeBase64(signature);
+                    byte[] expectedMac = decodeBase64Lenient(hmacSignAndEncode(signedRequests[1], secret));
+                    byte[] suppliedMac = decodeBase64Lenient(signature);
                     if (!MessageDigest.isEqual(expectedMac, suppliedMac)) {
                         log.debug("Signature is not correct, possibly the data was tampered with! No claims returned.");
                         return null;
@@ -738,6 +738,14 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             return JsonUtils.readValue(decodeIdToken.getClaims(), new TypeReference<>() {
             });
         }
+    }
+
+    private static byte[] decodeBase64Lenient(String value) {
+        // Normalize url-safe alphabet to standard and add padding — mirrors Commons Codec Base64.decodeBase64() leniency
+        String normalized = value.replace('-', '+').replace('_', '/');
+        int pad = (4 - normalized.length() % 4) % 4;
+        normalized = normalized + "=".repeat(pad);
+        return Base64.getDecoder().decode(normalized);
     }
 
     protected String hmacSignAndEncode(String data, String key) {
@@ -902,7 +910,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     }
 
     private String getClientAuthHeader(AbstractExternalOAuthIdentityProviderDefinition config) {
-        String clientAuth = new String(Base64.encodeBase64((config.getRelyingPartyId() + ":" + config.getRelyingPartySecret()).getBytes()));
+        String clientAuth = Base64.getEncoder().encodeToString((config.getRelyingPartyId() + ":" + config.getRelyingPartySecret()).getBytes(StandardCharsets.UTF_8));
         return "Basic " + clientAuth;
     }
 
@@ -1008,7 +1016,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
                     .getClientAuthenticationParameters(params, config, allowDynamicValueLookupInCustomZone);
         } else if (ClientAuthentication.secretNeeded(calcAuthMethod)) {
             String auth = clientId + ":" + clientSecret;
-            headers.add("Authorization", "Basic " + Base64.encodeBase64String(auth.getBytes(StandardCharsets.UTF_8)));
+            headers.add("Authorization", "Basic " + Base64.getEncoder().encodeToString(auth.getBytes(StandardCharsets.UTF_8)));
         } else {
             params.add(AbstractClientParametersAuthenticationFilter.CLIENT_ID, clientId);
         }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -741,8 +741,8 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     }
 
     private static byte[] decodeBase64Lenient(String value) {
-        // Normalize url-safe alphabet to standard and add padding — mirrors Commons Codec Base64.decodeBase64() leniency
-        String normalized = value.replace('-', '+').replace('_', '/');
+        // Normalize url-safe alphabet to standard, strip whitespace, and add padding — mirrors Commons Codec Base64.decodeBase64() leniency
+        String normalized = value.replace('-', '+').replace('_', '/').replaceAll("\\s", "");
         int pad = (4 - normalized.length() % 4) % 4;
         normalized = normalized + "=".repeat(pad);
         return Base64.getDecoder().decode(normalized);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/OidcMetadataFetcher.java
@@ -2,7 +2,7 @@ package org.cloudfoundry.identity.uaa.provider.oauth;
 
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.cloudfoundry.identity.uaa.cache.UrlContentCache;
 import org.cloudfoundry.identity.uaa.client.ClientJwtConfiguration;
@@ -164,7 +164,7 @@ public class OidcMetadataFetcher {
         if (config.getRelyingPartySecret() == null) {
             return null;
         }
-        String clientAuth = new String(Base64.encodeBase64((config.getRelyingPartyId() + ":" + config.getRelyingPartySecret()).getBytes()));
+        String clientAuth = Base64.getEncoder().encodeToString((config.getRelyingPartyId() + ":" + config.getRelyingPartySecret()).getBytes(StandardCharsets.UTF_8));
         return "Basic " + clientAuth;
     }
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/BannerValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/BannerValidator.java
@@ -1,6 +1,5 @@
 package org.cloudfoundry.identity.uaa.zone;
 
-import org.apache.commons.codec.binary.Base64;
 import org.cloudfoundry.identity.uaa.util.UaaUrlUtils;
 import org.cloudfoundry.identity.uaa.zone.BrandingInformation.Banner;
 import org.springframework.util.StringUtils;
@@ -28,10 +27,18 @@ public class BannerValidator {
                 }
             }
             if (StringUtils.hasText(banner.getLogo())) {
-                if (!Base64.isBase64(banner.getLogo())) {
+                if (!isValidBase64(banner.getLogo())) {
                     throw new InvalidIdentityZoneConfigurationException("Invalid banner logo. Must be in BASE64 format.", null);
                 }
             }
         }
+    }
+
+    private static final Pattern VALID_BASE64 =
+            Pattern.compile("^[A-Za-z0-9+/\\-_\\s]*={0,2}$");
+
+    private static boolean isValidBase64(String value) {
+        // Accept standard and url-safe base64, with optional whitespace — matches Commons Codec Base64.isBase64()
+        return VALID_BASE64.matcher(value).matches();
     }
 }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/BannerValidator.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/BannerValidator.java
@@ -35,10 +35,10 @@ public class BannerValidator {
     }
 
     private static final Pattern VALID_BASE64 =
-            Pattern.compile("^[A-Za-z0-9+/\\-_\\s]*={0,2}$");
+            Pattern.compile("^[A-Za-z0-9+/\\-_=\\s]*$");
 
     private static boolean isValidBase64(String value) {
-        // Accept standard and url-safe base64, with optional whitespace — matches Commons Codec Base64.isBase64()
+        // Accept standard and url-safe base64, including = anywhere — matches Commons Codec Base64.isBase64()
         return VALID_BASE64.matcher(value).matches();
     }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/login/test/MockMvcTestClient.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/login/test/MockMvcTestClient.java
@@ -18,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -39,7 +39,7 @@ public class MockMvcTestClient {
     public String getOAuthAccessToken(String username, String password, String grantType, String scope)
             throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64((username + ":" + password).getBytes()));
+                + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", basicDigestHeaderValue)
                 .param("grant_type", grantType)

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwk/RsaJsonWebKeyTestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/jwk/RsaJsonWebKeyTestUtils.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.oauth.jwk;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.bouncycastle.asn1.ASN1Sequence;
 
 import java.security.KeyFactory;
@@ -90,7 +90,7 @@ public class RsaJsonWebKeyTestUtils {
         PrivateKey privateKey = null;
 
         try {
-            final byte[] content = Base64.decodeBase64(m.group(2));
+            final byte[] content = Base64.getMimeDecoder().decode(m.group(2));
             KeyFactory fact = KeyFactory.getInstance("RSA");
             if ("RSA PRIVATE KEY".equals(type)) {
                 ASN1Sequence seq = ASN1Sequence.getInstance(content);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.identity.uaa.provider.oauth;
 import tools.jackson.core.type.TypeReference;
 import com.github.benmanes.caffeine.cache.Ticker;
 import com.nimbusds.jose.JWSSigner;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.identity.uaa.authentication.AccountNotPreCreatedException;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
@@ -323,7 +323,7 @@ class ExternalOAuthAuthenticationManagerIT {
         Mac mac = Mac.getInstance("HmacSHA256");
         mac.init(secretKey);
         byte[] hmacData = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
-        assertThat(new String(Base64.encodeBase64URLSafe(hmacData))).isEqualTo(externalOAuthAuthenticationManager.hmacSignAndEncode(data, key));
+        assertThat(new String(Base64.getUrlEncoder().withoutPadding().encode(hmacData))).isEqualTo(externalOAuthAuthenticationManager.hmacSignAndEncode(data, key));
     }
 
     @Test
@@ -546,7 +546,7 @@ class ExternalOAuthAuthenticationManagerIT {
 
         //UAA exchanges the code for a token
         mockUaaServer.expect(requestTo("http://localhost/oauth/token"))
-                .andExpect(header("Authorization", "Basic " + new String(Base64.encodeBase64("identity:identitysecret".getBytes()))))
+                .andExpect(header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes()))))
                 .andExpect(header("Accept", "application/json"))
                 .andExpect(bodyContains(
                         "grant_type=authorization_code",
@@ -945,7 +945,7 @@ class ExternalOAuthAuthenticationManagerIT {
 
         mockToken();
         mockUaaServer.expect(requestTo("http://localhost/token_key"))
-                .andExpect(header("Authorization", "Basic " + new String(Base64.encodeBase64("identity:identitysecret".getBytes()))))
+                .andExpect(header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes()))))
                 .andExpect(header("Accept", "application/json,application/jwk-set+json"))
                 .andRespond(withStatus(OK).contentType(APPLICATION_JSON).body(response));
 
@@ -1276,7 +1276,7 @@ class ExternalOAuthAuthenticationManagerIT {
         config.setTokenKeyUrl(new URL(keyUrl));
         mockToken();
         mockUaaServer.expect(requestTo(keyUrl))
-                .andExpect(header("Authorization", "Basic " + new String(Base64.encodeBase64("identity:identitysecret".getBytes()))))
+                .andExpect(header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes()))))
                 .andExpect(header("Accept", "application/json,application/jwk-set+json"))
                 .andRespond(withStatus(OK).contentType(APPLICATION_JSON).body(response));
     }
@@ -1320,7 +1320,7 @@ class ExternalOAuthAuthenticationManagerIT {
     private void mockToken() {
         String response = getIdTokenResponse();
         mockUaaServer.expect(requestTo("http://localhost/oauth/token"))
-                .andExpect(header("Authorization", "Basic " + new String(Base64.encodeBase64("identity:identitysecret".getBytes()))))
+                .andExpect(header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes()))))
                 .andExpect(header("Accept", "application/json"))
                 .andExpect(bodyContains(
                         "grant_type=authorization_code",

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/BannerValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/BannerValidatorTest.java
@@ -144,6 +144,8 @@ class BannerValidatorTest {
                 "SGVsbG8",
                 "SGVsbG-_",
                 "SGVsbG8g\nV29ybGQ=",
+                "SGVsbG8=V29ybGQ=",
+                "SGVsbG8===",
         };
 
         for (String base64 : validBase64) {
@@ -156,8 +158,6 @@ class BannerValidatorTest {
     @Test
     void base64LogoRejectsMalformedPayloads() {
         String[] invalidBase64 = {
-                "SGVsbG8=V29ybGQ=",
-                "SGVsbG8===",
                 "abc!def",
                 "SGVsbG8!",
                 "SGVsbG8@#$",

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/BannerValidatorTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/BannerValidatorTest.java
@@ -2,6 +2,9 @@ package org.cloudfoundry.identity.uaa.zone;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class BannerValidatorTest {
@@ -116,6 +119,49 @@ class BannerValidatorTest {
             testBanner.setLogo(base64);
             BannerValidator.validate(testBanner);
         }
+
+        for (String base64 : invalidBase64) {
+            BrandingInformation.Banner testBanner = new BrandingInformation.Banner();
+            testBanner.setLogo(base64);
+            assertThatThrownBy(() -> BannerValidator.validate(testBanner))
+                    .isInstanceOf(InvalidIdentityZoneConfigurationException.class)
+                    .hasMessageContaining("Invalid banner logo. Must be in BASE64 format.");
+        }
+    }
+
+    // Additional coverage confirming the JDK-regex-based Base64 validation, which replaced
+    // Apache Commons Codec's Base64.isBase64(), still accepts real standard/url-safe/MIME-chunked
+    // base64 data and still rejects malformed base64.
+    @Test
+    void base64LogoAcceptsRealEncodedPayloads() throws Exception {
+        byte[] payload = "some banner logo bytes".getBytes(StandardCharsets.UTF_8);
+        String[] validBase64 = {
+                Base64.getEncoder().encodeToString(payload),
+                Base64.getUrlEncoder().encodeToString(payload),
+                Base64.getUrlEncoder().withoutPadding().encodeToString(payload),
+                Base64.getMimeEncoder().encodeToString(payload),
+                "SGVsbG8=",
+                "SGVsbG8",
+                "SGVsbG-_",
+                "SGVsbG8g\nV29ybGQ=",
+        };
+
+        for (String base64 : validBase64) {
+            BrandingInformation.Banner testBanner = new BrandingInformation.Banner();
+            testBanner.setLogo(base64);
+            BannerValidator.validate(testBanner);
+        }
+    }
+
+    @Test
+    void base64LogoRejectsMalformedPayloads() {
+        String[] invalidBase64 = {
+                "SGVsbG8=V29ybGQ=",
+                "SGVsbG8===",
+                "abc!def",
+                "SGVsbG8!",
+                "SGVsbG8@#$",
+        };
 
         for (String base64 : invalidBase64) {
             BrandingInformation.Banner testBanner = new BrandingInformation.Banner();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/LoginServerSecurityIntegrationTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/LoginServerSecurityIntegrationTests.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.integration;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.cloudfoundry.identity.uaa.ServerRunningExtension;
 import org.cloudfoundry.identity.uaa.account.PasswordChangeRequest;
@@ -434,7 +434,7 @@ class LoginServerSecurityIntegrationTests {
 
     private String getAuthorizationEncodedValue(String username, String password) {
         String auth = username + ":" + password;
-        byte[] encodedAuth = Base64.encodeBase64(auth.getBytes(StandardCharsets.US_ASCII));
+        byte[] encodedAuth = Base64.getEncoder().encode(auth.getBytes(StandardCharsets.US_ASCII));
         return "Basic " + new String(encodedAuth);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/RemoteAuthenticationEndpointTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/RemoteAuthenticationEndpointTests.java
@@ -14,7 +14,7 @@
 
 package org.cloudfoundry.identity.uaa.integration;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.ServerRunningExtension;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
 import org.cloudfoundry.identity.uaa.oauth.UaaOauth2ErrorHandler;
@@ -128,7 +128,7 @@ class RemoteAuthenticationEndpointTests {
     private String getScimReadBearerToken() {
         HttpHeaders accessTokenHeaders = new HttpHeaders();
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64((testAccounts.getAdminClientId() + ":" + testAccounts.getAdminClientSecret()).getBytes()));
+                + new String(Base64.getEncoder().encode((testAccounts.getAdminClientId() + ":" + testAccounts.getAdminClientSecret()).getBytes()));
         accessTokenHeaders.add("Authorization", basicDigestHeaderValue);
 
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -142,7 +142,7 @@ class RemoteAuthenticationEndpointTests {
     private String getLoginReadBearerToken() {
         HttpHeaders accessTokenHeaders = new HttpHeaders();
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64("login:loginsecret".getBytes()));
+                + new String(Base64.getEncoder().encode("login:loginsecret".getBytes()));
         accessTokenHeaders.add("Authorization", basicDigestHeaderValue);
 
         LinkedMultiValueMap<String, String> params = new LinkedMultiValueMap<>();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OpenIdTokenGrantsIT.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/OpenIdTokenGrantsIT.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.integration.feature;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
 import org.cloudfoundry.identity.uaa.integration.util.IntegrationTestUtils;
 import org.cloudfoundry.identity.uaa.oauth.client.resource.ClientCredentialsResourceDetails;
@@ -176,7 +176,7 @@ class OpenIdTokenGrantsIT {
     @Test
     void passwordGrant() {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64("cf:".getBytes()));
+                + new String(Base64.getEncoder().encode("cf:".getBytes()));
 
         HttpHeaders headers = new HttpHeaders();
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
@@ -319,7 +319,7 @@ class OpenIdTokenGrantsIT {
         formData.add("code", location.split("code=")[1].split("&")[0]);
         HttpHeaders tokenHeaders = new HttpHeaders();
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64((clientId + ":" + clientSecret).getBytes()));
+                + new String(Base64.getEncoder().encode((clientId + ":" + clientSecret).getBytes()));
         tokenHeaders.set("Authorization", basicDigestHeaderValue);
 
         @SuppressWarnings("rawtypes")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/TestClient.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/integration/feature/TestClient.java
@@ -13,7 +13,7 @@
  *******************************************************************************/
 package org.cloudfoundry.identity.uaa.integration.feature;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.impl.config.LegacyTokenKey;
 import org.cloudfoundry.identity.uaa.oauth.KeyInfoService;
@@ -51,7 +51,7 @@ public class TestClient {
     }
 
     String getBasicAuthHeaderValue(String username, String password) {
-        return "Basic " + new String(Base64.encodeBase64((username + ":" + password).getBytes()));
+        return "Basic " + new String(Base64.getEncoder().encode((username + ":" + password).getBytes()));
     }
 
     public String getOAuthAccessToken(String username, String password, String grantType, String scope) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcTests.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
@@ -110,7 +110,7 @@ class PasscodeMockMvcTests {
                 mockSecurityContext
         );
 
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -199,7 +199,7 @@ class PasscodeMockMvcTests {
                 mockSecurityContext
         );
 
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -214,7 +214,7 @@ class PasscodeMockMvcTests {
 
     @Test
     void loginUsingInvalidPasscode() throws Exception {
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -231,7 +231,7 @@ class PasscodeMockMvcTests {
 
     @Test
     void loginUsingNoPasscode() throws Exception {
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/PasscodeMockMvcZonePathTests.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.login;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
@@ -123,7 +123,7 @@ class PasscodeMockMvcZonePathTests {
                 mockSecurityContext
         );
 
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -212,7 +212,7 @@ class PasscodeMockMvcZonePathTests {
                 mockSecurityContext
         );
 
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -227,7 +227,7 @@ class PasscodeMockMvcZonePathTests {
 
     @Test
     void loginUsingInvalidPasscode() throws Exception {
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)
@@ -244,7 +244,7 @@ class PasscodeMockMvcZonePathTests {
 
     @Test
     void loginUsingNoPasscode() throws Exception {
-        String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64("cf:".getBytes()));
+        String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode("cf:".getBytes()));
         MockHttpServletRequestBuilder post = post("/oauth/token")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_FORM_URLENCODED)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/audit/AuditCheckMockMvcTests.java
@@ -3,7 +3,7 @@ package org.cloudfoundry.identity.uaa.mock.audit;
 import tools.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.account.LostPasswordChangeRequest;
 import org.cloudfoundry.identity.uaa.account.event.PasswordChangeEvent;
@@ -504,7 +504,7 @@ class AuditCheckMockMvcTests {
         assertThat(((Authentication) event1.getSource()).getName()).isEqualTo(username);
         assertThat(event2.getName()).isEqualTo(username);
 
-        String encodedUsername = Utf8.decode(Base64.encodeBase64(MessageDigest.getInstance("SHA-1").digest(Utf8.encode(username))));
+        String encodedUsername = Utf8.decode(Base64.getEncoder().encode(MessageDigest.getInstance("SHA-1").digest(Utf8.encode(username))));
         assertLogMessage(testLogger.getMessageAtIndex(0), UserNotFound, encodedUsername, "");
         assertLogMessage(testLogger.getMessageAtIndex(1), PrincipalAuthenticationFailure, username, "null");
     }
@@ -685,7 +685,7 @@ class AuditCheckMockMvcTests {
     @Test
     void clientAuthenticationSuccess() throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64("login:loginsecret".getBytes()));
+                + new String(Base64.getEncoder().encode("login:loginsecret".getBytes()));
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", basicDigestHeaderValue)
                 .param("grant_type", "client_credentials")
@@ -705,7 +705,7 @@ class AuditCheckMockMvcTests {
     @Test
     void clientAuthenticationFailure() throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64("login:loginsecretwrong".getBytes()));
+                + new String(Base64.getEncoder().encode("login:loginsecretwrong".getBytes()));
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", basicDigestHeaderValue)
                 .param("grant_type", "client_credentials")
@@ -725,7 +725,7 @@ class AuditCheckMockMvcTests {
     @Test
     void clientAuthenticationFailureClientNotFound() throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64("login2:loginsecret".getBytes()));
+                + new String(Base64.getEncoder().encode("login2:loginsecret".getBytes()));
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", basicDigestHeaderValue)
                 .param("grant_type", "client_credentials")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/CheckTokenEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/CheckTokenEndpointDocs.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.token;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.mock.EndpointDocs;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
 import org.cloudfoundry.identity.uaa.test.UaaTestAccounts;
@@ -28,7 +28,7 @@ class CheckTokenEndpointDocs extends EndpointDocs {
 
     @Test
     void checkToken() throws Exception {
-        String identityClientAuthorizationWithUaaResource = new String(Base64.encodeBase64("app:appclientsecret".getBytes()));
+        String identityClientAuthorizationWithUaaResource = new String(Base64.getEncoder().encode("app:appclientsecret".getBytes()));
 
         String identityAccessToken = MockMvcUtils.getUserOAuthAccessToken(
                 mockMvc,

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeMockMvcBase.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenExchangeMockMvcBase.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.token;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.client.ClientJwtConfiguration;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -359,7 +359,7 @@ public class TokenExchangeMockMvcBase extends AbstractTokenMockMvcTests {
                 ;
         switch (clientAuthType) {
             case BASIC -> {
-                String authHeader = new String(Base64.encodeBase64((client.getClientId()+":"+client.getClientSecret()).getBytes()));
+                String authHeader = new String(Base64.getEncoder().encode((client.getClientId()+":"+client.getClientSecret()).getBytes()));
                 tokenExchange = tokenExchange
                         .header("Authorization", "Basic " + authHeader)
                         .param("client_id", client.getClientId());

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointDocs.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointDocs.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.token;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.mock.EndpointDocs;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.cloudfoundry.identity.uaa.zone.IdentityZoneProvisioning;
@@ -112,7 +112,7 @@ class TokenKeyEndpointDocs extends EndpointDocs {
         setUp("key");
         try {
             String basicDigestHeaderValue = "Basic "
-                    + new String(Base64.encodeBase64("app:appclientsecret".getBytes()));
+                    + new String(Base64.getEncoder().encode("app:appclientsecret".getBytes()));
 
             Snippet responseFields = responseFields(
                     fieldWithPath("kid").type(STRING).description("Key ID of key to be used for verification of the token."),
@@ -140,7 +140,7 @@ class TokenKeyEndpointDocs extends EndpointDocs {
     @Test
     void checkTokenKeysValues() throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64("app:appclientsecret".getBytes()));
+                + new String(Base64.getEncoder().encode("app:appclientsecret".getBytes()));
 
         Snippet responseFields = responseFields(
                 fieldWithPath("keys.[].kid").type(STRING).description("Key ID of key to be used for verification of the token."),

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.token;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.common.util.RandomValueStringGenerator;
@@ -297,7 +297,7 @@ class TokenKeyEndpointMockMvcTests {
 
     private String getBasicAuth(UaaClientDetails client) {
         return "Basic "
-                + new String(Base64.encodeBase64((client.getClientId() + ":" + client.getClientSecret()).getBytes()));
+                + new String(Base64.getEncoder().encode((client.getClientId() + ":" + client.getClientSecret()).getBytes()));
     }
 
     private void validateKey(Map<String, Object> key) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcTests.java
@@ -374,8 +374,8 @@ class TokenKeyEndpointMockMvcTests {
     }
 
     private void isUrlSafeBase64(String base64) {
-        java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
-        java.util.Base64.Decoder decoder = java.util.Base64.getUrlDecoder();
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        Base64.Decoder decoder = Base64.getUrlDecoder();
         assertThat(encoder.encodeToString(decoder.decode(base64))).isEqualTo(base64);
     }
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcZonePathTests.java
@@ -364,8 +364,8 @@ class TokenKeyEndpointMockMvcZonePathTests {
     }
 
     private void isUrlSafeBase64(String base64) {
-        java.util.Base64.Encoder encoder = java.util.Base64.getUrlEncoder().withoutPadding();
-        java.util.Base64.Decoder decoder = java.util.Base64.getUrlDecoder();
+        Base64.Encoder encoder = Base64.getUrlEncoder().withoutPadding();
+        Base64.Decoder decoder = Base64.getUrlDecoder();
         assertThat(encoder.encodeToString(decoder.decode(base64))).isEqualTo(base64);
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenKeyEndpointMockMvcZonePathTests.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.mock.token;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.oauth.common.util.RandomValueStringGenerator;
@@ -287,7 +287,7 @@ class TokenKeyEndpointMockMvcZonePathTests {
 
     private String getBasicAuth(UaaClientDetails client) {
         return "Basic "
-                + new String(Base64.encodeBase64((client.getClientId() + ":" + client.getClientSecret()).getBytes()));
+                + new String(Base64.getEncoder().encode((client.getClientId() + ":" + client.getClientSecret()).getBytes()));
     }
 
     private void validateKey(Map<String, Object> key) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -1735,7 +1735,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
                 .header("Authorization", "Basic "
-                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                        + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .session(session)
                 .param(OAuth2Utils.RESPONSE_TYPE, "code")
                 .param(SCOPE, "openid")
@@ -1840,17 +1840,17 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         String requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1";
         ResultMatcher status = status().is3xxRedirection();
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path1a/path1b/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://wrongsub.domain.com/path1/path2?query1=value1";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1&query2=value2";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
     }
 
     @Test
@@ -1862,7 +1862,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", "Basic "
-                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                        + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .param(GRANT_TYPE, "password")
                 .param(OAuth2Utils.CLIENT_ID, clientId)
                 .param("username", developer.getUserName())
@@ -1963,7 +1963,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2022,7 +2022,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2077,7 +2077,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2133,7 +2133,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2183,7 +2183,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2239,7 +2239,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2278,7 +2278,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         MvcResult result = mockMvc.perform(get("/oauth/authorize")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .session(session)
                         .param(RESPONSE_TYPE, "code")
                         .param(OAuth2Utils.STATE, "random-state")
@@ -2297,7 +2297,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         result = mockMvc.perform(post("/oauth/token")
                         .accept(APPLICATION_JSON)
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
                         .param("code", code))
@@ -3522,7 +3522,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3561,7 +3561,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3576,7 +3576,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         Thread.sleep(2000);
 
         authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3757,7 +3757,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         CompositeToken tokenResponse = JsonUtils.readValue(body, CompositeToken.class);
         String accessTokenHeaderRaw = tokenResponse.getValue().split("\\.")[0];
-        String accessTokenHeaderJson = new String(java.util.Base64.getDecoder().decode(accessTokenHeaderRaw));
+        String accessTokenHeaderJson = new String(Base64.getDecoder().decode(accessTokenHeaderRaw));
         Map<String, Object> headerMap =
                 JsonUtils.readValue(accessTokenHeaderJson, new TypeReference<>() {
                 });
@@ -3788,7 +3788,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         assertThat(tokenResponse.getRefreshToken()).isNotNull();
 
         String refreshTokenHeaderRaw = tokenResponse.getRefreshToken().getValue().split("\\.")[0];
-        String refreshTokenHeaderJson = new String(java.util.Base64.getDecoder().decode(refreshTokenHeaderRaw));
+        String refreshTokenHeaderJson = new String(Base64.getDecoder().decode(refreshTokenHeaderRaw));
         Map<String, Object> headerMap =
                 JsonUtils.readValue(refreshTokenHeaderJson, new TypeReference<>() {
                 });
@@ -3820,7 +3820,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         assertThat(tokenResponse.getIdTokenValue()).isNotNull();
 
         String idTokenHeaderRaw = tokenResponse.getIdTokenValue().split("\\.")[0];
-        String idTokenHeaderJson = new String(java.util.Base64.getDecoder().decode(idTokenHeaderRaw));
+        String idTokenHeaderJson = new String(Base64.getDecoder().decode(idTokenHeaderRaw));
         Map<String, Object> headerMap =
                 JsonUtils.readValue(idTokenHeaderJson, new TypeReference<>() {
                 });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -1735,7 +1735,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
                 .header("Authorization", "Basic "
-                        + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .session(session)
                 .param(OAuth2Utils.RESPONSE_TYPE, "code")
                 .param(SCOPE, "openid")
@@ -1840,17 +1840,17 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         String requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1";
         ResultMatcher status = status().is3xxRedirection();
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path1a/path1b/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://wrongsub.domain.com/path1/path2?query1=value1";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1&query2=value2";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
     }
 
     @Test
@@ -1862,7 +1862,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", "Basic "
-                        + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .param(GRANT_TYPE, "password")
                 .param(OAuth2Utils.CLIENT_ID, clientId)
                 .param("username", developer.getUserName())
@@ -1963,7 +1963,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2022,7 +2022,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2077,7 +2077,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2133,7 +2133,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2183,7 +2183,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2239,7 +2239,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2278,7 +2278,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         MvcResult result = mockMvc.perform(get("/oauth/authorize")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .session(session)
                         .param(RESPONSE_TYPE, "code")
                         .param(OAuth2Utils.STATE, "random-state")
@@ -2297,7 +2297,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         result = mockMvc.perform(post("/oauth/token")
                         .accept(APPLICATION_JSON)
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
                         .param("code", code))
@@ -3522,7 +3522,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3561,7 +3561,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3576,7 +3576,7 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
         Thread.sleep(2000);
 
         authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
@@ -1788,7 +1788,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
                 .header("Authorization", "Basic "
-                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                        + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .session(session)
                 .param(OAuth2Utils.RESPONSE_TYPE, "code")
                 .param(SCOPE, "openid")
@@ -1893,17 +1893,17 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         String requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1";
         ResultMatcher status = status().is3xxRedirection();
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path1a/path1b/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://wrongsub.domain.com/path1/path2?query1=value1";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1&query2=value2";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
     }
 
     @Test
@@ -1915,7 +1915,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", "Basic "
-                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                        + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .param(GRANT_TYPE, "password")
                 .param(OAuth2Utils.CLIENT_ID, clientId)
                 .param("username", developer.getUserName())
@@ -2016,7 +2016,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2075,7 +2075,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2130,7 +2130,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2186,7 +2186,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2236,7 +2236,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2292,7 +2292,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2331,7 +2331,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         MvcResult result = mockMvc.perform(get("/oauth/authorize")
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .session(session)
                         .param(RESPONSE_TYPE, "code")
                         .param(OAuth2Utils.STATE, "random-state")
@@ -2350,7 +2350,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         result = mockMvc.perform(post("/oauth/token")
                         .accept(APPLICATION_JSON)
                         .header("Authorization", "Basic "
-                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
+                                + new String(Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
                         .param("code", code))
@@ -3554,7 +3554,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3593,7 +3593,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3608,7 +3608,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         Thread.sleep(2000);
 
         authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3789,7 +3789,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         CompositeToken tokenResponse = JsonUtils.readValue(body, CompositeToken.class);
         String accessTokenHeaderRaw = tokenResponse.getValue().split("\\.")[0];
-        String accessTokenHeaderJson = new String(java.util.Base64.getDecoder().decode(accessTokenHeaderRaw));
+        String accessTokenHeaderJson = new String(Base64.getDecoder().decode(accessTokenHeaderRaw));
         Map<String, Object> headerMap =
                 JsonUtils.readValue(accessTokenHeaderJson, new TypeReference<>() {
                 });
@@ -3820,7 +3820,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         assertThat(tokenResponse.getRefreshToken()).isNotNull();
 
         String refreshTokenHeaderRaw = tokenResponse.getRefreshToken().getValue().split("\\.")[0];
-        String refreshTokenHeaderJson = new String(java.util.Base64.getDecoder().decode(refreshTokenHeaderRaw));
+        String refreshTokenHeaderJson = new String(Base64.getDecoder().decode(refreshTokenHeaderRaw));
         Map<String, Object> headerMap =
                 JsonUtils.readValue(refreshTokenHeaderJson, new TypeReference<>() {
                 });
@@ -3852,7 +3852,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         assertThat(tokenResponse.getIdTokenValue()).isNotNull();
 
         String idTokenHeaderRaw = tokenResponse.getIdTokenValue().split("\\.")[0];
-        String idTokenHeaderJson = new String(java.util.Base64.getDecoder().decode(idTokenHeaderRaw));
+        String idTokenHeaderJson = new String(Base64.getDecoder().decode(idTokenHeaderRaw));
         Map<String, Object> headerMap =
                 JsonUtils.readValue(idTokenHeaderJson, new TypeReference<>() {
                 });

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockZonePathTests.java
@@ -1788,7 +1788,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
                 .header("Authorization", "Basic "
-                        + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .session(session)
                 .param(OAuth2Utils.RESPONSE_TYPE, "code")
                 .param(SCOPE, "openid")
@@ -1893,17 +1893,17 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         String requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1";
         ResultMatcher status = status().is3xxRedirection();
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "http://subdomain.domain.com/path1/path1a/path1b/path2?query1=value1";
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://wrongsub.domain.com/path1/path2?query1=value1";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
         requestedUri = "https://subdomain.domain.com/path1/path2?query1=value1&query2=value2";
         status = status().is4xxClientError();
-        performAuthorize(state, clientId, "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
+        performAuthorize(state, clientId, "Basic " + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())), session, requestedUri, status);
     }
 
     @Test
@@ -1915,7 +1915,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", "Basic "
-                        + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                        + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                 .param(GRANT_TYPE, "password")
                 .param(OAuth2Utils.CLIENT_ID, clientId)
                 .param("username", developer.getUserName())
@@ -2016,7 +2016,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2075,7 +2075,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2130,7 +2130,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2186,7 +2186,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param("code", code)
                         .param(SCOPE, "openid")
@@ -2236,7 +2236,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2292,7 +2292,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         result = mockMvc.perform(post("/oauth/token")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .accept(APPLICATION_JSON)
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
@@ -2331,7 +2331,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         MvcResult result = mockMvc.perform(get("/oauth/authorize")
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .session(session)
                         .param(RESPONSE_TYPE, "code")
                         .param(OAuth2Utils.STATE, "random-state")
@@ -2350,7 +2350,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         result = mockMvc.perform(post("/oauth/token")
                         .accept(APPLICATION_JSON)
                         .header("Authorization", "Basic "
-                                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + SECRET).getBytes())))
+                                + new String(java.util.Base64.getEncoder().encode((clientId + ":" + SECRET).getBytes())))
                         .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
                         .param(OAuth2Utils.REDIRECT_URI, TEST_REDIRECT_URI)
                         .param("code", code))
@@ -3554,7 +3554,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3593,7 +3593,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
 
         String state = generator.generate();
         MockHttpServletRequestBuilder authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)
@@ -3608,7 +3608,7 @@ class TokenMvcMockZonePathTests extends AbstractTokenMockMvcTests {
         Thread.sleep(2000);
 
         authRequest = get("/oauth/authorize")
-                .header("Authorization", "Basic " + new String(org.apache.commons.codec.binary.Base64.encodeBase64("identity:identitysecret".getBytes())))
+                .header("Authorization", "Basic " + new String(java.util.Base64.getEncoder().encode("identity:identitysecret".getBytes())))
                 .header("Accept", APPLICATION_JSON_VALUE)
                 .session(session)
                 .param(GRANT_TYPE, GRANT_TYPE_AUTHORIZATION_CODE)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/util/MockMvcUtils.java
@@ -15,7 +15,7 @@
 package org.cloudfoundry.identity.uaa.mock.util;
 
 import tools.jackson.core.type.TypeReference;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthentication;
 import org.cloudfoundry.identity.uaa.authentication.UaaAuthenticationDetails;
@@ -980,7 +980,7 @@ public final class MockMvcUtils {
             IdentityZone zone,
             boolean opaque) throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64((clientId + ":" + clientSecret).getBytes()));
+                + Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes());
         MockHttpServletRequestBuilder oauthTokenPost =
                 post("/oauth/token")
                         .header("Authorization", basicDigestHeaderValue)
@@ -1025,8 +1025,7 @@ public final class MockMvcUtils {
 
     public static String getUserOAuthAccessTokenAuthCode(MockMvc mockMvc, String clientId, String clientSecret, String userId, String username, String password, String scope, TokenFormat tokenFormat) throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(org.apache.commons.codec.binary.Base64.encodeBase64((clientId + ":" + clientSecret)
-                .getBytes()));
+                + Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes());
         UaaPrincipal p = new UaaPrincipal(userId, username, "test@test.org", OriginKeys.UAA, "", IdentityZone.getUaaZoneId());
         UaaAuthentication auth = new UaaAuthentication(p, UaaAuthority.USER_AUTHORITIES, null);
         assertThat(auth.isAuthenticated()).isTrue();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointMockMvcTest.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.oauth;
 
 import tools.jackson.core.type.TypeReference;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.mock.token.AbstractTokenMockMvcTests;
 import org.cloudfoundry.identity.uaa.oauth.token.TokenConstants;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
@@ -63,7 +63,7 @@ class CheckTokenEndpointMockMvcTest extends AbstractTokenMockMvcTests {
         });
         token = (String) tokenMap.get("access_token");
         idToken = (String) tokenMap.get("id_token");
-        basic = new String(Base64.encodeBase64((clientId + ":" + clientSecret).getBytes()));
+        basic = new String(Base64.getEncoder().encode((clientId + ":" + clientSecret).getBytes()));
         allowQueryString = checkTokenEndpoint.isAllowQueryString();
         checkTokenEndpoint.setAllowQueryString(false);
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointMockMvcZonePathTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointMockMvcZonePathTest.java
@@ -1,7 +1,7 @@
 package org.cloudfoundry.identity.uaa.oauth;
 
 import tools.jackson.core.type.TypeReference;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.mock.util.MockMvcUtils;
 import org.cloudfoundry.identity.uaa.mock.util.ZoneResolutionMode;
 import org.cloudfoundry.identity.uaa.mock.token.AbstractTokenMockMvcTests;
@@ -74,7 +74,7 @@ class CheckTokenEndpointMockMvcZonePathTest extends AbstractTokenMockMvcTests {
         });
         token = (String) tokenMap.get("access_token");
         idToken = (String) tokenMap.get("id_token");
-        basic = new String(Base64.encodeBase64((clientId + ":" + clientSecret).getBytes()));
+        basic = new String(Base64.getEncoder().encode((clientId + ":" + clientSecret).getBytes()));
         allowQueryString = checkTokenEndpoint.isAllowQueryString();
         checkTokenEndpoint.setAllowQueryString(false);
     }
@@ -189,7 +189,7 @@ class CheckTokenEndpointMockMvcZonePathTest extends AbstractTokenMockMvcTests {
                 .andReturn().getResponse().getContentAsString();
         String zoneToken = JsonUtils.readValue(tokenResponse, new TypeReference<Map<String, Object>>() {}).get("access_token").toString();
 
-        String zoneBasic = new String(Base64.encodeBase64(("check-token-client:secret").getBytes()));
+        String zoneBasic = new String(Base64.getEncoder().encode(("check-token-client:secret").getBytes()));
         mockMvc.perform(mode.createRequestBuilder(subdomain, HttpMethod.POST, "/check_token")
                         .header("Authorization", "Basic " + zoneBasic)
                         .header(ACCEPT, APPLICATION_JSON_VALUE)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpointsMockMvcTests.java
@@ -4,7 +4,7 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -474,7 +474,7 @@ class ScimGroupEndpointsMockMvcTests {
 
             ScimUser zoneUser = createUserAndAddToGroups(result.getIdentityZone(), Sets.newHashSet(Collections.singletonList("scim.read")));
 
-            String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64((zonedClientId + ":" + zonedClientSecret).getBytes()));
+            String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode((zonedClientId + ":" + zonedClientSecret).getBytes()));
             MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                     .with(new SetServerNameRequestPostProcessor(result.getIdentityZone().getSubdomain() + ".localhost"))
                     .header("Authorization", basicDigestHeaderValue)

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpointsMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimGroupEndpointsMockMvcZonePathTests.java
@@ -4,7 +4,7 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.DefaultTestContext;
 import org.cloudfoundry.identity.uaa.client.UaaClientDetails;
 import org.cloudfoundry.identity.uaa.constants.OriginKeys;
@@ -479,7 +479,7 @@ class ScimGroupEndpointsMockMvcZonePathTests {
 
             ScimUser zoneUser = createUserAndAddToGroups(result.getIdentityZone(), Sets.newHashSet(Collections.singletonList("scim.read")));
 
-            String basicDigestHeaderValue = "Basic " + new String(Base64.encodeBase64((zonedClientId + ":" + zonedClientSecret).getBytes()));
+            String basicDigestHeaderValue = "Basic " + new String(Base64.getEncoder().encode((zonedClientId + ":" + zonedClientSecret).getBytes()));
             MockHttpServletRequestBuilder oauthTokenPost = mode.createRequestBuilder(result.getIdentityZone().getSubdomain(), HttpMethod.POST, "/oauth/token")
                     .header("Authorization", basicDigestHeaderValue)
                     .param("grant_type", "password")

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/test/TestClient.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/test/TestClient.java
@@ -1,6 +1,6 @@
 package org.cloudfoundry.identity.uaa.test;
 
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 import org.cloudfoundry.identity.uaa.mock.util.OAuthToken;
 import org.cloudfoundry.identity.uaa.oauth.token.TokenConstants;
 import org.cloudfoundry.identity.uaa.util.JsonUtils;
@@ -28,7 +28,7 @@ public class TestClient {
     public String getClientCredentialsOAuthAccessToken(String clientId, String clientSecret, String scope, String subdomain)
             throws Exception {
         String basicDigestHeaderValue = "Basic "
-                + new String(Base64.encodeBase64((clientId + ":" + clientSecret).getBytes()));
+                + Base64.getEncoder().encodeToString((clientId + ":" + clientSecret).getBytes());
         MockHttpServletRequestBuilder oauthTokenPost = post("/oauth/token")
                 .header("Authorization", basicDigestHeaderValue)
                 .param("grant_type", "client_credentials")


### PR DESCRIPTION
Migrate direct usages of `org.apache.commons.codec` (`Base64`, `Hex`, `DigestUtils`) to standard JDK APIs (`java.util.Base64`, `java.util.HexFormat`, `java.security.MessageDigest`), preserving prior encoding/decoding behavior.

The commons-codec dependency itself is intentionally kept in `gradle/libs.versions.toml` and `model/build.gradle.kts`: it is still required transitively by `xmlsec`, so we keep it declared explicitly (pinned to the latest version) rather than relying on an undeclared transitive version.

Adds `BannerValidatorTest` coverage for the JDK-regex-based Base64 validation that replaced Apache Commons Codec `Base64.isBase64()`, confirming it still accepts real standard/url-safe/MIME-chunked base64 payloads and still rejects malformed ones.

`S256PkceVerifier.compute()` now throws `IllegalStateException` instead of logging and returning null when `SHA-256` is unavailable. Not a regression: the old null return would have caused an opaque `NullPointerException` in `verify()`'s `codeChallenge.contentEquals(null)` call anyway. The new behavior fails fast with the real cause instead.