### PR TITLE
Pass through unrecognized claims in check_token and introspect responses

### DIFF
--- a/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/Claims.java
+++ b/model/src/main/java/org/cloudfoundry/identity/uaa/oauth/token/Claims.java
@@ -14,6 +14,8 @@
 
 package org.cloudfoundry.identity.uaa.oauth.token;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -25,7 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown = false)
 public class Claims {
 
     @JsonProperty(ClaimConstants.USER_ID)
@@ -98,6 +100,7 @@ public class Claims {
     private String clientAuth;
     @JsonProperty(ClaimConstants.ACT)
     private Map<String, Object> actorClaims;
+    private final Map<String, Object> additionalClaims = new HashMap<>();
 
     public String getUserId() {
         return userId;
@@ -378,5 +381,15 @@ public class Claims {
     @JsonIgnore
     public Map<String, Object> getClaimMap() {
         return JsonUtils.convertValue(this, HashMap.class);
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalClaims() {
+        return java.util.Collections.unmodifiableMap(additionalClaims);
+    }
+
+    @JsonAnySetter
+    public void setAdditionalClaim(String name, Object value) {
+        additionalClaims.put(name, value);
     }
 }

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/IntrospectionClaimsTest.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/IntrospectionClaimsTest.java
@@ -50,6 +50,10 @@ class IntrospectionClaimsTest {
 
         assertThat(claims.getJti()).isEqualTo("abc");
         assertThat(claims.getAdditionalClaims()).containsEntry("unknown", "some-value");
-        assertThat(JsonUtils.writeValueAsString(claims)).contains("\"unknown\":\"some-value\"");
+
+        String serialized = JsonUtils.writeValueAsString(claims);
+        assertThat(JsonUtils.readValue(serialized, java.util.Map.class))
+                .containsEntry("unknown", "some-value")
+                .doesNotContainKey("additionalClaims");
     }
 }

--- a/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/IntrospectionClaimsTest.java
+++ b/model/src/test/java/org/cloudfoundry/identity/uaa/oauth/token/IntrospectionClaimsTest.java
@@ -42,4 +42,14 @@ class IntrospectionClaimsTest {
                 .containsEntry("aud", Arrays.asList("openid", "login"))
                 .containsEntry("scope", Arrays.asList("openid"));
     }
+
+    @Test
+    void unrecognizedClaimsAreCapturedAndFlattenedBackOut() {
+        IntrospectionClaims claims = JsonUtils.readValue(
+                "{\"jti\":\"abc\",\"unknown\":\"some-value\"}", IntrospectionClaims.class);
+
+        assertThat(claims.getJti()).isEqualTo("abc");
+        assertThat(claims.getAdditionalClaims()).containsEntry("unknown", "some-value");
+        assertThat(JsonUtils.writeValueAsString(claims)).contains("\"unknown\":\"some-value\"");
+    }
 }

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
@@ -686,10 +686,9 @@ class CheckTokenEndpointTests {
         tokenServices.setUaaTokenEnhancer(new TestTokenEnhancer());
         OAuth2AccessToken accessToken = tokenServices.createAccessToken(authentication);
         Claims result = endpoint.checkToken(accessToken.getValue(), List.of(), request);
-        assertThat(result.getAdditionalClaims())
-                .as("custom claims added by a token enhancer must not be dropped")
+        assertThat(result.getAdditionalClaims()).as("custom claims added by a token enhancer must not be dropped")
                 .containsEntry("ex_groups", List.of("admin", "editor"))
-                .containsKey("ex_prop");
+                .containsEntry("ex_prop", Map.of("country", "nz"));
     }
 
     @MethodSource("data")

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/CheckTokenEndpointTests.java
@@ -681,6 +681,19 @@ class CheckTokenEndpointTests {
 
     @MethodSource("data")
     @ParameterizedTest
+    void additionalClaimsInResult(String signerKey, boolean useOpaque) throws Exception {
+        initCheckTokenEndpointTests(signerKey, useOpaque);
+        tokenServices.setUaaTokenEnhancer(new TestTokenEnhancer());
+        OAuth2AccessToken accessToken = tokenServices.createAccessToken(authentication);
+        Claims result = endpoint.checkToken(accessToken.getValue(), List.of(), request);
+        assertThat(result.getAdditionalClaims())
+                .as("custom claims added by a token enhancer must not be dropped")
+                .containsEntry("ex_groups", List.of("admin", "editor"))
+                .containsKey("ex_prop");
+    }
+
+    @MethodSource("data")
+    @ParameterizedTest
     void issuerInResults(String signerKey, boolean useOpaque) throws Exception {
         initCheckTokenEndpointTests(signerKey, useOpaque);
         ReflectionTestUtils.setField(tokenEndpointBuilder, "issuer", "http://some.other.issuer");


### PR DESCRIPTION
## Summary
- `CheckTokenEndpoint` and `IntrospectEndpoint` both decode a JWT into a `Claims`/`IntrospectionClaims` POJO annotated `@JsonIgnoreProperties(ignoreUnknown = true)`, so any top-level claim without a matching field is silently dropped from the response.
- `Claims` captures unrecognized claims via `@JsonAnySetter` and re-flattens them back to top level on serialization via `@JsonAnyGetter`, instead of discarding them.
- RFC 7662 (token introspection) explicitly allows this — section 2.2 says the response "MAY" include extension
  members beyond the standard set, and clients "SHOULD" ignore unrecognized ones. 
- Since the catch-all lives on the shared `Claims` class, this change applies to **both** `/check_token` and `/introspect` — any claim added to a token (e.g. by a custom `UaaTokenEnhancer`) that isn't one of the explicitly modeled fields now shows up in both endpoints' responses.

## Test plan
- [x] `IntrospectionClaimsTest` — verifies an unrecognized claim round-trips through deserialize/serialize and appears at the top level of the JSON output.
- [x] `CheckTokenEndpointTests#additionalClaimsInResult` — verifies custom top-level claims added by a `UaaTokenEnhancer` (`ex_groups`, `ex_prop`) are no longer dropped from the `/check_token` response.
- [x] Existing `IntrospectionClaimsTest`, `IntrospectEndpointTest`, and `CheckTokenEndpointTests` suites pass unchanged.