### PR TITLE
Fix ZonePathContextRewritingFilter rewriting `__Host-` cookie paths

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilter.java
@@ -316,6 +316,9 @@ public class ZonePathContextRewritingFilter extends OncePerRequestFilter {
         }
 
         private boolean shouldRewritePath(String name, String path) {
+            if (name != null && name.startsWith("__Host-")) {
+                return false;
+            }
             if (ignoreCookies.contains(name)) {
                 return false;
             }
@@ -351,7 +354,7 @@ public class ZonePathContextRewritingFilter extends OncePerRequestFilter {
                 return headerValue;
             }
             String cookieName = extractCookieNameFromSetCookieHeader(headerValue);
-            if (cookieName != null && ignoreCookies.contains(cookieName)) {
+            if (cookieName != null && (cookieName.startsWith("__Host-") || ignoreCookies.contains(cookieName))) {
                 return headerValue;
             }
             String pathToUse = originalContextPath;

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilterTests.java
@@ -460,6 +460,23 @@ class ZonePathContextRewritingFilterTests {
     }
 
     @Test
+    void addCookie_hostPrefixedCookie_leavesPathUnchanged() throws Exception {
+        request.setContextPath("/uaa");
+        request.setRequestURI("/uaa/z/myzone/login");
+
+        FilterChain chain = (_, res) -> {
+            Cookie c = new Cookie("__Host-X-Uaa-Csrf", "v");
+            c.setPath("/");
+            ((HttpServletResponse) res).addCookie(c);
+        };
+        filter.doFilter(request, response, chain);
+
+        Cookie[] cookies = response.getCookies();
+        assertThat(cookies).hasSize(1);
+        assertThat(cookies[0].getPath()).isEqualTo("/");
+    }
+
+    @Test
     void noZonePath_withContextPath_rewritesCookiePathToContextPath() throws Exception {
         request.setContextPath("/uaa");
         request.setRequestURI("/uaa/login");
@@ -596,8 +613,24 @@ class ZonePathContextRewritingFilterTests {
 
         String header = response.getHeader("Set-Cookie");
         assertThat(header)
-                .contains("Path=/")
+                .contains("Path=/;")
+                .doesNotContain("Path=/uaa")
                 .contains("Current-User=");
+    }
+
+    @Test
+    void addHeaderSetCookie_hostPrefixedCookie_leavesPathUnchanged() throws Exception {
+        request.setContextPath("/uaa");
+        request.setRequestURI("/uaa/z/myzone/login");
+
+        FilterChain chain = (_, res) -> ((HttpServletResponse) res).addHeader("Set-Cookie", "__Host-X-Uaa-Csrf=encoded; Path=/; HttpOnly");
+        filter.doFilter(request, response, chain);
+
+        String header = response.getHeader("Set-Cookie");
+        assertThat(header)
+                .contains("Path=/;")
+                .doesNotContain("Path=/uaa")
+                .contains("__Host-X-Uaa-Csrf=");
     }
 
     @Test
@@ -609,7 +642,9 @@ class ZonePathContextRewritingFilterTests {
         filter.doFilter(request, response, chain);
 
         String header = response.getHeader("Set-Cookie");
-        assertThat(header).contains("Path=/");
+        assertThat(header)
+                .contains("Path=/")
+                .doesNotContain("Path=/uaa");
     }
 
     @Test
@@ -621,7 +656,9 @@ class ZonePathContextRewritingFilterTests {
         filter.doFilter(request, response, chain);
 
         String header = response.getHeader("Set-Cookie");
-        assertThat(header).contains("Path=/");
+        assertThat(header)
+                .contains("Path=/")
+                .doesNotContain("Path=/uaa");
     }
 
     // --- zones.paths.enabled flag ---


### PR DESCRIPTION
RFC 6265bis requires `__Host-` prefixed cookies to unconditionally have `Path=/`. The `ZonePathContextRewritingFilter` was incorrectly mutating the path of these cookies to the zone context path (e.g. `/auth`), causing browsers to reject them and resulting in CSRF token mismatch errors.

This change updates the filter to exclude `__Host-` prefixed cookies from path rewriting, ensuring they retain their required `Path=/` attribute.