### PR TITLE
Enforce audience check for self-referencing OIDC identity providers

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -265,11 +265,11 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     protected AuthenticationData getExternalAuthenticationDetails(final Authentication authentication) {
         final ExternalOAuthCodeToken codeToken = (ExternalOAuthCodeToken) authentication;
 
-        // A caller that already supplies an origin (the interactive browser SSO callback,
-        // /login/callback/{origin}) is asserting a specific IdP by URL and must have the presented
-        // id_token bound to that IdP's own relying party. A caller that omits it (JWT Bearer grant,
-        // password grant with an id_token) is doing a machine-to-machine token exchange that already
-        // authenticates the calling client to /oauth/token directly, and deliberately chains tokens
+        // When the caller supplies an explicit origin (interactive browser callback: /login/callback/{origin}),
+        // bind the presented id_token to that IdP's relying party (audience).
+        // When origin is omitted (JWT Bearer/password-grant token exchange), we still validate audience for
+        // external IdPs, but skip the relying-party audience binding for self-referencing (UAA-issued) tokens
+        // to allow the intended token-chaining behavior.
         // minted for other clients in the same zone/origin - so it is exempt from that binding.
         final boolean enforceRelyingPartyAudience = hasLength(codeToken.getOrigin());
 

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -773,6 +773,12 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         if (tokenEndpointBuilder.getTokenEndpoint(identityZoneManager.getCurrentIdentityZone()).equals(config.getIssuer())) {
             List<SignatureVerifier> signatureVerifiers = getTokenKeyForUaaOrigin();
             jwtToken = buildIdTokenValidator(idToken, new ChainedSignatureVerifier(signatureVerifiers), keyInfoService);
+            if (hasLength(config.getRelyingPartyId())) {
+                // an explicitly registered self-referencing OIDC IdP must still bind the id_token
+                // to its own relying party, otherwise any token signed by this UAA instance
+                // (issued to any client, for any purpose) would be accepted as this IdP's id_token
+                jwtToken.checkAudience(config.getRelyingPartyId());
+            }
         } else {
             JsonWebKeySet<JsonWebKey> tokenKeyFromOAuth = getTokenKeyFromOAuth(config);
             jwtToken = buildIdTokenValidator(idToken, new ChainedSignatureVerifier(tokenKeyFromOAuth), keyInfoService)

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManager.java
@@ -265,6 +265,14 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
     protected AuthenticationData getExternalAuthenticationDetails(final Authentication authentication) {
         final ExternalOAuthCodeToken codeToken = (ExternalOAuthCodeToken) authentication;
 
+        // A caller that already supplies an origin (the interactive browser SSO callback,
+        // /login/callback/{origin}) is asserting a specific IdP by URL and must have the presented
+        // id_token bound to that IdP's own relying party. A caller that omits it (JWT Bearer grant,
+        // password grant with an id_token) is doing a machine-to-machine token exchange that already
+        // authenticates the calling client to /oauth/token directly, and deliberately chains tokens
+        // minted for other clients in the same zone/origin - so it is exempt from that binding.
+        final boolean enforceRelyingPartyAudience = hasLength(codeToken.getOrigin());
+
         IdentityProvider provider = null;
         if (!hasLength(codeToken.getOrigin())) {
             provider = resolveOriginProvider(codeToken.getIdToken());
@@ -286,7 +294,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             final AuthenticationData authenticationData = new AuthenticationData();
             authenticationData.setOrigin(origin);
 
-            final Map<String, Object> claims = getClaimsFromToken(codeToken, provider);
+            final Map<String, Object> claims = getClaimsFromToken(codeToken, provider, enforceRelyingPartyAudience);
 
             if (claims == null) {
                 return null;
@@ -641,6 +649,14 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             ExternalOAuthCodeToken codeToken,
             final IdentityProvider<T> identityProvider
     ) {
+        return getClaimsFromToken(codeToken, identityProvider, true);
+    }
+
+    protected <T extends AbstractExternalOAuthIdentityProviderDefinition<T>> Map<String, Object> getClaimsFromToken(
+            ExternalOAuthCodeToken codeToken,
+            final IdentityProvider<T> identityProvider,
+            final boolean enforceRelyingPartyAudience
+    ) {
         String tokenFieldName = getTokenFieldName(identityProvider.getConfig());
         String token = getTokenFromCode(codeToken, identityProvider);
         if ("access_token".equals(tokenFieldName) && token != null && OAUTH20.equals(identityProvider.getType())) {
@@ -648,12 +664,20 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         } else {
             codeToken.setIdToken(token);
         }
-        return getClaimsFromToken(token, identityProvider);
+        return getClaimsFromToken(token, identityProvider, enforceRelyingPartyAudience);
     }
 
     protected <T extends AbstractExternalOAuthIdentityProviderDefinition<T>> Map<String, Object> getClaimsFromToken(
             String idToken,
             final IdentityProvider<T> identityProvider
+    ) {
+        return getClaimsFromToken(idToken, identityProvider, true);
+    }
+
+    protected <T extends AbstractExternalOAuthIdentityProviderDefinition<T>> Map<String, Object> getClaimsFromToken(
+            String idToken,
+            final IdentityProvider<T> identityProvider,
+            final boolean enforceRelyingPartyAudience
     ) {
         log.debug("Extracting claims from id_token");
         if (idToken == null) {
@@ -731,7 +755,7 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
             log.debug("Request completed with status:{}", responseEntity.getStatusCode());
             return responseEntity.getBody();
         } else {
-            JwtTokenSignedByThisUAA jwtToken = validateToken(idToken, config);
+            JwtTokenSignedByThisUAA jwtToken = validateToken(idToken, config, enforceRelyingPartyAudience);
             log.debug("Decoding id_token");
             Jwt decodeIdToken = jwtToken.getJwt();
             log.debug("Deserializing id_token claims");
@@ -765,7 +789,11 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         }
     }
 
-    private JwtTokenSignedByThisUAA validateToken(String idToken, AbstractExternalOAuthIdentityProviderDefinition config) {
+    private JwtTokenSignedByThisUAA validateToken(
+            String idToken,
+            AbstractExternalOAuthIdentityProviderDefinition config,
+            boolean enforceRelyingPartyAudience
+    ) {
         log.debug("Validating id_token");
 
         JwtTokenSignedByThisUAA jwtToken;
@@ -773,10 +801,14 @@ public class ExternalOAuthAuthenticationManager extends ExternalLoginAuthenticat
         if (tokenEndpointBuilder.getTokenEndpoint(identityZoneManager.getCurrentIdentityZone()).equals(config.getIssuer())) {
             List<SignatureVerifier> signatureVerifiers = getTokenKeyForUaaOrigin();
             jwtToken = buildIdTokenValidator(idToken, new ChainedSignatureVerifier(signatureVerifiers), keyInfoService);
-            if (hasLength(config.getRelyingPartyId())) {
+            if (enforceRelyingPartyAudience && hasText(config.getRelyingPartyId())) {
                 // an explicitly registered self-referencing OIDC IdP must still bind the id_token
-                // to its own relying party, otherwise any token signed by this UAA instance
-                // (issued to any client, for any purpose) would be accepted as this IdP's id_token
+                // to its own relying party for an interactive login, otherwise any token signed by
+                // this UAA instance (issued to any client, for any purpose) would be accepted as
+                // this IdP's id_token. Machine-to-machine token exchanges (JWT Bearer grant,
+                // password grant with an id_token) are exempt: they already authenticate the
+                // calling client to /oauth/token directly, and deliberately chain tokens minted for
+                // other clients in the same zone/origin.
                 jwtToken.checkAudience(config.getRelyingPartyId());
             }
         } else {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -526,10 +526,12 @@ class ExternalOAuthAuthenticationManagerIT {
 
     @Test
     void self_referencing_oidc_idp_rejects_a_uaa_token_issued_to_a_different_client() {
+        // simulates the interactive browser callback (/login/callback/{origin}), which always
+        // supplies an explicit origin and therefore must bind the id_token's audience
         IdentityProvider<OIDCIdentityProviderDefinition> idpProvider = getProvider();
         idpProvider.setType(OriginKeys.OIDC10);
         idpProvider.getConfig().setIssuer(UAA_ISSUER_URL);
-        when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));
+        when(provisioning.retrieveByOrigin(eq(idpProvider.getOriginKey()), anyString())).thenReturn(idpProvider);
 
         // a token signed by this same UAA, but issued to a different client ("cf"), not the
         // self-referencing IdP's own relying party ("identity")
@@ -540,7 +542,7 @@ class ExternalOAuthAuthenticationManagerIT {
 
         CompositeToken token = getCompositeAccessToken();
         xCodeToken.setIdToken(token.getIdTokenValue());
-        xCodeToken.setOrigin(null);
+        xCodeToken.setOrigin(idpProvider.getOriginKey());
 
         assertThatThrownBy(() -> externalOAuthAuthenticationManager.getExternalAuthenticationDetails(xCodeToken))
                 .isInstanceOf(InvalidTokenException.class)
@@ -549,22 +551,52 @@ class ExternalOAuthAuthenticationManagerIT {
 
     @Test
     void self_referencing_oidc_idp_rejects_a_uaa_token_with_no_audience_claim() {
+        // simulates the interactive browser callback (/login/callback/{origin}), which always
+        // supplies an explicit origin and therefore must bind the id_token's audience
         IdentityProvider<OIDCIdentityProviderDefinition> idpProvider = getProvider();
         idpProvider.setType(OriginKeys.OIDC10);
         idpProvider.getConfig().setIssuer(UAA_ISSUER_URL);
-        when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));
+        when(provisioning.retrieveByOrigin(eq(idpProvider.getOriginKey()), anyString())).thenReturn(idpProvider);
 
-        // e.g. a plain access token response with no id_token/aud at all, as opposed to a real id_token
+        // an id_token with no aud claim at all - e.g. one that was never meant to be presented as
+        // an id_token to this relying party in the first place
         claims.put("sub", RandomStringUtils.random(50));
         claims.put("iss", UAA_ISSUER_URL);
         claims.put("origin", OriginKeys.UAA);
 
         CompositeToken token = getCompositeAccessToken(Collections.singletonList(ClaimConstants.AUD));
         xCodeToken.setIdToken(token.getIdTokenValue());
-        xCodeToken.setOrigin(null);
+        xCodeToken.setOrigin(idpProvider.getOriginKey());
 
         assertThatThrownBy(() -> externalOAuthAuthenticationManager.getExternalAuthenticationDetails(xCodeToken))
                 .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
+    void jwt_bearer_style_token_exchange_is_exempt_from_self_referencing_audience_check() {
+        // simulates the JWT Bearer grant / password-grant-with-id_token machine-to-machine path,
+        // which omits the origin and lets resolveOriginProvider() resolve the registered IdP by
+        // the token's own issuer claim. That path already authenticates the calling client to
+        // /oauth/token directly, and deliberately chains tokens minted for other clients.
+        IdentityProvider<OIDCIdentityProviderDefinition> idpProvider = getProvider();
+        idpProvider.setType(OriginKeys.OIDC10);
+        idpProvider.getConfig().setIssuer(UAA_ISSUER_URL);
+        when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));
+
+        String username = RandomStringUtils.random(50);
+        claims.put("sub", username);
+        claims.put("iss", UAA_ISSUER_URL);
+        claims.put("origin", OriginKeys.UAA);
+        claims.put(ClaimConstants.AUD, Collections.singletonList("cf"));
+
+        CompositeToken token = getCompositeAccessToken();
+        xCodeToken.setIdToken(token.getIdTokenValue());
+        xCodeToken.setOrigin(null);
+
+        AuthenticationData externalAuthenticationDetails = externalOAuthAuthenticationManager
+                .getExternalAuthenticationDetails(xCodeToken);
+
+        assertThat(username).isEqualTo(externalAuthenticationDetails.getUsername());
     }
 
     @Test
@@ -757,8 +789,8 @@ class ExternalOAuthAuthenticationManagerIT {
         xCodeToken.setIdToken(idToken);
         externalOAuthAuthenticationManager.authenticate(xCodeToken);
 
-        verify(externalOAuthAuthenticationManager, times(1)).getClaimsFromToken(same(xCodeToken), any());
-        verify(externalOAuthAuthenticationManager, times(1)).getClaimsFromToken(eq(idToken), any());
+        verify(externalOAuthAuthenticationManager, times(1)).getClaimsFromToken(same(xCodeToken), any(), eq(true));
+        verify(externalOAuthAuthenticationManager, times(1)).getClaimsFromToken(eq(idToken), any(), eq(true));
         verify(externalOAuthAuthenticationManager, never()).getRestTemplate(any());
 
         ArgumentCaptor<ApplicationEvent> userArgumentCaptor = ArgumentCaptor.forClass(ApplicationEvent.class);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/provider/oauth/ExternalOAuthAuthenticationManagerIT.java
@@ -525,6 +525,49 @@ class ExternalOAuthAuthenticationManagerIT {
     }
 
     @Test
+    void self_referencing_oidc_idp_rejects_a_uaa_token_issued_to_a_different_client() {
+        IdentityProvider<OIDCIdentityProviderDefinition> idpProvider = getProvider();
+        idpProvider.setType(OriginKeys.OIDC10);
+        idpProvider.getConfig().setIssuer(UAA_ISSUER_URL);
+        when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));
+
+        // a token signed by this same UAA, but issued to a different client ("cf"), not the
+        // self-referencing IdP's own relying party ("identity")
+        claims.put("sub", RandomStringUtils.random(50));
+        claims.put("iss", UAA_ISSUER_URL);
+        claims.put("origin", OriginKeys.UAA);
+        claims.put(ClaimConstants.AUD, Collections.singletonList("cf"));
+
+        CompositeToken token = getCompositeAccessToken();
+        xCodeToken.setIdToken(token.getIdTokenValue());
+        xCodeToken.setOrigin(null);
+
+        assertThatThrownBy(() -> externalOAuthAuthenticationManager.getExternalAuthenticationDetails(xCodeToken))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("audience");
+    }
+
+    @Test
+    void self_referencing_oidc_idp_rejects_a_uaa_token_with_no_audience_claim() {
+        IdentityProvider<OIDCIdentityProviderDefinition> idpProvider = getProvider();
+        idpProvider.setType(OriginKeys.OIDC10);
+        idpProvider.getConfig().setIssuer(UAA_ISSUER_URL);
+        when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));
+
+        // e.g. a plain access token response with no id_token/aud at all, as opposed to a real id_token
+        claims.put("sub", RandomStringUtils.random(50));
+        claims.put("iss", UAA_ISSUER_URL);
+        claims.put("origin", OriginKeys.UAA);
+
+        CompositeToken token = getCompositeAccessToken(Collections.singletonList(ClaimConstants.AUD));
+        xCodeToken.setIdToken(token.getIdTokenValue());
+        xCodeToken.setOrigin(null);
+
+        assertThatThrownBy(() -> externalOAuthAuthenticationManager.getExternalAuthenticationDetails(xCodeToken))
+                .isInstanceOf(InvalidTokenException.class);
+    }
+
+    @Test
     void when_exchanging_an_id_token_retrieved_by_an_external_oidc_idp_for_an_access_token_then_auth_data_should_contain_oidc_sub_claim() {
         IdentityProvider<OIDCIdentityProviderDefinition> idpProvider = getProvider();
         when(provisioning.retrieveAll(eq(true), anyString())).thenReturn(Collections.singletonList(idpProvider));


### PR DESCRIPTION
An IdP registered with an issuer equal to the current zone's own token
endpoint skipped audience validation on the presented id_token, since
that check was only wired up for external OIDC providers. Any UAA-signed
JWT for any client, not just the self-referencing IdP's own relying
party, was accepted as a valid id_token for that login, letting a token
issued in one client context be replayed to authenticate a different
external-OIDC-mapped identity.

Now the relying party's client ID is checked against the token's aud
claim whenever one is configured, matching the validation already done
for external providers. The internal id_token exchange used by the JWT
bearer grant is unaffected, since it never sets a relying party ID.