### PR TITLE
Potential fix for code scanning alert no. 125: Failure to use secure cookies

### DIFF
--- a/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilterTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilterTests.java
@@ -484,6 +484,7 @@ class ZonePathContextRewritingFilterTests {
         FilterChain chain = (_, res) -> {
             Cookie c = new Cookie("A", "b");
             c.setPath("/");
+            c.setSecure(true);
             ((HttpServletResponse) res).addCookie(c);
         };
         filter.doFilter(request, response, chain);
@@ -501,6 +502,7 @@ class ZonePathContextRewritingFilterTests {
         FilterChain chain = (_, res) -> {
             Cookie c = new Cookie("C", "d");
             c.setPath("/");
+            c.setSecure(true);
             ((HttpServletResponse) res).addCookie(c);
         };
         filter.doFilter(request, response, chain);
@@ -518,6 +520,7 @@ class ZonePathContextRewritingFilterTests {
         FilterChain chain = (_, res) -> {
             Cookie c = new Cookie("K", "v");
             c.setPath("/");
+            c.setSecure(true);
             ((HttpServletResponse) res).addCookie(c);
         };
         filter.doFilter(request, response, chain);
@@ -536,9 +539,11 @@ class ZonePathContextRewritingFilterTests {
             HttpServletResponse httpRes = (HttpServletResponse) res;
             Cookie c1 = new Cookie("One", "1");
             c1.setPath("/");
+            c1.setSecure(true);
             httpRes.addCookie(c1);
             Cookie c2 = new Cookie("Two", "2");
             c2.setPath("/custom");
+            c2.setSecure(true);
             httpRes.addCookie(c2);
         };
         filter.doFilter(request, response, chain);


### PR DESCRIPTION
Potential fix for [https://github.com/cloudfoundry/uaa/security/code-scanning/125](https://github.com/cloudfoundry/uaa/security/code-scanning/125)

Set the secure flag on each cookie in the shown test methods before adding it to the `HttpServletResponse`.

Best minimal fix in `server/src/test/java/org/cloudfoundry/identity/uaa/zone/ZonePathContextRewritingFilterTests.java`:
- In each lambda where a cookie is created and then added via `addCookie`, insert `cookie.setSecure(true);` after `setPath(...)` (or before `addCookie(...)`).
- Specifically in the shown region:
  - `noZonePath_withContextPath_rewritesCookiePathToContextPath`
  - `emptyOriginalContextPath_cookiePathRemainsSlash`
  - `originalContextPathSingleSlash_cookiePathRemainsSlash` (the flagged line)
  - `multipleCookies_mixedPaths_rewritesOnlySlashPath` (for both `c1` and `c2`)
- No imports or new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
