### PR TITLE
Fix cors allowed origin pattern matching

### DIFF
--- a/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
+++ b/server/src/main/java/org/cloudfoundry/identity/uaa/security/web/CorsFilter.java
@@ -324,7 +324,7 @@ public class CorsFilter extends OncePerRequestFilter {
     protected boolean isAllowedOrigin(final String origin, CorsConfiguration configuration) {
         for (Pattern pattern : configuration.getAllowedOriginPatterns()) {
             // Making sure that the pattern matches
-            if (pattern.matcher(origin).find()) {
+            if (pattern.matcher(origin).matches()) {
                 return true;
             }
         }
@@ -380,7 +380,11 @@ public class CorsFilter extends OncePerRequestFilter {
         if (configuration.getAllowedOrigins() != null) {
             for (String allowedOrigin : configuration.getAllowedOrigins()) {
                 try {
-                    configuration.getAllowedOriginPatterns().add(Pattern.compile(allowedOrigin));
+                    String patternToCompile = allowedOrigin;
+                    if (!patternToCompile.startsWith("^") && !patternToCompile.endsWith("$")) {
+                        patternToCompile = "^.*(?:" + patternToCompile + ")(?::\\d+)?$";
+                    }
+                    configuration.getAllowedOriginPatterns().add(Pattern.compile(patternToCompile));
                     log.debug("Origin '%s' is allowed for a %s CORS requests.".formatted(allowedOrigin, type));
                 } catch (PatternSyntaxException patternSyntaxException) {
                     log.error("Invalid regular expression pattern in cors.{}.allowed.origins: {}", type, allowedOrigin, patternSyntaxException);

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/CorsFilterDefaultZoneTests.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/security/web/CorsFilterDefaultZoneTests.java
@@ -434,6 +434,78 @@ class CorsFilterDefaultZoneTests {
         assertThat(logEvents.stream().anyMatch(logMsg -> logMsg.contains("Invalid regular expression pattern in cors.xhr.allowed.origins:"))).as("Did not find expected error message in log.").isTrue();
     }
 
+    @Test
+    void unanchoredOriginConfigurationAcceptsValidSubdomainsAndPorts() throws Exception {
+        CorsFilter corsFilter = new CorsFilter(mockIdentityZoneManager, false);
+        // User configures "example\.com" with no anchors
+        corsFilter.getDefaultConfiguration().setAllowedOrigins(Collections.singletonList("example\\.com"));
+        corsFilter.initialize();
+
+        FilterChain filterChain = newMockFilterChain();
+
+        // Standard request (should pass)
+        MockHttpServletResponse response1 = new MockHttpServletResponse();
+        MockHttpServletRequest request1 = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request1.addHeader("Origin", "https://example.com");
+        corsFilter.doFilter(request1, response1, filterChain);
+        assertThat(response1.getStatus()).isEqualTo(200);
+
+        // Subdomain + Port request (should pass due to auto-wrap)
+        MockHttpServletResponse response2 = new MockHttpServletResponse();
+        MockHttpServletRequest request2 = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request2.addHeader("Origin", "http://login.example.com:8080");
+        corsFilter.doFilter(request2, response2, filterChain);
+        assertThat(response2.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void unanchoredOriginConfigurationRejectsSpoofedDomains() throws Exception {
+        CorsFilter corsFilter = new CorsFilter(mockIdentityZoneManager, false);
+        // User configures "example\.com" with no anchors
+        corsFilter.getDefaultConfiguration().setAllowedOrigins(Collections.singletonList("example\\.com"));
+        corsFilter.initialize();
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = newMockFilterChain();
+
+        // Spoofed domain request (Must fail - 403 Forbidden)
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request.addHeader("Origin", "https://example.com.attacker.com");
+        corsFilter.doFilter(request, response, filterChain);
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void explicitlyAnchoredConfigurationIsStrictlyEnforced() throws Exception {
+        CorsFilter corsFilter = new CorsFilter(mockIdentityZoneManager, false);
+        // User configures a strict, fully anchored pattern
+        corsFilter.getDefaultConfiguration().setAllowedOrigins(Collections.singletonList("^https://secure\\.example\\.com$"));
+        corsFilter.initialize();
+
+        FilterChain filterChain = newMockFilterChain();
+
+        // Exact match (should pass)
+        MockHttpServletResponse response1 = new MockHttpServletResponse();
+        MockHttpServletRequest request1 = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request1.addHeader("Origin", "https://secure.example.com");
+        corsFilter.doFilter(request1, response1, filterChain);
+        assertThat(response1.getStatus()).isEqualTo(200);
+
+        // Subdomain request (should fail because auto-wrap was bypassed and ^ requires strict start)
+        MockHttpServletResponse response2 = new MockHttpServletResponse();
+        MockHttpServletRequest request2 = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request2.addHeader("Origin", "https://sub.secure.example.com");
+        corsFilter.doFilter(request2, response2, filterChain);
+        assertThat(response2.getStatus()).isEqualTo(403);
+        
+        // Port request (should fail because auto-wrap was bypassed and $ requires strict end)
+        MockHttpServletResponse response3 = new MockHttpServletResponse();
+        MockHttpServletRequest request3 = new MockHttpServletRequest("GET", "/uaa/userinfo");
+        request3.addHeader("Origin", "https://secure.example.com:8443");
+        corsFilter.doFilter(request3, response3, filterChain);
+        assertThat(response3.getStatus()).isEqualTo(403);
+    }
+
     private CorsFilter createConfiguredCorsFilter() {
         CorsFilter corsFilter = new CorsFilter(mockIdentityZoneManager, false);
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcTests.java
@@ -2156,7 +2156,7 @@ public class LoginMockMvcTests {
      */
     @Test
     void logOutCorsPreflight() throws Exception {
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout\\.do$"));
         corsFilter.getFilter().initialize();
 
@@ -2172,7 +2172,7 @@ public class LoginMockMvcTests {
      */
     @Test
     void logOutCorsPreflightForIdentityZone() throws Exception {
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout.do$"));
         corsFilter.getFilter().initialize();
 
@@ -2266,7 +2266,7 @@ public class LoginMockMvcTests {
     @Test
     void xhrCorsPreflightForNonDefaultZoneWhenZoneSpecificCorsPolicyIsNull() throws Exception {
         // setting the default zone CORS policy
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         corsFilter.getFilter().setCorsXhrAllowedUris(singletonList("^/logout.do$"));
         corsFilter.getFilter().initialize();
 

--- a/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
+++ b/uaa/src/test/java/org/cloudfoundry/identity/uaa/login/LoginMockMvcZonePathTests.java
@@ -2604,7 +2604,7 @@ public class LoginMockMvcZonePathTests {
     void logOutCorsPreflight(ZoneResolutionMode mode) throws Exception {
         String subdomain = new AlphanumericRandomValueStringGenerator(24).generate().toLowerCase();
         IdentityZone zone = MockMvcUtils.createOtherIdentityZone(subdomain, mockMvc, webApplicationContext, false, IdentityZoneHolder.getCurrentZoneId());
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH ? asList("^/logout\\.do$", "^/z/[^/]+/logout\\.do$") : singletonList("^/logout\\.do$");
         corsFilter.getFilter().setCorsXhrAllowedUris(allowedUris);
         corsFilter.getFilter().initialize();
@@ -2622,7 +2622,7 @@ public class LoginMockMvcZonePathTests {
     void logOutCorsPreflightForIdentityZone(ZoneResolutionMode mode) throws Exception {
         String subdomain = "testzone1";
         IdentityZone zone = MockMvcUtils.createOtherIdentityZone(subdomain, mockMvc, webApplicationContext, false, IdentityZoneHolder.getCurrentZoneId());
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH ? asList("^/logout.do$", "^/z/[^/]+/logout.do$") : singletonList("^/logout.do$");
         corsFilter.getFilter().setCorsXhrAllowedUris(allowedUris);
         corsFilter.getFilter().initialize();
@@ -2734,7 +2734,7 @@ public class LoginMockMvcZonePathTests {
     @EnumSource(ZoneResolutionMode.class)
     void xhrCorsPreflightForNonDefaultZoneWhenZoneSpecificCorsPolicyIsNull(ZoneResolutionMode mode) throws Exception {
         // setting the default zone CORS policy
-        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^*\\.localhost$"));
+        corsFilter.getFilter().setCorsXhrAllowedOrigins(asList("^localhost$", "^.*\\.localhost$"));
         // For ZONE_PATH mode, the request path is /z/{subdomain}/logout.do, so we need to allow that pattern
         List<String> allowedUris = mode == ZoneResolutionMode.ZONE_PATH
                 ? asList("^/logout.do$", "^/z/[^/]+/logout.do$")


### PR DESCRIPTION
**Ticket**: cors-allowed-origin-patterns-matched-with-find-instead-of-matches (Backward-Compatible Implementation)

**Fix**: Updated the CorsFilter to evaluate allowed origins using strict .matches() instead of the permissive .find() to prevent spoofed domain vulnerabilities (e.g., https://my-domain.com.attacker.com). To maintain backward compatibility for operators relying on legacy substring configurations, unanchored patterns are now conditionally auto-wrapped (e.g., ^.*(?:pattern)(?::\d+)?$) during compilation. This retains the intended substring support for dynamic schemes/subdomains and optional ports, while securely rejecting trailing malicious payloads. Test configurations were also updated to utilize syntactically correct regular expressions.