### PR TITLE
Fix PATCH /Users/{userId}/status ignoring caller's Accept header

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpoints.java
@@ -555,6 +555,7 @@ public class ScimUserEndpoints implements InitializingBean, ApplicationEventPubl
     }
 
     @PatchMapping("/Users/{userId}/status")
+    @ResponseBody
     public UserAccountStatus updateAccountStatus(@RequestBody UserAccountStatus status, @PathVariable String userId) {
         ScimUser user = scimUserProvisioning.retrieve(userId, identityZoneManager.getCurrentIdentityZoneId());
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
@@ -637,6 +637,26 @@ class ScimUserEndpointsMockMvcTests {
     }
 
     @Test
+    void unlockAccountWithoutAcceptHeader() throws Exception {
+        // Regression test: without @ResponseBody on updateAccountStatus, a caller
+        // that omits Accept: application/json (e.g. uaa-cli's unlock-user, which
+        // issues a raw PATCH via its curl helper) gets routed into Thymeleaf view
+        // resolution instead of the normal HttpMessageConverter path, and 500s.
+        ScimUser userToLockout = createUser(uaaAdminToken);
+        attemptUnsuccessfulLogin(5, userToLockout.getUserName(), "");
+
+        UserAccountStatus alteredAccountStatus = new UserAccountStatus();
+        alteredAccountStatus.setLocked(false);
+        updateAccountStatusWithoutAcceptHeader(userToLockout, alteredAccountStatus)
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(APPLICATION_JSON))
+                .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
+
+        attemptLogin(userToLockout)
+                .andExpect(redirectedUrl("/"));
+    }
+
+    @Test
     void accountStatusEmptyPatchDoesNotUnlock() throws Exception {
         ScimUser userToLockout = createUser(uaaAdminToken);
         attemptUnsuccessfulLogin(5, userToLockout.getUserName(), "");
@@ -1383,6 +1403,17 @@ class ScimUserEndpointsMockMvcTests {
                         patch("/Users/" + user.getId() + "/status")
                                 .header("Authorization", "Bearer " + uaaAdminToken)
                                 .accept(APPLICATION_JSON)
+                                .contentType(APPLICATION_JSON)
+                                .content(jsonStatus)
+                );
+    }
+
+    private ResultActions updateAccountStatusWithoutAcceptHeader(ScimUser user, UserAccountStatus alteredAccountStatus) throws Exception {
+        String jsonStatus = JsonUtils.writeValueAsString(alteredAccountStatus);
+        return mockMvc
+                .perform(
+                        patch("/Users/" + user.getId() + "/status")
+                                .header("Authorization", "Bearer " + uaaAdminToken)
                                 .contentType(APPLICATION_JSON)
                                 .content(jsonStatus)
                 );

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcTests.java
@@ -87,7 +87,6 @@ import static org.springframework.util.StringUtils.hasText;
 @ExtendWith(ZoneSeederExtension.class)
 @DefaultTestContext
 class ScimUserEndpointsMockMvcTests {
-    private static final MediaType APPLICATION_JSON_UTF8 = new MediaType("application", "json", java.nio.charset.StandardCharsets.UTF_8);
     private static final String HTTP_REDIRECT_EXAMPLE_COM = "http://redirect.example.com";
     private static final String USER_PASSWORD = "pas5Word";
     private String scimReadWriteToken;
@@ -630,7 +629,7 @@ class ScimUserEndpointsMockMvcTests {
         alteredAccountStatus.setLocked(false);
         updateAccountStatus(userToLockout, alteredAccountStatus)
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
 
         attemptLogin(userToLockout)
@@ -644,7 +643,7 @@ class ScimUserEndpointsMockMvcTests {
 
         updateAccountStatus(userToLockout, new UserAccountStatus())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string("{}"));
 
         attemptLogin(userToLockout)
@@ -672,7 +671,7 @@ class ScimUserEndpointsMockMvcTests {
         alteredAccountStatus.setLocked(false);
         updateAccountStatus(userToLockout, alteredAccountStatus)
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
 
         attemptLogin(userToLockout)
@@ -716,7 +715,7 @@ class ScimUserEndpointsMockMvcTests {
 
         updateAccountStatus(user, alteredAccountStatus)
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
 
         assertThat(usersRepository.checkPasswordChangeIndividuallyRequired(user.getId(), IdentityZoneHolder.get().getId())).isTrue();

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/scim/endpoints/ScimUserEndpointsMockMvcZonePathTests.java
@@ -96,7 +96,6 @@ import static org.springframework.util.StringUtils.hasText;
 @DefaultTestContext
 @EnabledIfZonePathsEnabled
 class ScimUserEndpointsMockMvcZonePathTests {
-    private static final MediaType APPLICATION_JSON_UTF8 = new MediaType("application", "json", java.nio.charset.StandardCharsets.UTF_8);
     private static final String HTTP_REDIRECT_EXAMPLE_COM = "http://redirect.example.com";
     private static final String USER_PASSWORD = "pas5Word";
     private String scimReadWriteToken;
@@ -660,7 +659,7 @@ class ScimUserEndpointsMockMvcZonePathTests {
         alteredAccountStatus.setLocked(false);
         updateAccountStatus(userToLockout, alteredAccountStatus)
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
 
         attemptLogin(userToLockout)
@@ -675,7 +674,7 @@ class ScimUserEndpointsMockMvcZonePathTests {
 
         updateAccountStatus(userToLockout, new UserAccountStatus())
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string("{}"));
 
         attemptLogin(userToLockout)
@@ -703,7 +702,7 @@ class ScimUserEndpointsMockMvcZonePathTests {
         alteredAccountStatus.setLocked(false);
         updateAccountStatus(userToLockout, alteredAccountStatus)
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
 
         attemptLogin(userToLockout)
@@ -747,7 +746,7 @@ class ScimUserEndpointsMockMvcZonePathTests {
 
         updateAccountStatus(user, alteredAccountStatus)
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+                .andExpect(content().contentType(APPLICATION_JSON))
                 .andExpect(content().string(JsonUtils.writeValueAsString(alteredAccountStatus)));
 
         assertThat(usersRepository.checkPasswordChangeIndividuallyRequired(user.getId(), IdentityZoneHolder.get().getId())).isTrue();


### PR DESCRIPTION
## Summary

- `updateAccountStatus` (backing account-unlock and force-password-change, `PATCH /Users/{userId}/status` in `ScimUserEndpoints`) is missing `@ResponseBody` — accidentally dropped in `6159e2f4` (2016) when the endpoint moved from PUT to PATCH, while every sibling endpoint in this `@Controller` class kept it.
- Without `@ResponseBody`, Spring falls back to view-name resolution instead of the normal `HttpMessageConverter` path. A client that doesn't send an explicit `Accept: application/json` header gets routed into Thymeleaf trying (and failing) to resolve a template named after the request path, and the call 500s.
- Found via [cloudfoundry/uaa-cli#333](https://github.com/cloudfoundry/uaa-cli/pull/333): `uaa-cli`'s `unlock-user` command issues a raw PATCH without an `Accept` header and always gets a 500 against current `develop`.
- The existing MockMvc tests for this endpoint never caught it because they explicitly set `Accept: application/json`, which happens to trigger a `ContentNegotiatingViewResolver` JSON fallback view that papers over the missing annotation.

Restoring `@ResponseBody` makes the endpoint correctly return JSON regardless of the caller's `Accept` header, consistent with every other endpoint in this file.

**Side effect:** the response `Content-Type` changes from the JSON fallback view's `application/json;charset=UTF-8` to the standard `HttpMessageConverter`'s `application/json` (no charset param) — matching every other endpoint here. Updated the two affected MockMvc test classes (`ScimUserEndpointsMockMvcTests`, `ScimUserEndpointsMockMvcZonePathTests`) to match; removed the now-unused `APPLICATION_JSON_UTF8` test constant that existed only for this endpoint.

## Test plan

- [x] `./gradlew :cloudfoundry-identity-uaa:test --tests ScimUserEndpointsMockMvcTests --tests ScimUserEndpointsMockMvcZonePathTests` — 150/150 passing
- [x] Manually reproduced against a freshly-booted instance: `PATCH /Users/{id}/status` without an `Accept` header 500s on `develop`, returns 200 with correct JSON after this fix
- [x] Confirmed with `Accept: application/json` explicitly set, `develop` already returns 200 (explains why existing tests didn't catch this)