### PR TITLE
Fix refresh token grant failing after client secret rotation (ADD)

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/UaaTokenServices.java
@@ -277,8 +277,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
                 claims.getGrantType(),
                 client);
 
-        throwIfInvalidRevocationHashSignature(claims.getRevSig(), user, client);
-
         Map<String, Object> additionalRootClaims = getAdditionalRootClaims(refreshTokenClaims);
 
         UserAuthenticationData authenticationData = new UserAuthenticationData(
@@ -388,16 +386,6 @@ public class UaaTokenServices implements AuthorizationServerTokenServices, Resou
 
     static boolean isRevocable(Claims claims, boolean isOpaque) {
         return isOpaque || claims.isRevocable();
-    }
-
-    private static void throwIfInvalidRevocationHashSignature(String revocableHashSignature, UaaUser user, ClientDetails client) {
-        if (hasText(revocableHashSignature)) {
-            String clientSecretForHash = getClientSecretForHash(client.getClientSecret());
-            String newRevocableHashSignature = UaaTokenUtils.getRevocableTokenSignature(client, clientSecretForHash, user);
-            if (!revocableHashSignature.equals(newRevocableHashSignature)) {
-                throw new TokenRevokedException("Invalid refresh token: revocable signature mismatch");
-            }
-        }
     }
 
     private static Set<String> getAcrAsSet(Map<String, Object> refreshTokenClaims) {

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -3190,6 +3190,45 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
     }
 
     @Test
+    void refreshTokenIssuedBeforeAddClientSecretStillWorksAfterAdd() throws Exception {
+        String clientId = "testclient" + generator.generate();
+        String scopes = "openid";
+        setUpClients(clientId, scopes, scopes, GRANT_TYPES, true);
+        String userId = "testuser" + generator.generate();
+        ScimUser user = setUpUser(jdbcScimUserProvisioning, jdbcScimGroupMembershipManager, jdbcScimGroupProvisioning, userId, scopes, OriginKeys.UAA, IdentityZoneHolder.get().getId());
+
+        // token is issued while the client only has a single secret
+        String body = mockMvc.perform(post("/oauth/token")
+                        .accept(MediaType.APPLICATION_JSON_VALUE)
+                        .with(httpBasic(clientId, SECRET))
+                        .param("grant_type", "password")
+                        .param("client_id", clientId)
+                        .param("client_secret", SECRET)
+                        .param("username", user.getUserName())
+                        .param("password", SECRET))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString();
+
+        Map<String, Object> bodyMap = JsonUtils.readValue(body, new TypeReference<>() {
+        });
+        String refreshToken = (String) bodyMap.get("refresh_token");
+        assertThat(refreshToken).isNotNull();
+
+        // a second secret is added for zero-downtime rotation; the original secret remains valid
+        clientDetailsService.addClientSecret(clientId, "newSecret", IdentityZoneHolder.get().getId());
+
+        // the refresh token issued before the rotation must still be redeemable with the original secret
+        mockMvc.perform(post("/oauth/token")
+                        .accept(MediaType.APPLICATION_JSON_VALUE)
+                        .with(httpBasic(clientId, SECRET))
+                        .param("grant_type", "refresh_token")
+                        .param("client_id", clientId)
+                        .param("client_secret", SECRET)
+                        .param("refresh_token", refreshToken))
+                .andExpect(status().isOk());
+    }
+
+    @Test
     void getClientCredentialsWithAuthoritiesExcludedForDefaultIdentityZone() throws Exception {
         Set<String> originalExclude = webApplicationContext.getBean(UaaTokenServices.class).getExcludedClaims();
         try {


### PR DESCRIPTION
## Summary

- Fixes #4047: after adding a second client secret via `changeMode=ADD` (the multi-secret, zero-downtime rotation feature), `grant_type=refresh_token` calls failed with `invalid_token: revocable signature mismatch` for any refresh token issued before the rotation — regardless of which secret was used to authenticate.
- Root cause: `UaaTokenServices.refreshAccessToken()` ran a second, redundant revocation-signature check (`throwIfInvalidRevocationHashSignature`) immediately after the correct check (`tokenValidationService.validateToken(...)`, which already loops over every currently valid client secret) had already passed. The redundant check compared against a single, hardcoded "newest secret" only, so it rejected tokens signed against an older still-valid secret.
- Fix: remove the redundant, single-secret check and its now-unused helper — the multi-secret-aware check performed a few lines earlier already covers this claim correctly.

## Test plan

- [x] Added `refreshTokenIssuedBeforeAddClientSecretStillWorksAfterAdd` in `TokenMvcMockTests.java`: issues a password-grant refresh token while the client has one secret, adds a second secret via `changeMode=ADD`, then confirms the original refresh token still redeems successfully.
- [x] Confirmed the new test fails against the pre-fix code and passes with the fix applied.
- [x] Ran the full `TokenMvcMockTests` suite and the `org.cloudfoundry.identity.uaa.oauth.*` package in the server module — all passing.
- [x] Manually reproduced the original bug end-to-end against a local UAA instance using `uaa-cli`, and confirmed the fix resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)