### PR TITLE
Don't bootstrap a dummy LDAP identity provider when unconfigured

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/db/DeleteUnconfiguredBootstrapIdentityProviders.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/db/DeleteUnconfiguredBootstrapIdentityProviders.java
@@ -1,0 +1,95 @@
+package org.cloudfoundry.identity.uaa.db;
+
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.provider.KeystoneIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.LdapIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * V2.0.2 ({@link BootstrapIdentityZones}) unconditionally inserted a placeholder
+ * {@code identity_provider} row for each of "uaa", "login-server", "ldap", and
+ * "keystone" in the {@code uaa} zone, with {@code config = null} - regardless
+ * of whether anything was ever actually configured for those origins. That
+ * row's mere existence blocks provisioning a real identity provider for that
+ * origin via {@code POST /identity-providers} (unique
+ * {@code (identity_zone_id, origin_key)} index), and serves no operational
+ * purpose if nothing has ever configured it.
+ * <p>
+ * This migration removes exactly those rows that are STILL in that
+ * never-configured state. It never touches a row that has ever had real
+ * configuration applied to it - whether by {@code IdentityProviderBootstrap},
+ * the REST API, or by hand. "ldap" and "keystone" rows can carry a non-null
+ * but still-empty JSON config (bootstrap code overwrites the literal
+ * {@code NULL} with an unconfigured definition on every boot), so this checks
+ * the parsed content, not just {@code config IS NULL}.
+ * <p>
+ * "uaa" is never touched: it's the mandatory internal auth source and is kept
+ * actively managed by {@code IdentityProviderBootstrap#updateDefaultZoneUaaIDP}.
+ * "login-server" has no bootstrap code that ever populates its config, so a
+ * plain {@code NULL} check is sufficient there.
+ */
+public class DeleteUnconfiguredBootstrapIdentityProviders extends BaseJavaMigration {
+
+    @Override
+    public void migrate(Context context) {
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true));
+        String uaaZoneId = IdentityZone.getUaaZoneId();
+
+        deleteIfConfigIsNull(jdbcTemplate, uaaZoneId, OriginKeys.LOGIN_SERVER);
+        deleteIfUnconfigured(jdbcTemplate, uaaZoneId, OriginKeys.KEYSTONE,
+                DeleteUnconfiguredBootstrapIdentityProviders::keystoneIsUnconfigured);
+        deleteIfUnconfigured(jdbcTemplate, uaaZoneId, OriginKeys.LDAP,
+                DeleteUnconfiguredBootstrapIdentityProviders::ldapIsUnconfigured);
+    }
+
+    private void deleteIfConfigIsNull(JdbcTemplate jdbcTemplate, String zoneId, String origin) {
+        jdbcTemplate.update(
+                "delete from identity_provider where identity_zone_id = ? and origin_key = ? and config is null",
+                zoneId, origin);
+    }
+
+    private void deleteIfUnconfigured(JdbcTemplate jdbcTemplate, String zoneId, String origin,
+            Predicate<String> isUnconfigured) {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                "select id, config from identity_provider where identity_zone_id = ? and origin_key = ?",
+                zoneId, origin);
+        for (Map<String, Object> row : rows) {
+            String config = (String) row.get("config");
+            if (config == null || isUnconfigured.test(config)) {
+                jdbcTemplate.update("delete from identity_provider where id = ?", row.get("id"));
+            }
+        }
+    }
+
+    private static boolean ldapIsUnconfigured(String config) {
+        try {
+            LdapIdentityProviderDefinition definition = JsonUtils.readValue(config, LdapIdentityProviderDefinition.class);
+            return definition == null || !definition.isConfigured();
+        } catch (JsonUtils.JsonUtilException e) {
+            // Not parseable as an LDAP definition - leave it alone rather than risk deleting
+            // something we don't understand.
+            return false;
+        }
+    }
+
+    private static boolean keystoneIsUnconfigured(String config) {
+        try {
+            KeystoneIdentityProviderDefinition definition = JsonUtils.readValue(config, KeystoneIdentityProviderDefinition.class);
+            return definition == null
+                    || definition.getAdditionalConfiguration() == null
+                    || definition.getAdditionalConfiguration().isEmpty();
+        } catch (JsonUtils.JsonUtilException e) {
+            return false;
+        }
+    }
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/db/DeleteUnconfiguredBootstrapIdentityProviders.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/db/DeleteUnconfiguredBootstrapIdentityProviders.java
@@ -7,9 +7,10 @@ import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.cloudfoundry.identity.uaa.zone.IdentityZone;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.SingleConnectionDataSource;
-import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Map;
@@ -40,16 +41,16 @@ import java.util.function.Predicate;
  */
 public class DeleteUnconfiguredBootstrapIdentityProviders extends BaseJavaMigration {
 
+    Logger logger = LoggerFactory.getLogger(DeleteUnconfiguredBootstrapIdentityProviders.class);
+
     @Override
     public void migrate(Context context) {
         JdbcTemplate jdbcTemplate = new JdbcTemplate(new SingleConnectionDataSource(context.getConnection(), true));
         String uaaZoneId = IdentityZone.getUaaZoneId();
 
         deleteIfConfigIsNull(jdbcTemplate, uaaZoneId, OriginKeys.LOGIN_SERVER);
-        deleteIfUnconfigured(jdbcTemplate, uaaZoneId, OriginKeys.KEYSTONE,
-                DeleteUnconfiguredBootstrapIdentityProviders::keystoneIsUnconfigured);
-        deleteIfUnconfigured(jdbcTemplate, uaaZoneId, OriginKeys.LDAP,
-                DeleteUnconfiguredBootstrapIdentityProviders::ldapIsUnconfigured);
+        deleteIfUnconfigured(jdbcTemplate, uaaZoneId, OriginKeys.KEYSTONE, this::keystoneIsUnconfigured);
+        deleteIfUnconfigured(jdbcTemplate, uaaZoneId, OriginKeys.LDAP, this::ldapIsUnconfigured);
     }
 
     private void deleteIfConfigIsNull(JdbcTemplate jdbcTemplate, String zoneId, String origin) {
@@ -71,24 +72,28 @@ public class DeleteUnconfiguredBootstrapIdentityProviders extends BaseJavaMigrat
         }
     }
 
-    private static boolean ldapIsUnconfigured(String config) {
+    private boolean ldapIsUnconfigured(String config) {
         try {
             LdapIdentityProviderDefinition definition = JsonUtils.readValue(config, LdapIdentityProviderDefinition.class);
             return definition == null || !definition.isConfigured();
         } catch (JsonUtils.JsonUtilException e) {
             // Not parseable as an LDAP definition - leave it alone rather than risk deleting
             // something we don't understand.
+            logger.warn("Could not parse ldap identity provider config as LdapIdentityProviderDefinition; leaving it alone", e);
             return false;
         }
     }
 
-    private static boolean keystoneIsUnconfigured(String config) {
+    private boolean keystoneIsUnconfigured(String config) {
         try {
             KeystoneIdentityProviderDefinition definition = JsonUtils.readValue(config, KeystoneIdentityProviderDefinition.class);
             return definition == null
                     || definition.getAdditionalConfiguration() == null
                     || definition.getAdditionalConfiguration().isEmpty();
         } catch (JsonUtils.JsonUtilException e) {
+            // Not parseable as a Keystone definition - leave it alone rather than risk deleting
+            // something we don't understand.
+            logger.warn("Could not parse keystone identity provider config as KeystoneIdentityProviderDefinition; leaving it alone", e);
             return false;
         }
     }

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/db/hsqldb/V4_114__DeleteUnconfiguredBootstrapIdentityProviders.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/db/hsqldb/V4_114__DeleteUnconfiguredBootstrapIdentityProviders.java
@@ -1,0 +1,6 @@
+package org.cloudfoundry.identity.uaa.db.hsqldb;
+
+import org.cloudfoundry.identity.uaa.db.DeleteUnconfiguredBootstrapIdentityProviders;
+
+public class V4_114__DeleteUnconfiguredBootstrapIdentityProviders extends DeleteUnconfiguredBootstrapIdentityProviders {
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/db/mysql/V4_114__DeleteUnconfiguredBootstrapIdentityProviders.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/db/mysql/V4_114__DeleteUnconfiguredBootstrapIdentityProviders.java
@@ -1,0 +1,6 @@
+package org.cloudfoundry.identity.uaa.db.mysql;
+
+import org.cloudfoundry.identity.uaa.db.DeleteUnconfiguredBootstrapIdentityProviders;
+
+public class V4_114__DeleteUnconfiguredBootstrapIdentityProviders extends DeleteUnconfiguredBootstrapIdentityProviders {
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/db/postgresql/V4_114__DeleteUnconfiguredBootstrapIdentityProviders.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/db/postgresql/V4_114__DeleteUnconfiguredBootstrapIdentityProviders.java
@@ -1,0 +1,6 @@
+package org.cloudfoundry.identity.uaa.db.postgresql;
+
+import org.cloudfoundry.identity.uaa.db.DeleteUnconfiguredBootstrapIdentityProviders;
+
+public class V4_114__DeleteUnconfiguredBootstrapIdentityProviders extends DeleteUnconfiguredBootstrapIdentityProviders {
+}

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityProviderBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityProviderBootstrap.java
@@ -140,6 +140,23 @@ public class IdentityProviderBootstrap
         Map<String, Object> ldap = new HashMap<>();
         ldap.put(LdapIdentityProviderDefinition.LDAP, ldapConfig);
         LdapIdentityProviderDefinition json = getLdapConfigAsDefinition(ldap);
+        /*
+          Only manufacture the bootstrap LDAP identity provider when there's something to
+          bootstrap: either real connection details were actually supplied (baseUrl set -
+          see LdapIdentityProviderDefinition.isConfigured()), or a provider already exists
+          for this zone (e.g. from a prior real config, the REST API, or the legacy Flyway
+          migration that used to insert one unconditionally). A `ldap:` block containing
+          only control flags like `override: false` - with no baseUrl/bind/search settings
+          - is not "configured" and must be treated the same as no `ldap:` block at all.
+          Merely activating the `ldap` Spring profile (with or without such a block) must
+          not create a dummy, unconfigured identity provider - that row blocks a real LDAP
+          IDP from being created via the REST API (unique origin/zone constraint) and has
+          no operational purpose. See TNZ-125736.
+         */
+        IdentityProvider<AbstractIdentityProviderDefinition> existing = getProviderByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId());
+        if (!json.isConfigured() && existing == null) {
+            return;
+        }
         provider.setConfig(json);
         provider.setActive(ldapProfile && json.isConfigured());
         /*
@@ -148,7 +165,6 @@ public class IdentityProviderBootstrap
          */
         boolean override = ldapConfig == null || ldapConfig.get("override") == null || (boolean) ldapConfig.get("override");
         if (!override) {
-            IdentityProvider<AbstractIdentityProviderDefinition> existing = getProviderByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId());
             override = existing == null || existing.getConfig() == null;
         }
         IdentityProviderWrapper<LdapIdentityProviderDefinition> wrapper = new IdentityProviderWrapper<>(provider);

--- a/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityProviderBootstrap.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/impl/config/IdentityProviderBootstrap.java
@@ -151,7 +151,8 @@ public class IdentityProviderBootstrap
           Merely activating the `ldap` Spring profile (with or without such a block) must
           not create a dummy, unconfigured identity provider - that row blocks a real LDAP
           IDP from being created via the REST API (unique origin/zone constraint) and has
-          no operational purpose. See TNZ-125736.
+          no operational purpose.
+          see https://github.com/cloudfoundry/uaa/issues/4062
          */
         IdentityProvider<AbstractIdentityProviderDefinition> existing = getProviderByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId());
         if (!json.isConfigured() && existing == null) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
@@ -117,15 +117,17 @@ class IdentityProviderBootstrapTest {
 
     @Test
     void upgradeLDAPProvider() throws Exception {
-        // A pre-existing LDAP-origin row (e.g. from the legacy Flyway migration, or a
-        // previously bootstrapped/REST-managed provider) must survive bootstrap running
-        // with no `ldap:` config supplied - it must not be deleted just because there's
-        // nothing to configure it with on this boot. See TNZ-125736.
+        // Originally added in 645b8a911 (2016) to prove bootstrap doesn't choke when an
+        // existing row's config JSON contains attributes unknown to
+        // LdapIdentityProviderDefinition (like "ldapdebug") - a legacy-shaped config blob,
+        // not the flattened shape bootstrap itself writes. Note the row's origin_key is
+        // "ldap2", not "ldap" - it's deliberately unrelated to the "ldap" origin
+        // addLdapProvider() manages, so it must survive bootstrap completely untouched.
         String insertSQL = "INSERT INTO identity_provider (id,identity_zone_id,name,origin_key,type,config)VALUES ('ldap','uaa','ldap','ldap2','ldap','{\"ldapdebug\":\"Test debug\",\"profile\":{\"file\":\"ldap/ldap-search-and-bind.xml\"},\"base\":{\"url\":\"ldap://localhost:389/\",\"userDn\":\"cn=admin,dc=test,dc=com\",\"password\":\"password\",\"searchBase\":\"dc=test,dc=com\",\"searchFilter\":\"cn={0}\",\"referral\":\"follow\"},\"groups\":{\"file\":\"ldap/ldap-groups-map-to-scopes.xml\",\"searchBase\":\"dc=test,dc=com\",\"groupSearchFilter\":\"member={0}\",\"searchSubtree\":true,\"maxSearchDepth\":10,\"autoAdd\":true,\"ignorePartialResultException\":true}}')";
         jdbcTemplate.update(insertSQL);
         bootstrap.afterPropertiesSet();
 
-        assertThat(provisioning.retrieveByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId())).isNotNull();
+        assertThat(provisioning.retrieveByOriginIgnoreActiveFlag("ldap2", IdentityZone.getUaaZoneId())).isNotNull();
     }
 
     @Test
@@ -193,6 +195,14 @@ class IdentityProviderBootstrapTest {
     private static HashMap<String, Object> getGenericLdapConfig() {
         HashMap<String, Object> ldapConfig = new HashMap<>();
 
+        // A real connection detail is required: since TNZ-125736, bootstrap only creates the
+        // provider row when either it's genuinely configured (LdapIdentityProviderDefinition
+        // isConfigured(), i.e. baseUrl set) or a row already exists for this zone. This helper
+        // is meant to represent a realistic, fully-configured LDAP setup, so it needs one.
+        // Note: keys here are relative to the `ldap:` block (see removedLdapBootstrapRemainsActive
+        // below) - LdapIdentityProviderDefinition.LDAP_BASE_URL is already "ldap."-prefixed and
+        // would double up once wrapped in {"ldap": ldapConfig} before flattening.
+        ldapConfig.put("base.url", "ldap://localhost:389/");
         ldapConfig.put(EMAIL_DOMAIN_ATTR, Collections.singletonList("test.domain"));
         ldapConfig.put(STORE_CUSTOM_ATTRIBUTES_NAME, false);
         ldapConfig.put(PROVIDER_DESCRIPTION, "Test LDAP Provider Description");

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
@@ -117,24 +117,44 @@ class IdentityProviderBootstrapTest {
 
     @Test
     void upgradeLDAPProvider() throws Exception {
+        // A pre-existing LDAP-origin row (e.g. from the legacy Flyway migration, or a
+        // previously bootstrapped/REST-managed provider) must survive bootstrap running
+        // with no `ldap:` config supplied - it must not be deleted just because there's
+        // nothing to configure it with on this boot. See TNZ-125736.
         String insertSQL = "INSERT INTO identity_provider (id,identity_zone_id,name,origin_key,type,config)VALUES ('ldap','uaa','ldap','ldap2','ldap','{\"ldapdebug\":\"Test debug\",\"profile\":{\"file\":\"ldap/ldap-search-and-bind.xml\"},\"base\":{\"url\":\"ldap://localhost:389/\",\"userDn\":\"cn=admin,dc=test,dc=com\",\"password\":\"password\",\"searchBase\":\"dc=test,dc=com\",\"searchFilter\":\"cn={0}\",\"referral\":\"follow\"},\"groups\":{\"file\":\"ldap/ldap-groups-map-to-scopes.xml\",\"searchBase\":\"dc=test,dc=com\",\"groupSearchFilter\":\"member={0}\",\"searchSubtree\":true,\"maxSearchDepth\":10,\"autoAdd\":true,\"ignorePartialResultException\":true}}')";
         jdbcTemplate.update(insertSQL);
         bootstrap.afterPropertiesSet();
+
+        assertThat(provisioning.retrieveByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId())).isNotNull();
     }
 
     @Test
-    void ldapProfileBootstrap() throws Exception {
+    void ldapProfileAloneDoesNotBootstrapDummyProvider() throws Exception {
+        // Activating the `ldap` Spring profile with no `ldap:` config and no pre-existing
+        // provider must not manufacture a dummy, unconfigured LDAP identity provider: that
+        // row has no operational purpose and blocks a real LDAP IDP from being created via
+        // the REST API (unique origin/zone constraint). See TNZ-125736.
         environment.setActiveProfiles(LDAP);
         bootstrap.afterPropertiesSet();
 
-        IdentityProvider<LdapIdentityProviderDefinition> ldapProvider = provisioning.retrieveByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId());
-        assertThat(ldapProvider).isNotNull();
-        assertThat(ldapProvider.getCreated()).isNotNull();
-        assertThat(ldapProvider.getLastModified()).isNotNull();
-        assertThat(ldapProvider.getType()).isEqualTo(LDAP);
-        LdapIdentityProviderDefinition definition = ldapProvider.getConfig();
-        assertThat(definition).isNotNull();
-        assertThat(definition.isConfigured()).isFalse();
+        assertThatThrownBy(() -> provisioning.retrieveByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId()))
+                .isInstanceOf(EmptyResultDataAccessException.class);
+    }
+
+    @Test
+    void ldapConfigWithOnlyOverrideFlagDoesNotBootstrapDummyProvider() throws Exception {
+        // A `ldap:` block containing nothing but the `override` control flag (no
+        // baseUrl/bind/search settings) carries no real LDAP configuration. It must be
+        // treated the same as no `ldap:` block at all - not as "config was supplied".
+        // See TNZ-125736.
+        environment.setActiveProfiles(LDAP);
+        HashMap<String, Object> ldapConfig = new HashMap<>();
+        ldapConfig.put("override", false);
+        bootstrap.setLdapConfig(ldapConfig);
+        bootstrap.afterPropertiesSet();
+
+        assertThatThrownBy(() -> provisioning.retrieveByOriginIgnoreActiveFlag(LDAP, IdentityZone.getUaaZoneId()))
+                .isInstanceOf(EmptyResultDataAccessException.class);
     }
 
     @Test

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
@@ -134,6 +134,12 @@ class IdentityProviderBootstrapTest {
         // provider must not manufacture a dummy, unconfigured LDAP identity provider: that
         // row has no operational purpose and blocks a real LDAP IDP from being created via
         // the REST API (unique origin/zone constraint). See TNZ-125736.
+        //
+        // Requires a clean DB: other tests in this class bootstrap a real LDAP provider,
+        // and @WithDatabaseContext doesn't roll back between tests, so without this an
+        // `existing` row from a previously-run test would make this assertion flaky
+        // depending on JUnit's (unspecified) method execution order.
+        TestUtils.cleanAndSeedDb(jdbcTemplate);
         environment.setActiveProfiles(LDAP);
         bootstrap.afterPropertiesSet();
 
@@ -147,6 +153,9 @@ class IdentityProviderBootstrapTest {
         // baseUrl/bind/search settings) carries no real LDAP configuration. It must be
         // treated the same as no `ldap:` block at all - not as "config was supplied".
         // See TNZ-125736.
+        //
+        // Requires a clean DB - see comment in ldapProfileAloneDoesNotBootstrapDummyProvider.
+        TestUtils.cleanAndSeedDb(jdbcTemplate);
         environment.setActiveProfiles(LDAP);
         HashMap<String, Object> ldapConfig = new HashMap<>();
         ldapConfig.put("override", false);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/config/IdentityProviderBootstrapTest.java
@@ -135,7 +135,8 @@ class IdentityProviderBootstrapTest {
         // Activating the `ldap` Spring profile with no `ldap:` config and no pre-existing
         // provider must not manufacture a dummy, unconfigured LDAP identity provider: that
         // row has no operational purpose and blocks a real LDAP IDP from being created via
-        // the REST API (unique origin/zone constraint). See TNZ-125736.
+        // the REST API (unique origin/zone constraint).
+        // see https://github.com/cloudfoundry/uaa/issues/4062
         //
         // Requires a clean DB: other tests in this class bootstrap a real LDAP provider,
         // and @WithDatabaseContext doesn't roll back between tests, so without this an
@@ -154,7 +155,7 @@ class IdentityProviderBootstrapTest {
         // A `ldap:` block containing nothing but the `override` control flag (no
         // baseUrl/bind/search settings) carries no real LDAP configuration. It must be
         // treated the same as no `ldap:` block at all - not as "config was supplied".
-        // See TNZ-125736.
+        // see https://github.com/cloudfoundry/uaa/issues/4062
         //
         // Requires a clean DB - see comment in ldapProfileAloneDoesNotBootstrapDummyProvider.
         TestUtils.cleanAndSeedDb(jdbcTemplate);
@@ -195,10 +196,11 @@ class IdentityProviderBootstrapTest {
     private static HashMap<String, Object> getGenericLdapConfig() {
         HashMap<String, Object> ldapConfig = new HashMap<>();
 
-        // A real connection detail is required: since TNZ-125736, bootstrap only creates the
-        // provider row when either it's genuinely configured (LdapIdentityProviderDefinition
+        // A real connection detail is required: bootstrap now only creates the provider row
+        // when either it's genuinely configured (LdapIdentityProviderDefinition
         // isConfigured(), i.e. baseUrl set) or a row already exists for this zone. This helper
         // is meant to represent a realistic, fully-configured LDAP setup, so it needs one.
+        // see https://github.com/cloudfoundry/uaa/issues/4062
         // Note: keys here are relative to the `ldap:` block (see removedLdapBootstrapRemainsActive
         // below) - LdapIdentityProviderDefinition.LDAP_BASE_URL is already "ldap."-prefixed and
         // would double up once wrapped in {"ldap": ldapConfig} before flattening.

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/db/DeleteUnconfiguredBootstrapIdentityProvidersTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/db/DeleteUnconfiguredBootstrapIdentityProvidersTest.java
@@ -1,0 +1,143 @@
+package org.cloudfoundry.identity.uaa.db;
+
+import org.cloudfoundry.identity.uaa.annotations.WithDatabaseContext;
+import org.cloudfoundry.identity.uaa.constants.OriginKeys;
+import org.cloudfoundry.identity.uaa.db.hsqldb.V4_114__DeleteUnconfiguredBootstrapIdentityProviders;
+import org.cloudfoundry.identity.uaa.provider.KeystoneIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.provider.LdapIdentityProviderDefinition;
+import org.cloudfoundry.identity.uaa.test.TestUtils;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
+import org.cloudfoundry.identity.uaa.zone.IdentityZone;
+import org.flywaydb.core.api.migration.Context;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@WithDatabaseContext
+class DeleteUnconfiguredBootstrapIdentityProvidersTest {
+
+    private DeleteUnconfiguredBootstrapIdentityProviders migration;
+    private Context context;
+    private Connection connection;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setup() throws SQLException {
+        // Since DeleteUnconfiguredBootstrapIdentityProviders exists, TestUtils no longer
+        // seeds login-server/ldap/keystone rows here (see its own comment) - this just gives
+        // us a clean uaa zone + admin user baseline. Each test below inserts whatever
+        // identity_provider rows it actually needs to exercise.
+        TestUtils.cleanAndSeedDb(jdbcTemplate);
+        // Flyway's BaseJavaMigration validates the class name (must start with V/R) in its
+        // own constructor, so the shared base class can't be instantiated directly - use one
+        // of the concrete per-engine subclasses, same as this suite runs against (hsqldb).
+        migration = new V4_114__DeleteUnconfiguredBootstrapIdentityProviders();
+        connection = jdbcTemplate.getDataSource().getConnection();
+        context = mock(Context.class);
+        when(context.getConnection()).thenReturn(connection);
+    }
+
+    @AfterEach
+    void closeConnection() {
+        try {
+            connection.close();
+        } catch (Exception _) {
+            // ignore
+        }
+    }
+
+    @Test
+    void deletesTheStillUnconfiguredLoginServerKeystoneAndLdapRows() {
+        // Reproduces exactly what V2.0.2 (BootstrapIdentityZones) leaves behind for a
+        // never-configured origin: a row with config=null.
+        insertProvider(OriginKeys.LOGIN_SERVER, null);
+        insertProvider(OriginKeys.KEYSTONE, null);
+        insertProvider(OriginKeys.LDAP, null);
+
+        migration.migrate(context);
+
+        assertThat(countOrigin(OriginKeys.LOGIN_SERVER)).isZero();
+        assertThat(countOrigin(OriginKeys.KEYSTONE)).isZero();
+        assertThat(countOrigin(OriginKeys.LDAP)).isZero();
+    }
+
+    @Test
+    void neverTouchesTheUaaOrigin() {
+        migration.migrate(context);
+
+        assertThat(countOrigin(OriginKeys.UAA)).isEqualTo(1);
+    }
+
+    @Test
+    void doesNotDeleteAnLdapProviderThatHasRealConnectionDetails() {
+        LdapIdentityProviderDefinition realConfig = new LdapIdentityProviderDefinition();
+        realConfig.setBaseUrl("ldap://localhost:389/");
+        insertProvider(OriginKeys.LDAP, JsonUtils.writeValueAsString(realConfig));
+
+        migration.migrate(context);
+
+        assertThat(countOrigin(OriginKeys.LDAP)).isEqualTo(1);
+    }
+
+    @Test
+    void doesNotDeleteAKeystoneProviderThatHasRealConfiguration() {
+        KeystoneIdentityProviderDefinition realConfig =
+                new KeystoneIdentityProviderDefinition(Collections.singletonMap("endpoint", "http://localhost:35357/v2.0"));
+        insertProvider(OriginKeys.KEYSTONE, JsonUtils.writeValueAsString(realConfig));
+
+        migration.migrate(context);
+
+        assertThat(countOrigin(OriginKeys.KEYSTONE)).isEqualTo(1);
+    }
+
+    @Test
+    void deletesAnLdapProviderWithNonNullButStillUnconfiguredContent() {
+        // This is what IdentityProviderBootstrap#addLdapProvider() writes when the `ldap`
+        // Spring profile is active but no real `ldap:` config was supplied (or it only
+        // contains control flags like `override`): a structurally-real but empty
+        // LdapIdentityProviderDefinition, not a SQL NULL. The migration has to recognize
+        // this as "still unconfigured" too, not just bail out on `config IS NOT NULL`.
+        insertProvider(OriginKeys.LDAP, JsonUtils.writeValueAsString(new LdapIdentityProviderDefinition()));
+
+        migration.migrate(context);
+
+        assertThat(countOrigin(OriginKeys.LDAP)).isZero();
+    }
+
+    @Test
+    void leavesAnUnparseableConfigAlone() {
+        insertProvider(OriginKeys.LDAP, "not valid json");
+
+        migration.migrate(context);
+
+        // Can't tell what this row represents, so don't risk deleting it.
+        assertThat(countOrigin(OriginKeys.LDAP)).isEqualTo(1);
+    }
+
+    private void insertProvider(String origin, String config) {
+        jdbcTemplate.update(
+                "insert into identity_provider (id, created, lastModified, version, identity_zone_id, name, origin_key, type, config, active) " +
+                        "values (?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0, ?, ?, ?, ?, ?, ?)",
+                UUID.randomUUID().toString(), IdentityZone.getUaaZoneId(), origin, origin, origin, config, true);
+    }
+
+    private int countOrigin(String origin) {
+        Integer count = jdbcTemplate.queryForObject(
+                "select count(*) from identity_provider where identity_zone_id = ? and origin_key = ?",
+                Integer.class, IdentityZone.getUaaZoneId(), origin);
+        return count == null ? 0 : count;
+    }
+}

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
@@ -97,7 +97,8 @@ public class TestUtils {
         // here too, but a later migration (DeleteUnconfiguredBootstrapIdentityProviders) removes
         // those placeholders again on any database where they were never actually configured -
         // which is every fresh database. Only "uaa" plus whatever origins real user data already
-        // references survive the full migration chain now, so that's what this seeds. See TNZ-125736.
+        // references survive the full migration chain now, so that's what this seeds.
+        // see https://github.com/cloudfoundry/uaa/issues/4062
         origins.add(OriginKeys.UAA);
         origins.addAll(jdbcTemplate.queryForList("SELECT DISTINCT origin from users", String.class));
         for (String origin : origins) {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/test/TestUtils.java
@@ -93,7 +93,12 @@ public class TestUtils {
         jdbcTemplate.update("insert into identity_zone VALUES (?,?,?,?,?,?,?,?,?)", uaa.getId(), t, t, uaa.getVersion(), uaa.getSubdomain(), uaa.getName(), uaa.getDescription(), null, true);
         Map<String, String> originMap = new HashMap<>();
         Set<String> origins = new LinkedHashSet<>();
-        origins.addAll(Arrays.asList(new String[]{OriginKeys.UAA, OriginKeys.LOGIN_SERVER, OriginKeys.LDAP, OriginKeys.KEYSTONE}));
+        // V2.0.2 (BootstrapIdentityZones) used to unconditionally seed login-server/ldap/keystone
+        // here too, but a later migration (DeleteUnconfiguredBootstrapIdentityProviders) removes
+        // those placeholders again on any database where they were never actually configured -
+        // which is every fresh database. Only "uaa" plus whatever origins real user data already
+        // references survive the full migration chain now, so that's what this seeds. See TNZ-125736.
+        origins.add(OriginKeys.UAA);
         origins.addAll(jdbcTemplate.queryForList("SELECT DISTINCT origin from users", String.class));
         for (String origin : origins) {
             String identityProviderId = UUID.randomUUID().toString();


### PR DESCRIPTION
## Problem

`IdentityProviderBootstrap.addLdapProvider()` unconditionally creates an `IdentityProvider` row with `origin_key="ldap"` in each zone on every startup, regardless of whether real LDAP configuration is supplied. Only the `active` flag depends on real config (`ldapProfile && json.isConfigured()`) - the row itself is always persisted.

Since `identity_provider` enforces a unique `(identity_zone_id, origin_key)` index, this causes two problems for anyone trying to manage LDAP identity providers via the REST API:

1. `POST /identity-providers` with `type=ldap` collides with the existing dummy row - only `PUT` against it is possible, so a real, independently-managed LDAP IDP can never be created fresh.
2. A `ldap:` config supplied with no real connection details (e.g. only `override: false`) does **not** prevent the dummy row from being created on a fresh zone/install - `override` only controls whether an *already-existing* row gets updated on a later boot, not whether one gets created in the first place. So `ldap.override: false` is not a usable workaround.

There's a second, deeper layer to this: even with the app-level fix below, `identity_provider` rows for `uaa`/`login-server`/`ldap`/`keystone` are *also* unconditionally inserted by a much older migration, `V2_0_2__BootstrapIdentityZones` (2014) - on *every* database, fresh or upgraded, since Flyway replays the full migration history regardless. That insert predates any application code and can't be prevented by fixing `IdentityProviderBootstrap` alone.

## Fix

Fixes #4062

Two parts, addressing both layers:

**1. `IdentityProviderBootstrap.addLdapProvider()`** - skip creating the bootstrap provider when there's no real configuration (`LdapIdentityProviderDefinition.isConfigured()`, i.e. no `baseUrl` - so a `ldap:` block with only control flags like `override` still counts as unconfigured) **and** no provider already exists for this zone. A provider that already exists - from a prior real config, the REST API, or the legacy Flyway migration - is left untouched; it's only new, never-configured zones that no longer get a dummy row on boot.

**2. A new migration, `V4_114__DeleteUnconfiguredBootstrapIdentityProviders`** - deletes the `login-server`/`ldap`/`keystone` rows `V2_0_2__BootstrapIdentityZones` left behind, but only if they're still genuinely unconfigured (`config IS NULL`, or for `ldap` specifically, a parsed config with no `baseUrl`). `uaa` is never touched - it's the mandatory internal auth source. Because Flyway replays every migration on every database, this closes the loop for both timeframes at once: a fresh install inserts-then-immediately-deletes these rows within the same initial `migrate()` run (never persisting), while an already-provisioned database gets them cleaned up retroactively on its next upgrade. A real, actively-configured provider is left alone either way.

Verified no blast radius concerns before adding the migration: no FK constraints anywhere reference `identity_provider(id)` (the columns that once did were dropped back in `V2_0_4`), and the two real callers that look up these origins already handle total absence gracefully (`DynamicZoneAwareAuthenticationManager#getProvider()` falls back to a synthetic inactive stub; so does `InvitationsController#acceptLdapInvitation()`).

## Testing

- `IdentityProviderBootstrapTest` - added tests for the profile-alone and override-only-config cases; updated `upgradeLDAPProvider` and `getGenericLdapConfig()` (pre-existing helpers whose assumptions no longer held once dummy rows stopped being free - see commit messages for details).
- `DeleteUnconfiguredBootstrapIdentityProvidersTest` - new, covers null-config deletion, semantic ldap/keystone "still unconfigured" detection, preservation of real configs, and defensive handling of unparseable JSON.
- `TestUtils.cleanAndSeedDb()` updated to match the new post-migration baseline; re-verified against all 10 test files that depend on it (160 tests).

ai-assisted=yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)