### PR TITLE
Restrict the stateless token-API request matcher to the user_token grant

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/beans/OauthEndpointBeanConfiguration.java
@@ -409,7 +409,8 @@ public class OauthEndpointBeanConfiguration {
                 entry("Authorization", asList("bearer "))
         ));
         bean.setParameters(Map.ofEntries(
-                entry("client_id", "")
+                entry("client_id", ""),
+                entry("grant_type", "user_token")
         ));
         return bean;
     }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/mock/token/TokenMvcMockTests.java
@@ -2977,6 +2977,25 @@ class TokenMvcMockTests extends AbstractTokenMockMvcTests {
     }
 
     @Test
+    void clientCredentials_rejectsUserAccessTokenPresentedAsClientBearerAuthentication() throws Exception {
+        // a client that both logs users in AND has its own client_credentials capability
+        String clientId = "testclient" + generator.generate();
+        setUpClients(clientId, "clients.write", "uaa.user", "password,client_credentials", true);
+
+        String username = createUserForPasswordGrant(jdbcScimUserProvisioning, jdbcScimGroupMembershipManager, jdbcScimGroupProvisioning, generator);
+        String userAccessToken = MockMvcUtils.getUserOAuthAccessToken(mockMvc, clientId, SECRET, username, SECRET, "uaa.user");
+
+        // the plain uaa.user token must not be accepted as proof of the client's own secret
+        // for a client_credentials request against the same client_id
+        mockMvc.perform(post("/oauth/token")
+                        .accept(APPLICATION_JSON_VALUE)
+                        .header("Authorization", "Bearer " + userAccessToken)
+                        .param("grant_type", "client_credentials")
+                        .param("client_id", clientId))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
     void clientCredentials_byDefault_willNotLockoutClientsUsingFormData() throws Exception {
         String clientId = "testclient" + generator.generate();
         String scopes = "space.*.developer,space.*.admin,org.*.reader,org.123*.admin,*.*,*";


### PR DESCRIPTION
oauthTokenApiRequestMatcher matched any /oauth/token request bearing an
Authorization: Bearer header and a client_id parameter, regardless of
grant_type. It was written for exactly one purpose (see the historical
XML config comment this replaced): UAA's non-standard user_token grant.

Because it never checked grant_type, a standard grant_type=client_credentials
request carrying a Bearer header and matching client_id also matched it,
routing the request to the uaa.user-scope-only resource filter chain
instead of the client-secret-authenticated one. TokenEndpoint then treated
the Bearer token's own client as "the authenticated client," and the one
remaining safety net (AbstractTokenGranter#isValidClientAuthentication)
fails open to CLIENT_AUTH_SECRET whenever it can't positively identify how
the client was authenticated - which is exactly the case for a
resource-owner Bearer token. Net effect: any user holding a plain access
token for a client that also supports client_credentials could mint a new
token carrying that client's own authorities, with no proof of the
client's secret.

Constraining the matcher to grant_type=user_token, matching its original
documented scope, routes client_credentials requests to the correct
client-secret-authenticated chain again.