### PR TITLE
Fix: skipSslValidation does not skip validation for certificate chains

### DIFF
--- a/docs/UAA-Configuration-Reference.md
+++ b/docs/UAA-Configuration-Reference.md
@@ -1932,7 +1932,10 @@ External OAuth 2.0 and OIDC provider definitions. Each provider entry includes:
 - `linkText` — Text for the login link
 - `relyingPartyId` / `relyingPartySecret` — Client credentials
 - `attributeMappings` — Attribute mapping configuration
-- `skipSslValidation` — Skip TLS validation when calling the provider. Default `false`
+- `skipSslValidation` — Skip TLS validation when calling the provider. This disables both
+  certificate chain validation and hostname verification, offering no protection against
+  man-in-the-middle attacks; it is intended for development and diagnostics. To trust a private
+  CA in production, use `caCertificates` instead, which keeps validation enabled. Default `false`
 - `caCertificates` — List of PEM-encoded CA certificates to trust, in addition to the JVM's default trust store, when calling the provider. Ignored if `skipSslValidation` is `true`
 
 [Back to table](#login--branding)
@@ -2102,7 +2105,7 @@ Bootstrap SAML Identity Provider definitions. Each entry is keyed by a provider 
 | `emailDomain` | `List<String>` | Email domains used for IDP discovery |
 | `externalGroupsWhitelist` | `List<String>` | External group names to map |
 | `attributeMappings` | `Map<String, Object>` | Attribute mapping configuration |
-| `skipSslValidation` | `boolean` | Skip TLS validation when fetching metadata URL. Default `false` |
+| `skipSslValidation` | `boolean` | Skip TLS validation when fetching metadata URL. Disables both certificate chain validation and hostname verification, offering no protection against man-in-the-middle attacks; intended for development and diagnostics. Use `caCertificates` to trust a private CA in production. Default `false` |
 | `caCertificates` | `List<String>` | PEM-encoded CA certificates to trust, in addition to the JVM's default trust store, when fetching the metadata URL. Ignored if `skipSslValidation` is `true` |
 | `storeCustomAttributes` | `boolean` | Persist custom SAML attributes on the user. Default `true` |
 | `authnContext` | `List<String>` | Requested authentication context class references |

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtils.java
@@ -29,7 +29,7 @@ import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
-import org.apache.hc.client5.http.ssl.TrustSelfSignedStrategy;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.HeaderElement;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpRequest;
@@ -222,9 +222,27 @@ public abstract class UaaHttpRequestUtils {
         return millis <= 0 ? Timeout.DISABLED : Timeout.ofMilliseconds(millis);
     }
 
+    /**
+     * The {@code skipSslValidation=true} escape hatch: accepts <em>any</em> server certificate chain,
+     * of any length, from any issuer. Combined with the {@link NoopHostnameVerifier} applied alongside
+     * it in {@link #getClientBuilder(boolean, HttpClientConfig)}, this disables peer authentication
+     * entirely and offers no protection against man-in-the-middle attacks.
+     * <p>
+     * This must be {@link TrustAllStrategy}, not {@code TrustSelfSignedStrategy}. The latter's
+     * {@code isTrusted} is {@code chain.length == 1}, and Apache's {@code TrustManagerDelegate} falls
+     * through to normal JDK PKIX validation whenever a strategy returns false -- so it silently
+     * validated (and rejected) every chain of two or more certificates, which is what any real
+     * identity provider behind a CA hierarchy serves. That made the flag a no-op precisely where
+     * operators needed it.
+     * <p>
+     * To trust a private CA <em>without</em> giving up validation, use the per-IDP
+     * {@code caCertificates} property instead, which is served by
+     * {@link org.cloudfoundry.identity.uaa.security.IdpOutboundTrustCache} and keeps both chain
+     * validation and hostname verification switched on.
+     */
     private static SSLContext getNonValidatingSslContext() {
         try {
-            return new SSLContextBuilder().loadTrustMaterial(null, new TrustSelfSignedStrategy()).build();
+            return new SSLContextBuilder().loadTrustMaterial(TrustAllStrategy.INSTANCE).build();
         } catch (KeyManagementException | KeyStoreException | NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/network/NetworkTestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/network/NetworkTestUtils.java
@@ -16,15 +16,32 @@
 package org.cloudfoundry.identity.uaa.test.network;
 
 import com.sun.net.httpserver.*;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x500.X500NameBuilder;
+import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.springframework.http.HttpHeaders;
 import org.cloudfoundry.identity.uaa.oauth.common.util.RandomValueStringGenerator;
 
 import javax.net.ssl.*;
 import java.io.*;
+import java.math.BigInteger;
 import java.net.InetSocketAddress;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.List;
@@ -32,6 +49,7 @@ import java.util.Map;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.cloudfoundry.identity.uaa.util.SocketUtils.getSelfCertificate;
 
@@ -46,6 +64,7 @@ public class NetworkTestUtils {
     public static final String keyPass = "password";
 
     static RandomValueStringGenerator generator = new RandomValueStringGenerator();
+    private static final AtomicLong serialNumbers = new AtomicLong();
 
     public static File getKeystore(Date issueDate,
             long validityDays) throws Exception {
@@ -96,6 +115,97 @@ public class NetworkTestUtils {
         }
         keyStore.store(new FileOutputStream(keystore, false), keyPass.toCharArray());
         return keystore;
+    }
+
+    /**
+     * A keystore whose single key entry holds a full leaf -&gt; intermediate -&gt; root certificate
+     * chain. The individual certificates are exposed so tests can assert on the chain or feed the
+     * root to a trust store.
+     */
+    public record ChainedKeystore(File file,
+            X509Certificate rootCertificate,
+            X509Certificate intermediateCertificate,
+            X509Certificate leafCertificate) {
+    }
+
+    /**
+     * Builds a keystore containing a three-certificate chain (leaf -&gt; intermediate -&gt; root) for
+     * {@code localhost}, in contrast to {@link #getKeystore(Date, long)}, which produces a single
+     * self-signed certificate. A server started with this presents all three certificates during
+     * the TLS handshake, the way a real identity provider behind a CA hierarchy does.
+     * <p>
+     * This distinction matters: a trust strategy that keys off {@code chain.length == 1} behaves
+     * completely differently against this keystore than against the single-certificate one.
+     */
+    public static ChainedKeystore getChainedKeystore(Date issueDate, long validityDays) throws Exception {
+        Security.addProvider(new BouncyCastleFipsProvider());
+
+        long validForSeconds = validityDays * 24 * 60 * 60;
+
+        KeyPair rootKeyPair = generateKeyPair();
+        KeyPair intermediateKeyPair = generateKeyPair();
+        KeyPair leafKeyPair = generateKeyPair();
+
+        X500Name rootName = distinguishedName("UAA Test Root CA");
+        X500Name intermediateName = distinguishedName("UAA Test Intermediate CA");
+        X500Name leafName = distinguishedName(commonName);
+
+        X509Certificate root = issueCertificate(rootName, rootKeyPair.getPublic(),
+                rootName, rootKeyPair.getPrivate(), issueDate, validForSeconds, true, null);
+        X509Certificate intermediate = issueCertificate(intermediateName, intermediateKeyPair.getPublic(),
+                rootName, rootKeyPair.getPrivate(), issueDate, validForSeconds, true, null);
+        X509Certificate leaf = issueCertificate(leafName, leafKeyPair.getPublic(),
+                intermediateName, intermediateKeyPair.getPrivate(), issueDate, validForSeconds, false, commonName);
+
+        KeyStore keyStore = KeyStore.getInstance("JKS");
+        keyStore.load(null, null);
+        keyStore.setKeyEntry(alias, leafKeyPair.getPrivate(), keyPass.toCharArray(),
+                new X509Certificate[]{leaf, intermediate, root});
+
+        File keystoreFile = new File(System.getProperty("java.io.tmpdir"), generator.generate() + ".jks");
+        if (!keystoreFile.createNewFile()) {
+            throw new FileNotFoundException("Unable to create file:" + keystoreFile);
+        }
+        keyStore.store(new FileOutputStream(keystoreFile, false), keyPass.toCharArray());
+
+        return new ChainedKeystore(keystoreFile, root, intermediate, leaf);
+    }
+
+    private static KeyPair generateKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X500Name distinguishedName(String cn) {
+        X500NameBuilder builder = new X500NameBuilder(BCStyle.INSTANCE);
+        builder.addRDN(BCStyle.OU, organizationalUnit);
+        builder.addRDN(BCStyle.O, organization);
+        builder.addRDN(BCStyle.CN, cn);
+        return builder.build();
+    }
+
+    private static X509Certificate issueCertificate(X500Name subject, PublicKey subjectPublicKey,
+            X500Name issuer, PrivateKey issuerPrivateKey,
+            Date issueDate, long validForSeconds,
+            boolean certificateAuthority, String dnsSubjectAltName) throws Exception {
+        Date notAfter = Date.from(issueDate.toInstant().plusSeconds(validForSeconds));
+        JcaX509v3CertificateBuilder certGen = new JcaX509v3CertificateBuilder(issuer,
+                BigInteger.valueOf(serialNumbers.incrementAndGet()), issueDate, notAfter, subject, subjectPublicKey);
+
+        certGen.addExtension(Extension.basicConstraints, true, new BasicConstraints(certificateAuthority));
+        certGen.addExtension(Extension.keyUsage, true, certificateAuthority
+                ? new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign)
+                : new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+        if (dnsSubjectAltName != null) {
+            certGen.addExtension(Extension.subjectAlternativeName, false,
+                    new GeneralNames(new GeneralName(GeneralName.dNSName, dnsSubjectAltName)));
+        }
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BouncyCastleFipsProvider.PROVIDER_NAME).build(issuerPrivateKey);
+        return new JcaX509CertificateConverter()
+                .setProvider(BouncyCastleFipsProvider.PROVIDER_NAME).getCertificate(certGen.build(signer));
     }
 
     public static HttpServer startHttpServer(HttpHandler handler) throws Exception {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/network/NetworkTestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/network/NetworkTestUtils.java
@@ -166,7 +166,9 @@ public class NetworkTestUtils {
         if (!keystoreFile.createNewFile()) {
             throw new FileNotFoundException("Unable to create file:" + keystoreFile);
         }
-        keyStore.store(new FileOutputStream(keystoreFile, false), keyPass.toCharArray());
+        try (FileOutputStream out = new FileOutputStream(keystoreFile, false)) {
+            keyStore.store(out, keyPass.toCharArray());
+        }
 
         return new ChainedKeystore(keystoreFile, root, intermediate, leaf);
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/network/NetworkTestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/network/NetworkTestUtils.java
@@ -228,8 +228,11 @@ public class NetworkTestUtils {
 
         char[] password = keypass.toCharArray();
         KeyStore ks = KeyStore.getInstance("JKS");
-        FileInputStream fis = new FileInputStream(keystore);
-        ks.load(fis, password);
+        // Must be closed: callers that delete the keystore afterwards cannot do so on Windows
+        // while a handle to it is still open.
+        try (FileInputStream fis = new FileInputStream(keystore)) {
+            ks.load(fis, password);
+        }
 
         KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
         kmf.init(ks, password);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
@@ -10,6 +10,7 @@ import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.cloudfoundry.identity.uaa.impl.config.RestTemplateConfig;
+import org.cloudfoundry.identity.uaa.security.IdpOutboundTrustCache;
 import org.cloudfoundry.identity.uaa.test.network.NetworkTestUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -32,9 +33,13 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.security.KeyStore;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -42,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.fail;
 import static org.cloudfoundry.identity.uaa.util.UaaHttpRequestUtils.createRequestFactory;
@@ -271,6 +277,89 @@ class UaaHttpRequestUtilsTest {
                 fail("We should not reach this step if the above URL is using a self signed certificate");
             } catch (RestClientException e) {
                 assertThat(e.getCause().getClass()).isEqualTo(SSLHandshakeException.class);
+            }
+        }
+    }
+
+    /**
+     * The rest of this class exercises a server presenting a single self-signed certificate. These
+     * tests use a server presenting a full leaf -&gt; intermediate -&gt; root chain, which is what real
+     * identity providers behind a CA hierarchy serve, and which is the case that
+     * {@code skipSslValidation=true} must also cover.
+     */
+    @Nested
+    class CertificateChain {
+
+        private NetworkTestUtils.ChainedKeystore chained;
+        private HttpsServer chainedServer;
+        private String chainedUrl;
+
+        @BeforeEach
+        void startChainedServer() throws Exception {
+            chained = NetworkTestUtils.getChainedKeystore(new Date(), 10);
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            chainedServer = NetworkTestUtils.startHttpsServer(chained.file(), NetworkTestUtils.keyPass,
+                    new NetworkTestUtils.SimpleHttpResponseHandler(headers, "OK"));
+            chainedUrl = "https://localhost:" + chainedServer.getAddress().getPort() + "/";
+        }
+
+        @AfterEach
+        void stopChainedServer() throws Exception {
+            chainedServer.stop(0);
+            Files.deleteIfExists(chained.file().toPath());
+        }
+
+        /**
+         * Guards the fixture itself: if this chain were malformed, the tests below would pass or
+         * fail for the wrong reasons.
+         */
+        @Test
+        void fixtureBuildsAThreeCertificateChain() {
+            assertThat(chained.leafCertificate().getIssuerX500Principal())
+                    .isEqualTo(chained.intermediateCertificate().getSubjectX500Principal());
+            assertThat(chained.intermediateCertificate().getIssuerX500Principal())
+                    .isEqualTo(chained.rootCertificate().getSubjectX500Principal());
+            assertThat(chained.rootCertificate().getIssuerX500Principal())
+                    .isEqualTo(chained.rootCertificate().getSubjectX500Principal());
+        }
+
+        @Test
+        void skipSslValidationTrustsFullCertificateChain() {
+            RestTemplate restTemplate = new RestTemplate(createRequestFactory(true, 10_000));
+            assertThat(restTemplate.getForEntity(chainedUrl, String.class).getStatusCode()).isEqualTo(OK);
+        }
+
+        @Test
+        void trustedOnlyRejectsUntrustedCertificateChain() {
+            RestTemplate restTemplate = new RestTemplate(createRequestFactory(false, 10_000));
+            assertThatThrownBy(() -> restTemplate.getForEntity(chainedUrl, String.class))
+                    .isInstanceOf(RestClientException.class)
+                    .hasCauseInstanceOf(SSLHandshakeException.class);
+        }
+
+        /**
+         * The secure alternative to {@code skipSslValidation}: trusting only the chain's root via
+         * per-IDP {@code caCertificates} validates the whole chain, with hostname verification left on.
+         */
+        @Test
+        void caCertificatesWithRootOnlyValidatesFullChain() {
+            SSLContext sslContext = new IdpOutboundTrustCache()
+                    .resolveSslContext("test-idp", List.of(pem(chained.rootCertificate())), false);
+
+            RestTemplate restTemplate = new RestTemplate(
+                    createRequestFactory(sslContext, 10_000, 10_000, RestTemplateConfig.createDefaults()));
+            assertThat(restTemplate.getForEntity(chainedUrl, String.class).getStatusCode()).isEqualTo(OK);
+        }
+
+        private String pem(X509Certificate certificate) {
+            try {
+                return "-----BEGIN CERTIFICATE-----\n"
+                        + Base64.getMimeEncoder(64, "\n".getBytes(StandardCharsets.UTF_8))
+                                .encodeToString(certificate.getEncoded())
+                        + "\n-----END CERTIFICATE-----\n";
+            } catch (CertificateEncodingException e) {
+                throw new IllegalStateException(e);
             }
         }
     }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/UaaHttpRequestUtilsTest.java
@@ -304,10 +304,18 @@ class UaaHttpRequestUtilsTest {
             chainedUrl = "https://localhost:" + chainedServer.getAddress().getPort() + "/";
         }
 
+        /**
+         * Null-guarded so that a failure part-way through {@link #startChainedServer()} surfaces its
+         * own cause rather than being masked by a NullPointerException here.
+         */
         @AfterEach
         void stopChainedServer() throws Exception {
-            chainedServer.stop(0);
-            Files.deleteIfExists(chained.file().toPath());
+            if (chainedServer != null) {
+                chainedServer.stop(0);
+            }
+            if (chained != null) {
+                Files.deleteIfExists(chained.file().toPath());
+            }
         }
 
         /**


### PR DESCRIPTION
## Problem

`skipSslValidation: true` on a SAML or OIDC identity provider does not actually skip TLS
validation when the remote server presents a **certificate chain**. It only skips validation
when the server presents exactly **one** certificate.

`UaaHttpRequestUtils.getNonValidatingSslContext()` built its `SSLContext` with
`TrustSelfSignedStrategy`, whose `isTrusted()` is literally:

```java
return chain.length == 1;
```

Apache's `SSLContextBuilder$TrustManagerDelegate.checkServerTrusted()` falls through to the JDK
default PKIX trust manager whenever the strategy returns false:

```java
if (!this.trustStrategy.isTrusted(chain, authType)) {
    this.trustManager.checkServerTrusted(chain, authType);
}
```

So the flag is **chain-length sensitive, not self-signed sensitive**:

| Server presents | `skipSslValidation=true` result |
| --- | --- |
| 1 self-signed cert | trusted (accidentally correct) |
| 1 leaf, no intermediates sent | trusted (accidentally) |
| leaf + intermediate | **full PKIX validation → `PKIX path building failed`** |
| leaf + intermediate + root | **full PKIX validation → `PKIX path building failed`** |

The behavior is not even monotonic: the *same* leaf is accepted when sent alone and rejected when
sent alongside its intermediate. No coherent threat model produces that ordering, which is the
clearest sign it was unintended rather than a deliberate narrowing.

This means the flag silently did nothing in precisely the situation operators set it for — an
identity provider behind a CA hierarchy, which is what essentially every real IdP is.

## Why this is not a security regression

- **The documented behavior is trust-everything.** `docs/UAA-Configuration-Reference.md`: "Skip
  TLS validation when calling the provider." No chain-length caveat is documented anywhere.
- **UAA's LDAP implementation of the same operator switch already trusts everything** —
  `SkipSslLdapSocketFactory`'s `checkServerTrusted` is an empty body. The HTTP path was the outlier;
  this makes them consistent.
- **`NoopHostnameVerifier` is already applied unconditionally on this path**, so peer authentication
  was already off. An attacker able to present a chain could already pass today by sending a single
  self-signed certificate instead — which is strictly *easier* to produce than a two-cert chain.
- The narrow behavior actively pushed operators toward worse workarounds: importing private CAs into
  the JVM-wide `cacerts`, disabling revocation checking globally, or reconfiguring the IdP to stop
  sending intermediates.

`TrustAllStrategy.INSTANCE` is not deprecated, is `@Contract(threading = STATELESS)`, and is
**already used for this exact purpose** in `LocalUaaRestTemplate`. After this change,
`grep -rn TrustAllStrategy server/src/main` finds every trust-everything site in the codebase.

## The secure alternative

The per-IdP `caCertificates` property (served by `IdpOutboundTrustCache`) trusts a private CA while
keeping **both** chain validation and hostname verification switched on. It already takes lower
precedence than `skipSslValidation` by design. This PR adds javadoc and reference-doc pointers
steering production use toward it, but deliberately does not change runtime precedence, log a
warning, or deprecate the property — those are defensible follow-ups that do not belong in a
cherry-pickable bugfix.

## Commits

Split so the defect is demonstrable by checkout, not just by assertion:

| Commit | Test result at that commit |
| --- | --- |
| `20a97cb8e` Add failing test | **13 passed, 1 failed** |
| `449d6450b` Fix | **14 passed, 0 failed** |
| `6984af52c`, `5f5dc3233` | test-fixture cleanups from review |

Verified by actually checking out `20a97cb8e` and running the suite there.

## Testing

New `NetworkTestUtils.getChainedKeystore()` builds a genuine root → intermediate → leaf chain
(proper `basicConstraints`, `keyUsage`, `SAN dNSName=localhost`) and stores it as a length-3 chain.
The existing `getKeystore()` is untouched, so its four callers keep the length-1 behavior.

New `@Nested class CertificateChain`:

- `skipSslValidationTrustsFullCertificateChain` — **the regression test.** Fails before the fix with
  `PKIX path building failed`, passes after.
- `fixtureBuildsAThreeCertificateChain` — proves the chain is well formed.
- `caCertificatesWithRootOnlyValidatesFullChain` — proves the chain is PKIX-valid when its root is
  trusted, so the test above fails for the right reason and not because of a bad fixture. Also the
  first coverage anywhere of `caCertificates` against a real intermediate-bearing chain.
- `trustedOnlyRejectsUntrustedCertificateChain` — guards the inverse, so a later change cannot make
  everything trusting unnoticed.

The pre-existing single-certificate `skipSslValidation` test still passes, which isolates the defect
to one variable: chain length.

Suites run green: `UaaHttpRequestUtilsTest` (14), `provider.saml.*` + `IdpOutboundTrustCacheTest` +
`OidcMetadataFetcherTest` + `CaCertAwareLdapSocketFactoryTest` (316), `util.*` + `ExternalOAuth*` +
`RestTemplateConfig*` (598), and all other `startHttpsServer` callers (30).

## Notes for reviewers

- The first commit is intentionally red. If CI gates every commit rather than the branch tip, expect
  `20a97cb8e` to fail; squash on merge if that is a problem.
- Removing the `TrustSelfSignedStrategy` import eliminates UAA's only reference to a `@Deprecated`
  httpclient5 class.
- `npx markdownlint-cli2` could not be run in my environment (npm registry auth failure). The added
  doc lines were checked manually against `.markdownlint.json` (MD013 = 120, tables exempt) and are
  91–97 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)