### PR TITLE
Return a minimal response for inactive tokens in /introspect

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/IntrospectEndpoint.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/oauth/IntrospectEndpoint.java
@@ -17,9 +17,17 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import java.util.Map;
+
 @Controller
 public class IntrospectEndpoint {
     protected final Logger logger = LoggerFactory.getLogger(getClass());
+
+    // RFC 7662 section 2.2: an inactive-token response MUST contain only "active": false
+    // and SHOULD NOT include any other information about the token. IntrospectionClaims
+    // has other fields (e.g. `revocable`, a primitive) that can't be suppressed via
+    // @JsonInclude once populated, so the inactive case returns this minimal value instead.
+    private static final Map<String, Object> INACTIVE_TOKEN_RESPONSE = Map.of("active", false);
 
     private final ResourceServerTokenServices resourceServerTokenServices;
 
@@ -30,24 +38,19 @@ public class IntrospectEndpoint {
 
     @PostMapping("/introspect")
     @ResponseBody
-    public IntrospectionClaims introspect(@RequestParam String token) {
-        IntrospectionClaims introspectionClaims = new IntrospectionClaims();
-
+    public Object introspect(@RequestParam String token) {
         try {
             OAuth2AccessToken oAuth2AccessToken = resourceServerTokenServices.readAccessToken(token);
             if (oAuth2AccessToken.isExpired()) {
-                introspectionClaims.setActive(false);
-                return introspectionClaims;
+                return INACTIVE_TOKEN_RESPONSE;
             }
             resourceServerTokenServices.loadAuthentication(token);
-            introspectionClaims = UaaTokenUtils.getClaims(oAuth2AccessToken.getValue(), IntrospectionClaims.class);
+            IntrospectionClaims introspectionClaims = UaaTokenUtils.getClaims(oAuth2AccessToken.getValue(), IntrospectionClaims.class);
             introspectionClaims.setActive(true);
-        } catch (InvalidTokenException _) {
-            introspectionClaims.setActive(false);
             return introspectionClaims;
+        } catch (InvalidTokenException _) {
+            return INACTIVE_TOKEN_RESPONSE;
         }
-
-        return introspectionClaims;
     }
 
     @RequestMapping(value = "/introspect")

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/IntrospectEndpointTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/oauth/IntrospectEndpointTest.java
@@ -5,11 +5,14 @@ import org.cloudfoundry.identity.uaa.oauth.common.OAuth2AccessToken;
 import org.cloudfoundry.identity.uaa.oauth.common.exceptions.InvalidTokenException;
 import org.cloudfoundry.identity.uaa.oauth.provider.token.ResourceServerTokenServices;
 import org.cloudfoundry.identity.uaa.oauth.token.IntrospectionClaims;
+import org.cloudfoundry.identity.uaa.util.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -40,7 +43,7 @@ class IntrospectEndpointTest {
         when(token.isExpired()).thenReturn(false);
         when(token.getValue()).thenReturn(validToken);
 
-        IntrospectionClaims claims = introspectEndpoint.introspect(validToken);
+        IntrospectionClaims claims = (IntrospectionClaims) introspectEndpoint.introspect(validToken);
         assertThat(claims.isActive()).isTrue();
 
         verify(resourceServerTokenServices).readAccessToken(validToken);
@@ -55,15 +58,15 @@ class IntrospectEndpointTest {
         when(resourceServerTokenServices.readAccessToken(validToken)).thenReturn(token);
         when(token.isExpired()).thenReturn(true);
 
-        IntrospectionClaims claims = introspectEndpoint.introspect(validToken);
-        assertThat(claims.isActive()).isFalse();
+        Object result = introspectEndpoint.introspect(validToken);
+        assertThat(result).isEqualTo(Map.of("active", false));
     }
 
     @Test
     void invalidToken_inReadAccessToken() {
         when(resourceServerTokenServices.readAccessToken(validToken)).thenThrow(new InvalidTokenException("Bla"));
-        IntrospectionClaims claims = introspectEndpoint.introspect(validToken);
-        assertThat(claims.isActive()).isFalse();
+        Object result = introspectEndpoint.introspect(validToken);
+        assertThat(result).isEqualTo(Map.of("active", false));
     }
 
     @Test
@@ -71,8 +74,25 @@ class IntrospectEndpointTest {
         OAuth2AccessToken token = mock(OAuth2AccessToken.class);
         when(resourceServerTokenServices.readAccessToken(validToken)).thenReturn(token);
         when(resourceServerTokenServices.loadAuthentication(validToken)).thenThrow(new InvalidTokenException("Bla"));
-        IntrospectionClaims claims = introspectEndpoint.introspect(validToken);
-        assertThat(claims.isActive()).isFalse();
+        Object result = introspectEndpoint.introspect(validToken);
+        assertThat(result).isEqualTo(Map.of("active", false));
+    }
+
+    @Test
+    void falseRevocableClaimIsNotSuppressedOnActiveToken() {
+        // A `false` value on an active token is real information and must still be
+        // returned, unlike the inactive-token case where no other fields are present.
+        String tokenWithRevocableFalse = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyZXZvY2FibGUiOmZhbHNlfQ.jS74pusAMo7VBsEN08rzpxMrk57ZMoRH3QX_gNUopJ4";
+        OAuth2AccessToken token = mock(OAuth2AccessToken.class);
+        when(resourceServerTokenServices.readAccessToken(tokenWithRevocableFalse)).thenReturn(token);
+        when(token.isExpired()).thenReturn(false);
+        when(token.getValue()).thenReturn(tokenWithRevocableFalse);
+
+        Object result = introspectEndpoint.introspect(tokenWithRevocableFalse);
+
+        assertThat(result).isInstanceOf(IntrospectionClaims.class);
+        assertThat(((IntrospectionClaims) result).isRevocable()).isFalse();
+        assertThat(JsonUtils.writeValueAsString(result)).contains("\"revocable\":false");
     }
 
     @Test
@@ -82,7 +102,7 @@ class IntrospectEndpointTest {
         when(token.isExpired()).thenReturn(false);
         when(token.getValue()).thenReturn(validToken);
 
-        IntrospectionClaims claimsResult = introspectEndpoint.introspect(validToken);
+        IntrospectionClaims claimsResult = (IntrospectionClaims) introspectEndpoint.introspect(validToken);
 
         assertThat(claimsResult.isActive()).isTrue();
         assertThat(claimsResult.getName()).isEqualTo("UAA username");
@@ -97,9 +117,8 @@ class IntrospectEndpointTest {
         when(token.isExpired()).thenReturn(false);
         when(token.getValue()).thenReturn(invalidToken);
 
-        IntrospectionClaims claimsResult = introspectEndpoint.introspect(invalidToken);
+        Object result = introspectEndpoint.introspect(invalidToken);
 
-        assertThat(claimsResult.isActive()).isFalse();
-        assertThat(claimsResult.getName()).isNull();
+        assertThat(result).isEqualTo(Map.of("active", false));
     }
 }

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/IntrospectEndpointMockMvcTest.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/oauth/IntrospectEndpointMockMvcTest.java
@@ -78,6 +78,20 @@ class IntrospectEndpointMockMvcTest extends AbstractTokenMockMvcTests {
     }
 
     @Test
+    void invalidTokenResponseContainsOnlyActiveField() throws Exception {
+        // RFC 7662 section 2.2: an inactive-token response SHOULD NOT include any
+        // additional information about the token.
+        mockMvc.perform(
+                post("/introspect")
+                        .with(httpBasic(CLIENT_ID, CLIENT_SECRET))
+                        .header(ACCEPT, APPLICATION_JSON_VALUE)
+                        .header(CONTENT_TYPE, APPLICATION_FORM_URLENCODED_VALUE)
+                        .param("token", "invalid-token"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("{\"active\":false}"));
+    }
+
+    @Test
     void deleteNotSupported() throws Exception {
         mockMvc.perform(
                 delete("/introspect")


### PR DESCRIPTION
## Summary
- RFC 7662 section 2.2 requires an inactive-token introspection response to contain only `"active": false` and nothing else — the authorization server SHOULD NOT include any additional information about an inactive token.
- `IntrospectEndpoint` was returning an empty `IntrospectionClaims` instance for expired/invalid tokens, relying on `@JsonInclude(NON_NULL)` to hide unset fields. That doesn't work for `revocable`, which is a primitive `boolean` inherited from `Claims` — primitives can't be null, so Jackson always serializes their default value. The response leaked `"revocable":false` alongside `"active":false`.
- `IntrospectEndpoint#introspect` now returns a plain minimal value (`{"active": false}`) for the inactive cases, and the populated `IntrospectionClaims` object only for the active case. This was chosen over suppressing `revocable` via `@JsonInclude` because that would also hide a legitimately-false `revocable` value on an *active* token's response, which is real information that should still be returned.

## Test plan
- [x] `IntrospectEndpointTest#expiredTokenIsInactive` / `invalidToken_inReadAccessToken` / `invalidToken_inLoadAuthentication` / `invalidJSONInClaims` — updated to assert the inactive response is exactly `{"active": false}`.
- [x] `IntrospectEndpointTest#falseRevocableClaimIsNotSuppressedOnActiveToken` — new test confirming an active token with an explicit `"revocable":false` claim still returns it.
- [x] `IntrospectEndpointMockMvcTest#invalidTokenResponseContainsOnlyActiveField` — new HTTP-level test asserting the raw response body for an invalid token is exactly `{"active":false}`.
- [x] Existing `IntrospectEndpointTest`, `IntrospectEndpointMockMvcTest`, and `CheckTokenEndpointTests` suites pass unchanged.